### PR TITLE
Add support for setting client_max_body_size

### DIFF
--- a/apps/files/app.js
+++ b/apps/files/app.js
@@ -313,7 +313,7 @@ app.use(cloudcmd({
         // treeroottitle: "Project Space"
         treeroot:               HOME,
         treeroottitle:          "Home Directory",
-        upload_max:             process.env.FILE_UPLOAD_MAX || 10485760000,
+        upload_max:             parseInt(process.env.FILE_UPLOAD_MAX) <= parseInt(process.env.NGINX_FILE_UPLOAD_MAX) ? parseInt(process.env.FILE_UPLOAD_MAX) : parseInt(process.env.NGINX_FILE_UPLOAD_MAX) || 10737420000,
         file_editor:            process.env.OOD_FILE_EDITOR || '/pun/sys/file-editor/edit',
         shell:                  (process.env.OOD_SHELL || process.env.OOD_SHELL === "") ? process.env.OOD_SHELL : '/pun/sys/shell/ssh/default',
         ssh_hosts:              sshAppUrls(sshHosts(process.env.OOD_SSH_HOSTS), oodShellUrl()),

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -81,6 +81,20 @@ module NginxStage
     end
   end
 
+  # Maximum file upload size that nginx will allow from clients in bytes
+  # @ example No maximum upload size supplied
+  #   nginx_file_upload_max #=> "10737420000"
+  # @ example 20 gigabyte file size upload limit
+  #   nginx_file_upload_max #=> "21474840000"
+  # @return [String] Maximum upload size for nginx
+  def self.upload_max(default: "10737420000")
+    upload_max = nginx_file_upload_max.to_s.strip
+    if upload_max.empty?
+      default
+    else
+      upload_max
+    end
+  end
 
   # Regex used to parse an app request
   # @example Dev app request
@@ -118,10 +132,11 @@ module NginxStage
       "ONDEMAND_PORTAL" => portal,
       "ONDEMAND_TITLE" => title,
       "SECRET_KEY_BASE" => SecretKeyBaseFile.new(user).secret,
+      "NGINX_FILE_UPLOAD_MAX" => upload_max,
       # only set these if corresponding config is set in nginx_stage.yml
       "OOD_DASHBOARD_TITLE" => title(default: nil),
       "OOD_PORTAL" => portal(default: nil),
-      "OOD_DEV_APPS_ROOT" => apps_root(env: :dev, owner: user)
+      "OOD_DEV_APPS_ROOT" => apps_root(env: :dev, owner: user),
     }.merge(pun_custom_env)
   end
 

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -67,6 +67,10 @@ module NginxStage
     # per-user NGINX configuration options
     #
 
+    # Max file upload size (e.g., 10737420000)
+    # @return [String] the max file size clients can upload in bytes
+    attr_accessor :nginx_file_upload_max
+
     # Custom environment variables to set in the PUN
     # @return [Hash<String, String>] custom env var key and value pairs
     attr_writer :pun_custom_env
@@ -464,6 +468,7 @@ module NginxStage
       self.disabled_shell = '/access/denied'
 
       self.disable_bundle_user_config = true
+      self.nginx_file_upload_max = '10737420000'
 
       read_configuration(default_config_path) if File.file?(default_config_path)
     end

--- a/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
+++ b/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
@@ -55,6 +55,12 @@ module NginxStage
       NginxStage.passenger_python
     end
 
+    # Max file upload size in bytes (e.g., 10737420000)
+    # @return [String] the max file size clients can upload
+    def nginx_file_upload_max
+      NginxStage.nginx_file_upload_max
+    end
+
     # Path to user's personal tmp root
     # @return [String] path to tmp root
     def tmp_root

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -90,6 +90,10 @@
 #
 #passenger_python: '/opt/ood/nginx_stage/bin/python'
 
+# Max file upload size in bytes (e.g., 10737420000)
+#
+#nginx_file_upload_max: '10737420000'
+
 # Root location of per-user NGINX configs
 #
 #pun_config_path: '/var/lib/ondemand-nginx/config/puns/%{user}.conf'

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -58,7 +58,7 @@ http {
   access_log   <%= access_log_path %> main;
   sendfile     on;
   tcp_nopush   on;
-  client_max_body_size 10G;
+  client_max_body_size <%= nginx_file_upload_max %>;
 
   server {
     listen      unix:<%= socket_path %>;


### PR DESCRIPTION
Allow configuration of maximum file upload size in nginx. Closes #424 and Closes #503 

Sets the default `client_max_body_size` to `10G` and allows overriding this value in `nginx_stage.yml` like so:
`nginx_file_upload_max: 50G`