### PR TITLE
Fix for Firefox not submitting

### DIFF
--- a/apps/dashboard/app/assets/javascripts/application.js
+++ b/apps/dashboard/app/assets/javascripts/application.js
@@ -102,7 +102,7 @@ function promiseLoginToXDMoD(xdmodUrl){
       .then(function(data){
         return new Promise(function(resolve, reject){
           var xdmodLogin = document.createElement('iframe');
-          xdmodLogin.style = 'display:none;left: -10000';
+          xdmodLogin.style = 'visibility: hidden; position: absolute;left: -1000px';
           xdmodLogin.id = 'xdmod_login_iframe'
           xdmodLogin.src = data;
           document.body.appendChild(xdmodLogin);


### PR DESCRIPTION
Working with @ericfranz found that FireFox was not doing the login properly.
The issue being that an iframe with display:none wont allow the javascript inside of it to click a form element.
Also left -10000 is not valid it needs to be in px