### PR TITLE
allowe the ssh command to be replaced by a wrapper in ood/apps/sys/dashboard/.env.production

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -47,9 +47,10 @@ var wss = new WebSocket.Server({ server: server });
 wss.on('connection', function connection (ws, req) {
   var match;
   var host = process.env.DEFAULT_SSHHOST || 'localhost';
+  var cmd = process.env.CUSTOM_SSH || 'ssh';
   var dir;
   var term;
-  var cmd, args;
+  var args;
 
   console.log('Connection established');
 
@@ -59,11 +60,10 @@ wss.on('connection', function connection (ws, req) {
     if (match[2]) dir = decodeURIComponent(match[2]);
   }
 
-  cmd = 'ssh';
   args = dir ? [host, '-t', 'cd \'' + dir.replace(/\'/g, "'\\''") + '\' ; exec ${SHELL} -l'] : [host];
 
   process.env.LANG = 'en_US.UTF-8'; // this patch (from b996d36) lost when removing wetty (2c8a022)
-  
+
   term = pty.spawn(cmd, args, {
     name: 'xterm-256color',
     cols: 80,

--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -47,7 +47,7 @@ var wss = new WebSocket.Server({ server: server });
 wss.on('connection', function connection (ws, req) {
   var match;
   var host = process.env.DEFAULT_SSHHOST || 'localhost';
-  var cmd = process.env.CUSTOM_SSH || 'ssh';
+  var cmd = process.env.OOD_SSH_WRAPPER || 'ssh';
   var dir;
   var term;
   var args;


### PR DESCRIPTION
Our situation:
We use the same login nodes for all clusters. When using the shell app we wanted a shell directly to the right cluster and needed to pass some ssh arguments.
We had the information in the url but no clean way to pass to the ssh command.
Rather than hacink the shell app.js wit our custom code it would be nice to just set the ssh wrapper to use by the shell app in the settings.env

For all users:
- This allows for a per cluster different set environment through the gui.
- Different clients if needed
- a lot more possibility to tailor the command as needed

or just do nothing and the basic system ssh keeps in effect

