### PR TITLE
fix xdmod job report page limit number

### DIFF
--- a/apps/dashboard/app/views/dashboard/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/dashboard/_xdmod_widget_jobs.html.erb
@@ -79,7 +79,7 @@ var helpers = {
     return "Recently Completed Jobs - " + thirtyDaysAgo + " to " + today;
   },
   page_limit: function(){
-    return jobsPageLimit;
+    return Math.min(jobsPageLimit, parseInt(this.totalCount));
   },
   xdmod_url: function(){
     return '<%= Configuration.xdmod_host %>';


### PR DESCRIPTION
the report limits display of first 10 pages
if the total count is fewer than 10 jobs (such as 7) the text read

"Showing first 10 of 7 jobs..."

Now it says

"Showing first 7 of 7 jobs..."