### PR TITLE
Fix #405

### DIFF
--- a/nginx_stage/lib/nginx_stage/user.rb
+++ b/nginx_stage/lib/nginx_stage/user.rb
@@ -31,13 +31,11 @@ module NginxStage
     attr_reader :groups
 
     # @param user [String] the user name defining this object
-    # @raise [InvalidUser] if user doesn't exist on local system
+    # @raise [ArgumentError] if user or primary group doesn't exist on local system
     def initialize(user)
       @passwd = Etc.getpwnam user.to_s
       @group = Etc.getgrgid gid
       @groups = get_groups
-    rescue ArgumentError
-      raise InvalidUser, "user doesn't exist: #{user}"
     end
 
     # User's primary group name


### PR DESCRIPTION
Just let the ArgumentError go up the stack because it's fairly informative out of the box. This also allows for errors for invalid group ids to be thrown. This is to fix #405.

```text
irb(main):001:0> require 'etc'
=> true
irb(main):002:0> Etc.getpwnam 'john'
Traceback (most recent call last):
        3: from /opt/rh/rh-ruby25/root/usr/bin/irb:11:in `<main>'
        2: from (irb):2
        1: from (irb):2:in `getpwnam'
ArgumentError (can't find user for john)
irb(main):003:0> Etc.getgrgid 1001
Traceback (most recent call last):
        3: from /opt/rh/rh-ruby25/root/usr/bin/irb:11:in `<main>'
        2: from (irb):3
        1: from (irb):3:in `getgrgid'
ArgumentError (can't find group for 1001)
```