### PR TITLE
Parameterize and underscore job names

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -421,7 +421,9 @@ module BatchConnect
           ENV["OOD_PORTAL"].to_s,    # the OOD portal id
           ENV["RAILS_RELATIVE_URL_ROOT"].to_s.sub(/^\/[^\/]+\//, ""),  # the OOD app
           token                 # the Batch Connect app
-        ].reject(&:blank?).join("/").parameterize.underscore
+        ].reject(&:blank?).join("/").tap do |jb_nm|
+          jb_nm.replace(jb_nm.parameterize.underscore ) if Configuration.sanitize_bc_job_names?
+        end
       end
 
       # Render a list of files using ERB

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -418,8 +418,8 @@ module BatchConnect
       # Namespace the job name
       def job_name
         [
-          ENV["OOD_PORTAL"],    # the OOD portal id
-          ENV["RAILS_RELATIVE_URL_ROOT"].sub(/^\/[^\/]+\//, ""),  # the OOD app
+          ENV["OOD_PORTAL"].to_s,    # the OOD portal id
+          ENV["RAILS_RELATIVE_URL_ROOT"].to_s.sub(/^\/[^\/]+\//, ""),  # the OOD app
           token                 # the Batch Connect app
         ].reject(&:blank?).join("/").parameterize.underscore
       end

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -421,7 +421,7 @@ module BatchConnect
           ENV["OOD_PORTAL"],    # the OOD portal id
           ENV["RAILS_RELATIVE_URL_ROOT"].sub(/^\/[^\/]+\//, ""),  # the OOD app
           token                 # the Batch Connect app
-        ].reject(&:blank?).join("/")
+        ].reject(&:blank?).join("/").parameterize.underscore
       end
 
       # Render a list of files using ERB

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -218,6 +218,10 @@ end
     Pathname.new(ENV['OOD_LOCALES_ROOT'] || "/etc/ood/config/locales")
   end
 
+  def sanitize_bc_job_names?
+    to_bool(ENV['OOD_SANITIZE_BC_JOB_NAMES'])
+  end
+
   private
 
   # The environment

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -71,13 +71,6 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
   end
 
   test "generated job_name should be valid for Grid Engine and PBSPro" do
-    # Environment variables are used in job_name
-    ood_portal = ENV['OOD_PORTAL']
-    relative_root = ENV['RAILS_RELATIVE_URL_ROOT']
-
-    ENV['OOD_PORTAL'] = 'ondemand'
-    ENV['RAILS_RELATIVE_URL_ROOT'] = 'sys/dashboard/sys'
-
     Dir.mktmpdir("dbroot") do |dir|
       dir = Pathname.new(dir)
       BatchConnect::Session.stubs(:db_root).returns(dir)
@@ -96,8 +89,5 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       sessions = BatchConnect::Session.all
       refute sessions.map { |session| session.send :job_name }.any? { |job_name| /[:\/]/.match?(job_name) }
     end
-
-    ENV['OOD_PORTAL'] = ood_portal
-    ENV['RAILS_RELATIVE_URL_ROOT'] = relative_root
   end
 end


### PR DESCRIPTION
Fixes problems seen by Grid Engine and PBSPro where semi-colons or forward slashes are put in Batch Connect job names.