### PR TITLE
make icons aria-hidden and use title in links instead of data-ttitle

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -44,7 +44,7 @@ module ApplicationHelper
   end
 
   def fa_icon(icon, fa_style: "fas", id: "")
-    content_tag(:i, "", id: id, class: [fa_style, "fa-#{icon}", "fa-fw", "app-icon"] , title: "FontAwesome icon specified: #{icon}")
+    content_tag(:i, "", id: id, class: [fa_style, "fa-#{icon}", "fa-fw", "app-icon"] , title: "FontAwesome icon specified: #{icon}", "aria-hidden": true)
   end
 
   def app_icon_tag(app)
@@ -65,7 +65,7 @@ module ApplicationHelper
     if %w(fa fas far fab fal).include?(icon_uri.scheme)
       fa_icon(icon_uri.host, fa_style: icon_uri.scheme)
     else
-      image_tag icon_uri.to_s, class: "app-icon", title: icon_uri.to_s
+      image_tag icon_uri.to_s, class: "app-icon", title: icon_uri.to_s, "aria-hidden": true
     end
   end
 

--- a/apps/dashboard/app/views/apps/_app_list_item.html.erb
+++ b/apps/dashboard/app/views/apps/_app_list_item.html.erb
@@ -3,12 +3,12 @@
     link_to(
       link.url.to_s,
       class: "list-group-item",
+      title: link.title,
       data: {
         toggle: "popover",
         content: manifest_markdown(link.description),
         html: true,
         trigger: "hover",
-        title: link.title,
         container: "body"
       },
       target: link.new_tab? ? "_blank" : nil


### PR DESCRIPTION
This hidses FA icons from screen readers and sets the icons to use a real `title` instead of `data-title`. This means screen readers don't read the icons and they just read the text.

Fixes #663 