### PR TITLE
Better default for dex frontend configuration

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -49,6 +49,7 @@ module OodPortalGenerator
       end
       @dex_config[:frontend] = {
         dir: '/usr/share/ondemand-dex/web',
+        theme: 'ondemand',
       }.merge(frontend)
       # Pass values back to main ood-portal.conf view
       if enabled? && self.class.installed?
@@ -195,9 +196,7 @@ module OodPortalGenerator
     end
 
     def frontend
-      @config.fetch(:frontend, {
-        theme: 'ondemand',
-      })
+      @config.fetch(:frontend, {})
     end
 
     def copy_ssl_certs


### PR DESCRIPTION
This means a user can do this and not have to worry about also setting `frontend`:

```yaml
dex:
  frontend:
    extra:
      ...
```

Without this change to define extra settings and use our theme they would have to do this:

```yaml
dex:
  frontend:
    theme: ondemand
    extra:
      ...
```