### PR TITLE
include gems for status apps

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -69,3 +69,8 @@ gem 'ood_support', '~> 0.0.2'
 gem 'ood_appkit', '~> 1.1'
 gem 'ood_core', '~> 0.11'
 gem 'pbs', '~> 2.2.1'
+
+# gems to include in ondemand-gems repo for status apps to use
+gem "sinatra", require: false
+gem "sinatra-contrib", require: false
+gem "erubi", require: false

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (8.6.5)
       execjs
+    backports (3.18.1)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -113,6 +114,9 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     mocha (1.11.2)
+    multi_json (1.15.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -130,6 +134,8 @@ GEM
       ffi (~> 1.9, >= 1.9.6)
     public_suffix (4.0.5)
     rack (2.2.3)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -169,6 +175,7 @@ GEM
     redcarpet (3.5.0)
     request_store (1.5.0)
       rack (>= 1.4)
+    ruby2_keywords (0.0.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -184,6 +191,18 @@ GEM
       ffi (~> 1.9)
     sdoc (1.1.0)
       rdoc (>= 5.0)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.8.1)
+      backports (>= 2.8.2)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.8.1)
+      sinatra (= 2.0.8.1)
+      tilt (~> 2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -221,6 +240,7 @@ DEPENDENCIES
   data-confirm-modal (~> 1.2)
   dotenv-rails (~> 2.1)
   dotiw
+  erubi
   font-awesome-sass (= 5.12.0)
   jbuilder (~> 2.0)
   jquery-datatables-rails (~> 3.4)
@@ -236,6 +256,8 @@ DEPENDENCIES
   redcarpet (~> 3.3)
   sass-rails (~> 5.0)
   sdoc
+  sinatra
+  sinatra-contrib
   thor (= 0.19.1)
   timecop (~> 0.9)
   turbolinks (~> 5.2.0)


### PR DESCRIPTION
gems in the dashboard (and other core app) gemfiles get
added to the ondemand-gems rpm which gets installed system wide
and made available when doing module load ondemand

so with these three gems we can make status apps like the system status
app or the example passenger app, without requiring a Gemfile or
installing gems to the app directory