### PR TITLE
[WIP] Move home directory check to PUN

### DIFF
--- a/nginx_stage/lib/nginx_stage/generator_helpers.rb
+++ b/nginx_stage/lib/nginx_stage/generator_helpers.rb
@@ -26,13 +26,6 @@ module NginxStage
           raise InvalidUser, "user is special: #{user} (#{user.uid} < #{min_uid})"
         end
       end
-
-      # Validate that the user's home directory exists
-      self.add_hook :validate_user_has_home_dir do
-        unless Dir.exist?(user.dir)
-          raise InvalidUser, "home directory '#{user.dir}' does not exist for user: #{user}"
-        end
-      end
     end
 
     # Add support for accepting SKIP_NGINX as an option

--- a/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
+++ b/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
@@ -87,6 +87,48 @@ module NginxStage
       end
     end
 
+    def missing_home_directory?
+      ! File.directory? user.dir
+    end
+
+    def fix_missing_home_directory
+      # instead of embedded string, lets make this a FILE that is on the file system that we can read
+      # oh thats escaping ' with the idea that we can embed it in a ' in nginx config and it will work
+      <<-EOF.gsub("'", %q{\\\'})
+        <html>
+        <head>
+          <style>
+            body {
+              font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+              font-size: 16px;
+              line-height: 1.4;
+              color: #333;
+              font-weight: 300;
+              padding: 15px;
+            }
+            h2 {
+              font-weight: 500;
+              font-size: 30px;
+            }
+            .text-danger {
+              color: #a94442;
+            }
+          </style>
+        </head>
+        <body>
+          <h2>Home directory not found</h2>
+          <p>
+          Your home directory at #{user.dir} appears to be missing. If this is the first time you have logged in with this account, you may
+          need to access our systems using SSH in order to trigger the creation of your home directory.
+          </p>
+          <ol>
+            <li><a target="_blank" href="/pun/sys/shell/ssh/default">Open Shell to create home directory</a></li>
+            <li><a href="/nginx/stop?redir=/pun/sys/dashboard">Restart Web Server</a></li>
+        </body>
+        </html>
+      EOF
+    end
+
     # View used to confirm whether the user wants to restart the PUN to reload
     # configuration changes
     # @return [String] restart confirmation view

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -62,6 +62,13 @@ http {
     }
     <%- end -%>
 
+    <%- if missing_home_directory? -%>
+    location ~ ^/pun/sys/dashboard(/.*|$) {
+      default_type text/html;
+      return 500 '<%= fix_missing_home_directory %>';
+    }
+    <%- end -%>
+
     # Give apps the ability to download files from filesystem
     location <%= sendfile_uri %> {
       internal;


### PR DESCRIPTION
Now if the user's home directory does not exist, an error page
will be displayed for any request to the dashboard app

this error page will provide directions to attempt to ssh to the default
ssh host configured for the shell app in order to auto-create this directory

it will also provide a link to restart the app


See https://discourse.osc.edu/t/launching-ondemand-when-home-directory-does-not-exist/53 for screenshots