### PR TITLE
Fix font awesome icon usage for activejobs

### DIFF
--- a/apps/activejobs/app/views/jobs/_extended_panel.html.erb
+++ b/apps/activejobs/app/views/jobs/_extended_panel.html.erb
@@ -47,9 +47,9 @@
       <% end %>
       <div class="col-md-12">
         <% if ENV["USER"] == data.username %>
-            <%= link_to "#{icon("folder-open")} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.file_explorer_url %>
-            <%= link_to "#{icon("terminal")} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.shell_url %>
-            <%= link_to "#{icon("trash-o")} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" } %>
+            <%= link_to "#{icon("fas", "folder-open")} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.file_explorer_url %>
+            <%= link_to "#{icon("fas", "terminal")} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.shell_url %>
+            <%= link_to "#{icon("fas", "trash-o")} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" } %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Fixes #323

OnDemand production:

<img width="405" alt="Screen Shot 2019-11-26 at 12 58 07 PM" src="https://user-images.githubusercontent.com/739622/69663830-b21c9d00-104c-11ea-800f-eb15fb1fd076.png">

Vagrant with this fix:

<img width="412" alt="Screen Shot 2019-11-26 at 12 58 14 PM" src="https://user-images.githubusercontent.com/739622/69663842-b9dc4180-104c-11ea-8143-c986edf7bef3.png">


