### PR TITLE
add support for KDE bc desktop

### DIFF
--- a/apps/bc_desktop/template/desktops/kde.sh
+++ b/apps/bc_desktop/template/desktops/kde.sh
@@ -1,0 +1,1 @@
+startkde


### PR DESCRIPTION
With the realizations in #388 I was able to get a KDE desktop to run at OSC in a container, even though we don't support kde or have the libraries on the host.

With this PR users could choose KDE given their setup is correct or they have a container to do so. If you want to test this, you can use my image at `/users/PZS0714/johrstrom/Public/images/sing/kde.sif` 

with this `submit.yml.erb` 

```ruby
<%
  image="/users/PZS0714/johrstrom/Public/images/sing/" + desktop + ".sif"
%>
---
script:
  native:
    resources:
      nodes: "<%= bc_num_slots %><%= node_type %>"
  template: "vnc"
batch_connect:
  websockify_cmd: '/usr/bin/websockify'
  script_wrapper: |
    cat << "CTRSCRIPT" > container.sh
    export PATH="$PATH:/opt/TurboVNC/bin"
    echo "path is $PATH"
    %s  
    CTRSCRIPT

    export SINGULARITY_BINDPATH="$HOME,/etc,/fs,/srv,/var,/run,/tmp:$TMPDIR"
    echo "bindpath is $SINGULARITY_BINDPATH"

    singularity run -p <%= image %> /bin/bash container.sh
```

and this `form.yml`

```yaml
---
title: "Owens VDI Container"
description: |
  This app will launch an interactive desktop with one core which could be shared. It
  is a small environment for lightweight tasks (similar to a login node) such as accessing
  & viewing files, submitting jobs, compiling code, and running visualization software.
  You should be provisioned a desktop nearly immediately.

  If you need dedicated resources for compute or memory intensive workloads use the 
  [Owens Desktop](/pun/sys/dashboard/batch_connect/sys/bc_desktop/owens/session_contexts/new) 
  app where you will have full access to them.
cluster: "quick"
attributes:
  desktop:
    widget: select
    label: "Desktop environment"
    options:
      - ["KDE", "kde"]
      - ["Mate", "mate"]
  bc_num_slots: 1
  bc_num_hours:
    value: 8
  bc_queue: null
  node_type: ":ppn=1:owens"
  bc_email_on_started: 0
  bc_account:
    help: "You can leave this blank if **not** in multiple projects."
submit: submit/container_wrapper.yml.erb
```