### PR TITLE
Supporting SELinux with OnDemand

### DIFF
--- a/packaging/ondemand-selinux-systemd.te
+++ b/packaging/ondemand-selinux-systemd.te
@@ -1,0 +1,11 @@
+require {
+  type systemd_logind_t;
+  class dbus send_msg;
+}
+
+#============= httpd_t ==============
+allow httpd_t systemd_logind_t:dbus send_msg;
+
+#============= systemd_logind_t ==============
+# PUN startup
+allow systemd_logind_t httpd_t:dbus send_msg;

--- a/packaging/ondemand-selinux.fc
+++ b/packaging/ondemand-selinux.fc
@@ -1,0 +1,3 @@
+/var/lib/ondemand-nginx(/.*)?     gen_context(system_u:object_r:httpd_var_lib_t,s0)
+/var/lib/ondemand-nginx/tmp(/.*)? gen_context(system_u:object_r:httpd_tmp_t,s0)
+/var/log/ondemand-nginx(/.*)?     gen_context(system_u:object_r:httpd_log_t,s0)

--- a/packaging/ondemand-selinux.te
+++ b/packaging/ondemand-selinux.te
@@ -9,19 +9,15 @@ require {
   type shadow_t;
   type ptmx_t;
   type sshd_key_t;
-  type tmp_t;
   type chkpwd_t;
   type initrc_var_run_t;
-  type var_spool_t;
   class chr_file { ioctl open read write };
   class fifo_file { create getattr ioctl open read setattr unlink write };
   class netlink_audit_socket { nlmsg_relay create write };
   class capability { audit_write fowner net_admin };
   class dbus send_msg;
   class file { getattr open read };
-  class sock_file write;
   class process { noatsecure rlimitinh siginh };
-  class lnk_file read;
 }
 
 #============= httpd_t ==============
@@ -37,14 +33,8 @@ allow httpd_t systemd_logind_t:dbus send_msg;
 allow httpd_t ptmx_t:chr_file { ioctl open read write };
 allow httpd_t sshd_key_t:file { getattr open read };
 
-# trqauthd socket
-allow httpd_t tmp_t:sock_file write;
-
 # Job Composer
 allow httpd_t httpd_sys_script_t:process { noatsecure rlimitinh siginh };
-
-# Moab
-allow httpd_t var_spool_t:lnk_file read;
 
 #============= systemd_logind_t ==============
 # PUN startup

--- a/packaging/ondemand-selinux.te
+++ b/packaging/ondemand-selinux.te
@@ -1,14 +1,21 @@
-
-module ondemand-selinux 1.0;
+module ondemand-selinux @VERSION@;
 
 require {
-	type httpd_tmp_t;
-	type devpts_t;
-	type ptmx_t;
-	type httpd_t;
-	class fifo_file { create getattr ioctl open read setattr unlink write };
-	class chr_file { ioctl open read write };
-	class file { create getattr ioctl lock open read unlink write };
+  type httpd_tmp_t;
+  type devpts_t;
+  type httpd_t;
+  type systemd_logind_t;
+  type shadow_t;
+  type ptmx_t;
+  type sshd_key_t;
+  type tmp_t;
+  class chr_file { ioctl open read write };
+  class fifo_file { create getattr ioctl open read setattr unlink write };
+  class netlink_audit_socket nlmsg_relay;
+  class capability { audit_write fowner };
+  class dbus send_msg;
+  class file { getattr open read };
+  class sock_file write;
 }
 
 #============= httpd_t ==============
@@ -16,4 +23,23 @@ require {
 #!!!! This avc can be allowed using the boolean 'daemons_use_tty'
 allow httpd_t devpts_t:chr_file open;
 allow httpd_t httpd_tmp_t:fifo_file { create getattr ioctl open read setattr unlink write };
+
+#!!!! This avc can be allowed using the boolean 'httpd_mod_auth_pam'
+allow httpd_t self:netlink_audit_socket nlmsg_relay;
+
+# PUN startup
+#!!!! This avc can be allowed using the boolean 'httpd_mod_auth_pam'
+allow httpd_t self:capability { audit_write fowner };
+allow httpd_t shadow_t:file { getattr open read };
+allow httpd_t systemd_logind_t:dbus send_msg;
+
+# Shell app
 allow httpd_t ptmx_t:chr_file { ioctl open read write };
+allow httpd_t sshd_key_t:file { getattr open read };
+
+# trqauthd socket
+allow httpd_t tmp_t:sock_file write;
+
+#============= systemd_logind_t ==============
+# PUN startup
+allow systemd_logind_t httpd_t:dbus send_msg;

--- a/packaging/ondemand-selinux.te
+++ b/packaging/ondemand-selinux.te
@@ -15,7 +15,6 @@ require {
   class fifo_file { create getattr ioctl open read setattr unlink write };
   class netlink_audit_socket { nlmsg_relay create write };
   class capability { audit_write fowner net_admin };
-  class dbus send_msg;
   class file { getattr open read };
   class process { noatsecure rlimitinh siginh };
 }
@@ -27,7 +26,6 @@ allow httpd_t chkpwd_t:process { noatsecure rlimitinh siginh };
 allow httpd_t httpd_tmp_t:fifo_file { create getattr ioctl open read setattr unlink write };
 allow httpd_t initrc_var_run_t:file read;
 allow httpd_t self:capability net_admin;
-allow httpd_t systemd_logind_t:dbus send_msg;
 
 # Shell app
 allow httpd_t ptmx_t:chr_file { ioctl open read write };
@@ -35,7 +33,3 @@ allow httpd_t sshd_key_t:file { getattr open read };
 
 # Job Composer
 allow httpd_t httpd_sys_script_t:process { noatsecure rlimitinh siginh };
-
-#============= systemd_logind_t ==============
-# PUN startup
-allow systemd_logind_t httpd_t:dbus send_msg;

--- a/packaging/ondemand-selinux.te
+++ b/packaging/ondemand-selinux.te
@@ -2,6 +2,7 @@ module ondemand-selinux @VERSION@;
 
 require {
   type httpd_tmp_t;
+  type httpd_sys_script_t;
   type devpts_t;
   type httpd_t;
   type systemd_logind_t;
@@ -9,28 +10,27 @@ require {
   type ptmx_t;
   type sshd_key_t;
   type tmp_t;
+  type chkpwd_t;
+  type initrc_var_run_t;
+  type var_spool_t;
   class chr_file { ioctl open read write };
   class fifo_file { create getattr ioctl open read setattr unlink write };
-  class netlink_audit_socket nlmsg_relay;
-  class capability { audit_write fowner };
+  class netlink_audit_socket { nlmsg_relay create write };
+  class capability { audit_write fowner net_admin };
   class dbus send_msg;
   class file { getattr open read };
   class sock_file write;
+  class process { noatsecure rlimitinh siginh };
+  class lnk_file read;
 }
 
 #============= httpd_t ==============
 
-#!!!! This avc can be allowed using the boolean 'daemons_use_tty'
-allow httpd_t devpts_t:chr_file open;
-allow httpd_t httpd_tmp_t:fifo_file { create getattr ioctl open read setattr unlink write };
-
-#!!!! This avc can be allowed using the boolean 'httpd_mod_auth_pam'
-allow httpd_t self:netlink_audit_socket nlmsg_relay;
-
 # PUN startup
-#!!!! This avc can be allowed using the boolean 'httpd_mod_auth_pam'
-allow httpd_t self:capability { audit_write fowner };
-allow httpd_t shadow_t:file { getattr open read };
+allow httpd_t chkpwd_t:process { noatsecure rlimitinh siginh };
+allow httpd_t httpd_tmp_t:fifo_file { create getattr ioctl open read setattr unlink write };
+allow httpd_t initrc_var_run_t:file read;
+allow httpd_t self:capability net_admin;
 allow httpd_t systemd_logind_t:dbus send_msg;
 
 # Shell app
@@ -39,6 +39,12 @@ allow httpd_t sshd_key_t:file { getattr open read };
 
 # trqauthd socket
 allow httpd_t tmp_t:sock_file write;
+
+# Job Composer
+allow httpd_t httpd_sys_script_t:process { noatsecure rlimitinh siginh };
+
+# Moab
+allow httpd_t var_spool_t:lnk_file read;
 
 #============= systemd_logind_t ==============
 # PUN startup

--- a/packaging/ondemand-selinux.te
+++ b/packaging/ondemand-selinux.te
@@ -1,0 +1,19 @@
+
+module ondemand-selinux 1.0;
+
+require {
+	type httpd_tmp_t;
+	type devpts_t;
+	type ptmx_t;
+	type httpd_t;
+	class fifo_file { create getattr ioctl open read setattr unlink write };
+	class chr_file { ioctl open read write };
+	class file { create getattr ioctl lock open read unlink write };
+}
+
+#============= httpd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'daemons_use_tty'
+allow httpd_t devpts_t:chr_file open;
+allow httpd_t httpd_tmp_t:fifo_file { create getattr ioctl open read setattr unlink write };
+allow httpd_t ptmx_t:chr_file { ioctl open read write };

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -8,7 +8,11 @@
 %{!?package_release: %define package_release 1}
 %{!?git_tag: %define git_tag v%{package_version}}
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
-%global selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
+%if 0%{?rhel} >= 7
+%define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
+%else
+%define selinux_policy_ver %(rpm -qa --qf "%%{name}|%%{version}-%%{release}\\n" | grep selinux-policy | awk -F '|' '{ print $2 }')
+%endif
 %global selinux_module_version %{package_version}.%{package_release}
 
 Name:      %{package_name}
@@ -21,6 +25,7 @@ License:   MIT
 URL:       https://osc.github.io/Open-OnDemand
 Source0:   https://github.com/OSC/%{package_name}/archive/%{git_tag}.tar.gz
 Source1:   ondemand-selinux.te
+Source2:   ondemand-selinux-systemd.te
 
 # Disable debuginfo as it causes issues with bundled gems that build libraries
 %global debug_package %{nil}
@@ -71,11 +76,7 @@ access, job submission and interactive work on compute nodes.
 Summary: SELinux policy for OnDemand
 BuildRequires:      selinux-policy, selinux-policy-devel, checkpolicy, policycoreutils
 Requires:           %{name} = %{version}
-%if 0%{?rhel} >= 7
 Requires:           selinux-policy >= %{selinux_policy_ver}
-%else
-Requires:           selinux-policy
-%endif
 Requires(post):     /usr/sbin/semodule, /sbin/restorecon, /usr/sbin/setsebool, /usr/sbin/selinuxenabled, /usr/sbin/semanage
 Requires(post):     policycoreutils-python
 Requires(post):     selinux-policy-targeted
@@ -91,7 +92,11 @@ SELinux policy for OnDemand
 %build
 %__mkdir selinux
 cd selinux
+echo "SELinux policy %{selinux_policy_ver}"
 %__cp %{SOURCE1} ./ondemand-selinux.te
+%if 0%{?rhel} >= 7
+%__cat %{SOURCE2} >> ./ondemand-selinux.te
+%endif
 %__sed -i 's/@VERSION@/%{selinux_module_version}/' ./ondemand-selinux.te
 %__make -f %{_datadir}/selinux/devel/Makefile
 
@@ -245,12 +250,20 @@ echo "boolean -m --on httpd_can_network_connect" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_execmem" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_use_nfs" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_setrlimit" >> $SELINUX_TEMP
+%if 0%{?rhel} >= 7
 echo "boolean -m --on httpd_mod_auth_pam" >> $SELINUX_TEMP
+%else
+echo "boolean -m --on allow_httpd_mod_auth_pam" >> $SELINUX_TEMP
+%endif
 echo "boolean -m --on httpd_unified" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_run_stickshift" >> $SELINUX_TEMP
 echo "boolean -m --on use_nfs_home_dirs" >> $SELINUX_TEMP
+%if 0%{?rhel} >= 7
 echo "boolean -m --on daemons_use_tty" >> $SELINUX_TEMP
-semanage import -S targeted -f $SELINUX_TEMP
+%else
+echo "boolean -m --on allow_daemons_use_tty" >> $SELINUX_TEMP
+%endif
+semanage -S targeted -i $SELINUX_TEMP
 semodule -i %{_datadir}/selinux/packages/%{name}-selinux/%{name}-selinux.pp 2>/dev/null || :
 semanage fcontext -a -t httpd_var_lib_t '%{_sharedstatedir}/ondemand-nginx(/.*)?' 2>/dev/null || :
 semanage fcontext -a -t httpd_tmp_t '%{_sharedstatedir}/ondemand-nginx/tmp(/.*)?' 2>/dev/null || :

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -242,7 +242,11 @@ echo "boolean -m --on httpd_can_network_connect" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_execmem" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_use_nfs" >> $SELINUX_TEMP
 echo "boolean -m --on httpd_setrlimit" >> $SELINUX_TEMP
-echo "boolean -m --on use_nfs_home_dirs"
+echo "boolean -m --on httpd_mod_auth_pam" >> $SELINUX_TEMP
+echo "boolean -m --on httpd_unified" >> $SELINUX_TEMP
+echo "boolean -m --on httpd_run_stickshift" >> $SELINUX_TEMP
+echo "boolean -m --on use_nfs_home_dirs" >> $SELINUX_TEMP
+echo "boolean -m --on daemons_use_tty" >> $SELINUX_TEMP
 semanage import -S targeted -f $SELINUX_TEMP
 semodule -i %{_datadir}/selinux/packages/%{name}-selinux/%{name}-selinux.pp 2>/dev/null || :
 semanage fcontext -a -t httpd_var_lib_t '%{_sharedstatedir}/ondemand-nginx(/.*)?' 2>/dev/null || :

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -69,9 +69,13 @@ access, job submission and interactive work on compute nodes.
 
 %package -n %{name}-selinux
 Summary: SELinux policy for OnDemand
-BuildRequires:      selinux-policy-devel, checkpolicy, policycoreutils
+BuildRequires:      selinux-policy, selinux-policy-devel, checkpolicy, policycoreutils
 Requires:           %{name} = %{version}
+%if 0%{?rhel} >= 7
 Requires:           selinux-policy >= %{selinux_policy_ver}
+%else
+Requires:           selinux-policy
+%endif
 Requires(post):     /usr/sbin/semodule, /sbin/restorecon, /usr/sbin/setsebool, /usr/sbin/selinuxenabled, /usr/sbin/semanage
 Requires(post):     policycoreutils-python
 Requires(post):     selinux-policy-targeted

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -81,7 +81,6 @@ Requires(postun):   /usr/sbin/semodule, /sbin/restorecon
 SELinux policy for OnDemand
 
 %prep
-%dump
 %setup -q -n %{package_name}-%{git_tag_minus_v}
 
 


### PR DESCRIPTION
Piecing together the method from Fedora guidelines and Foreman:

https://fedoraproject.org/wiki/PackagingDrafts/SELinux
https://github.com/theforeman/foreman-packaging/blob/rpm/1.23/packages/foreman/foreman-selinux/foreman-selinux.spec
https://github.com/theforeman/foreman-selinux

Foreman used entire repo just for SELinux but I'm hoping we can do everything in just single policy file and some logic in spec file.

So far policy changes are based on using Vagrant w/ SLURM and enabling SELinux in Permissive mode. I am setting up a system at OSC that uses a more production-like environment with SELinux to get a better sense of what else would be required.