### PR TITLE
dashboard: ignore cache keys that do not exist

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -67,7 +67,7 @@ module BatchConnect
    end
    
    def update_with_cache(cache)
-      self.attributes = cache.select { |k,v| self[k.to_sym].cacheable?(app_specific_cache_enabled?)  }
+      self.attributes = cache.select { |k,v| self[k.to_sym] && self[k.to_sym].cacheable?(app_specific_cache_enabled?)  }
    end 
 
    private

--- a/apps/dashboard/test/models/batch_connect/session_context_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_context_test.rb
@@ -101,4 +101,14 @@ class BatchConnect::SessionContextTest < ActiveSupport::TestCase
   
      assert_equal ["", "28"], [context["bc_account"].value, context["num_cores"].value]
    end
+
+   test "should ignore bad cache keys when updating cache using update_with_cache" do
+     app = BatchConnect::App.new(router: nil)
+     app.stubs(:form_config).returns(attributes: { num_cores: { widget: "number_field", value: "1" } }, form: ["bc_account", "num_cores"])
+     context = app.build_session_context
+
+     context.update_with_cache({"bc_account" => "PZS0714", "num_cores" => "28", "bad_key_1" => "1", "bad_key_2" => "2"})
+
+     assert_equal ["PZS0714", "28"], [context["bc_account"].value, context["num_cores"].value]
+   end
 end


### PR DESCRIPTION
To reproduce - take a context.json that stores the cache values of any batch connect app, and modify it to include key value pairs where the key is not an attribute defined in the app.