### PR TITLE
Make Dashboard logo responsive

### DIFF
--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -10,16 +10,9 @@ module DashboardHelper
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      logo_css_attributes = "margin-bottom: 10px;"
-
-      if uri.extname == ".svg"
-        logo_css_attributes.concat("height: #{Configuration.logo_height if Configuration.logo_height}px;")
-        %(<img src="#{uri}" alt="logo" style="#{ logo_css_attributes }" />).html_safe
-      else
-        %(<img src="#{uri}" alt="logo" style="#{ logo_css_attributes }" />).html_safe
-      end
+      tag.img src: uri, alt: "logo", height: Configuration.logo_height, style: "margin-bottom: 10px"
     else # default logo image
-      image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", style: "margin-bottom: 10px")
+      image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85px", style: "margin-bottom: 10px")
     end
   end
 

--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -6,14 +6,18 @@ module DashboardHelper
     text
   end
 
-  def logo_image_tag(url)
+  def logo_image_tag(url, responsive = false)
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      content_tag(:div, class: "row") do
-        content_tag(:div, class: "col-sm-6 col-md-6 col-lg-6") do
-          image_tag("#{uri}", class: "img-responsive", alt: "logo").html_safe
+      if responsive
+        content_tag(:div, class: "row") do
+          content_tag(:div, class: "col-sm-6 col-md-6 col-lg-6") do
+            image_tag("#{uri}", class: "img-responsive", alt: "logo").html_safe
+          end
         end
+      else
+        %(<img src="#{uri}" alt="logo" />).html_safe
       end
     else # default logo image
       image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", style: "margin-bottom: 10px")

--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -10,7 +10,11 @@ module DashboardHelper
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      %(<img src="#{uri}" alt="logo" />).html_safe
+      content_tag(:div, class: "row") do
+        content_tag(:div, class: "col-sm-6 col-md-6 col-lg-6") do
+          image_tag("#{uri}", class: "img-responsive", alt: "logo").html_safe
+        end
+      end
     else # default logo image
       image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", style: "margin-bottom: 10px")
     end

--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -6,18 +6,17 @@ module DashboardHelper
     text
   end
 
-  def logo_image_tag(url, responsive = false)
+  def logo_image_tag(url)
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      if responsive
-        content_tag(:div, class: "row") do
-          content_tag(:div, class: "col-sm-6 col-md-6 col-lg-6") do
-            image_tag("#{uri}", class: "img-responsive", alt: "logo").html_safe
-          end
-        end
+      logo_css_attributes = "margin-bottom: 10px;"
+
+      if uri.extname == ".svg"
+        logo_css_attributes.concat("height: #{Configuration.logo_height if Configuration.logo_height}px;")
+        %(<img src="#{uri}" alt="logo" style="#{ logo_css_attributes }" />).html_safe
       else
-        %(<img src="#{uri}" alt="logo" />).html_safe
+        %(<img src="#{uri}" alt="logo" style="#{ logo_css_attributes }" />).html_safe
       end
     else # default logo image
       image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", style: "margin-bottom: 10px")

--- a/apps/dashboard/app/views/shared/_welcome.html.erb
+++ b/apps/dashboard/app/views/shared/_welcome.html.erb
@@ -1,1 +1,1 @@
-<%= t('dashboard.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img, responsive = true) : "") %>
+<%= t('dashboard.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>

--- a/apps/dashboard/app/views/shared/_welcome.html.erb
+++ b/apps/dashboard/app/views/shared/_welcome.html.erb
@@ -1,1 +1,1 @@
-<%= t('dashboard.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>
+<%= t('dashboard.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img, responsive = true) : "") %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -188,7 +188,7 @@ end
   end
 
   # Dashboard logo height used to set the height style attribute
-  # @return [String, nil] Logo height in pixels
+  # @return [String, nil] Logo height
   def logo_height
     ENV["OOD_DASHBOARD_LOGO_HEIGHT"]
   end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -187,6 +187,12 @@ end
     !to_bool(ENV["DISABLE_DASHBOARD_LOGO"])
   end
 
+  # Dashboard logo height used to set the height style attribute
+  # @return [String, nil] Logo height in pixels
+  def logo_height
+    ENV["OOD_DASHBOARD_LOGO_HEIGHT"]
+  end
+
   def brand_bg_color
     ENV.values_at('OOD_BRAND_BG_COLOR', 'BOOTSTRAP_NAVBAR_DEFAULT_BG', 'BOOTSTRAP_NAVBAR_INVERSE_BG').compact.first
   end

--- a/apps/dashboard/config/examples/osc/env
+++ b/apps/dashboard/config/examples/osc/env
@@ -4,6 +4,7 @@ MOTD_PATH="/etc/motd"
 MOTD_FORMAT="osc"
 
 OOD_DASHBOARD_LOGO="/public/logo.png"
+OOD_DASHBOARD_LOGO_HEIGHT="85px"
 OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/supercomputing_support"
 OOD_DASHBOARD_SUPPORT_EMAIL="oschelp@osc.edu"
 


### PR DESCRIPTION
We wanted to use an SVG version of our at OSC. SVGs scale infinitely, I needed to set the height on the image. I made use of Bootstrap 3's grid system to do this responsively.

**Net Improvements:**
* Fixes Dashboard logo appearing to be cut off on mobile devices

**Old version:**
<img src="https://user-images.githubusercontent.com/6081892/85456997-896e6e80-b56d-11ea-803d-c3133bc581c7.PNG" width="250">

**New version:**
<img src="https://user-images.githubusercontent.com/6081892/85457014-8d01f580-b56d-11ea-9cd0-e41cda0f990f.PNG" width="250">