### PR TITLE
Make default job host configurable in Job Composer

### DIFF
--- a/apps/myjobs/app/models/manifest.rb
+++ b/apps/myjobs/app/models/manifest.rb
@@ -52,7 +52,7 @@ class Manifest
   end
 
   def default_host
-    OODClusters.first ? OODClusters.first.id.to_s : ""
+    Configuration.default_batch_host || ''
   end
 
   def default_notes

--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -45,7 +45,7 @@ class Workflow < ApplicationRecord
     path = Pathname.new(path).expand_path rescue Pathname.new(path)
     workflow = Workflow.new
     workflow.name = ''
-    workflow.batch_host = OODClusters.first.id
+    workflow.batch_host = Configuration.default_batch_host || ''
     workflow.script_name = ''
     workflow.staging_template_dir = path.to_s
 

--- a/apps/myjobs/config/configuration_singleton.rb
+++ b/apps/myjobs/config/configuration_singleton.rb
@@ -132,7 +132,7 @@ class ConfigurationSingleton
     (ENV['OOD_MAX_SCRIPT_SIZE_KB'] || 65).to_i
   end
 
-  # The XMoD host
+  # The XDMoD host
   # @return [String, null] the host, or null if not set
   def xdmod_host
     ENV["OOD_XDMOD_HOST"]

--- a/apps/myjobs/config/configuration_singleton.rb
+++ b/apps/myjobs/config/configuration_singleton.rb
@@ -144,6 +144,26 @@ class ConfigurationSingleton
     xdmod_host.present?
   end
 
+  # Default cluster for submitting jobs
+  # @return default cluster for submitting jobs, or first if none specified
+  def default_job_cluster
+    clusters.find(clusters.first) {|c| c.job_config[:default] }
+  end
+
+  # id of default cluster for submitting jobs
+  # @return the id of default cluster for submitting jobs
+  def default_batch_host
+    default_job_cluster.try(:id)
+  end
+
+  # Get clusters that a user can submit jobs to
+  # @return [OodCore::Clusters] clusters object is a list of clusters
+  def clusters
+    @clusters ||= OodCore::Clusters.new(
+      OodAppkit.clusters.select(&:job_allow?).reject { |c| c.metadata.hidden  }
+    )
+  end
+
   private
 
   # The environment

--- a/apps/myjobs/config/initializers/ood_appkit.rb
+++ b/apps/myjobs/config/initializers/ood_appkit.rb
@@ -1,5 +1,4 @@
 # config/initializers/ood_appkit.rb
 
-OODClusters = OodCore::Clusters.new(
-  OodAppkit.clusters.select(&:job_allow?).reject { |c| c.metadata.hidden }
-)
+# FIXME: temporary till we update code to use Configuration.clusters
+OODClusters = Configuration.clusters


### PR DESCRIPTION
This is an updated version of the original https://github.com/OSC/ondemand/pull/530

Marked as draft because these are missing:

1. automated test for the default host
2. proper manual testing 
3. update dashboard app to handle default host
4. probably should also refactor job composer to use the Configuration.clusters as well... (and reduce the number of places where this original OODClusters or new Configuration.clusters is referenced in the code)

Will include this in the 1.8 patch release.