### PR TITLE
Support ondemand SCL

### DIFF
--- a/nginx_stage/etc/profile
+++ b/nginx_stage/etc/profile
@@ -6,6 +6,6 @@
 # 2. Check if Software Collections is installed, then source the defined
 #    package scripts.
 #
-SCL_PKGS=${SCL_PKGS:-"rh-git29 rh-nodejs6 rh-ruby24"}
+SCL_PKGS=${SCL_PKGS:-"ondemand"}
 SCL_SOURCE="$(command -v scl_source)"
 [[ "${SCL_SOURCE}" ]] && source "${SCL_SOURCE}" enable ${SCL_PKGS}

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -128,10 +128,10 @@ module NginxStage
   # Arguments used during execution of nginx binary
   # @example Start the per-user NGINX for user Bob
   #   nginx_args(user: 'bob')
-  #   #=> ['-c', '/var/lib/nginx/config/puns/bob.conf']
+  #   #=> ['-c', '/var/lib/ondemand-nginx/config/puns/bob.conf']
   # @example Stop the per-user NGINX for user Bob
   #   nginx_args(user: 'bob', signal: :stop)
-  #   #=> ['-c', '/var/lib/nginx/config/puns/bob.conf', '-s', 'stop']
+  #   #=> ['-c', '/var/lib/ondemnad-nginx/config/puns/bob.conf', '-s', 'stop']
   # @param user [String] the owner of the nginx process
   # @param signal [Symbol] the signal sent to the nginx process
   # @return [Array<String>] the shell arguments used to execute the nginx process

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -131,7 +131,7 @@ module NginxStage
   #   #=> ['-c', '/var/lib/ondemand-nginx/config/puns/bob.conf']
   # @example Stop the per-user NGINX for user Bob
   #   nginx_args(user: 'bob', signal: :stop)
-  #   #=> ['-c', '/var/lib/ondemnad-nginx/config/puns/bob.conf', '-s', 'stop']
+  #   #=> ['-c', '/var/lib/ondemand-nginx/config/puns/bob.conf', '-s', 'stop']
   # @param user [String] the owner of the nginx process
   # @param signal [Symbol] the signal sent to the nginx process
   # @return [Array<String>] the shell arguments used to execute the nginx process

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -396,8 +396,7 @@ module NginxStage
       self.nginx_signals    = %i(stop quit reopen reload)
       self.mime_types_path  = '/opt/ood/ondemand/root/etc/nginx/mime.types'
 
-      # default is set in sbin/nginx_stage
-      self.passenger_root = ENV['PASSENGER_ROOT']
+      self.passenger_root = '/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini'
 
       self.passenger_ruby   = "#{root}/bin/ruby"
       self.passenger_nodejs = "#{root}/bin/node"

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -82,7 +82,7 @@ module NginxStage
     # Path to generated per-user NGINX config file
     # @example User Bob's nginx config
     #   pun_config_path(user: 'bob')
-    #   #=> "/var/lib/nginx/config/puns/bob.conf"
+    #   #=> "/var/lib/ondemand-nginx/config/puns/bob.conf"
     # @param user [String] the user of the nginx process
     # @return [String] the path to the per-user nginx config file
     def pun_config_path(user:)
@@ -94,7 +94,7 @@ module NginxStage
     # Path to generated per-user secret key base file
     # @example User Bob's secret key base file
     #   pun_config_path(user: 'bob')
-    #   #=> "/var/lib/nginx/config/puns/bob.secret_key_base.txt"
+    #   #=> "/var/lib/ondemand-nginx/config/puns/bob.secret_key_base.txt"
     # @param user [String] the user of the nginx process
     # @return [String] the path to the per-user nginx config file
     def pun_secret_key_base_path(user:)
@@ -106,7 +106,7 @@ module NginxStage
     # Path to user's personal tmp root
     # @example User Bob's nginx tmp root
     #   pun_tmp_root(user: 'bob')
-    #   #=> "/var/lib/nginx/tmp/bob"
+    #   #=> "/var/lib/ondemand-nginx/tmp/bob"
     # @param user [String] the user of the nginx process
     # @return [String] the path to the tmp root
     def pun_tmp_root(user:)
@@ -118,7 +118,7 @@ module NginxStage
     # Path to the user's personal access.log
     # @example User Bob's nginx access log
     #   pun_access_log_path(user: 'bob')
-    #   #=> "/var/log/nginx/bob/access.log"
+    #   #=> "/var/log/ondemand-nginx/bob/access.log"
     # @param user [String] the user of the nginx process
     # @return [String] the path to the nginx access log
     def pun_access_log_path(user:)
@@ -130,7 +130,7 @@ module NginxStage
     # Path to the user's personal error.log
     # @example User Bob's nginx error log
     #   pun_error_log_path(user: 'bob')
-    #   #=> "/var/log/nginx/bob/error.log"
+    #   #=> "/var/log/ondemand-nginx/bob/error.log"
     # @param user [String] the user of the nginx process
     # @return [String] the path to the nginx error log
     def pun_error_log_path(user:)
@@ -142,7 +142,7 @@ module NginxStage
     # Path to the user's per-user NGINX pid file
     # @example User Bob's pid file
     #   pun_pid_path(user: 'bob')
-    #   #=> "/var/run/nginx/bob/passenger.pid"
+    #   #=> "/var/run/ondemand-nginx/bob/passenger.pid"
     # @param user [String] the user of nginx process
     # @return [String] the path to the pid file
     def pun_pid_path(user:)
@@ -154,7 +154,7 @@ module NginxStage
     # Path to the user's per-user NGINX socket file
     # @example User Bob's socket file
     #   socket_path(user: 'bob')
-    #   #=> "/var/run/nginx/bob/passenger.sock"
+    #   #=> "/var/run/ondemand-nginx/bob/passenger.sock"
     # @param user [String] the user of nginx process
     # @return [String] the path to the socket file
     def pun_socket_path(user:)
@@ -210,10 +210,10 @@ module NginxStage
     # Path to generated NGINX app config
     # @example Dev app owned by Bob
     #   app_config_path(env: :dev, owner: 'bob', name: 'rails1')
-    #   #=> "/var/lib/nginx/config/apps/dev/bob/rails1.conf"
+    #   #=> "/var/lib/ondemand-nginx/config/apps/dev/bob/rails1.conf"
     # @example User app owned by Dan
     #   app_config_path(env: :usr, owner: 'dan', name: 'fillsim')
-    #   #=> "/var/lib/nginx/config/apps/usr/dan/fillsim.conf"
+    #   #=> "/var/lib/ondemand-nginx/config/apps/usr/dan/fillsim.conf"
     # @param env [Symbol] environment the app is run under
     # @param owner [String] the owner of the app
     # @param name [String] the name of the app
@@ -392,9 +392,9 @@ module NginxStage
       self.template_root         = "#{root}/templates"
 
       self.proxy_user       = 'apache'
-      self.nginx_bin        = '/usr/sbin/nginx'
+      self.nginx_bin        = '/opt/ood/ondemand/root/usr/sbin/nginx'
       self.nginx_signals    = %i(stop quit reopen reload)
-      self.mime_types_path  = '/etc/nginx/mime.types'
+      self.mime_types_path  = '/opt/ood/ondemand/root/etc/nginx/mime.types'
 
       # default is set in sbin/nginx_stage
       self.passenger_root = ENV['PASSENGER_ROOT']
@@ -406,14 +406,14 @@ module NginxStage
       self.pun_custom_env      = {}
       self.pun_custom_env_declarations = []
       self.pun_custom_html_root = '/etc/ood/config/pun/html'
-      self.pun_config_path     = '/var/lib/nginx/config/puns/%{user}.conf'
-      self.pun_secret_key_base_path = '/var/lib/nginx/config/puns/%{user}.secret_key_base.txt'
+      self.pun_config_path     = '/var/lib/ondemand-nginx/config/puns/%{user}.conf'
+      self.pun_secret_key_base_path = '/var/lib/ondemand-nginx/config/puns/%{user}.secret_key_base.txt'
 
-      self.pun_tmp_root        = '/var/tmp/nginx/%{user}'
-      self.pun_access_log_path = '/var/log/nginx/%{user}/access.log'
-      self.pun_error_log_path  = '/var/log/nginx/%{user}/error.log'
-      self.pun_pid_path        = '/var/run/nginx/%{user}/passenger.pid'
-      self.pun_socket_path     = '/var/run/nginx/%{user}/passenger.sock'
+      self.pun_tmp_root        = '/var/tmp/ondemand-nginx/%{user}'
+      self.pun_access_log_path = '/var/log/ondemand-nginx/%{user}/access.log'
+      self.pun_error_log_path  = '/var/log/ondemand-nginx/%{user}/error.log'
+      self.pun_pid_path        = '/var/run/ondemand-nginx/%{user}/passenger.pid'
+      self.pun_socket_path     = '/var/run/ondemand-nginx/%{user}/passenger.sock'
       self.pun_sendfile_root   = '/'
       self.pun_sendfile_uri    = '/sendfile'
       self.pun_app_configs     = [
@@ -423,9 +423,9 @@ module NginxStage
       ]
 
       self.app_config_path   = {
-        dev: '/var/lib/nginx/config/apps/dev/%{owner}/%{name}.conf',
-        usr: '/var/lib/nginx/config/apps/usr/%{owner}/%{name}.conf',
-        sys: '/var/lib/nginx/config/apps/sys/%{name}.conf'
+        dev: '/var/lib/ondemand-nginx/config/apps/dev/%{owner}/%{name}.conf',
+        usr: '/var/lib/ondemand-nginx/config/apps/usr/%{owner}/%{name}.conf',
+        sys: '/var/lib/ondemand-nginx/config/apps/sys/%{name}.conf'
       }
       self.app_root          = {
         dev: '/var/www/ood/apps/dev/%{owner}/gateway/%{name}',

--- a/nginx_stage/sbin/nginx_stage
+++ b/nginx_stage/sbin/nginx_stage
@@ -26,8 +26,6 @@ else
   source "${ROOT_DIR}/etc/profile"
 fi
 
-export PASSENGER_ROOT=$(passenger-config about root)
-
 # Environment is set, so call Ruby now
 #
 exec \

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -91,7 +91,7 @@
 
 # Root location of per-user NGINX tmp dirs
 #
-#pun_tmp_root: '/var/lib/ondemand-nginx/tmp/%{user}'
+#pun_tmp_root: '/var/tmp/ondemand-nginx/%{user}'
 
 # Path to the per-user NGINX access log
 #

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -50,7 +50,7 @@
 #
 #proxy_user: 'apache'
 
-# Path to system-installed NGINX binary
+# Path to NGINX executable used by OnDemand
 #
 #nginx_bin: '/opt/ood/ondemand/root/usr/sbin/nginx'
 
@@ -62,16 +62,16 @@
 #  - 'reopen'
 #  - 'reload'
 
-# Path to system-installed NGINX 'mime.types' file
+# Path to NGINX 'mime.types' file used by OnDemand
 #
 #mime_types_path: '/opt/ood/ondemand/root/etc/nginx/mime.types'
 
-# Path to system-installed Passenger 'locations.ini' file.
+# Path to Passenger 'locations.ini' file used by OnDemand.
 #
 #passenger_root: '/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini'
 #
 
-# Path to system-installed Ruby binary
+# Path to Ruby binary used by nginx_stage
 #
 #passenger_ruby: '/opt/ood/nginx_stage/bin/ruby'
 

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -52,7 +52,7 @@
 
 # Path to system-installed NGINX binary
 #
-#nginx_bin: '/usr/sbin/nginx'
+#nginx_bin: '/opt/ood/ondemand/root/usr/sbin/nginx'
 
 # White-list of signals that can be sent to the NGINX process
 #
@@ -64,13 +64,11 @@
 
 # Path to system-installed NGINX 'mime.types' file
 #
-#mime_types_path: '/etc/nginx/mime.types'
+#mime_types_path: '/opt/ood/ondemand/root/etc/nginx/mime.types'
 
 # Path to system-installed Passenger 'locations.ini' file.
-# In CentOS6/RHEL6 it is /usr/lib/ruby/1.8/phusion_passenger/locations.ini
-# To determine for your system, run command: passenger-config about root
 #
-#passenger_root: '/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini'
+#passenger_root: '/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini'
 #
 
 # Path to system-installed Ruby binary
@@ -89,27 +87,27 @@
 
 # Root location of per-user NGINX configs
 #
-#pun_config_path: '/var/lib/nginx/config/puns/%{user}.conf'
+#pun_config_path: '/var/lib/ondemand-nginx/config/puns/%{user}.conf'
 
 # Root location of per-user NGINX tmp dirs
 #
-#pun_tmp_root: '/var/lib/nginx/tmp/%{user}'
+#pun_tmp_root: '/var/lib/ondemand-nginx/tmp/%{user}'
 
 # Path to the per-user NGINX access log
 #
-#pun_access_log_path: '/var/log/nginx/%{user}/access.log'
+#pun_access_log_path: '/var/log/ondemand-nginx/%{user}/access.log'
 
 # Path to the per-user NGINX error log
 #
-#pun_error_log_path: '/var/log/nginx/%{user}/error.log'
+#pun_error_log_path: '/var/log/ondemand-nginx/%{user}/error.log'
 
 # Path to the per-user NGINX pid file
 #
-#pun_pid_path: '/var/run/nginx/%{user}/passenger.pid'
+#pun_pid_path: '/var/run/ondemand-nginx/%{user}/passenger.pid'
 
 # Path to the per-user NGINX socket file
 #
-#pun_socket_path: '/var/run/nginx/%{user}/passenger.sock'
+#pun_socket_path: '/var/run/ondemand-nginx/%{user}/passenger.sock'
 
 # Path to the local filesystem root where the per-user NGINX process serves
 # files from for the user making use of the sendfile feature in NGINX
@@ -138,9 +136,9 @@
 # A hash detailing the path to the per-user NGINX app configs
 #
 #app_config_path:
-#  dev: '/var/lib/nginx/config/apps/dev/%{owner}/%{name}.conf'
-#  usr: '/var/lib/nginx/config/apps/usr/%{owner}/%{name}.conf'
-#  sys: '/var/lib/nginx/config/apps/sys/%{name}.conf'
+#  dev: '/var/lib/ondemand-nginx/config/apps/dev/%{owner}/%{name}.conf'
+#  usr: '/var/lib/ondemand-nginx/config/apps/usr/%{owner}/%{name}.conf'
+#  sys: '/var/lib/ondemand-nginx/config/apps/sys/%{name}.conf'
 
 # A hash detailing the locations on the file system where apps reside for the
 # corresponding environment

--- a/ood-portal-generator/bin/generate
+++ b/ood-portal-generator/bin/generate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCL_SOURCE=$(command -v scl_source)
-[[ "${SCL_SOURCE}" ]] && source "${SCL_SOURCE}" enable rh-ruby24 &> /dev/null
+[[ "${SCL_SOURCE}" ]] && source "${SCL_SOURCE}" enable ondemand &> /dev/null
 
 ROOT_DIR="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
 

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -56,7 +56,7 @@ module OodPortalGenerator
       # Per-user NGINX sub-uri
       @nginx_uri       = opts.fetch(:nginx_uri, "/nginx")
       @pun_uri         = opts.fetch(:pun_uri, "/pun")
-      @pun_socket_root = opts.fetch(:pun_socket_root, "/var/run/nginx")
+      @pun_socket_root = opts.fetch(:pun_socket_root, "/var/run/ondemand-nginx")
       @pun_max_retries = opts.fetch(:pun_max_retries, 5)
 
       # OpenID Connect sub-uri

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -181,8 +181,8 @@
 # connect to
 # Example:
 #     pun_socket_root: '/path/to/pun/sockets'
-# Default: '/var/run/nginx' (default location set in nginx_stage)
-#pun_socket_root: '/var/run/nginx'
+# Default: '/var/run/ondemand-nginx' (default location set in nginx_stage)
+#pun_socket_root: '/var/run/ondemand-nginx'
 
 # Number of times the proxy attempts to connect to the PUN Unix socket before
 # giving up and displaying an error to the user

--- a/tests.sh
+++ b/tests.sh
@@ -4,6 +4,7 @@ set -ex
 
 # Get dependencies
 yum install -y centos-release-scl
+yum install -y https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-2.el${OS_VERSION}.noarch.rpm
 yum install -y \
   make \
   curl \
@@ -13,10 +14,11 @@ yum install -y \
   rh-ruby24-rubygem-bundler \
   rh-ruby24-ruby-devel \
   rh-nodejs6 \
-  rh-git29
+  rh-git29 \
+  ondemand-runtime
 
 # Setup environment
-source scl_source enable rh-ruby24 rh-nodejs6 rh-git29 || :
+source scl_source enable ondemand || :
 
 # Build and install
 rake -mj ${NUM_TASKS:-$(nproc)} && rake install


### PR DESCRIPTION
Support ondemand SCL
    
* Replace /var/lib/nginx with /var/lib/ondemand-nginx
* Replace /var/run/nginx with /var/run/ondemand-nginx
* Replace /var/log/nginx with /var/log/ondemand-nginx
* Load ondemand SCL only

Migrations of /var/lib and /var/log locations will be handled by ondemand RPM.