### PR TITLE
add missing stats to XDMoD report request

### DIFF
--- a/apps/dashboard/app/views/dashboard/_xdmod_widget_job_efficiency.html.erb
+++ b/apps/dashboard/app/views/dashboard/_xdmod_widget_job_efficiency.html.erb
@@ -51,8 +51,9 @@ jobsUrl.searchParams.set('config', JSON.stringify({
   "end_date": today,
   "order_by":{
     "field":"core_time_bad",
-    "dirn":"desc"},
-  "statistics":["core_time_bad","bad_core_ratio"]
+    "dirn":"desc"
+  },
+  "statistics": ["core_time","core_time_bad","bad_core_ratio","job_count","job_count_bad","bad_job_ratio"]
 }));
 
 var template_source = $('#job-efficiency-template').html();


### PR DESCRIPTION
the job efficiency report request wasn't specifying all the statistics required
which caused the report to return a subset of the required data in XDMoD 9