### PR TITLE
Add ood_cookie_same_site to OIDC configs.

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -87,6 +87,7 @@ module OodPortalGenerator
       @oidc_session_inactivity_timeout  = opts.fetch(:oidc_session_inactivity_timeout, 28800)
       @oidc_session_max_duration        = opts.fetch(:oidc_session_max_duration, 28800)
       @oidc_state_max_number_of_cookies = opts.fetch(:oidc_state_max_number_of_cookies, '10 true')
+      @oidc_cookie_same_site            = opts.fetch(:oidc_cookie_same_site, @ssl ? 'Off' : 'On')
       @oidc_settings                    = opts.fetch(:oidc_settings, {})
     end
 

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -306,6 +306,14 @@
 # Default: "10 true"
 #oidc_state_max_number_of_cookies: "10 true"
 
+# OIDC Enable SameSite cookie
+# When ssl is defined this defaults to 'Off'
+# When ssl is not defined this defaults to 'On'
+# Example:
+#     oidc_cookie_same_site: 'Off'
+# Default: 'On'
+#oidc_cookie_same_site: 'On'
+
 # Additional OIDC settings as key-value pairs
 # Example:
 #     oidc_settings:

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -66,6 +66,7 @@
   OIDCSessionInactivityTimeout 28800
   OIDCSessionMaxDuration 28800
   OIDCStateMaxNumberOfCookies 10 true
+  OIDCCookieSameSite On
 
   # Lua configuration
   #

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -86,6 +86,7 @@
   OIDCSessionInactivityTimeout 28800
   OIDCSessionMaxDuration 28800
   OIDCStateMaxNumberOfCookies 10 true
+  OIDCCookieSameSite Off
 
   # Lua configuration
   #

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -86,6 +86,7 @@
   OIDCSessionInactivityTimeout 28800
   OIDCSessionMaxDuration 28800
   OIDCStateMaxNumberOfCookies 10 true
+  OIDCCookieSameSite Off
 
   # Lua configuration
   #

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -74,6 +74,7 @@
   OIDCSessionInactivityTimeout 28800
   OIDCSessionMaxDuration 28800
   OIDCStateMaxNumberOfCookies 10 true
+  OIDCCookieSameSite On
   OIDCPassClaimsAs environment
   OIDCPassIDTokenAs serialized
   OIDCPassRefreshToken On

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -86,6 +86,7 @@
   OIDCSessionInactivityTimeout 28800
   OIDCSessionMaxDuration 28800
   OIDCStateMaxNumberOfCookies 10 true
+  OIDCCookieSameSite Off
   OIDCPassClaimsAs environment
   OIDCPassIDTokenAs serialized
   OIDCPassRefreshToken On

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -112,6 +112,7 @@ Listen <%= addr_port %>
   OIDCSessionInactivityTimeout <%= @oidc_session_inactivity_timeout %>
   OIDCSessionMaxDuration <%= @oidc_session_max_duration %>
   OIDCStateMaxNumberOfCookies <%= @oidc_state_max_number_of_cookies %>
+  OIDCCookieSameSite <%= @oidc_cookie_same_site %>
   <%- @oidc_settings.keys.sort.each do |oidc_setting| -%>
   <%= oidc_setting %> <%= @oidc_settings[oidc_setting] %>
   <%- end -%>


### PR DESCRIPTION
This sets OIDCCookieSameSite to On by default without SSL, and Off (default) with SSL
This is mostly to work around restrictions in Chrome when dealing with non-SSL sites