### PR TITLE
Add backwards compatibility in Shell app for default SSH host

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -74,7 +74,7 @@ glob.sync(path.join((process.env.OOD_CLUSTERS || '/etc/ood/config/clusters.d'), 
     if (isDefault) default_sshhost = host;
   });
 
-default_sshhost = process.env.OOD_DEFAULT_SSHHOST || default_sshhost;
+default_sshhost = process.env.OOD_DEFAULT_SSHHOST || process.env.DEFAULT_SSHHOST|| default_sshhost;
 if (default_sshhost) host_allowlist.add(default_sshhost);
 function host_and_dir_from_url(url){
   let match = url.match(host_path_rx),


### PR DESCRIPTION
All environment variables in the Shell app are prepended with `OOD`. This PR adds adds backwards compatibility for `DEFAULT_SSHHOST` so its accepted, though `OOD_DEFAULT_SSHHOST` is preferred. Closes #602