### PR TITLE
Add delete column

### DIFF
--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -218,6 +218,24 @@ function create_datatable(options){
                 data:               "cluster_title",
                 className:          "small",
                 "autoWidth":        true
+            },
+            {
+                data:               null,
+                className:          "small",
+                "autoWidth":        true,
+                "render":           function(data){
+                  console.log(data)
+                  if(data.username == JobStatusapp.username){
+                    return "<div>" +
+                              "<button class='btn btn-danger action-btn' data-method='delete'" +
+                              "data-confirm='Are you sure you want to delete " + data.pbsid + "'" +
+                              "href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
+                              ">D</button>" +
+                            "</div>";
+                  }else{
+                    return "";
+                  }
+                }
             }
         ]
     }).on( 'error.dt', function ( e, settings, techNote, message ) {

--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -227,10 +227,10 @@ function create_datatable(options){
                   console.log(data)
                   if(data.username == JobStatusapp.username){
                     return "<div>" +
-                              "<button class='btn btn-danger action-btn' data-method='delete'" +
+                              "<a class='btn btn-danger action-btn' data-method='delete'" +
                               "data-confirm='Are you sure you want to delete " + data.pbsid + "'" +
                               "href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
-                              ">D</button>" +
+                              ">D</a>" +
                             "</div>";
                   }else{
                     return "";

--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -231,9 +231,8 @@ function create_datatable(options){
                               " data-confirm='Are you sure you want to delete " + data.pbsid + "'" +
                               " href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
                               " aria-label='delete job' >" + 
-                                "<i class='glyphicon glyphicon-trash' aria-hidden='true'>" +
-                                  "<span class='action-btn-tooltip'>Delete Job</span>"
-                                "</i>" +
+                                "<i class='glyphicon glyphicon-trash' aria-hidden='true'></i>" +  
+                                "<span class='action-btn-tooltip'>Delete Job</span>" +
                               "</a>" +
                             "</div>";
                   }else{

--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -224,15 +224,13 @@ function create_datatable(options){
                 className:          "small",
                 "autoWidth":        true,
                 "render":           function(data){
-                  console.log(data)
                   if(data.username == JobStatusapp.username){
                     return "<div>" +
-                              "<a class='btn btn-danger action-btn' data-method='delete'" +
+                              "<a class='btn btn-danger btn-xs action-btn' data-method='delete'" +
                               " data-confirm='Are you sure you want to delete " + data.jobname  + " - " + data.pbsid + "'" +
                               " href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
-                              " aria-label='delete job' >" + 
+                              " aria-labeledby='title' data-toggle='tooltip' title='Delete Job' >" + 
                                 "<i class='glyphicon glyphicon-trash' aria-hidden='true'></i>" +  
-                                "<span class='action-btn-tooltip'>Delete Job</span>" +
                               "</a>" +
                             "</div>";
                   }else{

--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -228,9 +228,13 @@ function create_datatable(options){
                   if(data.username == JobStatusapp.username){
                     return "<div>" +
                               "<a class='btn btn-danger action-btn' data-method='delete'" +
-                              "data-confirm='Are you sure you want to delete " + data.pbsid + "'" +
-                              "href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
-                              ">D</a>" +
+                              " data-confirm='Are you sure you want to delete " + data.pbsid + "'" +
+                              " href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
+                              " aria-label='delete job' >" + 
+                                "<i class='glyphicon glyphicon-trash' aria-hidden='true'>" +
+                                  "<span class='action-btn-tooltip'>Delete Job</span>"
+                                "</i>" +
+                              "</a>" +
                             "</div>";
                   }else{
                     return "";

--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -224,17 +224,17 @@ function create_datatable(options){
                 className:          "small",
                 "autoWidth":        true,
                 "render":           function(data){
-                  if(data.username == JobStatusapp.username){
+                  if(data.delete_path == "" || data.status == "completed"){
+                    return ""
+                  } else {
                     return "<div>" +
                               "<a class='btn btn-danger btn-xs action-btn' data-method='delete'" +
                               " data-confirm='Are you sure you want to delete " + data.jobname  + " - " + data.pbsid + "'" +
-                              " href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
+                              " href='" + data.delete_path + "'" +
                               " aria-labeledby='title' data-toggle='tooltip' title='Delete Job' >" + 
                                 "<i class='glyphicon glyphicon-trash' aria-hidden='true'></i>" +  
                               "</a>" +
                             "</div>";
-                  }else{
-                    return "";
                   }
                 }
             }

--- a/apps/activejobs/app/assets/javascripts/application.js.erb
+++ b/apps/activejobs/app/assets/javascripts/application.js.erb
@@ -228,7 +228,7 @@ function create_datatable(options){
                   if(data.username == JobStatusapp.username){
                     return "<div>" +
                               "<a class='btn btn-danger action-btn' data-method='delete'" +
-                              " data-confirm='Are you sure you want to delete " + data.pbsid + "'" +
+                              " data-confirm='Are you sure you want to delete " + data.jobname  + " - " + data.pbsid + "'" +
                               " href='" + JobStatusapp.delete_job_path(data.pbsid, data.cluster) + "'" +
                               " aria-label='delete job' >" + 
                                 "<i class='glyphicon glyphicon-trash' aria-hidden='true'></i>" +  

--- a/apps/activejobs/app/assets/stylesheets/jobs.scss
+++ b/apps/activejobs/app/assets/stylesheets/jobs.scss
@@ -25,3 +25,7 @@ tr.shown td.details-control {
   right: 0;
   height: auto;
 }
+
+.action-btn {
+  margin: 1px;
+}

--- a/apps/activejobs/app/assets/stylesheets/jobs.scss
+++ b/apps/activejobs/app/assets/stylesheets/jobs.scss
@@ -29,3 +29,19 @@ tr.shown td.details-control {
 .action-btn {
   margin: 1px;
 }
+
+.action-btn .action-btn-tooltip {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: white;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+}
+
+.action-btn:hover .action-btn-tooltip {
+  visibility: visible;
+}
+

--- a/apps/activejobs/app/assets/stylesheets/jobs.scss
+++ b/apps/activejobs/app/assets/stylesheets/jobs.scss
@@ -29,19 +29,3 @@ tr.shown td.details-control {
 .action-btn {
   margin: 1px;
 }
-
-.action-btn .action-btn-tooltip {
-  visibility: hidden;
-  width: 120px;
-  background-color: black;
-  color: white;
-  text-align: center;
-  border-radius: 6px;
-  padding: 5px 0;
-  position: absolute;
-}
-
-.action-btn:hover .action-btn-tooltip {
-  visibility: visible;
-}
-

--- a/apps/activejobs/app/models/jobs_json_request_handler.rb
+++ b/apps/activejobs/app/models/jobs_json_request_handler.rb
@@ -81,10 +81,15 @@ class JobsJsonRequestHandler
         walltime_used: j.wallclock_time,
         username: j.job_owner,
         extended_available: extended_available,
-        nodes: j.allocated_nodes.map{ |node| node.name }.reject(&:blank?)
+        nodes: j.allocated_nodes.map{ |node| node.name }.reject(&:blank?),
+        delete_path: users_job?(j.job_owner) ? UrlHelper.instance.delete_job_path(pbsid: j.id, cluster: cluster.id.to_s) : ""
       }
     }
   end
+
+        # delete_job_path: function(id, cluster){
+        #   return "<%= delete_job_path %>?cluster="  + cluster + "&pbsid=" + id
+        # }
 
   # FIXME: remove when LSF and PBSPro are confirmed to handle job ids gracefuly
   def convert_info_filtered(info_all, cluster)
@@ -95,4 +100,15 @@ class JobsJsonRequestHandler
       convert_info(info_all.reject {|job| rx.match?(job.id) }, cluster)
     end
   end
+
+  # small helper to just cache the @user
+  def users_job?(owner)
+    @user ||= ENV["USER"]
+    owner == @user
+  end
+end
+
+class UrlHelper
+  include Singleton
+  include Rails.application.routes.url_helpers
 end

--- a/apps/activejobs/app/models/jobs_json_request_handler.rb
+++ b/apps/activejobs/app/models/jobs_json_request_handler.rb
@@ -87,10 +87,6 @@ class JobsJsonRequestHandler
     }
   end
 
-        # delete_job_path: function(id, cluster){
-        #   return "<%= delete_job_path %>?cluster="  + cluster + "&pbsid=" + id
-        # }
-
   # FIXME: remove when LSF and PBSPro are confirmed to handle job ids gracefuly
   def convert_info_filtered(info_all, cluster)
     if cluster.job_adapter.supports_job_arrays?

--- a/apps/activejobs/app/views/jobs/index.html.erb
+++ b/apps/activejobs/app/views/jobs/index.html.erb
@@ -32,7 +32,7 @@
 <div class="row">
   <div class="col-md-12">
     <h2>Active Jobs</h2>
-    <table id="job_status_table" class="table datatable display" cellspacing="0" width="100%">
+    <table id="job_status_table" class="table datatable display table-hover" cellspacing="0" width="100%">
       <thead>
       <tr>
         <th></th>

--- a/apps/activejobs/app/views/jobs/index.html.erb
+++ b/apps/activejobs/app/views/jobs/index.html.erb
@@ -44,6 +44,7 @@
         <th>Queue</th>
         <th>Status</th>
         <th>Cluster</th>
+        <th>Actions</th>
       </tr>
       </thead>
     </table>

--- a/apps/activejobs/app/views/layouts/application.html.erb
+++ b/apps/activejobs/app/views/layouts/application.html.erb
@@ -7,10 +7,7 @@
 
     <script>
       var JobStatusapp = {
-        username: "<%= OodSupport::User.new.name %>",
-        delete_job_path: function(id, cluster){
-          return "<%= delete_job_path %>?cluster="  + cluster + "&pbsid=" + id
-        }
+        username: "<%= OodSupport::User.new.name %>"
       };
     </script>
 

--- a/apps/activejobs/app/views/layouts/application.html.erb
+++ b/apps/activejobs/app/views/layouts/application.html.erb
@@ -7,7 +7,10 @@
 
     <script>
       var JobStatusapp = {
-        username: "<%= OodSupport::User.new.name %>"
+        username: "<%= OodSupport::User.new.name %>",
+        delete_job_path: function(id, cluster){
+          return "<%= delete_job_path %>?cluster="  + cluster + "&pbsid=" + id
+        }
       };
     </script>
 


### PR DESCRIPTION
Adds a delete column to active jobs to enable #416.  Looks like the image below.

I called it 'actions' column and left a small button to leave room for #138. 

There is a confirmation button, but maybe it should say the job name instead of the jobid? It may be easier to recognize that way.

![image](https://user-images.githubusercontent.com/4874123/76770405-4a619d80-6774-11ea-9795-49b6f552e297.png)
