### PR TITLE
Allow grafana config to override cluster name

### DIFF
--- a/apps/activejobs/app/helpers/jobs_helper.rb
+++ b/apps/activejobs/app/helpers/jobs_helper.rb
@@ -20,6 +20,7 @@ module JobsHelper
     grafana_uri = nil
     if c && c.custom_allow?(:grafana)
       server = c.custom_config(:grafana)
+      cluster = server.fetch(:cluster_override, cluster)
       query_params = {
         orgId: server[:orgId],
         theme: server[:theme] || 'light',


### PR DESCRIPTION
This is especially useful on Pitzer Expansion where the cluster config name in OOD is `pitzer-exp` but the cluster is still called `pitzer` for Prometheus/Grafana.