### PR TITLE
Refactor Shell app, add code standards and utility functions 

### DIFF
--- a/apps/shell/.eslintignore
+++ b/apps/shell/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+tests

--- a/apps/shell/.eslintrc.json
+++ b/apps/shell/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "extends": [
+    "standard",
+    "prettier",
+    "plugin:node/recommended"
+  ],
+  "plugins": [
+    "prettier"
+  ],
+  "rules": {
+    "prettier/prettier": "error",
+    "no-unused-vars": "warn",
+    "func-names": "off",
+    "object-shorthand": "off",
+    "semi": "off",
+    "multiline-comment-style": [
+      "error",
+      "starred-block"
+    ],
+    "no-var": "error",
+    "new-cap": "off",
+    "no-template-curly-in-string": "warn"
+  },
+  "env": {
+    "node": true,
+    "browser": true
+  }
+}

--- a/apps/shell/.gitignore
+++ b/apps/shell/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.vscode
+tmp

--- a/apps/shell/.prettierignore
+++ b/apps/shell/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+package.json

--- a/apps/shell/.prettierrc.json
+++ b/apps/shell/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "proseWrap": "always"
+}

--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -78,8 +78,13 @@ default_sshhost = process.env.DEFAULT_SSHHOST || default_sshhost;
 if (default_sshhost) host_whitelist.add(default_sshhost);
 function host_and_dir_from_url(url){
   let match = url.match(host_path_rx),
-  hostname = match[1] === "default" ? default_sshhost : match[1],
-  directory = match[2] ? decodeURIComponent(match[2]) : null;
+  hostname = default_sshhost, 
+  directory = null;
+
+  if (match) {
+    hostname = match[1] === "default" ? default_sshhost : match[1];
+    directory = match[2] ? decodeURIComponent(match[2]) : null;
+  }
 
   return [hostname, directory];
 }

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -41,10 +41,14 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "jest": "^26.1.0",
     "prettier": "2.0.5",
     "prettier-eslint": "^11.0.0"
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "scripts": {
+    "test": "npx jest"
   }
 }

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -30,5 +30,21 @@
     "minimist": "1.2.5",
     "inherits": "2.0.3",
     "http-errors": "1.7.2"
+  },
+  "devDependencies": {
+    "eslint": "7.2.0",
+    "eslint-config-node": "^4.1.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "prettier": "2.0.5",
+    "prettier-eslint": "^11.0.0"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   }
 }

--- a/apps/shell/utils/helpers.js
+++ b/apps/shell/utils/helpers.js
@@ -1,0 +1,106 @@
+const glob = require('glob');
+const path = require('path');
+const yaml = require('js-yaml');
+const fs = require('fs');
+
+const HOST_PATH_RX = '/ssh/([^\\/\\?]+)([^\\?]+)?(\\?.*)?$';
+
+let defaultSshHost = () => {
+  return process.env.DEFAULT_SSHHOST ? process.env.DEFAULT_SSHHOST : null;
+};
+
+const wsErrorMessage = (message) => {
+  return (
+    [
+      'HTTP/1.1 401 Unauthorized',
+      'Content-Type: text/html; charset=UTF-8',
+      'Content-Encoding: UTF-8',
+      'Connection: close',
+      `X-OOD-Failure-Reason: ${message}`,
+    ].join('\r\n') + '\r\n\r\n'
+  );
+};
+
+const hostAllowList = () => {
+  let hostAllowList = new Set();
+
+  if (process.env.SSHHOST_WHITELIST) {
+    hostAllowList = new Set(process.env.SSHHOST_WHITELIST.split(':'));
+  }
+
+  glob
+    .sync(
+      path.join(
+        process.env.OOD_CLUSTERS || '/etc/ood/config/clusters.d',
+        '*.y*ml',
+      ),
+    )
+    .map((yml) => yaml.safeLoad(fs.readFileSync(yml)))
+    .filter(
+      (config) =>
+        config.v2 &&
+        config.v2.login &&
+        config.v2.login.host &&
+        !(config.v2 && config.v2.metadata && config.v2.metadata.hidden),
+    )
+    .forEach((config) => {
+      const host = config.v2.login.host;
+      const isDefault = config.v2.login.default;
+      hostAllowList.add(host);
+      if (isDefault) {
+        defaultSshHost = host;
+      }
+    });
+
+  if (defaultSshHost) {
+    hostAllowList.add(defaultSshHost);
+  }
+
+  return hostAllowList;
+};
+
+const parseUrl = (url) => {
+  const match = url.match(HOST_PATH_RX);
+  let hostname = defaultSshHost();
+  let directory = null;
+
+  if (match) {
+    hostname = match[1] === 'default' ? defaultSshHost() : match[1];
+    directory = match[2] ? decodeURIComponent(match[2]) : null;
+  }
+
+  return [hostname, directory];
+};
+
+function defaultServerOrigin(headers) {
+  let origin;
+
+  if (headers['x-forwarded-proto'] && headers['x-forwarded-host']) {
+    origin = headers['x-forwarded-proto'] + '://' + headers['x-forwarded-host'];
+  }
+
+  return origin;
+}
+
+function customServerOrigin(defaultValue = null) {
+  let customOrign;
+
+  if (process.env.OOD_SHELL_ORIGIN_CHECK) {
+    // if ENV is set, do not use default!
+    if (process.env.OOD_SHELL_ORIGIN_CHECK.startsWith('http')) {
+      customOrign = process.env.OOD_SHELL_ORIGIN_CHECK;
+    }
+  } else {
+    customOrign = defaultValue;
+  }
+
+  return customOrign;
+}
+
+module.exports = {
+  parseUrl,
+  hostAllowList,
+  defaultServerOrigin,
+  customServerOrigin,
+  wsErrorMessage,
+};


### PR DESCRIPTION
This PR accomplishes a couple of things. 

1.  We needed code linting, there's quite a few people who work on the Shell app and a styling standard needs enforced. I chose [Standard JavaScript](https://github.com/standard/standard) and am also enforcing rules with [Prettier ](https://prettier.io/) along with ESLint.  Yes you have to setup ESLint on VSCode or Sublime or whatever now, but it's worth and we won't have to go back and forth in PRs about styling. Increased development velocity is essential.

2. This PR is a major refactor that laid down the foundation so we can write tests for the Shell app. `app.js` imports helper functions from `utils/helpers.js` and our tests will do the same.

3. There was lots of [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) in the websocket connection upgrade handler, that's now moved into a helper function (`wsErrorMessage`)