### PR TITLE
Allow users to specify cluster in the submit.yml.erb

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -142,7 +142,9 @@ module BatchConnect
       self.created_at = Time.now.to_i
 
       submit_script = app.submit_opts(context, fmt: format) # could raise an exception
-      set_cluster_id(context, submit_script) # could also raise ClusterNotFound exception
+
+      self.cluster_id = submit_script.fetch(:cluster, context.try(:cluster)).to_s
+      raise(ClusterNotFound, I18n.t('dashboard.batch_connect_missing_cluster')) unless self.cluster_id.present?
 
       stage(app.root.join("template"), context: context) &&
         submit(submit_script)
@@ -433,19 +435,6 @@ module BatchConnect
           file.rename rendered_file     # keep same file permissions
           rendered_file.write(rendered)
         end
-      end
-
-      # Sets the self.cluster_id from the SessionContext (the form.yml.erb)
-      # or the submit_opts from the submit.yml.erb.
-      # Throws a ClusterNotFound if it cannot be set from either of these.
-      def set_cluster_id(context, submit_opts)
-        self.cluster_id = if submit_opts.fetch(:cluster, nil)
-                            submit_opts.fetch(:cluster, nil).to_s
-                          elsif context.respond_to?(:cluster)
-                            context.cluster
-                          else
-                            raise(ClusterNotFound, I18n.t('dashboard.batch_connect_missing_cluster'))
-                          end
       end
   end
 end

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -75,6 +75,9 @@ en:
     batch_connect_no_apps: "There are no available Interactive Apps."
     batch_connect_no_sessions: "You have no active sessions."
     batch_connect_sandbox: " [Sandbox]"
+    batch_connect_missing_cluster: |
+      The cluster was never set. Either set it in form.yml.erb with `cluster` or `form.cluster` or
+      set `cluster` in submit.yml.erb.
     batch_connect_sessions_data_html: |
       The %{title} session data for this session can be accessed
       under the %{data_link_tag}.

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -91,22 +91,36 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
   end
 
   test "session correctly sets cluster_id from the form" do
+    BatchConnect::Session.any_instance.stubs(:stage).returns(true)
+    BatchConnect::Session.any_instance.stubs(:submit).returns(true)
     BatchConnect::SessionContext.any_instance.stubs(:cluster).returns('owens')
+    BatchConnect::App.any_instance.stubs(:submit_opts).returns({})
 
+    app = BatchConnect::App.from_token("dev/test")
     session = BatchConnect::Session.new
-    session.send(:set_cluster_id, BatchConnect::SessionContext.new, {})
+
+    session.save(app: app, context: BatchConnect::SessionContext.new)
     assert_equal 'owens', session.cluster_id
   end
 
   test "session correctly sets cluster_id from the sumit options" do
+    BatchConnect::Session.any_instance.stubs(:stage).returns(true)
+    BatchConnect::Session.any_instance.stubs(:submit).returns(true)
+    BatchConnect::App.any_instance.stubs(:submit_opts).returns({:cluster => 'owens'})
+
+    app = BatchConnect::App.from_token("dev/test")
     session = BatchConnect::Session.new
-    session.send(:set_cluster_id, BatchConnect::SessionContext.new, {:cluster => 'owens'})
+
+    session.save(app: app, context: BatchConnect::SessionContext.new)
     assert_equal 'owens', session.cluster_id
   end
 
   test "session throws exception when no cluster is available" do
-    assert_raise BatchConnect::Session::ClusterNotFound do
-      BatchConnect::Session.new.send(:set_cluster_id, BatchConnect::SessionContext.new, {})
-    end
+    app = BatchConnect::App.from_token("dev/test")
+    session = BatchConnect::Session.new
+
+    save = session.save(app: app, context: BatchConnect::SessionContext.new)
+    assert_equal false, save
+    assert_equal I18n.t('dashboard.batch_connect_missing_cluster'), session.errors[:save].first
   end
 end

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -89,4 +89,24 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       assert_equal 'ood-sys-dashboard-rstudio', BatchConnect::Session.new.script_options[:job_name]
     end
   end
+
+  test "session correctly sets cluster_id from the form" do
+    BatchConnect::SessionContext.any_instance.stubs(:cluster).returns('owens')
+
+    session = BatchConnect::Session.new
+    session.send(:set_cluster_id, BatchConnect::SessionContext.new, {})
+    assert_equal 'owens', session.cluster_id
+  end
+
+  test "session correctly sets cluster_id from the sumit options" do
+    session = BatchConnect::Session.new
+    session.send(:set_cluster_id, BatchConnect::SessionContext.new, {:cluster => 'owens'})
+    assert_equal 'owens', session.cluster_id
+  end
+
+  test "session throws exception when no cluster is available" do
+    assert_raise BatchConnect::Session::ClusterNotFound do
+      BatchConnect::Session.new.send(:set_cluster_id, BatchConnect::SessionContext.new, {})
+    end
+  end
 end


### PR DESCRIPTION
Fix for #529 

Users can now specify the cluster in the form.yml.erb or the submit.yml.erb files.  If not defined in either, the dashboard now throws a translatable error message. 

cluster is expected to be a string on the top level yaml of the submit.yml file.  Something like this:
```erb
<%-
  cluster = 'owens'
-%>
---
cluster: "<%= cluster %>"
batch_connect:
  template: "basic"
```
