### PR TITLE
bump base ruby apps to next version

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   {
     "name": "dashboard",
     "url": "https://github.com/OSC/ood-dashboard",
-    "tag": "v1.35.2",
+    "tag": "v1.35.3",
     "app": true
   },
   {
@@ -20,19 +20,19 @@
   {
     "name": "file-editor",
     "url": "https://github.com/OSC/ood-fileeditor",
-    "tag": "v1.4.4",
+    "tag": "v1.4.5",
     "app": true
   },
   {
     "name": "activejobs",
     "url": "https://github.com/OSC/ood-activejobs",
-    "tag": "v1.9.3",
+    "tag": "v1.9.4",
     "app": true
   },
   {
     "name": "myjobs",
     "url": "https://github.com/OSC/ood-myjobs",
-    "tag": "v2.15.1",
+    "tag": "v2.15.2",
     "app": true
   },
   {


### PR DESCRIPTION
Updates all the base apps for Debian pathes.

See the description given in the [files app PR](https://github.com/OSC/ood-fileeditor/pull/89) for the more details on that issue.