### PR TITLE
Copy paste NoVNC chrome

### DIFF
--- a/apps/dashboard/public/noVNC-1.0.0/app.v1.js
+++ b/apps/dashboard/public/noVNC-1.0.0/app.v1.js
@@ -1077,16 +1077,23 @@ var UI = {
 
     readLocalClipboard() {
         // navigator.clipboard and navigator.clipbaord.readText is not available in all browsers
-        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.readText !== "undefined") {
-            navigator.clipboard.readText()
-                .then((clipboardText) => {
-                    const text = document.getElementById('noVNC_clipboard_text').value;
-                    if (clipboardText !== text) {
-                        document.getElementById('noVNC_clipboard_text').value = clipboardText;
-                        UI.clipboardSend();
-                    }
-                })
-                .catch(err => Log.Warn("<< UI.readLocalClipboard: Failed to read system clipboard-: " + err));
+        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.readText !== "undefined" &&
+            typeof navigator.permissions !== "undefined" && typeof navigator.permissions.query !== "undefined"
+           ) {
+            navigator.permissions.query({name: 'clipboard-read'})
+            .then(() => navigator.clipboard.readText())
+            .then((clipboardText) => {
+                const text = document.getElementById('noVNC_clipboard_text').value;
+                if (clipboardText !== text) {
+                    document.getElementById('noVNC_clipboard_text').value = clipboardText;
+                    UI.clipboardSend();
+                }
+            })
+            .catch((err) => {
+                if(err.name !== 'TypeError'){
+                  Log.Warn("<< UI.readLocalClipboard: Failed to read system clipboard-: " + err);
+                }
+            });
         }
     },
 

--- a/apps/dashboard/public/noVNC-1.0.0/app.v1.js
+++ b/apps/dashboard/public/noVNC-1.0.0/app.v1.js
@@ -1058,12 +1058,17 @@ var UI = {
     // further information at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
 
     writeLocalClipboard(text) {
-        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.writeText !== "undefined") {
-            navigator.clipboard.writeText(text).then(() => {
+        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.writeText !== "undefined"
+            && typeof navigator.permissions !== "undefined" && typeof navigator.permissions.query !== "undefined"
+           ) {
+            navigator.permissions.query({name: 'clipboard-write'})
+            .then(() => { return navigator.clipboard.writeText(text) })
+            .then(() => {
                 let debugMessage = text.substr(0, 40) + "...";
                 Log.Debug('>> UI.setClipboardText: navigator.clipboard.writeText with ' + debugMessage);
-            }).catch(() => {
-                Log.Error(">> UI.setClipboardText: Failed to write system clipboard (trying to copy from NoVNC clipboard)");
+            }).catch((err) => {
+                if(err.name !== 'TypeError')
+                    Log.Error(">> UI.setClipboardText: Failed to write system clipboard (trying to copy from NoVNC clipboard)");
             });
         }
     },

--- a/apps/dashboard/public/noVNC-1.0.0/app.v1.js
+++ b/apps/dashboard/public/noVNC-1.0.0/app.v1.js
@@ -1062,7 +1062,7 @@ var UI = {
             && typeof navigator.permissions !== "undefined" && typeof navigator.permissions.query !== "undefined"
            ) {
             navigator.permissions.query({name: 'clipboard-write'})
-            .then(() => { return navigator.clipboard.writeText(text) })
+            .then(() => navigator.clipboard.writeText(text))
             .then(() => {
                 let debugMessage = text.substr(0, 40) + "...";
                 Log.Debug('>> UI.setClipboardText: navigator.clipboard.writeText with ' + debugMessage);

--- a/apps/dashboard/public/noVNC-1.0.0/app.v1.js
+++ b/apps/dashboard/public/noVNC-1.0.0/app.v1.js
@@ -1058,17 +1058,19 @@ var UI = {
     // further information at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
 
     writeLocalClipboard(text) {
-        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.writeText !== "undefined"
-            && typeof navigator.permissions !== "undefined" && typeof navigator.permissions.query !== "undefined"
+        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.writeText !== "undefined" &&
+            typeof navigator.permissions !== "undefined" && typeof navigator.permissions.query !== "undefined"
            ) {
             navigator.permissions.query({name: 'clipboard-write'})
             .then(() => navigator.clipboard.writeText(text))
             .then(() => {
                 let debugMessage = text.substr(0, 40) + "...";
                 Log.Debug('>> UI.setClipboardText: navigator.clipboard.writeText with ' + debugMessage);
-            }).catch((err) => {
-                if(err.name !== 'TypeError')
+            })
+            .catch((err) => {
+                if(err.name !== 'TypeError'){
                     Log.Error(">> UI.setClipboardText: Failed to write system clipboard (trying to copy from NoVNC clipboard)");
+                }
             });
         }
     },


### PR DESCRIPTION
Fixes https://github.com/OSC/ondemand/issues/198 for Chrome. See issue for summary of solution.

Note: after this is approved, we will need to use our poor-man's cache bust of `noVNC-1.0.0/app.v1.js` by renaming it `noVNC-1.0.0/app.v2.js`.