### PR TITLE
Update native instructions for Windows noVNC sessions

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_windows.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc_windows.html.erb
@@ -5,9 +5,6 @@
     is a good option.
   </li>
   <li>
-    Start an SSH tunnel through your preferred SSH client or through your <a href="https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701">Windows Terminal</a> Linux distribution.
-  </li>
-  <li>
     <% if Configuration.native_vnc_login_host %>
     <p>
       Copy/paste in your terminal to establish the SSH tunnel:
@@ -20,6 +17,7 @@
     </p>
     <pre><code>ssh -f -N -L <%= localport %>:<%= connect.host %>:<%= connect.port %> <%= ENV["USER"] %>@<strong>SSH_HOST</strong></code></pre>
     <% end %>
+    <p>For terminals in Windows you can use: <a href="https://github.com/PowerShell/PowerShell/releases/latest">Powershell</a>,  <a href="https://www.chiark.greenend.org.uk/~sgtatham/putty/">PuTTy</a> and <a href="https://docs.microsoft.com/en-us/windows/wsl/install-win10">Windows Subsystem Linux</a> distributions</p>
   </li>
   <li>
     Open a VNC client and connect to

--- a/apps/dashboard/test/models/batch_connect/vnc_view_test.rb
+++ b/apps/dashboard/test/models/batch_connect/vnc_view_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BatchConnect::VncViewTest < ActiveSupport::TestCase
+  test "should have Windows VNC native instructions partial" do
+    assert Rails.root.join('app/views/batch_connect/sessions/connections/_native_vnc_windows.html.erb').file?, "_native_vnc_windows.html.erb partial is required to exist so we can override it in /etc for OSC Connect directions"
+  end
+end

--- a/apps/dashboard/test/system/configuration_singleton_test.rb
+++ b/apps/dashboard/test/system/configuration_singleton_test.rb
@@ -238,4 +238,9 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     ENV["OOD_BALANCE_PATH"] = "https://example.com/balance.json:ftp://path_b/balance.json"
     assert_equal ["https://example.com/balance.json", "ftp://path_b/balance.json"], ConfigurationSingleton.new.balance_paths
   end
+
+  test "can set native vnc login host" do
+    ENV["OOD_NATIVE_VNC_LOGIN_HOST"] = "owens.osc.edu"
+    assert_equal ENV["OOD_NATIVE_VNC_LOGIN_HOST"], ConfigurationSingleton.new.native_vnc_login_host
+  end
 end


### PR DESCRIPTION
Update native instructions for Windows noVNC sessions, they make more sense now

<img src="https://user-images.githubusercontent.com/6081892/89666645-bae69380-d8a8-11ea-997e-db1008d29c78.png" width=700>

Add test to check existence of partial `app/views/batch_connect/sessions/connections/_native_vnc_windows.html.erb`:
