### PR TITLE
Add support for view.html.erb in VNC apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.7.12] - 2020-05-12
+### Fixed
+- Fix nginx_clean --user --force to properly force kill PUN [#485](https://github.com/OSC/ondemand/issues/485)
+- Linux Host Adapter: fix to work when a user's default shell is not bash [#187](https://github.com/OSC/ood_core/issues/187)
+- Linux Host Adapter: fix issue with wrong arguments passed to pstree [#188](https://github.com/OSC/ood_core/pull/188)
+
 ## [1.7.11] - 2020-04-23
 ### Fixed
 - update to latest `ood_core` patch version to fix calls to
@@ -388,7 +394,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - From 1.3.7 - 1.4.2 updated app versions
 
 
-[Unreleased]: https://github.com/OSC/ondemand/compare/v1.7.11...HEAD
+[Unreleased]: https://github.com/OSC/ondemand/compare/v1.7.12...HEAD
+[1.7.12]: https://github.com/OSC/ondemand/compare/v1.7.11...v1.7.12
 [1.7.11]: https://github.com/OSC/ondemand/compare/v1.7.10...v1.7.11
 [1.7.10]: https://github.com/OSC/ondemand/compare/v1.7.9...v1.7.10
 [1.7.9]: https://github.com/OSC/ondemand/compare/v1.7.8...v1.7.9

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -42,7 +42,7 @@ module BatchConnect::SessionsHelper
           concat created(session)
           concat time(session)
           concat id(session)
-          concat custom_vnc_html(session) if session.running? && session.script_type["vnc"] && session.view
+          concat custom_vnc_html(session) if session.running? && session.view && session.script_type == "vnc"
         end
       )
       concat content_tag(:div) { yield }

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -166,7 +166,7 @@ module BatchConnect::SessionsHelper
     asset_path("noVNC-#{version}/vnc.html?autoconnect=true&password=#{password}&path=rnode/#{connect.host}/#{connect.websocket}/websockify&resize=#{resize}", skip_pipeline: true)
   end
 
-  def connection_tabs(id, tabs)
+  def connection_tabs(id, tabs, is_vnc_session = false, vnc_custom_view = {})
     tabs = Array.wrap(tabs)
     if tabs.any? && tabs.size == 1
       # hr + content
@@ -182,6 +182,16 @@ module BatchConnect::SessionsHelper
     else
       # tabs
       content_tag(:div) do
+        # render custom html if vnc apps have view.html.erb
+        if is_vnc_session && [:connect, :view ].all? { |k| vnc_custom_view.key? k }
+          concat content_tag(:hr)
+          concat(
+            content_tag(:div) do
+              render partial: "batch_connect/sessions/connections/custom", locals: { connect: vnc_custom_view[:connect], view: vnc_custom_view[:view].to_s }
+            end
+          )
+          concat content_tag(:hr)
+        end
         # menu
         concat(
           content_tag(:ul, class: "nav nav-tabs") do

--- a/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
@@ -2,10 +2,10 @@
   <%= session_view session do %>
     <%
       if session.running?
-        if session.view && ! session.script_type["vnc"]
+        if session.view && ! session.script_type == "vnc"
           views = { partial: "custom", locals: { connect: session.connect, view: session.view } }
         else
-          if session.script_type["vnc"]
+          if session.script_type == "vnc"
             views = []
             views << { title: "noVNC Connection",    partial: "novnc",      locals: { connect: session.connect, app_title: session.title } }
             views << { title: "Native Instructions", partial: "native_vnc", locals: { connect: session.connect } } if ENV["ENABLE_NATIVE_VNC"]

--- a/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
@@ -2,10 +2,17 @@
   <%= session_view session do %>
     <%
       if session.running?
-        if session.view
+        if session.view && session.script_type != "vnc"
           views = { partial: "custom", locals: { view: session.view, connect: session.connect } }
         else
           if session.script_type == "vnc"
+            if session.view
+            %>
+              <hr/>
+              <%= OodAppkit.markdown.render(ERB.new(session.view, nil, "-").result(session.connect.instance_eval { binding })).html_safe %>
+              <hr/>
+            <%
+            end
             views = []
             views << { title: "noVNC Connection",    partial: "novnc",      locals: { connect: session.connect, app_title: session.title } }
             views << { title: "Native Instructions", partial: "native_vnc", locals: { connect: session.connect } } if ENV["ENABLE_NATIVE_VNC"]

--- a/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
@@ -21,13 +21,49 @@
         views = { partial: "bad" }
       end
     %>
-    <%=
-      connection_tabs(
-        session.id,
-        views,
-        session.script_type["vnc"] ? true : false,
-        session.running? && session.script_type["vnc"] ? { connect: session.connect, view: session.view } : nil,
-      )
+
+    <%
+      id = session.id
+      tabs = Array.wrap(views)
+
+      if tabs.any? && tabs.size == 1
+        # hr + content
+        capture do
+          tab = tabs.first
+          concat content_tag(:hr)
+          concat(
+            content_tag(:div, class: "ood-appkit markdown") do
+              render partial: "batch_connect/sessions/connections/#{tab[:partial]}", locals: tab[:locals]
+            end
+          )
+        end
+      else
+        # tabs
+        content_tag(:div) do
+          # menu
+          concat(
+            content_tag(:hr) do
+              content_tag(:ul, class: "nav nav-tabs") do
+                tabs.map { |t| t[:title] }.map.with_index do |title, idx|
+                  content_tag(:li, class: "#{"active" if idx.zero?}") do
+                    link_to title, "##{id}_#{idx}", data: { toggle: "tab" }
+                  end
+                end.join("\n").html_safe
+              end
+            end
+          )
+          # content
+          concat(
+            content_tag(:div, class: "tab-content") do
+              tabs.map.with_index do |tab, idx|
+                content_tag(:div, id: "#{id}_#{idx}", class: "tab-pane ood-appkit markdown #{"active" if idx == 0}") do
+                  render partial: "batch_connect/sessions/connections/#{tab[:partial]}", locals: tab[:locals]
+                end
+              end.join("\n").html_safe
+            end
+          )
+        end
+      end
     %>
   <% end %>
 <% end %>

--- a/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/_panel.html.erb
@@ -2,17 +2,10 @@
   <%= session_view session do %>
     <%
       if session.running?
-        if session.view && session.script_type != "vnc"
-          views = { partial: "custom", locals: { view: session.view, connect: session.connect } }
+        if session.view && ! session.script_type["vnc"]
+          views = { partial: "custom", locals: { connect: session.connect, view: session.view } }
         else
-          if session.script_type == "vnc"
-            if session.view
-            %>
-              <hr/>
-              <%= OodAppkit.markdown.render(ERB.new(session.view, nil, "-").result(session.connect.instance_eval { binding })).html_safe %>
-              <hr/>
-            <%
-            end
+          if session.script_type["vnc"]
             views = []
             views << { title: "noVNC Connection",    partial: "novnc",      locals: { connect: session.connect, app_title: session.title } }
             views << { title: "Native Instructions", partial: "native_vnc", locals: { connect: session.connect } } if ENV["ENABLE_NATIVE_VNC"]
@@ -28,6 +21,13 @@
         views = { partial: "bad" }
       end
     %>
-    <%= connection_tabs(session.id, views) %>
+    <%=
+      connection_tabs(
+        session.id,
+        views,
+        session.script_type["vnc"] ? true : false,
+        session.running? && session.script_type["vnc"] ? { connect: session.connect, view: session.view } : nil,
+      )
+    %>
   <% end %>
 <% end %>


### PR DESCRIPTION
This PR adds functionality for rendering custom `view.html.erb` templates in batch connect noVNC applications. Closes #488

Add `view.html.erb` to the root directory of any VNC batch connect application and it will be rendered interactive sessions list on the dashboard like this:

![image](https://user-images.githubusercontent.com/6081892/81976915-3bbe2800-95f7-11ea-86f2-6fb8a110a820.png)

`view.html.erb`:
```html
<h2>Header</h2>
<p>Custom HTML in view.html.erb</p>
```