### PR TITLE
Fix Safari CORS bug in noVNC

### DIFF
--- a/apps/dashboard/public/noVNC-1.1.0/vnc.html
+++ b/apps/dashboard/public/noVNC-1.1.0/vnc.html
@@ -58,7 +58,7 @@
     <script nomodule src="shims/url-search-params@0.1.2.min.js"></script>
 
     <!-- this is included as a normal file in order to catch script-loading errors as well -->
-    <script src="app/error-handler.js"></script>
+    <script nomodule src="app/error-handler.js"></script>
 
     <!-- begin scripts -->
     <script type="module">
@@ -76,7 +76,7 @@
             }
         });
     </script>
-    <script type="module" crossorigin="anonymous" src="app/ui.js"></script>
+    <script type="module" crossorigin="use-credentials" src="app/ui.js"></script>
 
 <!-- end scripts -->
 </head>


### PR DESCRIPTION
This PR fixes https://discourse.osc.edu/t/bc-desktop-stopped-working-in-macos-safari-possibly-across-ood-1-7-upgrade/904

Safari 13.1.1 was failing to load app/ui.js because noVNC was attempting to load the ui module without credentials.

![image](https://user-images.githubusercontent.com/6081892/83073584-ab440680-a03e-11ea-950e-473a3ca52450.png)
