### PR TITLE
add a gh action for creating documentation issues on PRs

### DIFF
--- a/.github/workflows/document-merge.yml
+++ b/.github/workflows/document-merge.yml
@@ -1,0 +1,26 @@
+name: Create Document issue for Merge Request
+
+# Run this action when we merge into master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  # Create an issue on the documentation repository to document whatever was just pulled in.
+  create-doc-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create an issue on the documentation repository
+        run: |
+          TITLE=$(git log --oneline | head -n 1 | cut -d' ' -f2-)
+
+          curl --silent --output /dev/null --request POST \
+          --url https://api.github.com/repos/OSC/ood-documentation/issues \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data "{
+              'title': 'OOD PR $TITLE',
+              'body': 'Create documentation for https://github.com/OSC/ondemand/commit/$GITHUB_SHA'
+            }"


### PR DESCRIPTION
We have so many things in flight and being pulled in. I thought it may be nice to have some automation to create documentation tickets whenever we pull in something so things so we at least have the reminder in the form of issues on the documentation repo.