### PR TITLE
job composer guard clauses for nil staged_dir/script_path

### DIFF
--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -79,11 +79,11 @@ class Workflow < ApplicationRecord
   end
 
   def staged_script_exists?
-    File.file? self.script_path
+    File.file? self.script_path.to_s
   end
 
   def script_path
-    Pathname.new(self.staged_dir).join(self.script_name.to_s)
+    Pathname.new(self.staged_dir).join(self.script_name.to_s) unless self.staged_dir.nil?
   end
 
   def script_path=(new_path)
@@ -116,7 +116,7 @@ class Workflow < ApplicationRecord
       stdout, stderr, status = Open3.capture3 "rsync -r --exclude='manifest.yml' #{Shellwords.escape(staging_template_dir.to_s)}/ #{Shellwords.escape(self.staged_dir)}"
       raise IOError if status.exitstatus != 0
     end
-    Pathname.new(self.staged_dir)
+    Pathname.new(self.staged_dir.to_s)
   end
 
   # Get an array of WorkflowFile Objects of all the files of a directory
@@ -128,8 +128,8 @@ class Workflow < ApplicationRecord
   # @return [WorkflowFile] An array of WorkflowFile Objects of all the files of a directory
   def folder_contents
     return @folder_contents if defined? @folder_contents
-    
-    if File.directory?(self.staged_dir)
+
+    if self.staged_dir && File.directory?(self.staged_dir)
       @folder_contents = Find.find(self.staged_dir).drop(1).select {
         |f| File.file?(f)
       }.map {

--- a/apps/myjobs/app/views/workflows/show.json.jbuilder
+++ b/apps/myjobs/app/views/workflows/show.json.jbuilder
@@ -2,7 +2,7 @@ json.extract! @workflow, :pbsid, :name, :batch_host, :script_path, :staged_scrip
 json.extract! @workflow, :xdmod_url if @workflow.xdmod_url_available?
 json.set! 'status_label', status_label(@workflow)
 json.set! 'active', @workflow.active?
-json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir)
+json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir) if @workflow.staged_dir
 json.set! 'host_title', cluster_title(@workflow.batch_host)
 json.folder_contents (@workflow.folder_contents).each do |file|
   json.set! 'path', file.path


### PR DESCRIPTION
Add guard clauses for when staged_dir and script_path are nil in a workflow which can happen in a rare cases that have yet to be determined (something obviously went wrong  in the staging process).