### PR TITLE
Always load ondemand SCL environment for nginx_stage

### DIFF
--- a/nginx_stage/sbin/nginx_stage
+++ b/nginx_stage/sbin/nginx_stage
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
 
 # The purpose of this script is to wrap up the necessary environment for the
-# per-user NGINX (PUN) processes to run under. The PUN requires the following
-# software in its environment:
-#
-# - ruby 2.4
-# - node.js 6
-# - git 2.9
-#
-# It also assumes Passenger 5 & NGINX 1.14+ are installed at /usr/bin/passenger and /usr/sbin/nginx
-
+# per-user NGINX (PUN) processes to run under. The PUN requires the ondemand
+# Software Collection.
 
 # Root directory for this library
 #
 ROOT_DIR="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
+
+# Source in the default environment
+source "${ROOT_DIR}/etc/profile"
 
 # Allow admin to override the environment the PUN runs in
 #
@@ -21,9 +17,6 @@ NGINX_PROFILE=${NGINX_PROFILE:-/etc/ood/profile}
 if [[ -f "${NGINX_PROFILE}" ]]; then
   # Source in the custom environment
   source "${NGINX_PROFILE}"
-else
-  # Source in the default environment
-  source "${ROOT_DIR}/etc/profile"
 fi
 
 # Environment is set, so call Ruby now


### PR DESCRIPTION
Now that we ship a ondemand SCL it should be loaded always and before anything in /etc/ood/profile could possibly prevent it from loading.  A site-specific /etc/ood/profile can still make changes after ondemand SCL is loaded.

I added a commit to docs https://github.com/OSC/ood-documentation/pull/142 that could be reverted or re-worded if this merged for 1.5.