### PR TITLE
allow batch_connect apps to accept regular expressions as their

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -117,7 +117,7 @@ module BatchConnect
     # The clusters the batch connect app is configured to use
     # @return [Array<String>, []] the clusters the app wants to use
     def configured_clusters
-      Array.wrap(form_config.fetch(:cluster, nil)).compact.map(&:to_sym)
+      Array.wrap(form_config.fetch(:cluster, nil)).compact.map { |c| c.to_s.strip.eql?("*") ? ".*" : c.to_s.strip }
     end
 
     # The clusters that the batch connect app can use. It's a combination
@@ -125,8 +125,10 @@ module BatchConnect
     # to use.
     # @return [OodCore::Clusters] clusters available to the app user
     def clusters
+      cluster_regex = configured_clusters.join('|')
+
       OodAppkit.clusters.select do |cluster|
-        (configured_clusters.include? cluster.id) && cluster.job_allow?
+        cluster.id.to_s.match(/^#{cluster_regex}$/) && cluster.job_allow?
       end
     end
 

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -132,7 +132,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       r.path.join("form.yml").write("cluster: '*'")
 
       app = BatchConnect::App.new(router: r)
-      STDERR.write "#{app.configured_clusters} and #{app.clusters.inspect}"
       assert app.valid?
       assert_equal good_clusters, app.clusters # make sure you only allow good clusters
     }

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -120,4 +120,62 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       assert_equal [ OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}}) ], app.clusters
     }
   end
+
+  test "app with special case of all clusters (*)" do
+    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
+
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      # note the format here, it's a string not array for backward compatability
+      # and it's the special case * (not the regex .*). Also note the quotes, those
+      # are nessecary for yaml to parse it correctly
+      r.path.join("form.yml").write("cluster: '*'")
+
+      app = BatchConnect::App.new(router: r)
+      STDERR.write "#{app.configured_clusters} and #{app.clusters.inspect}"
+      assert app.valid?
+      assert_equal good_clusters, app.clusters # make sure you only allow good clusters
+    }
+  end
+
+  test "app with all clusters regex" do
+    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
+
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      # not the special case * but the regex .*
+      r.path.join("form.yml").write("cluster: .*")
+
+      app = BatchConnect::App.new(router: r)
+      assert app.valid?
+      assert_equal good_clusters, app.clusters # make sure you only allow good clusters
+    }
+  end
+
+  test "app with single regex to get owens" do
+    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
+
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      r.path.join("form.yml").write("cluster: o.*")
+
+      app = BatchConnect::App.new(router: r)
+      assert app.valid?
+      assert_equal [ OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}}) ], app.clusters
+    }
+  end
+
+  test "app with single regex to get owens and pitzer" do
+    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
+
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      # try to pick up owens pitzter and ruby by regexs
+      r.path.join("form.yml").write("cluster:\n  - o.*\n  - p.*\n  - r.*")
+
+      app = BatchConnect::App.new(router: r)
+      assert app.valid?
+      assert_equal good_clusters, app.clusters # make sure you only allow good clusters
+    }
+  end
 end


### PR DESCRIPTION
Solution for #531.  The only oddity I found is that `*` needs to be quoted where something like `.*` doesn't. YAML for whatever reason doesn't parse it correctly so we'll have to be sure to highlight that folks need to use `cluster: '*'` if they want to use that alias.