### PR TITLE
add a container desktop

### DIFF
--- a/apps/bc_desktop/template/desktops/container.sh
+++ b/apps/bc_desktop/template/desktops/container.sh
@@ -1,0 +1,32 @@
+CONTAINER_CMD=${CONTAINER_CMD:-singularity}
+CONTAINER_MNTS=${CONTAINER_MNTS:-""}
+CONTAINER_ARGS=${CONTAINER_ARGS:-""}
+SEPERATOR=${SEPERATOR:-"%"}
+  
+function singularity_mounts(){
+  MOUNTS=$(echo $1 | tr $2 ,)
+  echo "-B $MOUNTS"
+}
+
+function podman_mounts(){
+  IFS="$2" PATHS=($1)
+
+  MOUNTS=""
+  for PATH in "${PATHS[@]}"
+  do
+    MOUNTS="$MOUNTS -v $PATH"
+  done
+
+  echo $MOUNTS
+}
+
+if [[ "$CONTAINER_CMD" == "singularity" ]]; then
+  MOUNT_ARG=$(singularity_mounts $CONTAINER_MNTS $SEPERATOR)
+elif [[ "$CONTAINER_CMD" == "podman" ]] || [[ "$CONTAINER_CMD" == "docker" ]]; then
+  MOUNT_ARG=$(podman_mounts $CONTAINER_MNTS $SEPERATOR)
+fi
+
+CMD="$CONTAINER_CMD run $CONTAINER_ARGS $MOUNT_ARG $CONTAINER_IMAGE $DESKTOP_CMD"
+
+echo "executing $CMD"
+$CMD


### PR DESCRIPTION
This allows folks to run VDIs or desktops from within a container. It lets users choose what mounts to use and what other arguments to pass to the container runtime. It could support podman or docker as well as singularity.  It's a possible solution for #388. 

I got this to work with a basic centos7 image (base meaning nothing installed, just pulled from dockerhub) with this `submit/container.yml.erb`. 

```ruby
---
script:
  native:
    resources:
      nodes: "<%= bc_num_slots %><%= node_type %>"
  job_environment:
    CONTAINER_IMAGE: "/users/PZS0714/johrstrom/Public/images/sing/centos7_base.sif"
    CONTAINER_CMD: "singularity"
    CONTAINER_ARGS: "-p"
    SEPERATOR: "%"
    CONTAINER_MNTS: "/etc%/usr%/dev:ro%/tmp:/tmp%/home:/home%/fs%/lib:/lib%/lib64:/lib64%/var:/var"
    DESKTOP_CMD: "/usr/bin/bash\ -c\ $PBS_O_WORKDIR/desktops/mate.sh"
```

To test this you use this file for your `submit` along with `attributes.desktop: container`. 