### PR TITLE
fix favorite path example

### DIFF
--- a/apps/dashboard/config/examples/osc/initializers/ood.rb
+++ b/apps/dashboard/config/examples/osc/initializers/ood.rb
@@ -4,7 +4,7 @@ OodFilesApp.candidate_favorite_paths.tap do |paths|
   paths.concat projects.map { |p| FavoritePath.new(Pathname.new("/fs/project/#{p}"), title: "Project")  }
 
   # add scratch space directories
-  paths << FavoritePath.new(Pathname.new("/fs/scratch/#{User.new.name}"), "Scratch")
+  paths << FavoritePath.new(Pathname.new("/fs/scratch/#{User.new.name}"), title: "Scratch")
   paths.concat projects.map { |p| FavoritePath.new(Pathname.new("/fs/scratch/#{p}"), title: "Scratch")  }
 end
 # uncomment if you want to revert to the old menu


### PR DESCRIPTION
The example for adding titles to favourite paths currently breaks with this error. 

```text
App 71969 output: Error: The application encountered the following error: wrong number of arguments (given 2, expected 1) (ArgumentError)
App 71969 output:     /users/PZS0714/johrstrom/ondemand/misc/ondemand/apps/dashboard/app/apps/favorite_path.rb:2:in `initialize'
App 71969 output:     /users/PZS0714/johrstrom/ondemand/misc/ondemand/apps/dashboard/config/initializers/paths.rb:7:in `new'
App 71969 output:     /users/PZS0714/johrstrom/ondemand/misc/ondemand/apps/dashboard/config/initializers/paths.rb:7:in `block in <top (required)>'
App 71969 output:     /users/PZS0714/johrstrom/ondemand/misc/ondemand/apps/dashboard/config/initializers/paths.rb:1:in `tap'
App 71969 output:     /users/PZS0714/johrstrom/ondemand/misc/ondemand/apps/dashboard/config/initializers/paths.rb:1:in `<top (required)>'
```