### PR TITLE
Change default path for dev apps: require opt in

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -395,7 +395,7 @@ module NginxStage
         sys: '/var/lib/nginx/config/apps/sys/%{name}.conf'
       }
       self.app_root          = {
-        dev: '~%{owner}/%{portal}/dev/%{name}',
+        dev: '/var/www/ood/apps/dev/%{owner}/gateway/%{name}',
         usr: '/var/www/ood/apps/usr/%{owner}/gateway/%{name}',
         sys: '/var/www/ood/apps/sys/%{name}'
       }

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -146,7 +146,7 @@
 # corresponding environment
 #
 #app_root:
-#  dev: '~%{owner}/%{portal}/dev/%{name}'
+#  dev: '/var/www/ood/apps/dev/%{owner}/gateway/%{name}'
 #  usr: '/var/www/ood/apps/usr/%{owner}/gateway/%{name}'
 #  sys: '/var/www/ood/apps/sys/%{name}'
 


### PR DESCRIPTION
Now the default path for dev apps is similar to usr apps - it is the local disk
of the webnode, and requires a symlink "gateway" to be created pointing to the users
"sandbox" dev directory in their home directory