### PR TITLE
Only restart Apache if changes take place

### DIFF
--- a/ood-portal-generator/sbin/update_ood_portal
+++ b/ood-portal-generator/sbin/update_ood_portal
@@ -19,7 +19,7 @@ usage () {
     echo "Usage: update_ood_portal [-r|--rpm] [-f|--force] [--detailed-exitcodes]"
     echo "-r|--rpm              Execution performed during RPM install"
     echo "-f|--force            Force replacement of configs even if checksums differ"
-    echo "--detailed-exitcodes  Exit with 2 when changes are made and 4 when changes skipped"
+    echo "--detailed-exitcodes  Exit with 3 when changes are made and 4 when changes skipped"
 }
 
 OPTS=`getopt -o rfh --long rpm,force,detailed-exitcodes,help -n 'update_ood_portal' -- "$@"`

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -323,7 +323,7 @@ touch %{_localstatedir}/www/ood/apps/sys/myjobs/tmp/restart.txt
 
 # Rebuild Apache config and restart Apache httpd if config changed
 /opt/ood/ood-portal-generator/sbin/update_ood_portal --rpm --detailed-exitcodes
-if [[ $? -eq 2 ]] ; then
+if [[ $? -eq 3 ]] ; then
 %if %{with systemd}
 /bin/systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service &>/dev/null || :
 %else

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -322,7 +322,8 @@ touch %{_localstatedir}/www/ood/apps/sys/activejobs/tmp/restart.txt
 touch %{_localstatedir}/www/ood/apps/sys/myjobs/tmp/restart.txt
 
 # Rebuild Apache config and restart Apache httpd if config changed
-if /opt/ood/ood-portal-generator/sbin/update_ood_portal --rpm ; then
+/opt/ood/ood-portal-generator/sbin/update_ood_portal --rpm --detailed-exitcodes
+if [[ $? -eq 2 ]] ; then
 %if %{with systemd}
 /bin/systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service &>/dev/null || :
 %else


### PR DESCRIPTION
Fixes #69

@ericfranz @MorganRodgers @johrstrom This is a must before we announce latest 1.6 to public to avoid restarting Apache for no changes.

This can be released as 1.6.17-2