### PR TITLE
Serve error file missing_home_directory.html

### DIFF
--- a/nginx_stage/html/missing_home_directory.html
+++ b/nginx_stage/html/missing_home_directory.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+  <style>
+    body {
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      font-size: 20px;
+      line-height: 1.4;
+      color: #333;
+      font-weight: 300;
+      padding: 15px;
+    }
+    h2 {
+      font-weight: 500;
+      font-size: 30px;
+    }
+    .btn-primary {
+      text-decoration: none;
+      font-weight: 400;
+      padding: 10px 16px;
+      border-radius: 6px;
+      color: #fff;
+      background-color: #337ab7;
+    }
+  </style>
+</head>
+<body>
+  <h2>Home directory not found</h2>
+  <p>
+  Your home directory appears to be missing. The home directory mount may be unavailable,
+  or your home directory may need to still be created. Please contact support for help
+  and attempt to restart your web server by clicking below when the problem has been fixed.
+  </p>
+  <p>
+    <a href="/nginx/stop?redir=/pun/sys/dashboard" class="btn-primary">Restart Web Server</a></li>
+  </p>
+</body>
+</html>

--- a/nginx_stage/html/missing_home_directory.html.example.pam_mkhomedir
+++ b/nginx_stage/html/missing_home_directory.html.example.pam_mkhomedir
@@ -1,0 +1,31 @@
+<html>
+<head>
+  <style>
+    body {
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      font-size: 20px;
+      line-height: 1.4;
+      color: #333;
+      font-weight: 300;
+      padding: 15px;
+    }
+    h2 {
+      font-weight: 500;
+      font-size: 30px;
+    }
+    .text-danger {
+      color: #a94442;
+    }
+  </style>
+</head>
+<body>
+  <h2>Home directory not found</h2>
+  <p>
+  Your home directory appears to be missing. If this is the first time you have logged in with this account, you may
+  need to access our systems using SSH in order to trigger the creation of your home directory.
+  </p>
+  <ol>
+    <li><a target="_blank" href="/pun/sys/shell/ssh/default">Open Shell to create home directory</a></li>
+    <li><a href="/nginx/stop?redir=/pun/sys/dashboard">Restart Web Server</a></li>
+</body>
+</html>

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -349,6 +349,13 @@ module NginxStage
     # @return [String] user shell that is blocked
     attr_accessor :disabled_shell
 
+    # Path to the root directory for custom html files
+    # that NGINX can serve. Currently only the missing_home_directory.html
+    # error page can be customized with this mechanism.
+    #
+    # @return [String] path to the custom html root
+    attr_accessor :pun_custom_html_root
+
     #
     # Configuration module
     #
@@ -398,6 +405,7 @@ module NginxStage
 
       self.pun_custom_env      = {}
       self.pun_custom_env_declarations = []
+      self.pun_custom_html_root = '/etc/ood/config/pun/html'
       self.pun_config_path     = '/var/lib/nginx/config/puns/%{user}.conf'
       self.pun_secret_key_base_path = '/var/lib/nginx/config/puns/%{user}.secret_key_base.txt'
 

--- a/nginx_stage/lib/nginx_stage/generator_helpers.rb
+++ b/nginx_stage/lib/nginx_stage/generator_helpers.rb
@@ -26,13 +26,6 @@ module NginxStage
           raise InvalidUser, "user is special: #{user} (#{user.uid} < #{min_uid})"
         end
       end
-
-      # Validate that the user's home directory exists
-      self.add_hook :validate_user_has_home_dir do
-        unless Dir.exist?(user.dir)
-          raise InvalidUser, "home directory '#{user.dir}' does not exist for user: #{user}"
-        end
-      end
     end
 
     # Add support for accepting SKIP_NGINX as an option

--- a/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
+++ b/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
@@ -87,6 +87,18 @@ module NginxStage
       end
     end
 
+    def missing_home_directory?
+      ! Dir.exist?(user.dir)
+    end
+
+    def custom_html_root
+      NginxStage.pun_custom_html_root
+    end
+
+    def default_html_root
+      File.join NginxStage.root, "html"
+    end
+
     # Array of env vars to declare in NGINX config using env directive
     # @return [Array<String>] list of env vars to declare in NGINX config
     def env_declarations

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -72,6 +72,21 @@ http {
       alias "<%= sendfile_root %>";
     }
 
+    <%- if missing_home_directory? -%>
+    rewrite ^/pun/sys/dashboard(/.*|$) /pun/custom_html/missing_home_directory.html;
+    <%- end -%>
+
+    location = /pun/custom_html/missing_home_directory.html {
+      add_header Cache-Control "no-store";
+      root <%= custom_html_root %>;
+      try_files /missing_home_directory.html /pun/html/missing_home_directory.html;
+    }
+
+    location ~ /pun/html/([0-9a-z_\.]+)$ {
+      add_header Cache-Control "no-store";
+      alias <%= default_html_root %>/$1;
+    }
+
     # Include all app configs user has access to
     <%- app_configs.each do |app_config| -%>
     include <%= app_config %>;


### PR DESCRIPTION
serve error file missing_home_directory.html if user's home directory
is missing, by default from
/opt/ood/nginx_stage/html/missing_home_directory.html

optionally load custom error file at
/etc/ood/config/pun/html/missing_home_directory.html if it exists

in both cases, set Cache-Control header to no-store so user can restart
webserver easily by clicking a button, and not view the cached file
instead