### PR TITLE
dashboard: avoid colon in rake task's job script name

### DIFF
--- a/apps/dashboard/lib/tasks/test.rake
+++ b/apps/dashboard/lib/tasks/test.rake
@@ -15,7 +15,7 @@ namespace :test do
         end
         puts "Testing cluster '#{cluster.id}'..."
         test_string = "TEST A B C"
-        output_path = WORKDIR.join("output_#{cluster.id}_#{Time.now.iso8601}.log")
+        output_path = WORKDIR.join("output_#{cluster.id}_#{Time.now.iso8601}.log".parameterize.underscore)
         script = OodCore::Job::Script.new(
           job_name: "test_jobs_#{cluster.id}",
           workdir: WORKDIR,


### PR DESCRIPTION
parameterize.underscore the name of the job script in order to avoid
illegal characters like colon, which cause problems with some schedulers (pbspro?)

fixes issue raised in https://github.com/OSC/ondemand/issues/341