### PR TITLE
Better gitlab-ci deployment workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,17 +33,19 @@ rpm-build-el8:
       - tmp/output
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
 
-
-rpm-deploy:
-  variables:
-    RLS_SCRIPT: "./tmp/ondemand-packaging/release.py"
-    RLS_KEY: "/systems/osc_certs/ssh/ondemand-packaging/id_rsa"
-    RLS_OUTPUT: "./tmp/output/*"
-    SECTION: "main"
+rpm-deploy-ci:
   stage: deploy
   only:
     - tags
   script:
-    - if [[ "$CI_COMMIT_TAG" =~ .*_.* ]]; then export SECTION=ci; fi
-    - $RLS_SCRIPT --debug --pkey $RLS_KEY -c $SECTION $RLS_OUTPUT
-    - rm -rf $RLS_OUTPUT
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c ci ./tmp/output/*
+
+rpm-deploy:
+  stage: deploy
+  only:
+    - tags
+  except:
+    variables:
+      - $CI_COMMIT_TAG" =~ /_/
+  script:
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,6 @@ rpm-deploy:
     - tags
   except:
     variables:
-      - $CI_COMMIT_TAG" =~ /_/
+      - $CI_COMMIT_TAG =~ /_/
   script:
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,6 @@ rpm-deploy:
     - tags
   except:
     variables:
-      - $CI_COMMIT_TAG =~ /_/
+      - $CI_COMMIT_TAG =~ /.*_.*/
   script:
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*


### PR DESCRIPTION
* Always deploy packages to the ci repos
* Only deploy non-CI releases to latest repo

This avoids dev nodes getting many versions behind.