### PR TITLE
Set BUNDLE_USER_CONFIG to /dev/null in PUN environment

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -351,6 +351,11 @@ module NginxStage
     # @return [String] user shell that is blocked
     attr_accessor :disabled_shell
 
+    # Set BUNDLE_USER_CONFIG to /dev/null in the PUN environment
+    # NB: This prevents a user's ~/.bundle/config from affecting OnDemand applications
+    # @return [Boolean] set BUNDLE_USER_CONFIG to /dev/null in PUN environment
+    attr_accessor :disable_bundle_user_config
+
     # Path to the root directory for custom html files
     # that NGINX can serve. Currently only the missing_home_directory.html
     # error page can be customized with this mechanism.
@@ -457,6 +462,8 @@ module NginxStage
       self.user_regex     = '[\w@\.\-]+'
       self.min_uid        = 1000
       self.disabled_shell = '/access/denied'
+
+      self.disable_bundle_user_config = true
 
       read_configuration(default_config_path) if File.file?(default_config_path)
     end

--- a/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
+++ b/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
@@ -112,6 +112,10 @@ module NginxStage
       %w(PATH LD_LIBRARY_PATH X_SCLS MANPATH PCP_DIR PERL5LIB PKG_CONFIG_PATH PYTHONPATH XDG_DATA_DIRS SCLS RUBYLIB)
     end
 
+    def disable_bundle_user_config?
+      NginxStage.disable_bundle_user_config
+    end
+
     # View used to confirm whether the user wants to restart the PUN to reload
     # configuration changes
     # @return [String] restart confirmation view

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -206,3 +206,8 @@
 #     the PUN using other commands (e.g., `nginx`, `nginx_clean`, ...)
 #
 #disabled_shell: '/access/denied'
+
+# Set BUNDLE_USER_CONFIG to /dev/null in the PUN environment
+# NB: This prevents a user's ~/.bundle/config from affecting OnDemand applications
+#
+#disable_bundle_user_config: true

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -87,6 +87,10 @@ http {
       alias <%= default_html_root %>/$1;
     }
 
+    <%- if disable_bundle_user_config? -%>
+    passenger_env_var BUNDLE_USER_CONFIG /dev/null
+
+    <%- end -%>
     # Include all app configs user has access to
     <%- app_configs.each do |app_config| -%>
     include <%= app_config %>;

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -29,6 +29,11 @@ http {
   passenger_default_user <%= user %>;
   passenger_load_shell_envvars off;
 
+  <%- if disable_bundle_user_config? -%>
+  passenger_env_var BUNDLE_USER_CONFIG /dev/null;
+
+  <%- end -%>
+
   # Kill all apps after they idle timeout
   passenger_min_instances 0;
 
@@ -87,10 +92,6 @@ http {
       alias <%= default_html_root %>/$1;
     }
 
-    <%- if disable_bundle_user_config? -%>
-    passenger_env_var BUNDLE_USER_CONFIG /dev/null
-
-    <%- end -%>
     # Include all app configs user has access to
     <%- app_configs.each do |app_config| -%>
     include <%= app_config %>;

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -5,7 +5,7 @@
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
 %define major_version %(echo %{git_tag_minus_v} | cut -d. -f1)
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
-%define runtime_version %{major_version}.%{minor_version}-6
+%define runtime_version %{major_version}.%{minor_version}-7
 %define next_major_version %(echo $((%{major_version}+1))).0
 %define next_minor_version %{major_version}.%(echo $((%{minor_version}+1)))
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)


### PR DESCRIPTION
Fixes #302

The bump for ondemand-runtime will pull in build from https://github.com/OSC/ondemand-packaging/pull/83 that has `ondemand-ruby` now depending on `ondemand-rubygem-bundler` which uses bundler 1.17.3.