### PR TITLE
add en_US.UTF-8 as LANG (for new terminal backend)

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -62,6 +62,8 @@ wss.on('connection', function connection (ws) {
   cmd = 'ssh';
   args = dir ? [host, '-t', 'cd \'' + dir.replace(/\'/g, "'\\''") + '\' ; exec ${SHELL} -l'] : [host];
 
+  process.env.LANG = 'en_US.UTF-8'; // this patch (from b996d36) lost when removing wetty (2c8a022)
+  
   term = pty.spawn(cmd, args, {
     name: 'xterm-256color',
     cols: 80,


### PR DESCRIPTION
Currently, the LANG env var defaults to LANG=C, which actually was also an issue resolved back in 2016 for https://github.com/OSC/ood-shell/issues/3 when wetty was still in use.

The fix provided in this commit (https://github.com/OSC/ood-shell/commit/b996d368a503a2df5259d9053059feeeb0d1b2aa) was removed when moving away from wetty in this commit (https://github.com/OSC/ood-shell/commit/2c8a02283e3a7549747c244e73e6e5c231232ae5).