### PR TITLE
Sanitize batch connect job name with new ood_core sanitize_job_name method

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -31,6 +31,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'climate_control', '0.2.0'
 end
 
 group :development do

--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -65,5 +65,5 @@ gem 'local_time', '~> 1.0.3'
 # OOD specific gems
 gem 'ood_support', '~> 0.0.2'
 gem 'ood_appkit', '~> 1.1'
-gem 'ood_core', '~> 0.11.1'
+gem 'ood_core', '~> 0.11'
 gem 'pbs', '~> 2.2.1'

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -226,7 +226,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   mocha (~> 1.1)
   ood_appkit (~> 1.1)
-  ood_core (~> 0.11.1)
+  ood_core (~> 0.11)
   ood_support (~> 0.0.2)
   pbs (~> 2.2.1)
   rails (= 5.2.4.1)

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     browser (2.7.1)
     builder (3.2.4)
     byebug (11.1.1)
+    climate_control (0.2.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -213,6 +214,7 @@ DEPENDENCIES
   bootstrap_form (~> 2.4)
   browser (~> 2.2)
   byebug
+  climate_control (= 0.2.0)
   coffee-rails (~> 4.2)
   data-confirm-modal (~> 1.2)
   dotenv-rails (~> 2.1)

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -166,23 +166,6 @@ module BatchConnect::SessionsHelper
     asset_path("noVNC-#{version}/vnc.html?autoconnect=true&password=#{password}&path=rnode/#{connect.host}/#{connect.websocket}/websockify&resize=#{resize}", skip_pipeline: true)
   end
 
-  def session_save_errors(errors)
-    capture do
-      errors.keys.each do |key|
-        case key
-        when :submit
-          concat content_tag(:h4, t('dashboard.batch_connect_sessions_errors_submission'))
-          concat content_tag(:pre, errors[key].first)
-        when :stage
-          concat content_tag(:h4, t('dashboard.batch_connect_sessions_errors_staging'))
-          concat content_tag(:pre, errors[key].first)
-        else
-          errors[key].each { |m| concat content_tag(:h4, m) }
-        end
-      end
-    end
-  end
-
   def connection_tabs(id, tabs)
     tabs = Array.wrap(tabs)
     if tabs.any? && tabs.size == 1

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -239,7 +239,7 @@ module BatchConnect
       opts = opts.to_h.compact.deep_symbolize_keys
 
       opts = {
-        job_name: job_name,
+        job_name: adapter.sanitize_job_name(job_name),
         workdir: staged_root,
         output_path: output_file,
         shell_path: shell_path

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -17,7 +17,18 @@
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>
-    <%= session_save_errors @session.errors %>
+
+    <% @session.errors.each do |key, error| %>
+      <% if key == :submit %>
+        <h4><%= t('dashboard.batch_connect_sessions_errors_submission') %></h4>
+        <pre><%= error %></pre>
+      <% elsif key == :stage %>
+        <h4><%= t('dashboard.batch_connect_sessions_errors_staging') %></h4>
+        <pre><%= error %></pre>
+      <% else %>
+        <h4><%= error %></h4>
+      <% end %>
+    <% end %>
 
     <p class="small">
       <%= t('dashboard.batch_connect_sessions_data_html',

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -30,16 +30,25 @@
       <% end %>
     <% end %>
 
-    <p class="small">
-      <%= t('dashboard.batch_connect_sessions_data_html',
+    <ul>
+      <% if @session.errors.include?(:submit) %>
+      <li>
+        If this job failed to submit because of an invalid job name
+        please ask your administrator to configure OnDemand to set the
+        environment variable OOD_JOB_NAME_ILLEGAL_CHARS.
+      </li>
+      <% end %>
+      <li>
+        <%= t('dashboard.batch_connect_sessions_data_html',
             title: @app.title,
             data_link_tag: link_to(
               t('dashboard.batch_connect_sessions_staged_root'),
               OodAppkit.files.url(path: @session.staged_root).to_s,
               target: "_blank")
             )
-      %>
-    </p>
+            %>
+      </li>
+    </ul>
   </div>
 <%- end -%>
 

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -33,9 +33,7 @@
     <ul>
       <% if @session.errors.include?(:submit) %>
       <li>
-        If this job failed to submit because of an invalid job name
-        please ask your administrator to configure OnDemand to set the
-        environment variable OOD_JOB_NAME_ILLEGAL_CHARS.
+        <%= t('dashboard.batch_connect_sessions_error_invalid_job_name_html') %>
       </li>
       <% end %>
       <li>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -78,6 +78,10 @@ en:
     batch_connect_sessions_data_html: |
       The %{title} session data for this session can be accessed
       under the %{data_link_tag}.
+    batch_connect_sessions_error_invalid_job_name_html: |
+      If this job failed to submit because of an invalid job name
+      please ask your administrator to configure OnDemand to set the
+      environment variable OOD_JOB_NAME_ILLEGAL_CHARS.
     batch_connect_sessions_delete_confirm: "Are you sure?"
     batch_connect_sessions_delete_hover: "Delete Session"
     batch_connect_sessions_delete_title: "Delete"

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
     batch_connect_no_sessions: "You have no active sessions."
     batch_connect_sandbox: " [Sandbox]"
     batch_connect_sessions_data_html: |
-      * The %{title} session data for this session can be accessed
+      The %{title} session data for this session can be accessed
       under the %{data_link_tag}.
     batch_connect_sessions_delete_confirm: "Are you sure?"
     batch_connect_sessions_delete_hover: "Delete Session"

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -69,4 +69,24 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       assert_equal ["A", "B", "C", "D.bak"], dir.children.map(&:basename).map(&:to_s).sort
     end
   end
+
+  test "default job name uses / as delimiter" do
+    BatchConnect::Session.any_instance.stubs(:adapter).returns(OodCore::Job::Adapter.new)
+    BatchConnect::Session.any_instance.stubs(:token).returns('rstudio')
+    BatchConnect::Session.any_instance.stubs(:staged_root).returns(Pathname.new("/dev/null"))
+
+    with_modified_env(OOD_PORTAL: 'ood', RAILS_RELATIVE_URL_ROOT: '/pun/sys/dashboard') do
+      assert_equal 'ood/sys/dashboard/rstudio', BatchConnect::Session.new.script_options[:job_name]
+    end
+  end
+
+  test "job name replaces / with - when sanitizing" do
+    BatchConnect::Session.any_instance.stubs(:adapter).returns(OodCore::Job::Adapter.new)
+    BatchConnect::Session.any_instance.stubs(:token).returns('rstudio')
+    BatchConnect::Session.any_instance.stubs(:staged_root).returns(Pathname.new("/dev/null"))
+
+    with_modified_env(OOD_PORTAL: 'ood', RAILS_RELATIVE_URL_ROOT: '/pun/sys/dashboard', OOD_JOB_NAME_ILLEGAL_CHARS: '/') do
+      assert_equal 'ood-sys-dashboard-rstudio', BatchConnect::Session.new.script_options[:job_name]
+    end
+  end
 end

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -2,9 +2,14 @@ ENV['RAILS_ENV'] ||= 'test'
 ENV['OOD_LOCALES_ROOT'] = Rails.root.join('config/locales').to_s
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'climate_control'
 
 class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
+
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options, &block)
+  end
 end
 
 require 'mocha/minitest'


### PR DESCRIPTION
TODO: 

- [x] If the interactive batch job is rejected upon submission, append to the error message the possibility that the job was rejected due to the bad job name and direct the admin to set the illegal chars. i.e. 
  > When attempting to submit this job OnDemand set the job name to "ondemand/...". If any of these characters are not allowed, please ask your administrator to configure OnDemand to set the environment variable OOD_JOB_NAME_ILLEGAL_CHARS. For example OOD_JOB_NAME_ILLEGAL_CHARS="/" will ensure that / is replaced with -
- [x] Move message to locales.