### PR TITLE
Prep 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 
 env:
-  - OS_TYPE=centos OS_VERSION=6
   - OS_TYPE=centos OS_VERSION=7
+  - OS_TYPE=centos OS_VERSION=8
 
 services:
   - docker

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -1,15 +1,13 @@
 %{!?ncpus: %define ncpus 12}
 %global package_name ondemand
-%global major 1
-%global minor 6
-%global patch 17
-%global ondemand_version %{major}.%{minor}
-%{!?package_version: %define package_version %{major}.%{minor}.%{patch}}
 %{!?package_release: %define package_release 1}
 %{!?git_tag: %define git_tag v%{package_version}}
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
+%define runtime_version %(echo %{git_tag_minus_v} | sed -r 's/^([0-9])\.([0-9]).*/\\1.\\2/g')
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 %global selinux_module_version %{package_version}.%{package_release}
+
+%define __brp_mangle_shebangs /bin/true
 
 Name:      %{package_name}
 Version:   %{package_version}
@@ -44,20 +42,28 @@ Source3:   ondemand-selinux.fc
 # node.js packages used in the apps
 AutoReqProv:     no
 
-BuildRequires:   ondemand-runtime = %{ondemand_version}
-BuildRequires:   ondemand-scldevel = %{ondemand_version}
-BuildRequires:   sqlite-devel, curl, make
-BuildRequires:   ondemand-ruby = %{ondemand_version}
-BuildRequires:   ondemand-nodejs = %{ondemand_version}
+BuildRequires:   ondemand-runtime = %{runtime_version}
+BuildRequires:   ondemand-scldevel = %{runtime_version}
+BuildRequires:   sqlite-devel, curl, make, zlib-devel, libxslt-devel
+BuildRequires:   ondemand-ruby = %{runtime_version}
+BuildRequires:   ondemand-nodejs = %{runtime_version}
+BuildRequires:   rsync
 BuildRequires:   git
 Requires:        git
-Requires:        sudo, lsof, sqlite-devel, cronie, wget, curl, make, rsync, file, libxml2
-Requires:        ondemand-apache = %{ondemand_version}
-Requires:        ondemand-nginx = 1.14.0
-Requires:        ondemand-passenger = 5.3.7
-Requires:        ondemand-ruby = %{ondemand_version}
-Requires:        ondemand-nodejs = %{ondemand_version}
-Requires:        ondemand-runtime = %{ondemand_version}
+%if 0%{?rhel} >= 8
+BuildRequires:   python2
+Requires:        python2
+%else
+BuildRequires:   python
+Requires:        python
+%endif
+Requires:        sudo, lsof, sqlite-devel, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib
+Requires:        ondemand-apache = %{runtime_version}
+Requires:        ondemand-nginx = 1.17.3
+Requires:        ondemand-passenger = 6.0.4
+Requires:        ondemand-ruby = %{runtime_version}
+Requires:        ondemand-nodejs = %{runtime_version}
+Requires:        ondemand-runtime = %{runtime_version}
 
 %if %{with systemd}
 BuildRequires: systemd
@@ -99,6 +105,11 @@ echo "SELinux policy %{selinux_policy_ver}"
 %__make -f %{_datadir}/selinux/devel/Makefile
 
 scl enable ondemand - << \EOS
+set -x
+set -e
+%if 0%{?rhel} >= 8
+export PYTHON=python2
+%endif
 rake -mj%{ncpus}
 EOS
 
@@ -107,6 +118,8 @@ EOS
 %__install -p -m 644 -D selinux/%{name}-selinux.pp %{buildroot}%{_datadir}/selinux/packages/%{name}-selinux/%{name}-selinux.pp
 
 scl enable ondemand - << \EOS
+set -x
+set -e
 rake install PREFIX=%{buildroot}/opt/ood
 %__rm %{buildroot}/opt/ood/apps/*/log/production.log
 echo "%{git_tag}" > %{buildroot}/opt/ood/VERSION

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -46,22 +46,17 @@ BuildRequires:   ondemand-runtime = %{runtime_version}
 BuildRequires:   ondemand-scldevel = %{runtime_version}
 BuildRequires:   sqlite-devel, curl, make, zlib-devel, libxslt-devel
 BuildRequires:   ondemand-ruby = %{runtime_version}
+BuildRequires:   ondemand-python = %{runtime_version}
 BuildRequires:   ondemand-nodejs = %{runtime_version}
 BuildRequires:   rsync
 BuildRequires:   git
 Requires:        git
-%if 0%{?rhel} >= 8
-BuildRequires:   python2
-Requires:        python2
-%else
-BuildRequires:   python
-Requires:        python
-%endif
 Requires:        sudo, lsof, sqlite-devel, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib
 Requires:        ondemand-apache = %{runtime_version}
 Requires:        ondemand-nginx = 1.17.3
 Requires:        ondemand-passenger = 6.0.4
 Requires:        ondemand-ruby = %{runtime_version}
+Requires:        ondemand-python = %{runtime_version}
 Requires:        ondemand-nodejs = %{runtime_version}
 Requires:        ondemand-runtime = %{runtime_version}
 
@@ -107,9 +102,6 @@ echo "SELinux policy %{selinux_policy_ver}"
 scl enable ondemand - << \EOS
 set -x
 set -e
-%if 0%{?rhel} >= 8
-export PYTHON=python2
-%endif
 rake -mj%{ncpus}
 EOS
 

--- a/tests.sh
+++ b/tests.sh
@@ -9,7 +9,8 @@ sed -i -r '/^tsflags/d' /etc/yum.conf
 yum install -y --skip-broken centos-release-scl
 yum install -y https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm
 yum install -y \
-  make \
+  make gcc gcc-c++ \
+  zlib-devel libxslt-devel \
   curl \
   sqlite-devel \
   git \

--- a/tests.sh
+++ b/tests.sh
@@ -9,12 +9,18 @@ sed -i -r '/^tsflags/d' /etc/yum.conf
 yum install -y --skip-broken centos-release-scl
 yum install -y https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm
 yum install -y \
-  make gcc gcc-c++ \
-  zlib-devel libxslt-devel \
+  make \
+  gcc \
+  gcc-c++ \
+  zlib-devel \
+  libxslt-devel \
   curl \
+  rsync \
   sqlite-devel \
   git \
+  redhat-rpm-config \
   ondemand-ruby \
+  ondemand-python \
   ondemand-nodejs \
   ondemand-runtime
 

--- a/tests.sh
+++ b/tests.sh
@@ -6,18 +6,15 @@ set -ex
 sed -i -r '/^tsflags/d' /etc/yum.conf
 
 # Get dependencies
-yum install -y centos-release-scl
-yum install -y https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-4.noarch.rpm
+yum install -y --skip-broken centos-release-scl
+yum install -y https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm
 yum install -y \
   make \
   curl \
   sqlite-devel \
   git \
-  rh-ruby24 \
-  rh-ruby24-rubygem-rake \
-  rh-ruby24-rubygem-bundler \
-  rh-ruby24-ruby-devel \
-  rh-nodejs6 \
+  ondemand-ruby \
+  ondemand-nodejs \
   ondemand-runtime
 
 # Setup environment


### PR DESCRIPTION
* Support EL8 , drop EL6
* Update passenger to 6.0.4 and nginx to 1.17.3
* Determine ondemand-runtime version by git tag when building ondemand packages