### PR TITLE
Fix preserving selection in myjobs job options

### DIFF
--- a/apps/myjobs/app/views/workflows/_edit_form.html.erb
+++ b/apps/myjobs/app/views/workflows/_edit_form.html.erb
@@ -9,7 +9,7 @@
     <%# select in bootstrap_form?@%>
 
     
-    <%= f.select :script_path, grouped_options_for_select(workflow.grouped_script_options), { label: t('jobcomposer.options_script_title'), help: t('jobcomposer.options_script_help') }, { class: "selectpicker", id: "workflow_script_path" }  %>
+    <%= f.select :script_path, grouped_options_for_select(workflow.grouped_script_options, workflow.script_path), { label: t('jobcomposer.options_script_title'), help: t('jobcomposer.options_script_help') }, { class: "selectpicker", id: "workflow_script_path" }  %>
 
     <%= render partial: "edit_form_job_attrs", locals: { f: f } %>
 


### PR DESCRIPTION
Fixes #389 

Unlike other form helpers that auto-set the value, this does not occur in the case of select
when you are using a helper method like options_for_select or grouped_options_for_select
(or at least this is the case for bootstrap_form helper when using grouped_options_for_select)

Those methods produce the string of option tags, so you need to provide the current selection value
as an argument to those methods

See https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-grouped_options_for_select