### PR TITLE
Fix favicon on dashboard,

### DIFF
--- a/apps/activejobs/app/views/layouts/application.html.erb
+++ b/apps/activejobs/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 
-  <%= favicon_link_tag nil, href: OodAppkit.public.url.join('favicon.ico') %>
+  <%= favicon_link_tag 'favicon.ico', href: OodAppkit.public.url.join('favicon.ico') %>
   <%= render partial: '/layouts/nav/styles', locals: { bg_color: Configuration.brand_bg_color, link_active_color: Configuration.brand_link_active_bg_color } %>
 </head>
 <body>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="<%= Configuration.locale %>">
 <head>
   <title><%= content_for?(:title) ? yield(:title) : "Dashboard" %></title>
-  <%= favicon_link_tag OodAppkit.public.url.join('favicon.ico') %>
+  <%= favicon_link_tag 'favicon.ico', href: OodAppkit.public.url.join('favicon.ico') %>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>

--- a/apps/file-editor/app/views/layouts/application.html.erb
+++ b/apps/file-editor/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
 
   <title>Editor</title>
-  <%= favicon_link_tag nil, href: OodAppkit.public.url.join('favicon.ico') %>
+  <%= favicon_link_tag 'favicon.ico', href: OodAppkit.public.url.join('favicon.ico') %>
 
   <%= stylesheet_link_tag "application", media: "all" %>
 

--- a/apps/myjobs/app/views/layouts/application.html.erb
+++ b/apps/myjobs/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
 
   <title>Job Composer</title>
-  <%= favicon_link_tag nil, href: OodAppkit.public.url.join('favicon.ico') %>
+  <%= favicon_link_tag 'favicon.ico', href: OodAppkit.public.url.join('favicon.ico') %>
 
   <%= stylesheet_link_tag    "application", media: "all" %>
   <script>


### PR DESCRIPTION
 fixes #322

Can't set to `nil` like other apps because that throws errors. Seems setting favicon normally to `/public/favicon.ico` doesn't work unless you do so in `href` I think because PUN URL gets prefixed even if begins with "/".