### PR TITLE
nginx_stage: generate secret key and set to env

### DIFF
--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -19,6 +19,7 @@ require_relative "nginx_stage/generators/nginx_clean_generator"
 require_relative "nginx_stage/application"
 
 require 'etc'
+require 'securerandom'
 
 # The main namespace for NginxStage. Provides a global configuration.
 module NginxStage
@@ -116,10 +117,39 @@ module NginxStage
       "ONDEMAND_VERSION" => ondemand_version,
       "ONDEMAND_PORTAL" => portal,
       "ONDEMAND_TITLE" => title,
+      "SECRET_KEY_BASE" => secret_key_base(user: user),
       # only set these if corresponding config is set in nginx_stage.yml
       "OOD_DASHBOARD_TITLE" => title(default: nil),
-      "OOD_PORTAL" => portal(default: nil)
+      "OOD_PORTAL" => portal(default: nil),
     }.merge(pun_custom_env)
+  end
+
+  def self.secret_key_base(user:)
+    @secret_key_base ||= find_or_generate_secret_key_base(user: user)
+  end
+
+  def self.find_or_generate_secret_key_base(user:)
+    path = pun_secret_key_base_path(user: user)
+
+    if File.file?(path) && File.readable?(path)
+      # use existing key
+      File.read(path)
+    else
+      # generate new key
+      secret = SecureRandom.hex(64)
+      cache_secret_key_base user: user, secret: secret
+      secret
+    end
+  end
+
+  def self.cache_secret_key_base(user:, secret:)
+    File.write pun_secret_key_base_path(user: user), secret, { perm: 0600 }
+  rescue => e
+    $stderr.puts "Failed to write secret to pun_secret_key_base_path: #{pun_secret_key_base_path(user: user)}"
+    $stderr.puts e.message
+    $stderr.puts e.backtrace
+
+    abort
   end
 
   # Arguments used during execution of nginx binary

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -4,7 +4,7 @@ require_relative "nginx_stage/errors"
 require_relative "nginx_stage/user"
 require_relative "nginx_stage/pid_file"
 require_relative "nginx_stage/socket_file"
-require_relative "nginx_stage/secret_base_key_file"
+require_relative "nginx_stage/secret_key_base_file"
 require_relative "nginx_stage/views/pun_config_view"
 require_relative "nginx_stage/views/app_config_view"
 require_relative "nginx_stage/generator"
@@ -117,7 +117,7 @@ module NginxStage
       "ONDEMAND_VERSION" => ondemand_version,
       "ONDEMAND_PORTAL" => portal,
       "ONDEMAND_TITLE" => title,
-      "SECRET_KEY_BASE" => SecretBaseKeyFile.new(user).secret,
+      "SECRET_KEY_BASE" => SecretKeyBaseFile.new(user).secret,
       # only set these if corresponding config is set in nginx_stage.yml
       "OOD_DASHBOARD_TITLE" => title(default: nil),
       "OOD_PORTAL" => portal(default: nil)

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -78,11 +78,10 @@ module NginxStage
     # @return [Array<String>] the array of env var names
     attr_accessor :pun_custom_env_declarations
 
-    # Root location where per-user NGINX configs are generated
     # Path to generated per-user NGINX config file
     # @example User Bob's nginx config
     #   pun_config_path(user: 'bob')
-    #   #=> "/var/log/nginx/config/puns/bob.conf"
+    #   #=> "/var/lib/nginx/config/puns/bob.conf"
     # @param user [String] the user of the nginx process
     # @return [String] the path to the per-user nginx config file
     def pun_config_path(user:)
@@ -90,6 +89,22 @@ module NginxStage
     end
 
     attr_writer :pun_config_path
+
+    # Path to generated per-user secret key base file
+    # @example User Bob's secret key base file
+    #   pun_config_path(user: 'bob')
+    #   #=> "/var/lib/nginx/config/puns/bob.secret_key_base.txt"
+    # @param user [String] the user of the nginx process
+    # @return [String] the path to the per-user nginx config file
+    def pun_secret_key_base_path(user:)
+      File.expand_path @pun_secret_key_base_path % {user: user}
+    end
+    #FIXME: another option is we add a new directory
+    # /var/lib/nginx/config/puns/
+    # /var/lib/nginx/config/secrets/
+    # does any code in here assume all files in the directory /var/lib/nginx/config/puns/ are pun config files?
+
+    attr_writer :pun_secret_key_base_path
 
     # Path to user's personal tmp root
     # @example User Bob's nginx tmp root
@@ -376,6 +391,8 @@ module NginxStage
       self.pun_custom_env      = {}
       self.pun_custom_env_declarations = []
       self.pun_config_path     = '/var/lib/nginx/config/puns/%{user}.conf'
+      self.pun_secret_key_base_path = '/var/lib/nginx/config/puns/%{user}.secret_key_base.txt'
+
       self.pun_tmp_root        = '/var/lib/nginx/tmp/%{user}'
       self.pun_access_log_path = '/var/log/nginx/%{user}/access.log'
       self.pun_error_log_path  = '/var/log/nginx/%{user}/error.log'

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -99,10 +99,6 @@ module NginxStage
     def pun_secret_key_base_path(user:)
       File.expand_path @pun_secret_key_base_path % {user: user}
     end
-    #FIXME: another option is we add a new directory
-    # /var/lib/nginx/config/puns/
-    # /var/lib/nginx/config/secrets/
-    # does any code in here assume all files in the directory /var/lib/nginx/config/puns/ are pun config files?
 
     attr_writer :pun_secret_key_base_path
 

--- a/nginx_stage/lib/nginx_stage/generator.rb
+++ b/nginx_stage/lib/nginx_stage/generator.rb
@@ -107,9 +107,9 @@ module NginxStage
     # @param destination [String] the relative path to the destination file
     # @param data [String] the given data
     # @return [void]
-    def create_file(destination, data = "")
+    def create_file(destination, data = "", mode: 0644)
       empty_directory File.dirname(destination)
-      File.open(destination, "wb", 0644) { |f| f.write data }
+      File.open(destination, "wb", mode) { |f| f.write data }
     end
 
     # Create an empty directory if it doesn't already exist

--- a/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
+++ b/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
@@ -79,7 +79,7 @@ module NginxStage
     # Generate per user secret_key_base file if it doesn't already exist
     add_hook :create_secret_key_base do
       begin
-        secret = SecretBaseKeyFile.new(user)
+        secret = SecretKeyBaseFile.new(user)
         secret.generate unless secret.exist?
       rescue => e
         $stderr.puts "Failed to write secret to path: #{secret.path}"

--- a/nginx_stage/lib/nginx_stage/secret_base_key_file.rb
+++ b/nginx_stage/lib/nginx_stage/secret_base_key_file.rb
@@ -1,0 +1,40 @@
+require 'securerandom'
+
+module NginxStage
+  # A class to handle a PID file
+  class SecretBaseKeyFile
+    # Path of the secret base key file
+    # @return [String] the path of the secret file
+    attr_reader :path
+
+    # Secret base key string
+    # @return [String, nil] the 128 char secret base key, or nil if file doesn't exist
+    def secret
+      @secret ||= File.read(path) if File.file?(path) && File.readable?(path)
+    end
+
+    # Generate new secret and store in file
+    # @return [String] the secret generated
+    def generate
+      @secret = SecureRandom.hex(64)
+
+      # FIXME: this now generates the PUN config directory if it doesn't exist
+      # instead of Generator#template => Generator#create_file => Generator#empty_directory
+      FileUtils.mkdir_p File.dirname(path), mode: 0755
+
+      File.write path, @secret, { perm: 0600 }
+
+      @secret
+    end
+
+    # @return [Boolean] whether or not the file exists
+    def exist?
+      File.file?(path)
+    end
+
+    # @param user [String] the user we want to get the secret for
+    def initialize(user)
+      @path = NginxStage.pun_secret_key_base_path(user: user)
+    end
+  end
+end

--- a/nginx_stage/lib/nginx_stage/secret_key_base_file.rb
+++ b/nginx_stage/lib/nginx_stage/secret_key_base_file.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
 module NginxStage
-  # A class to handle a PID file
+  # A class to handle generating storing and retrieving per user secret key base
   class SecretKeyBaseFile
     # Path of the secret base key file
     # @return [String] the path of the secret file

--- a/nginx_stage/lib/nginx_stage/secret_key_base_file.rb
+++ b/nginx_stage/lib/nginx_stage/secret_key_base_file.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 module NginxStage
   # A class to handle a PID file
-  class SecretBaseKeyFile
+  class SecretKeyBaseFile
     # Path of the secret base key file
     # @return [String] the path of the secret file
     attr_reader :path


### PR DESCRIPTION
Generate a unique secrete key for each user and set it to SECRET_KEY_BASE env var.

TODO: Fix this so that:

1. Add object `SecretBaseKeyFile. new(path)` that implements `SecretBaseKeyFile#generate` and `SecretBaseKeyFile#exist?` and `SecretBaseKeyFile#secret` and maybe ``SecretBaseKeyFile#build(user:)`. `SecretBaseKeyFile#secret` would output a warning or raise exception if secret is nil (?) - could just output a warning for now...
2. Add to `pun_config_generator` a block like:

   ```ruby
   add_hook :create_secret_key_base do
     secret = SecretKeyBaseFile.build(user: user)
     secret.generate unless secret.exist?
   end
   ```

3. Update `NginxStage.nginx_env` to use `'SECRET_KEY_BASE' => SecretKeyBaseFile.build(user: user).secret`

This ensures the secret is only generated during the launching of a PUN (and not attempted when executing other commands that retrieve `NginxStage.nginx_env`. Because the "query" method `NginxStage.nginx_env` should not produce the side effect of a command method like `SecretKeyBaseFile#generate`.