### PR TITLE
Shell websocket error fix

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -8,6 +8,7 @@ var hbs       = require('hbs');
 var dotenv    = require('dotenv');
 var Tokens    = require('csrf');
 var url       = require('url');
+var URLSearchParams = require('url-search-params');
 var port      = 3000;
 
 // Read in environment variables

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -20,7 +20,8 @@
     "hbs": "^4.1.0",
     "minimist": ">=1.2.2",
     "node-pty": "^0.9.0",
-    "ws": ">=7.2.0"
+    "ws": ">=7.2.0",
+    "url-search-params": ">=0.10.0",
   },
   "private": true,
   "resolutions": {

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -21,7 +21,7 @@
     "minimist": ">=1.2.2",
     "node-pty": "^0.9.0",
     "ws": ">=7.2.0",
-    "url-search-params": ">=0.10.0",
+    "url-search-params": ">=0.10.0"
   },
   "private": true,
   "resolutions": {


### PR DESCRIPTION
Using the shell application on Chromium based browsers brought up an error when trying to connect. I was able to track down the error to `URLSearchParams` not being defined. I added an `npm` package which fixes this with a polyfill. I tested it on my cluster and it worked.