### PR TITLE
radio button groups in batch connect apps

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -16,7 +16,7 @@ module BatchConnect::SessionContextsHelper
         form.check_box attrib.id, all_options, attrib.checked_value, attrib.unchecked_value
       end
     when "radio", "radio_button"
-      form.collection_radio_buttons attrib.id,   attrib.select_choices, :second, :first, checked: [attrib.value] + Array.wrap(attrib.field_options[:checked])
+      form.collection_radio_buttons attrib.id,   attrib.select_choices, :second, :first, checked: (attrib.value.presence || attrib.field_options[:checked])
     else
       form.send widget, attrib.id, all_options
     end

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -15,6 +15,8 @@ module BatchConnect::SessionContextsHelper
       form.form_group attrib.id, help: field_options[:help] do
         form.check_box attrib.id, all_options, attrib.checked_value, attrib.unchecked_value
       end
+    when "radio", "radio_button"
+      form.collection_radio_buttons attrib.id,   attrib.select_choices, :second, :first, checked: [attrib.value] + Array.wrap(attrib.field_options[:checked])
     else
       form.send widget, attrib.id, all_options
     end


### PR DESCRIPTION
Supports specifying widget type "radio" or "radio_button", works
similar to select field:

    version:
      widget: radio
      label: "MATLAB version"
      help: "This defines the version of MATLAB you want to load."
      options:
        - [ "R2018b", "matlab/r2018b" ]
        - [ "R2018a", "matlab/r2018a" ]
        - [ "R2017a", "matlab/r2017a" ]
        - [ "R2016b", "matlab/r2016b" ]
        - [ "R2015b", "matlab/r2015b" ]
      checked: "matlab/r2018a"

doesn't support arbitrary option data attributes like in select fields