### PR TITLE
Fix nginx_clean --user flag

### DIFF
--- a/nginx_stage/lib/nginx_stage/generators/nginx_clean_generator.rb
+++ b/nginx_stage/lib/nginx_stage/generators/nginx_clean_generator.rb
@@ -44,7 +44,7 @@ module NginxStage
 
     add_option :user do
       {
-        opt_args: ["-u", "--user", "# Operate on specific user", "# Default: nil (all users)"],
+        opt_args: ["-u", "--user=USER", "# Operate on specific user", "# Default: nil (all users)"],
         default: nil,
       }
     end
@@ -56,7 +56,7 @@ module NginxStage
     add_hook :delete_puns_of_users_with_no_sessions do
       NginxStage.active_users.each do |u|
         begin
-          next if (user && user != u)
+          next if (user && user != u.to_s)
           pid_path = PidFile.new NginxStage.pun_pid_path(user: u)
           socket = SocketFile.new NginxStage.pun_socket_path(user: u)
           cleanup_stale_files(pid_path, socket) unless pid_path.running_process? 


### PR DESCRIPTION
Fixes #485

Verified in Docker:

```
[root@a00186abb497 /]# /ondemand/nginx_stage/sbin/nginx_stage nginx_clean --user ood --force
ood
```

The issue was the comparison `user != u` was comparing a string against `NginxStage::User`, so doing `to_s` fixes the mixed class comparison.