### PR TITLE
Add shell check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ script:
       -w "/data" \
       ${OS_TYPE}:${OS_VERSION} \
       ./tests.sh
+  - shellcheck ood-portal-generator/sbin/update_ood_portal
+  - shellcheck -x nginx_stage/sbin/nginx_stage
+  - shellcheck nginx_stage/sbin/update_nginx_stage
 
 notifications:
   email:

--- a/nginx_stage/sbin/nginx_stage
+++ b/nginx_stage/sbin/nginx_stage
@@ -9,13 +9,16 @@
 ROOT_DIR="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
 
 # Source in the default environment
+# shellcheck source=/etc/profile
 source "${ROOT_DIR}/etc/profile"
 
 # Allow admin to override the environment the PUN runs in
 #
+
 NGINX_PROFILE=${NGINX_PROFILE:-/etc/ood/profile}
 if [[ -f "${NGINX_PROFILE}" ]]; then
   # Source in the custom environment
+  # shellcheck source=nginx_stage/etc/profile
   source "${NGINX_PROFILE}"
 fi
 

--- a/ood-portal-generator/sbin/update_ood_portal
+++ b/ood-portal-generator/sbin/update_ood_portal
@@ -22,8 +22,11 @@ usage () {
     echo "--detailed-exitcodes  Exit with 3 when changes are made and 4 when changes skipped"
 }
 
+OPTS=$(getopt -o rfh --long rpm,force,detailed-exitcodes,help -n 'update_ood_portal' -- "$@")
 
-if ! OPTS=$(getopt -o rfh --long rpm,force,detailed-exitcodes,help -n 'update_ood_portal' -- "$@"); then
+# more readable this way, so disable this shellcheck
+# shellcheck disable=SC2181
+if [[ $? -ne 0 ]]; then
     echo "Failed parsing options"
     usage
     exit 1

--- a/ood-portal-generator/sbin/update_ood_portal
+++ b/ood-portal-generator/sbin/update_ood_portal
@@ -22,8 +22,8 @@ usage () {
     echo "--detailed-exitcodes  Exit with 3 when changes are made and 4 when changes skipped"
 }
 
-OPTS=`getopt -o rfh --long rpm,force,detailed-exitcodes,help -n 'update_ood_portal' -- "$@"`
-if [[ $? -ne 0 ]]; then
+
+if ! OPTS=$(getopt -o rfh --long rpm,force,detailed-exitcodes,help -n 'update_ood_portal' -- "$@"); then
     echo "Failed parsing options"
     usage
     exit 1
@@ -44,19 +44,19 @@ done
 echo "Generating Apache config using YAML config: '${CONFIG}'"
 
 NEW_APACHE=$(mktemp)
-"${BIN}" -c "${CONFIG}" > $NEW_APACHE
+"${BIN}" -c "${CONFIG}" > "$NEW_APACHE"
 
 # Create checksum file if the path to ood-portal.conf not in checksum file
 # Checksum is based on mktemp generated ood-portal.conf but using path of real ood-portal.conf
-if ! grep -q "$APACHE" $SUM 1>/dev/null 2>&1; then
+if ! grep -q "$APACHE" "$SUM" 1>/dev/null 2>&1; then
     echo "Generating Apache config checksum file: '${SUM}'"
-    NEW_SUM=$(sha256sum $NEW_APACHE | cut -d' ' -f1)
-    echo "${NEW_SUM} ${APACHE}" > $SUM
+    NEW_SUM=$(sha256sum "$NEW_APACHE" | cut -d' ' -f1)
+    echo "${NEW_SUM} ${APACHE}" > "$SUM"
 fi
 
 # If checksum of ood-portal.conf matches or ood-portal.conf doesn't exit, replace is possible.
 # If the checksum matches this means a site has not changed ood-portal.conf outside ood-portal-generator
-if sha256sum --quiet --status --check $SUM 1>/dev/null 2>&1 || [ ! -f "$APACHE" ]; then
+if sha256sum --quiet --status --check "$SUM" 1>/dev/null 2>&1 || [ ! -f "$APACHE" ]; then
     REPLACE=true
 else
     REPLACE=false
@@ -74,7 +74,7 @@ if ! cmp -s "${NEW_APACHE}" "${APACHE}"; then
     echo "Generating new Apache config at: '${APACHE}'"
     cat "${NEW_APACHE}" > "${APACHE}"
     echo "Generating Apache config checksum file: '${SUM}'"
-    sha256sum $APACHE > $SUM
+    sha256sum "$APACHE" > "$SUM"
     ret=$CHANGE_EXIT
     CHANGED=true
   else
@@ -87,7 +87,7 @@ else
   echo "No change in Apache config."
 fi
 
-rm -f $NEW_APACHE
+rm -f "$NEW_APACHE"
 
 if [ $RPM -eq 1 ] || ! $REPLACE; then
     exit $ret


### PR DESCRIPTION
Adds shellcheck items to travis CI and also fixes all the issues with our shells that would have caused tests to fail.