### PR TITLE
Add support for custom info in batch connect apps

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -42,9 +42,18 @@ module BatchConnect::SessionsHelper
           concat created(session)
           concat time(session)
           concat id(session)
+          safe_concat custom_info_view(session) if session.info_view
         end
       )
       concat content_tag(:div) { yield }
+    end
+  end
+
+  def custom_info_view(session)
+    content_tag(:div) do
+      content_tag(:hr) do
+        render partial: "batch_connect/sessions/connections/info", locals: { view: session.info_view, session: session }
+      end
     end
   end
 
@@ -182,6 +191,7 @@ module BatchConnect::SessionsHelper
     else
       # tabs
       content_tag(:div) do
+        concat content_tag(:hr)
         # menu
         concat(
           content_tag(:ul, class: "nav nav-tabs") do

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -200,6 +200,12 @@ module BatchConnect
       file.read if file.file?
     end
 
+    # View used for session info if it exists
+    # @return [String, nil] session info
+    def session_info_view
+      Pathname.new(root).glob("info.{md,html}.erb").find(&:file?).try(:read)
+    end
+
     # Paths to custom javascript files
     # @return [Pathname] paths to custom javascript files that exist
     def custom_javascript_files

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -41,6 +41,10 @@ module BatchConnect
     # @return [String, nil] session view
     attr_accessor :view
 
+    # The view used to display custom info for this session
+    # @return [String, nil] session info
+    attr_accessor :info_view
+
     # Batch connect script type
     # @return [String] script type
     attr_accessor :script_type
@@ -48,7 +52,7 @@ module BatchConnect
     # Attributes used for serialization
     # @return [Hash] attributes to be serialized
     def attributes
-      %w(id cluster_id job_id created_at token title view script_type).map do |attribute|
+      %w(id cluster_id job_id created_at token title view info_view script_type).map do |attribute|
         [ attribute, nil ]
       end.to_h
     end
@@ -140,6 +144,7 @@ module BatchConnect
       self.token      = app.token
       self.title      = app.title
       self.view       = app.session_view
+      self.info_view  = app.session_info_view
       self.created_at = Time.now.to_i
 
       submit_script = app.submit_opts(context, fmt: format) # could raise an exception

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_info.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_info.html.erb
@@ -1,0 +1,1 @@
+<%= OodAppkit.markdown.render(ERB.new(view, nil, "-").result(session.instance_eval { binding })).html_safe %>


### PR DESCRIPTION
Adds functionality to allow any batch connect application include `info.html.erb` in its root directory and that info will be rendered in the session panel view. Closes #488.

<img src="https://user-images.githubusercontent.com/6081892/85978262-5fbda900-b9ac-11ea-9c6e-9393a3d7f3f8.png" width="750"/>

`info.html.erb` in this example:
```html
Custom info.html.erb on Code Server app

<h1>HTML works here</h1>

Customize your batch connect apps with custom info.html.erb
```