### PR TITLE
Document ondemand_title for nginx_stage.yml

### DIFF
--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -23,6 +23,11 @@
 #
 #ondemand_portal: null
 
+# Title of this OnDemand portal that apps *should* display in their navbar
+# NB: If this is not set then most apps will use default title "Open OnDemand"
+#
+#ondemand_title: null
+
 # Custom environment variables to set for the PUN environment
 # Below is an example of the use for setting env vars.
 #


### PR DESCRIPTION
While syncing up Puppet's template with comments from this repo's example I noticed `ondemand_title` was not documented. I still see it referenced in code.