### PR TITLE
Change /bin/env to /usr/bin/env in all shebangs

### DIFF
--- a/nginx_stage/bin/node
+++ b/nginx_stage/bin/node
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # Passenger `node` wrapper script

--- a/nginx_stage/bin/python
+++ b/nginx_stage/bin/python
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # Passenger `python` wrapper script

--- a/nginx_stage/bin/ruby
+++ b/nginx_stage/bin/ruby
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # Passenger `ruby` wrapper script

--- a/ood_auth_map/bin/ood_auth_map.mapfile
+++ b/ood_auth_map/bin/ood_auth_map.mapfile
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'ood_auth_map'

--- a/ood_auth_map/bin/ood_auth_map.regex
+++ b/ood_auth_map/bin/ood_auth_map.regex
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'ood_auth_map'


### PR DESCRIPTION
Ubuntu doesn't provide this symlink.
```
$ docker run --rm centos:7 ls /bin/env /usr/bin/env
/bin/env
/usr/bin/env

$ docker run --rm ubuntu:18.04 ls /bin/env /usr/bin/env
ls: cannot access '/bin/env': No such file or directory
/usr/bin/env
```