### PR TITLE
Make Native Instructions tab for VNC sessions available for other OOD sites

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
@@ -1,62 +1,19 @@
+<%# Random port from 10000 - 65535 deterministically generated %>
+<% localport = Digest::MD5.hexdigest("#{connect.host}:#{connect.port}").to_i(16) % 55535 + 10000 %>
+
 <% if browser.platform == :windows %>
 
-  <ol>
-    <li>
-      Download the latest
-      <a href="https://github.com/OSC/osc-connect/releases/latest" rel="noopener" target="_blank">OSC Connect</a>
-      if you don't already have it
-    </li>
-    <li>
-      Launch <strong>OSC Connect</strong>
-    </li>
-    <li>
-      Click - <%= link_to "osc://:#{connect.password}@#{connect.host}:#{connect.port}", "osc://:#{connect.password}@#{connect.host}:#{connect.port}", onclick: "$.get('" + analytics_path(type: "launch_osc_connect") + "');" %>
-    </li>
-  </ol>
+  <%= render partial: 'batch_connect/sessions/connections/native_vnc_windows.html.erb', :locals => { :connect => connect, :localport => localport } %>
 
-  <p>
-    <a href="https://www.osc.edu/resources/getting_started/howto/howto_connect_to_osc_services_using_osc_connect" rel="noopener" target="_blank">Troubleshoot OSC Connect issues</a>
-  </p>
+<% elsif browser.platform == :mac %>
 
-<% elsif browser.platform == :mac || browser.platform == :linux %>
+  <%= render partial: 'batch_connect/sessions/connections/native_vnc_mac.html.erb', :locals => { :connect => connect, :localport => localport } %>
 
-  <%# Random port from 10000 - 65535 deterministically generated %>
-  <% localport = Digest::MD5.hexdigest("#{connect.host}:#{connect.port}").to_i(16) % 55535 + 10000 %>
+<% elsif browser.platform == :linux %>
 
-  <ol>
-    <li>Open a terminal window</li>
-    <li>
-      <p>
-        Copy/paste in your terminal and replace <code>SSH_HOST</code> with a
-        valid HPC login server to establish the SSH tunnel:
-      </p>
-      <% if browser.platform == :mac %>
-        <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %><strong>@SSH_HOST</strong></code></pre>
-      <% else %>
-        <pre><code>ssh -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<strong>SSH_HOST</strong></code></pre>
-      <% end %>
-    </li>
-    <% if browser.platform == :mac %>
-      <li>
-        <p>Use the code below to establish the VNC connection:</p>
-        <pre>open vnc://:<%= connect.password %>@localhost:<%= localport %></pre>
-      </li>
-    <% else %>
-      <li>
-        <p>
-          Open a VNC client and connect to
-          <code>localhost:<%= localport %></code> within the client
-        </p>
-      </li>
-      <li>
-        <p>Use the VNC password: <code><%= connect.password %></code></p>
-      </li>
-    <% end %>
-  </ol>
+  <%= render partial: 'batch_connect/sessions/connections/native_vnc_linux.html.erb', :locals => { :connect => connect, :localport => localport } %>
 
 <% else %>
-
   We do not currently support documentation for connecting to a VNC session
   with a native client for your operating system.
-
 <% end %>

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_linux.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_linux.html.erb
@@ -1,0 +1,33 @@
+<ol>
+  <li>Open a terminal window</li>
+  <li>
+    <% if Configuration.native_vnc_login_host %>
+    <p>
+      Copy/paste in your terminal to establish the SSH tunnel:
+    </p>
+    <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<%= Configuration.native_vnc_login_host %></code></pre>
+    <% else %>
+    <p>
+      Copy/paste in your terminal and replace <code>SSH_HOST</code> with a
+      valid HPC login server to establish the SSH tunnel:
+    </p>
+    <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<strong>SSH_HOST</strong></code></pre>
+    <% end %>
+  </li>
+  <% if browser.platform == :mac %>
+    <li>
+      <p>Use the code below to establish the VNC connection:</p>
+      <pre>open vnc://:<%= connect.password %>@localhost:<%= localport %></pre>
+    </li>
+  <% else %>
+    <li>
+      <p>
+        Open a VNC client and connect to
+        <code>localhost:<%= localport %></code> within the client
+      </p>
+    </li>
+    <li>
+      <p>Use the VNC password: <code><%= connect.password %></code></p>
+    </li>
+  <% end %>
+</ol>

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_mac.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_mac.html.erb
@@ -1,0 +1,33 @@
+<ol>
+  <li>Open a terminal window</li>
+  <li>
+    <% if Configuration.native_vnc_login_host %>
+    <p>
+      Copy/paste in your terminal to establish the SSH tunnel:
+    </p>
+    <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<%= Configuration.native_vnc_login_host %></code></pre>
+    <% else %>
+    <p>
+      Copy/paste in your terminal and replace <code>SSH_HOST</code> with a
+      valid HPC login server to establish the SSH tunnel:
+    </p>
+    <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<strong>SSH_HOST</strong></code></pre>
+    <% end %>
+  </li>
+  <% if browser.platform == :mac %>
+    <li>
+      <p>Use the code below to establish the VNC connection:</p>
+      <pre>open vnc://:<%= connect.password %>@localhost:<%= localport %></pre>
+    </li>
+  <% else %>
+    <li>
+      <p>
+        Open a VNC client and connect to
+        <code>localhost:<%= localport %></code> within the client
+      </p>
+    </li>
+    <li>
+      <p>Use the VNC password: <code><%= connect.password %></code></p>
+    </li>
+  <% end %>
+</ol>

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_windows.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_windows.html.erb
@@ -1,0 +1,31 @@
+<ol>
+  <li>
+    Download any VNC viewer,
+    <a href="https://www.realvnc.com/en/connect/download/viewer/" rel="noopener" target="_blank">RealVNC</a>
+    is a good option.
+  </li>
+  <li>
+    Start an SSH tunnel through your preferred SSH client or through your <a href="https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701">Windows Terminal</a> Linux distribution.
+  </li>
+  <li>
+    <% if Configuration.native_vnc_login_host %>
+    <p>
+      Copy/paste in your terminal to establish the SSH tunnel:
+    </p>
+    <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<%= Configuration.native_vnc_login_host %></code></pre>
+    <% else %>
+    <p>
+      Copy/paste in your terminal and replace <code>SSH_HOST</code> with a
+      valid HPC login server to establish the SSH tunnel:
+    </p>
+    <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<strong>SSH_HOST</strong></code></pre>
+    <% end %>
+  </li>
+  <li>
+    Open a VNC client and connect to
+    <code>localhost:<%= localport %></code> within the client
+  </li>
+  <li>
+    <p>Use the VNC password: <code><%= connect.password %></code></p>
+  </li>
+</ol>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -241,6 +241,11 @@ end
     Pathname.new(ENV['OOD_LOCALES_ROOT'] || "/etc/ood/config/locales")
   end
 
+  # Set the login host in the Native Instructions VNC session partial
+  def native_vnc_login_host
+    ENV['OOD_NATIVE_VNC_LOGIN_HOST']
+  end
+
   private
 
   # The environment


### PR DESCRIPTION
This PR makes the `Native Instructions` tab for VNC interactive sessions available. Closes #618

* Allow OOD_NATIVE_VNC_LOGIN_HOST to be set (purely for visual improvements)
* Fix Linux connection instructions

If you set `OOD_NATIVE_VNC_LOGIN_HOST` then the command will be auto populated with that host. This is purely for visual improvement and has no impact on the VNC connection at all.

To enable the Native Instructions tab, `ENABLE_NATIVE_VNC` must be set to a truthy value such as `1` or `true`

To override the template for different platforms (Windows, MacOS, Linux):
`views/batch_connect/sessions/connections/_native_vnc_{windows,mac,linux}.html.erb`

Screenshots (on Windows):
<img src="https://user-images.githubusercontent.com/6081892/89325138-5e8c3580-d656-11ea-84fc-6a9de7b2b33c.png" width=700>
and without `OOD_NATIVE_VNC_LOGIN_HOST` set
<img src="https://user-images.githubusercontent.com/6081892/89325209-76fc5000-d656-11ea-9e15-4aa563bcfea7.png" width=700>