### PR TITLE
Add -r|--rpm flags to update_ood_portal

### DIFF
--- a/ood-portal-generator/sbin/update_ood_portal
+++ b/ood-portal-generator/sbin/update_ood_portal
@@ -2,11 +2,34 @@
 
 ROOT="$(dirname "$(readlink -f "${0}")")"
 
+RPM=0
 CONFIG="${CONFIG:-/etc/ood/config/ood_portal.yml}"
 APACHE="${APACHE:-/opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf}"
 BIN="${BIN:-${ROOT}/../bin/generate}"
 
 set -e
+
+usage () {
+    echo "Usage: update_ood_portal [-r|--rpm]"
+    echo "-r|--rpm      Execution performed during RPM install"
+}
+
+OPTS=`getopt -o rh --long rpm,help -n 'update_ood_portal' -- "$@"`
+if [[ $? -ne 0 ]]; then
+    echo "Failed parsing options"
+    usage
+    exit 1
+fi
+
+eval set -- "$OPTS"
+
+while true; do
+    case "$1" in
+        -h|--help) usage ; exit 0 ; shift ;;
+        -r|--rpm) RPM=1 ; shift ;;
+        *) break ;;
+    esac
+done
 
 echo "Generating Apache config using YAML config: '${CONFIG}'"
 
@@ -19,9 +42,14 @@ if ! cmp -s <(echo "${NEW_APACHE}") "${APACHE}"; then
   fi
   echo "Generating new Apache config at: '${APACHE}'"
   echo "${NEW_APACHE}" > "${APACHE}"
+  ret=0
 else
   echo "No change in Apache config."
-  exit 1
+  ret=1
+fi
+
+if [ $RPM -eq 1 ]; then
+    exit $ret
 fi
 
 echo "Completed successfully!"
@@ -39,3 +67,5 @@ else
   echo "    sudo service httpd24-htcacheclean condrestart"
   echo ""
 fi
+
+exit $ret


### PR DESCRIPTION
This is needed to make output more friendly for RPMs using new flag but keep old behavior if run without new flag.

Copied into vagrant:

```
[root@ood ~]# /opt/ood/ood-portal-generator/sbin/update_ood_portal 
Generating Apache config using YAML config: '/etc/ood/config/ood_portal.yml'
No change in Apache config.
Completed successfully!

Restart the httpd24-httpd service now.

Suggested command:
    sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service

[root@ood ~]# /opt/ood/ood-portal-generator/sbin/update_ood_portal -h
Usage: update_ood_portal [-r|--rpm]
-r|--rpm      Execution performed during RPM install
[root@ood ~]# /opt/ood/ood-portal-generator/sbin/update_ood_portal -r
Generating Apache config using YAML config: '/etc/ood/config/ood_portal.yml'
No change in Apache config.
[root@ood ~]# /opt/ood/ood-portal-generator/sbin/update_ood_portal --rpm
Generating Apache config using YAML config: '/etc/ood/config/ood_portal.yml'
No change in Apache config.
```