### PR TITLE
Remove Safari compatibility alert (#608)

### DIFF
--- a/apps/dashboard/app/views/layouts/_browser_warning.html.erb
+++ b/apps/dashboard/app/views/layouts/_browser_warning.html.erb
@@ -1,19 +1,3 @@
-<% if !ENV["DISABLE_SAFARI_BASIC_AUTH_WARNING"] && browser.safari? %>
-    <div class="alert alert-danger alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert">
-        <span aria-hidden="true">&times;</span>
-        <span class="sr-only">Close</span>
-      </button>
-      As currently configured, the Cluster and Interactive Apps of Open
-      OnDemand do not work with Safari. This is due to a bug in Safari with
-      using websockets through servers protected using "Basic" auth. Open
-      OnDemand can be installed with another authentication mechanism such as
-      Shibboleth or OpenID Connect. If "Basic" auth is required, Mac users
-      can connect with other browsers like Chrome or Firefox. Please contact
-      this site’s technical support and report this message.
-    </div>
-<% end %>
-
 <% if !browser.modern? %>
     <div class="alert alert-danger alert-dismissible" role="alert">
       <button type="button" class="close" data-dismiss="alert">


### PR DESCRIPTION
* Dex is now the default recommendation for auth instead of Basic Auth. Closes #608 

We will document this in https://github.com/OSC/ood-documentation/issues/333