### PR TITLE
Support putting OnDemand into maintenance mode

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -23,6 +23,10 @@ module OodPortalGenerator
       @map_fail_uri     = opts.fetch(:map_fail_uri, nil)
       @pun_stage_cmd    = opts.fetch(:pun_stage_cmd, "sudo /opt/ood/nginx_stage/sbin/nginx_stage")
 
+      # Maintenance configuration
+      @use_maintenance          = opts.fetch(:use_maintenance, true)
+      @maintenance_ip_whitelist = Array(opts.fetch(:maintenance_ip_whitelist, []))
+
       if OodPortalGenerator.scl_apache?
         default_htpasswd = "/opt/rh/httpd24/root/etc/httpd/.htpasswd"
       else
@@ -75,6 +79,16 @@ module OodPortalGenerator
       # Register unmapped user sub-uri
       @register_uri  = opts.fetch(:register_uri, nil)
       @register_root = opts.fetch(:register_root, nil)
+    end
+
+    # Helper method to escape IP for maintenance rewrite condition
+    def escape_ip(value)
+      # Value is already escaped
+      if value.split(%r{\\.}, 4).size == 4
+        value
+      else
+        value.split('.', 4).join('\.')
+      end
     end
 
     # Render the provided template as a string

--- a/ood-portal-generator/share/maintenance.html
+++ b/ood-portal-generator/share/maintenance.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Open OnDemand Maintenance</title>
+  </head>
+
+  <body>
+    <h1>Open OnDemand is currently offline for maintenance</h1>
+  </body>
+</html>

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -47,6 +47,20 @@
 # Default: true
 #use_rewrites: true
 
+# Should Maintenance Rewrite rules be added
+# Example:
+#   use_maintenance: false
+# Default: true
+#use_maintenance: true
+
+# List of IPs to whitelist when maintenance is enabled
+# Example:
+#   maintenance_ip_whitelist:
+#     - 192.168.0..*
+#     - 192.168.1..*
+# Default: [] (no IPs whitelisted)
+#maintenance_ip_whitelist: []
+
 # Root directory of the Lua handler code
 # Example:
 #     lua_root: '/path/to/lua/handlers'

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -25,6 +25,32 @@ describe OodPortalGenerator::Application do
     it 'runs generate' do
       expect { described_class.generate() }.to output(/VirtualHost/).to_stdout
     end
+
+    it 'generates default template' do
+      expected_rendered = read_fixture('ood-portal.conf.default')
+      expect(described_class.output).to receive(:write).with(expected_rendered)
+      described_class.generate()
+    end
+
+    it 'generates without maintenance' do
+      allow(described_class).to receive(:context).and_return({use_maintenance: false})
+      expected_rendered = read_fixture('ood-portal.conf.nomaint')
+      expect(described_class.output).to receive(:write).with(expected_rendered)
+      described_class.generate()
+    end
+
+    it 'generates maintenance template with IP whitelist' do
+      allow(described_class).to receive(:context).and_return({maintenance_ip_whitelist: ['192.168.1..*', '10.0.0..*']})
+      expected_rendered = read_fixture('ood-portal.conf.maint_with_ips')
+      expect(described_class.output).to receive(:write).with(expected_rendered)
+      described_class.generate()
+    end
+    it 'generates maintenance template with IP whitelist already escaped' do
+      allow(described_class).to receive(:context).and_return({maintenance_ip_whitelist: ['192\.168\.1\..*', '10\.0\.0\..*']})
+      expected_rendered = read_fixture('ood-portal.conf.maint_with_ips')
+      expect(described_class.output).to receive(:write).with(expected_rendered)
+      described_class.generate()
+    end
   end
 
   describe 'apache' do

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -49,6 +49,8 @@
   RewriteCond /var/www/ood/public/maintenance/index.html -f
   RewriteCond /etc/ood/maintenance.enable -f
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
+  RewriteCond %{REMOTE_ADDR} !^192\.168\.1\..*
+  RewriteCond %{REMOTE_ADDR} !^10\.0\.0\..*
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
   Header Set Cache-Control "max-age=0, no-store"

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -44,15 +44,6 @@
 #
 <VirtualHost *:80>
 
-  # Support maintenance page during outages of OnDemand
-  RewriteEngine On
-  RewriteCond /var/www/ood/public/maintenance/index.html -f
-  RewriteCond /etc/ood/maintenance.enable -f
-  RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
-  RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
-  ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
-
 
   # Lua configuration
   #

--- a/ood-portal-generator/spec/fixtures/sum.default
+++ b/ood-portal-generator/spec/fixtures/sum.default
@@ -1,1 +1,1 @@
-8f4b132db04e928c2070ff108a28e9587d59f1b5a6fcb0340aff857a24415194 /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf
+ccb6b87a2077dae62cc7a498dd06102c6589bdc178d6af4a8ff5d250f479e535 /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -76,6 +76,20 @@ Listen <%= addr_port %>
   <%- end -%>
   <%- end -%>
 
+  <%- if @use_rewrites && @use_maintenance -%>
+  # Support maintenance page during outages of OnDemand
+  RewriteEngine On
+  RewriteCond <%= @public_root %>/maintenance/index.html -f
+  RewriteCond /etc/ood/maintenance.enable -f
+  RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
+  <%- @maintenance_ip_whitelist.each do |ip| -%>
+  RewriteCond %{REMOTE_ADDR} !^<%= escape_ip(ip) %>
+  <%- end -%>
+  RewriteRule ^.*$ <%= @public_uri %>/maintenance/index.html [R=503,L]
+  ErrorDocument 503 <%= @public_uri %>/maintenance/index.html
+  Header Set Cache-Control "max-age=0, no-store"
+
+  <%- end -%>
   <%- if @ssl -%>
   SSLEngine On
   <%- @ssl.each do |line| -%>

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -186,6 +186,9 @@ fi
     %{buildroot}%{_sysconfdir}/ood/config/ood_portal.yml
 %__mkdir_p %{buildroot}%{apache_confd}
 touch %{buildroot}%{apache_confd}/ood-portal.conf
+%__mkdir_p %{buildroot}%{_localstatedir}/www/ood/public/maintenance
+%__install -D -m 644 ood-portal-generator/share/maintenance.html \
+    %{buildroot}%{_localstatedir}/www/ood/public/maintenance/index.html
 
 %__install -D -m 644 nginx_stage/share/nginx_stage_example.yml \
     %{buildroot}%{_sysconfdir}/ood/config/nginx_stage.yml
@@ -349,11 +352,14 @@ fi
 
 %dir %{_localstatedir}/www/ood
 %dir %{_localstatedir}/www/ood/public
+%dir %{_localstatedir}/www/ood/public/maintenance
 %dir %{_localstatedir}/www/ood/register
 %dir %{_localstatedir}/www/ood/discover
 %dir %{_localstatedir}/www/ood/apps
 %dir %{_localstatedir}/www/ood/apps/sys
 %dir %{_localstatedir}/www/ood/apps/usr
+%config(noreplace,missingok) %{_localstatedir}/www/ood/public/maintenance/index.html
+%ghost %{_sysconfdir}/ood/maintenance.enable
 
 %dir %{_sysconfdir}/ood
 %dir %{_sysconfdir}/ood/config


### PR DESCRIPTION
A few items that may need to still be addressed:

* Adding default image to serve. I put RewriteCond assuming there is one
* Possibly add helper script or nginx_stage subcommand to touch the file and execute `nginx_stage nginx_clean -f`.

This mimics XDMOD maintenance mode used at OSC