### PR TITLE
Add flags to bundle install to improve gem install speed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,18 +51,17 @@ end
 namespace :build do
   desc "Build gems"
   task :gems do
+    bundle_args = ["--jobs 4", "--retry 2"]
     if VENDOR_BUNDLE
-      bundle_args = "--path vendor/bundle"
-    else
-      bundle_args = ""
+      bundle_args << "--path vendor/bundle"
     end
     if PASSENGER_APP_ENV == "production"
-      bundle_args = "#{bundle_args} --without doc test development"
+      bundle_args << "--without doc test development"
     end
     apps.each do |a|
       next unless a.ruby_app?
       chdir a.path do
-        sh "bin/bundle install #{bundle_args}"
+        sh "bin/bundle install #{bundle_args.join(' ')}"
       end
     end
   end

--- a/apps/activejobs/bin/setup
+++ b/apps/activejobs/bin/setup
@@ -42,7 +42,7 @@ chdir APP_ROOT do
   puts "RAILS_RELATIVE_URL_ROOT = #{APP.url    || "not set"}"
 
   puts "\n== Installing dependencies =="
-  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install"
+  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install --jobs 4 --retry 2"
 
   if APP.production?
     puts "\n== Compiling assets =="

--- a/apps/dashboard/bin/setup
+++ b/apps/dashboard/bin/setup
@@ -43,7 +43,7 @@ chdir APP_ROOT do
   puts "RAILS_RELATIVE_URL_ROOT = #{APP.url    || "not set"}"
 
   puts "\n== Installing dependencies =="
-  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install"
+  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install --jobs 4 --retry 2"
 
   if APP.production?
     puts "\n== Compiling assets =="

--- a/apps/file-editor/bin/setup
+++ b/apps/file-editor/bin/setup
@@ -47,7 +47,7 @@ chdir APP_ROOT do
   puts "RAILS_RELATIVE_URL_ROOT = #{APP.url || "not set"}"
 
   puts "\n== Installing dependencies =="
-  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install"
+  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install --jobs 4 --retry 2"
 
   if APP.production?
     puts "\n== Compiling assets =="

--- a/apps/myjobs/bin/setup
+++ b/apps/myjobs/bin/setup
@@ -42,7 +42,7 @@ chdir APP_ROOT do
   puts "RAILS_RELATIVE_URL_ROOT = #{APP.url    || "not set"}"
 
   puts "\n== Installing dependencies =="
-  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install"
+  sh "bin/bundle check 1>/dev/null 2>&1 || bin/bundle install --jobs 4 --retry 2"
 
   if APP.production?
     puts "\n== Compiling assets =="


### PR DESCRIPTION
Shaved 30s to 1 minute off RPM builds of OnDemand. These are flags commonly used by CI/CD tools like Travis and Appveyor. I think the retry one is especially useful to avoid build failures from intermittent issues with rubygems.org.