### PR TITLE
Update rendering logic in session panel helper

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -61,10 +61,10 @@ gem 'mocha', '~> 1.1', group: :test
 gem 'autoprefixer-rails', '~> 8.4'
 gem 'dotiw'
 gem 'local_time', '~> 1.0.3'
+gem 'turbolinks', '~> 5.2.0'
 
 # OOD specific gems
 gem 'ood_support', '~> 0.0.2'
 gem 'ood_appkit', '~> 1.1'
 gem 'ood_core', '~> 0.11'
 gem 'pbs', '~> 2.2.1'
-gem 'turbolinks', '~> 5.2.0'

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -42,6 +42,7 @@ module BatchConnect::SessionsHelper
           concat created(session)
           concat time(session)
           concat id(session)
+          concat tag.hr                         if session.info_view
           safe_concat custom_info_view(session) if session.info_view
         end
       )
@@ -51,9 +52,7 @@ module BatchConnect::SessionsHelper
 
   def custom_info_view(session)
     content_tag(:div) do
-      content_tag(:hr) do
-        render partial: "batch_connect/sessions/connections/info", locals: { view: session.info_view, session: session }
-      end
+      concat render partial: "batch_connect/sessions/connections/info", locals: { view: session.info_view, session: session }
     end
   end
 
@@ -181,7 +180,7 @@ module BatchConnect::SessionsHelper
       # hr + content
       capture do
         tab = tabs.first
-        concat content_tag(:hr)
+        concat tag.hr
         concat(
           content_tag(:div, class: "ood-appkit markdown") do
             render partial: "batch_connect/sessions/connections/#{tab[:partial]}", locals: tab[:locals]
@@ -191,7 +190,6 @@ module BatchConnect::SessionsHelper
     else
       # tabs
       content_tag(:div) do
-        concat content_tag(:hr)
         # menu
         concat(
           content_tag(:ul, class: "nav nav-tabs") do


### PR DESCRIPTION
Moves rendering `<hr>` tag from `custom_info_view()` into `session_view()`

The `info` partial shouldn't be aware of where its rendered, this PR fixes that
