### PR TITLE
Show error message if info partial fails to render

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -52,12 +52,12 @@ module BatchConnect::SessionsHelper
 
   def custom_info_view(session)
     content_tag(:div) do
-      concat render partial: "batch_connect/sessions/connections/info", locals: { view: session.info_view, session: session }
-    rescue => e
-      Rails.logger.error("Failed to render partial: #{e.class} - #{e.message}")
-      content_tag(:div, class: "alert alert-danger", role: "alert") do
-        concat tag.h4 "Failed to render partial", class: "alert-heading"
-        concat tag.p "#{e.class} - #{e.message}"
+      concat session.render_info_view if session.render_info_view
+
+      if session.render_info_view_error_message
+        content_tag(:div, class: "alert alert-danger", role: "alert") do
+          concat tag.p session.render_info_view_error_message
+        end
       end
     end
   end

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -52,7 +52,7 @@ module BatchConnect::SessionsHelper
   def custom_info_view(session)
     concat tag.hr
     content_tag(:div) do
-      concat session.render_info_view if session.render_info_view
+      concat session.render_info_view
 
       if session.render_info_view_error_message
         content_tag(:div, class: "alert alert-danger", role: "alert") do

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -42,8 +42,7 @@ module BatchConnect::SessionsHelper
           concat created(session)
           concat time(session)
           concat id(session)
-          concat tag.hr                         if session.info_view
-          safe_concat custom_info_view(session) if session.info_view
+          safe_concat custom_info_view(session) if session.app.session_info_view
         end
       )
       concat content_tag(:div) { yield }
@@ -51,6 +50,7 @@ module BatchConnect::SessionsHelper
   end
 
   def custom_info_view(session)
+    concat tag.hr
     content_tag(:div) do
       concat session.render_info_view if session.render_info_view
 

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -53,6 +53,12 @@ module BatchConnect::SessionsHelper
   def custom_info_view(session)
     content_tag(:div) do
       concat render partial: "batch_connect/sessions/connections/info", locals: { view: session.info_view, session: session }
+    rescue => e
+      Rails.logger.error("Failed to render partial: #{e.class} - #{e.message}")
+      content_tag(:div, class: "alert alert-danger", role: "alert") do
+        concat tag.h4 "Failed to render partial", class: "alert-heading"
+        concat tag.p "#{e.class} - #{e.message}"
+      end
     end
   end
 

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -214,7 +214,7 @@ module BatchConnect
     # View used for session info if it exists
     # @return [String, nil] session info
     def session_info_view
-      Pathname.new(root).glob("info.{md,html}.erb").find(&:file?).try(:read)
+      @session_info_view ||= Pathname.new(root).glob("info.{md,html}.erb").find(&:file?).try(:read)
     rescue
       nil
     end

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -215,6 +215,8 @@ module BatchConnect
     # @return [String, nil] session info
     def session_info_view
       Pathname.new(root).glob("info.{md,html}.erb").find(&:file?).try(:read)
+    rescue
+      nil
     end
 
     # Paths to custom javascript files

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -56,7 +56,8 @@ module BatchConnect
     # @return [Boolean] true if job is completed
     attr_accessor :cache_completed
 
-    # 
+    # Error message about failing to parse info view ERB template.
+    # @return [String] error message
     attr_reader :render_info_view_error_message
 
     # Return parsed markdown from info.{md, html}.erb

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -41,10 +41,6 @@ module BatchConnect
     # @return [String, nil] session view
     attr_accessor :view
 
-    # The view used to display custom info for this session
-    # @return [String, nil] session info
-    attr_accessor :info_view
-
     # Batch connect script type
     # @return [String] script type
     attr_accessor :script_type

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -61,13 +61,13 @@ module BatchConnect
     attr_reader :render_info_view_error_message
 
     # Return parsed markdown from info.{md, html}.erb
-    # @return [String, Boolean] return HTML if no error while parsing, else return false
+    # @return [String, nil] return HTML if no error while parsing, else return nil
     def render_info_view
       @render_info_view ||= OodAppkit.markdown.render(ERB.new(self.app.session_info_view, nil, "-").result(binding)).html_safe
     rescue => e
-      @render_info_view_error_message = "Error when rendering info view: #{e.class} - #{e.message}"
+      @render_info_view_error_message = "Error when rendering info view: #{e.class} - #{e.message}" if self.app.session_info_view != nil
       Rails.logger.error(@render_info_view_error_message)
-      false
+      nil
     end
 
     # Return the Batch Connect app from the session token
@@ -82,7 +82,7 @@ module BatchConnect
     # Attributes used for serialization
     # @return [Hash] attributes to be serialized
     def attributes
-      %w(id cluster_id job_id created_at token title view info_view script_type cache_completed).map do |attribute|
+      %w(id cluster_id job_id created_at token title view script_type cache_completed).map do |attribute|
         [ attribute, nil ]
       end.to_h
     end
@@ -210,7 +210,6 @@ module BatchConnect
       self.token      = app.token
       self.title      = app.title
       self.view       = app.session_view
-      self.info_view  = app.session_info_view
       self.created_at = Time.now.to_i
 
       submit_script = app.submit_opts(context, fmt: format) # could raise an exception

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -63,9 +63,9 @@ module BatchConnect
     # Return parsed markdown from info.{md, html}.erb
     # @return [String, nil] return HTML if no error while parsing, else return nil
     def render_info_view
-      @render_info_view ||= OodAppkit.markdown.render(ERB.new(self.app.session_info_view, nil, "-").result(binding)).html_safe
+      @render_info_view ||= OodAppkit.markdown.render(ERB.new(self.app.session_info_view, nil, "-").result(binding)).html_safe if self.app.session_info_view
     rescue => e
-      @render_info_view_error_message = "Error when rendering info view: #{e.class} - #{e.message}" if self.app.session_info_view != nil
+      @render_info_view_error_message = "Error when rendering info view: #{e.class} - #{e.message}"
       Rails.logger.error(@render_info_view_error_message)
       nil
     end

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -56,6 +56,25 @@ module BatchConnect
     # @return [Boolean] true if job is completed
     attr_accessor :cache_completed
 
+    # 
+    attr_reader :render_info_view_error_message
+
+    # Return parsed markdown from info.{md, html}.erb
+    # @return [String, Boolean] return HTML if no error while parsing, else return false
+    def render_info_view
+      @render_info_view ||= OodAppkit.markdown.render(ERB.new(self.app.session_info_view, nil, "-").result(binding)).html_safe
+    rescue => e
+      @render_info_view_error_message = "Error when rendering info view: #{e.class} - #{e.message}"
+      Rails.logger.error(@render_info_view_error_message)
+      false
+    end
+
+    # Return the Batch Connect app from the session token
+    # @return [BatchConnect::App]
+    def app
+      BatchConnect::App.from_token(self.token)
+    end
+    
     # How many days before a Session record is considered old and ready to delete
     OLD_IN_DAYS=7
 

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_info.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_info.html.erb
@@ -1,1 +1,0 @@
-<%= OodAppkit.markdown.render(ERB.new(view, nil, "-").result(session.instance_eval { binding })).html_safe %>


### PR DESCRIPTION
If an interactive session has an `info.{md,html}.erb` file that cannot render properly, this PR fixes the entire page breaking and isolates the error to only break within the session panel itself.

Closes #654

**Merge message:**
* `info.{md,html}.erb` isn't cached anymore, now it is pulled directly from the app directory.
* If a batch connect session has a custom info view and the view has an error while being parsed, `session.render_info_view_error_message` is set.
* Developing a custom info view is a pleasant experience now, you don't have to launch a new session to test your view changes anymore.

**Screenshot:**
<img src=https://user-images.githubusercontent.com/6081892/92496178-d0135280-f1c5-11ea-94b3-83a6eee865ba.png width=750>