### PR TITLE
Fix activejobs when ganglia or grafana is not present

### DIFF
--- a/apps/activejobs/app/helpers/jobs_helper.rb
+++ b/apps/activejobs/app/helpers/jobs_helper.rb
@@ -22,6 +22,7 @@ module JobsHelper
       server = c.custom_config(:grafana)
       query_params = {
         orgId: server[:orgId],
+        theme: server[:theme] || 'light',
         from: "#{start_seconds}000",
         to: 'now',
         "var-#{server[:labels]['cluster']}": cluster,

--- a/apps/activejobs/app/views/jobs/_job_details_node_view.html.erb
+++ b/apps/activejobs/app/views/jobs/_job_details_node_view.html.erb
@@ -1,3 +1,4 @@
+<% if has_ganglia(data.cluster) || has_grafana(data.cluster) %>
 <div class="col-md-12">
   <tr>
     <td>
@@ -22,3 +23,4 @@
     </td>
   </tr>
 </div>
+<% end %>

--- a/apps/activejobs/spec/helpers/jobs_helper_spec.rb
+++ b/apps/activejobs/spec/helpers/jobs_helper_spec.rb
@@ -9,22 +9,22 @@ RSpec.describe JobsHelper, type: :helper do
   end
   describe 'build_grafana_link' do
     it 'generates cpu panel URL' do
-      expected_url = "https://grafana.domain/d-solo/aaba6Ahbauquag/ondemand-clusters/?orgId=3&from=1582303423000&to=now&var-cluster=owens&var-host=o0484&panelId=20&var-jobid=9427651"
+      expected_url = "https://grafana.domain/d-solo/aaba6Ahbauquag/ondemand-clusters/?orgId=3&theme=light&from=1582303423000&to=now&var-cluster=owens&var-host=o0484&panelId=20&var-jobid=9427651"
       expect(build_grafana_link('owens', '1582303423', 'cpu', 'o0484', '9427651')).to eq(expected_url)
     end
 
     it 'generates memory panel URL' do
-      expected_url = "https://grafana.domain/d-solo/aaba6Ahbauquag/ondemand-clusters/?orgId=3&from=1582303423000&to=now&var-cluster=owens&var-host=o0484&panelId=24&var-jobid=9427651"
+      expected_url = "https://grafana.domain/d-solo/aaba6Ahbauquag/ondemand-clusters/?orgId=3&theme=light&from=1582303423000&to=now&var-cluster=owens&var-host=o0484&panelId=24&var-jobid=9427651"
       expect(build_grafana_link('owens', '1582303423', 'memory', 'o0484', '9427651')).to eq(expected_url)
     end
 
     it 'generates node dashboard URL' do
-      expected_url = "https://grafana.domain/d/aaba6Ahbauquag/ondemand-clusters/?orgId=3&from=1582303423000&to=now&var-cluster=owens&var-host=o0484"
+      expected_url = "https://grafana.domain/d/aaba6Ahbauquag/ondemand-clusters/?orgId=3&theme=light&from=1582303423000&to=now&var-cluster=owens&var-host=o0484"
       expect(build_grafana_link('owens', '1582303423', 'node', 'o0484')).to eq(expected_url)
     end
 
     it 'generates job dashboard URL' do
-      expected_url = "https://grafana.domain/d/aaba6Ahbauquag/ondemand-clusters/?orgId=3&from=1582303423000&to=now&var-cluster=owens&var-host=o0484&var-jobid=9427651"
+      expected_url = "https://grafana.domain/d/aaba6Ahbauquag/ondemand-clusters/?orgId=3&theme=light&from=1582303423000&to=now&var-cluster=owens&var-host=o0484&var-jobid=9427651"
       expect(build_grafana_link('owens', '1582303423', 'job', 'o0484', '9427651')).to eq(expected_url)
     end
   end


### PR DESCRIPTION
There are some HTML elements that get added if neither grafana or ganglia are present in cluster config. This is slight regression due to #400 

<img width="1188" alt="Screen Shot 2020-02-24 at 9 19 49 AM" src="https://user-images.githubusercontent.com/739622/75159850-f587b580-56e6-11ea-8ee7-0c17e6cbef34.png">

Notice the two dashes.  This change brings back past behavior where essentially the entire partial is ignored if a site doesn't configure ganglia or grafana.