### PR TITLE
update rake for nginx_stage and ood_auth_map

### DIFF
--- a/nginx_stage/nginx_stage.gemspec
+++ b/nginx_stage/nginx_stage.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0.1"
   spec.add_development_dependency "minitest"
 end

--- a/ood_auth_map/ood_auth_map.gemspec
+++ b/ood_auth_map/ood_auth_map.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0.1"
 end


### PR DESCRIPTION
Simple rake updates for nginx_stage and ood_auth_map to get rid of security alerts and be in line with all our other apps.