### PR TITLE
Use latest runtime

### DIFF
--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -5,12 +5,12 @@
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
 %define major_version %(echo %{git_tag_minus_v} | cut -d. -f1)
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
-%define runtime_version %{major_version}.%{minor_version}-5
+%define runtime_version %{major_version}.%{minor_version}-6
 %define next_major_version %(echo $((%{major_version}+1))).0
 %define next_minor_version %{major_version}.%(echo $((%{minor_version}+1)))
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 %global selinux_module_version %{package_version}.%{package_release}
-%global gem_home %{scl_ondemand_gem_home}/ondemand/%{version}
+%global gem_home %{scl_ondemand_core_gem_home}/%{version}
 %global gems_name ondemand-gems-%{version}
 
 %define __brp_mangle_shebangs /bin/true


### PR DESCRIPTION
This ensures the various GEM_PATH locations exist so we don't end up trying to iterate over non-existant directories.