### PR TITLE
fix accidental rename of variable

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -77,7 +77,7 @@ glob.sync(path.join((process.env.OOD_CLUSTERS || '/etc/ood/config/clusters.d'), 
   });
 
 default_sshhost = process.env.OOD_DEFAULT_SSHHOST || process.env.DEFAULT_SSHHOST || default_sshhost || first_available_host;
-if (default_sshhost) host_whitelist.add(default_sshhost);
+if (default_sshhost) host_allowlist.add(default_sshhost);
 
 function host_and_dir_from_url(url){
   let match = url.match(host_path_rx), 


### PR DESCRIPTION
during a manual merge conflict resolution, the name of a variable accidentally got renamed