### PR TITLE
Fix bin/setup for dashboard

### DIFF
--- a/apps/dashboard/bin/setup
+++ b/apps/dashboard/bin/setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require "pathname"
 require "fileutils"
+require "rake"
 
 include FileUtils
 


### PR DESCRIPTION
This fixes a change introduced in #93.

Error I was getting:

```
Traceback (most recent call last):
	3: from ./bin/setup:36:in `<main>'
	2: from /opt/rh/rh-ruby25/root/usr/share/ruby/fileutils.rb:122:in `cd'
	1: from /opt/rh/rh-ruby25/root/usr/share/ruby/fileutils.rb:122:in `chdir'
./bin/setup:45:in `block in <main>': undefined method `sh' for main:Object (NoMethodError)
```