### PR TITLE
allow users to change cluster dropdown in the form yml

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -135,7 +135,9 @@ module BatchConnect
     # Whether this is a valid app the user can use
     # @return [Boolean] whether valid app
     def valid?
-      form_config.any? && configured_clusters.any? && clusters.any?
+      form_config.any? &&
+        # top level cluster(s) is defined and valid OR form.cluster exists
+        ((configured_clusters.any? && clusters.any?) || form_config.fetch(:form, []).include?('cluster'))
     end
 
     # The reason why this app may or may not be valid
@@ -306,8 +308,9 @@ module BatchConnect
       end
 
       # add a widget for choosing the cluster if one doesn't already exist
+      # and if users aren't defining they're own form.cluster and attributes.cluster
       def add_cluster_widget(attributes, attribute_list)
-        return if attribute_list.include?("cluster") && !attributes[:cluster].nil?
+        return unless configured_clusters.any?
 
         attribute_list.prepend("cluster") unless attribute_list.include?("cluster")
 

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -135,9 +135,13 @@ module BatchConnect
     # Whether this is a valid app the user can use
     # @return [Boolean] whether valid app
     def valid?
-      form_config.any? &&
-        # top level cluster(s) is defined and valid OR form.cluster exists
-        ((configured_clusters.any? && clusters.any?) || form_config.fetch(:form, []).include?('cluster'))
+      if form_config.empty?
+        false
+      elsif configured_clusters.any?
+        clusters.any?
+      else
+        true
+      end
     end
 
     # The reason why this app may or may not be valid

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -305,9 +305,11 @@ module BatchConnect
         @ood_app ||= OodApp.new(router)
       end
 
-      # add a widget for choosing the cluster.
+      # add a widget for choosing the cluster if one doesn't already exist
       def add_cluster_widget(attributes, attribute_list)
-        attribute_list.prepend("cluster") unless attribute_list.include? "cluster"
+        return if attribute_list.include?("cluster") && !attributes[:cluster].nil?
+
+        attribute_list.prepend("cluster") unless attribute_list.include?("cluster")
 
         if clusters.size > 1
           attributes[:cluster] = {

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -177,4 +177,31 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       assert_equal good_clusters, app.clusters # make sure you only allow good clusters
     }
   end
+
+  test "app with user defined cluster" do
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      r.path.join("form.yml").write("form:\n  - cluster")
+
+      app = BatchConnect::App.new(router: r)
+      # it's valid but there are no clusters. they're user defined and not validated by us
+      assert app.valid?
+      assert_equal [], app.clusters
+    }
+  end
+
+
+  test "valid yaml but invalid cluster" do
+    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
+
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      # try to pick up owens pitzter and ruby by regexs
+      r.path.join("form.yml").write("form:\n  - foo\n")
+
+      app = BatchConnect::App.new(router: r)
+      # need to have either cluster or form.cluster
+      assert ! app.valid?
+    }
+  end
 end

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -189,19 +189,4 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       assert_equal [], app.clusters
     }
   end
-
-
-  test "valid yaml but invalid cluster" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
-    Dir.mktmpdir { |dir|
-      r = PathRouter.new(dir)
-      # try to pick up owens pitzter and ruby by regexs
-      r.path.join("form.yml").write("form:\n  - foo\n")
-
-      app = BatchConnect::App.new(router: r)
-      # need to have either cluster or form.cluster
-      assert ! app.valid?
-    }
-  end
 end


### PR DESCRIPTION
Fixes #532 

* users can change the order (the cluster is usually first) by
  specifying cluster in the form
* if attributes are specified the bc app now respects that config
  but does not do any validation