### PR TITLE
allow batch_connect apps to use multiple clusters

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -65,7 +65,7 @@ class BatchConnect::SessionContextsController < ApplicationController
 
     # Set the rendering format for displaying attributes
     def set_render_format
-      @render_format = @app.cluster.job_config[:adapter] if @app.cluster
+      @render_format = @app.clusters.first.job_config[:adapter] unless @app.clusters.empty?
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -114,22 +114,26 @@ module BatchConnect
       )
     end
 
-    # Cluster id the batch connect app uses
-    # @return [String, nil] cluster id used by app
-    def cluster_id
-      form_config.fetch(:cluster, nil)
+    # The clusters the batch connect app is configured to use
+    # @return [Array<String>, []] the clusters the app wants to use
+    def configured_clusters
+      Array.wrap(form_config.fetch(:cluster, nil)).compact.map(&:to_sym)
     end
 
-    # The cluster that the batch connect app uses
-    # @return [OodCore::Cluster, nil] cluster that app uses
-    def cluster
-      OodAppkit.clusters[cluster_id] if cluster_id
+    # The clusters that the batch connect app can use. It's a combination
+    # of what the app is configured to use and what the user is allowed
+    # to use.
+    # @return [OodCore::Clusters] clusters available to the app user
+    def clusters
+      OodAppkit.clusters.select do |cluster|
+        (configured_clusters.include? cluster.id) && cluster.job_allow?
+      end
     end
 
     # Whether this is a valid app the user can use
     # @return [Boolean] whether valid app
     def valid?
-      (! form_config.empty?) && cluster && cluster.job_allow?
+      form_config.any? && configured_clusters.any? && clusters.any?
     end
 
     # The reason why this app may or may not be valid
@@ -137,12 +141,11 @@ module BatchConnect
     def validation_reason
       return @validation_reason if @validation_reason
 
-      if !cluster_id
-        "This app does not specify a cluster."
-      elsif !cluster
-        "This app requires a cluster that does not exist."
-      elsif !cluster.job_allow?
-        "You do not have access to use this app."
+      if configured_clusters.empty?
+        "This app does not specify any cluster."
+      elsif clusters.empty?
+        "This app requires clusters that do not exist " +
+        "or you do not have access to."
       else
         ""
       end
@@ -153,6 +156,8 @@ module BatchConnect
     def build_session_context
       local_attribs = form_config.fetch(:attributes, {})
       attrib_list   = form_config.fetch(:form, [])
+      add_cluster_widget(local_attribs, attrib_list)
+
       BatchConnect::SessionContext.new(
         attrib_list.map do |attribute_id|
           attribute_opts = local_attribs.fetch(attribute_id.to_sym, {})
@@ -296,6 +301,24 @@ module BatchConnect
       # The OOD app object describing this app
       def ood_app
         @ood_app ||= OodApp.new(router)
+      end
+
+      # add a widget for choosing the cluster.
+      def add_cluster_widget(attributes, attribute_list)
+        attribute_list.prepend("cluster") unless attribute_list.include? "cluster"
+
+        if clusters.size > 1
+          attributes[:cluster] = {
+            widget: "select",
+            label: "Cluster",
+            options: clusters.map { |cluster| cluster.id.to_s }
+          }
+        else
+          attributes[:cluster] = {
+            value: clusters.first.id.to_s,
+            widget: "hidden_field"
+          }
+        end
       end
   end
 end

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -136,7 +136,7 @@ module BatchConnect
     # @return [Boolean] whether saved successfully
     def save(app:, context:, format: nil)
       self.id         = SecureRandom.uuid
-      self.cluster_id = app.cluster_id
+      self.cluster_id = context.cluster
       self.token      = app.token
       self.title      = app.title
       self.view       = app.session_view


### PR DESCRIPTION
A possible fix to #227.  

Users only need to add items to the `cluster` attribute like below to enable a dropdown. If only 1 cluster is given, a hidden element in the form is generated that has the value of the cluster so it has backward compatibility. 
```yaml
cluster:
- owens
- pitzer
```

A possible enhancement may be to allow users to redo the cluster attribute as so say turn `owens` into `Owens` for example.  This is also rather simplistic so check or enforce that all the clusters be of the same scheduler type.