### PR TITLE
More files app escaping

### DIFF
--- a/apps/files/lib/cloudcmd/lib/client/dom.js
+++ b/apps/files/lib/cloudcmd/lib/client/dom.js
@@ -1576,7 +1576,7 @@ var CloudCmd, Util, DOM, CloudFunc;
                     path    = CurrentInfo.dirPath,
                     Dialog  = DOM.Dialog;
 
-                Dialog.prompt(TITLE, msg, path, {cancel: false}).then(function(path) {
+                Dialog.prompt(TITLE, msg, Handlebars.Utils.escapeExpression(path), {cancel: false}).then(function(path) {
                     CloudCmd.loadDir({
                         path: path
                     });

--- a/apps/files/lib/cloudcmd/lib/cloudfunc.js
+++ b/apps/files/lib/cloudcmd/lib/cloudfunc.js
@@ -234,7 +234,7 @@
                 linkResult  = templateLink({
                     link        : link,
                     title       : file.name,
-                    name        : Handlebars.Utils.escapeExpression(file.name),
+                    name        : file.name,
                     attribute   : new Handlebars.SafeString(attribute)
                 });
 


### PR DESCRIPTION
- `templateLink({` is already a handlebars template so it will escape all the values by default, so we don’t need to escape again
- The Go To dialog - we insert the value we get from the URL on the page - which is provided by the user - and in this case may contain bad characters
- since its the only dialog that takes the current browser URL and displays the value, this is the only one we escape
