### PR TITLE
sha256sum shouldn't be in brackets.

### DIFF
--- a/ood-portal-generator/sbin/update_ood_portal
+++ b/ood-portal-generator/sbin/update_ood_portal
@@ -56,7 +56,7 @@ fi
 
 # If checksum of ood-portal.conf matches or ood-portal.conf doesn't exit, replace is possible.
 # If the checksum matches this means a site has not changed ood-portal.conf outside ood-portal-generator
-if [ sha256sum --quiet --status --check $SUM 1>/dev/null 2>&1 ] || [ ! -f "$APACHE" ]; then
+if sha256sum --quiet --status --check $SUM 1>/dev/null 2>&1 || [ ! -f "$APACHE" ]; then
     REPLACE=true
 else
     REPLACE=false


### PR DESCRIPTION
The redirection to /dev/null was eating a `[: too many arguments` error which wasn't letting people update during an upgrade process.

See [this discourse topic](https://discourse.osc.edu/t/update-ood-portal-in-ondemand-1-6-19-1-el7-x86-64-refuses-to-make-new-configuration/546).