### PR TITLE
Reject hidden files from the script suggestion list

### DIFF
--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -135,7 +135,13 @@ class Workflow < ActiveRecord::Base
     return @folder_contents if defined? @folder_contents
     
     if File.directory?(self.staged_dir)
-      @folder_contents = Find.find(self.staged_dir).drop(1).select {|f| File.file?(f) }.map {|f| WorkflowFile.new(f, self.staged_dir)}
+      @folder_contents = Find.find(self.staged_dir).drop(1).select {
+        |f| File.file?(f)
+      }.map {
+        |f| WorkflowFile.new(f, self.staged_dir)
+      }.reject {
+        |wf| wf.under_dotfile?
+      }
     else
       @folder_contents = []
     end
@@ -156,7 +162,7 @@ class Workflow < ActiveRecord::Base
   #
   # @return [["Suggested file(s)",[[relative_file_path, file_path]]], ["Other valid file(s)",[[relative_file_path, file_path]]]] Category with no files will be omitted
   def grouped_script_options
-    group_options = {
+    {
       "Suggested file(s)" => folder_contents.select(&:suggested_script?).map { |f| [f.relative_path, f.path] },
       "Other valid file(s)" => folder_contents.select(&:valid_script?).reject(&:suggested_script?).map { |f| [f.relative_path, f.path] },
     }.reject {|k,v| v.empty?}

--- a/apps/myjobs/test/models/workflow_file_test.rb
+++ b/apps/myjobs/test/models/workflow_file_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class WorkflowFileTest < ActiveSupport::TestCase
+  test "it recognizes hidden files" do
+    assert WorkflowFile.new(
+        Pathname.new('/home/johrstrom/.wine/drive_c'),
+        Pathname.new('/home/johrstrom/ondemand/and/so/on')
+    ).under_dotfile?
+  end
+end


### PR DESCRIPTION
- Changes `WorkflowFile#{path,staged_dir}` to be methods to maintain backward compatibility, while using Pathnames internally
- Removed unnecessary assignment in `WorkflowFile#grouped_script_options`
- Add a test for WorkflowFile

Note that this change also hides dot files and descendants from the Job Details panel in the workflow list view, which may or may not be desirable.

Fixes #346.