### PR TITLE
use oscwiag token instead of gh action token

### DIFF
--- a/.github/workflows/document-merge.yml
+++ b/.github/workflows/document-merge.yml
@@ -22,6 +22,6 @@ jobs:
 
           curl --silent --output /dev/null --request POST \
           --url https://api.github.com/repos/OSC/ood-documentation/issues \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'Authorization: token ${{ secrets.OSCWIAG_ISSUE_TOKEN }}' \
           --header 'content-type: application/json' \
           --data "$BODY"


### PR DESCRIPTION
OK third time's the charm. I created a new token for the oscwiag user, applied it to this repo and so the tickets will be created by @oscwiag. 