### PR TITLE
Explicitly stringify the values for pun_custom_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed a crash in nginx_stage relating to numeric values in pun_custom_env
+
 ## [1.5.5] - 2019-02-18
 ### Fixed
 - Fixed bug in Active Jobs that broke when cluster configs changed

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -72,7 +72,7 @@ module NginxStage
     attr_writer :pun_custom_env
 
     def pun_custom_env
-      transform_keys(@pun_custom_env) { |key| key.to_s }
+      Hash[@pun_custom_env.map {|key, value| [key.to_s, value.to_s]}]
     end
 
     # Custom environment variables to pass to the PUN using NGINX env directive
@@ -471,15 +471,6 @@ module NginxStage
           $stderr.puts %{Warning: invalid configuration option "#{k}"}
         end
       end
-    end
-
-    def transform_keys(hash_obj)
-      # see https://apidock.com/rails/Hash/transform_keys
-      result = {}
-      hash_obj.each do |key, value|
-        result[yield(key)] = value
-      end
-      result
     end
 
     private

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -72,6 +72,8 @@ module NginxStage
     attr_writer :pun_custom_env
 
     def pun_custom_env
+      # Ensure that both keys and values are strings to avoid a crash when
+      # rendering the template
       Hash[@pun_custom_env.map {|key, value| [key.to_s, value.to_s]}]
     end
 


### PR DESCRIPTION
Fixes error where integer values for pun_custom_env would cause TypeErrors: "no implicit conversion of Integer into String".

Fixes #26.