### PR TITLE
XDMoD integration minor fixes

### DIFF
--- a/apps/dashboard/app/views/dashboard/_xdmod_widget_job_efficiency.html.erb
+++ b/apps/dashboard/app/views/dashboard/_xdmod_widget_job_efficiency.html.erb
@@ -115,13 +115,16 @@ promiseLoggedIntoXDMoD(xdmodUrl)
     else{
       throw new Error('Job data returned by request is invalid.')
     }
-
-
   })
   .catch((error) => {
     console.error(error);
     render_jobs_template({error: error});
     render_core_hours_template({error: error});
+
+    // error - report back for analytics purposes
+    let analyticsUrl = new URL("<%= analytics_url(type: 'xdmod_job_widget_efficiency_error') %>");
+    analyticsUrl.searchParams.append('error', error);
+    fetch(analyticsUrl);
   });
 }());
 </script>

--- a/apps/dashboard/app/views/dashboard/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/dashboard/_xdmod_widget_jobs.html.erb
@@ -146,6 +146,11 @@ promiseLoggedIntoXDMoD(xdmodUrl)
   .catch((error) => {
     console.error(error);
     render_template({error: error});
+
+    // error - report back for analytics purposes
+    let analyticsUrl = new URL("<%= analytics_url(type: 'xdmod_jobs_widget_error') %>");
+    analyticsUrl.searchParams.append('error', error);
+    fetch(analyticsUrl);
   });
 }());
 </script>

--- a/apps/dashboard/app/views/dashboard/index.html.erb
+++ b/apps/dashboard/app/views/dashboard/index.html.erb
@@ -2,19 +2,30 @@
 
 
 <% if Configuration.xdmod_integration_enabled? %>
-  <%# This assumes @motd_file responds to `to_partial_path` %>
-  <%# render @motd if @motd %>
   <div class="row">
-    <div class="col-md-8">
-      <%# This assumes @motd_file responds to `to_partial_path` %>
-      <%= render @motd if @motd %>
-    </div>
-    <div class="col-md-4">
-      <div class="xdmod">
-        <%= render "xdmod_widget_job_efficiency" %>
-        <%= render "xdmod_widget_jobs" %>
+    <% if @motd %>
+      <div class="col-md-8">
+        <%# This assumes @motd_file responds to `to_partial_path` %>
+        <%= render @motd %>
       </div>
-    </div>
+      <div class="col-md-4">
+        <div class="xdmod">
+          <%= render "xdmod_widget_job_efficiency" %>
+          <%= render "xdmod_widget_jobs" %>
+        </div>
+      </div>
+    <% else %>
+      <div class="col-md-4">
+        <div class="xdmod">
+          <%= render "xdmod_widget_job_efficiency" %>
+        </div>
+      </div>
+      <div class="col-md-8">
+        <div class="xdmod">
+          <%= render "xdmod_widget_jobs" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 <% else %>
   <%= render @motd if @motd %>

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -38,7 +38,11 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   gem 'rails-controller-testing'
+  gem 'mocha', '~> 1.1'
+  gem 'climate_control', '~> 0.2'
+  gem 'timecop', '~> 0.9'
 end
+
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     bootstrap_form (2.7.0)
     builder (3.2.4)
     byebug (11.1.3)
+    climate_control (0.2.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -108,6 +109,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    mocha (1.11.2)
     mustache (1.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.10)
@@ -201,6 +203,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -217,6 +220,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.4.1)
   bootstrap_form (~> 2.7.0)
   byebug
+  climate_control (~> 0.2)
   coffee-rails (~> 4.2)
   dotenv-rails (~> 2.1)
   font-awesome-sass (~> 5.0)
@@ -225,6 +229,7 @@ DEPENDENCIES
   jquery-rails
   js-routes (~> 1.2.4)
   local_time (~> 1.0.3)
+  mocha (~> 1.1)
   ood_appkit (~> 1.1.4)
   osc_machete_rails (~> 1.3.0)
   pbs (~> 2.2.1)
@@ -235,6 +240,7 @@ DEPENDENCIES
   sdoc
   sqlite3 (= 1.3.13)
   thor (= 0.19.1)
+  timecop (~> 0.9)
   uglifier (>= 1.3.0)
 
 BUNDLED WITH

--- a/apps/myjobs/app/assets/javascripts/workflows.js.coffee
+++ b/apps/myjobs/app/assets/javascripts/workflows.js.coffee
@@ -106,8 +106,13 @@ $(window).focus ->
     if(data.xdmod_url)
       # details external url
       $("#job-details-id").html('<a target="_blank" href="'+data.xdmod_url+'">'+data.pbsid+' - <i style="display: inline" class="fa fa-external-link-square-alt"></i>&nbsp;XDMoD</a>')
+      if(data.xdmod_url_warning_message)
+        $("#job-details-xdmod-warning").text(data.xdmod_url_warning_message)
+      else
+        $("#job-details-xdmod-warning").text('')
     else
       $("#job-details-id").text(data.pbsid)
+      $("#job-details-xdmod-warning").text('')
     $("#job-details-name").text(data.name)
     $("#job-details-server").val(data.host_title)
     $("#job-details-staged-dir").text(data.staged_dir)

--- a/apps/myjobs/app/assets/stylesheets/application.css.scss
+++ b/apps/myjobs/app/assets/stylesheets/application.css.scss
@@ -90,3 +90,7 @@
   border-color: #ccc;
   box-shadow: none;
 }
+
+tr.active .bg-warning {
+  background-color: transparent;
+}

--- a/apps/myjobs/app/helpers/workflows_helper.rb
+++ b/apps/myjobs/app/helpers/workflows_helper.rb
@@ -1,2 +1,7 @@
 module WorkflowsHelper
+  def xdmod_url_warning_message(workflow)
+    return nil unless workflow.completed_at
+
+    I18n.t('jobcomposer.xdmod_url_warning_message') if I18n.t('jobcomposer.xdmod_url_warning_message_seconds_after_job_completion').to_i > (Time.now - workflow.completed_at).to_i
+  end
 end

--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -197,6 +197,10 @@ class Workflow < ApplicationRecord
     "#{Configuration.xdmod_host}/index.php#job_viewer?action=show&realm=SUPREMM&resource_id=#{xdmod_resource_id}&local_job_id=#{pbsid_number}"
   end
 
+  def completed_at
+    jobs.first.try(:updated_at)
+  end
+
   def xdmod_url_available?
     Configuration.xdmod_integration_enabled? && xdmod_resource_id && completed?
   end

--- a/apps/myjobs/app/views/workflows/index.html.erb
+++ b/apps/myjobs/app/views/workflows/index.html.erb
@@ -89,6 +89,8 @@
                     <%= link_to(workflow.xdmod_url, target: "_blank")  do %>
                       <%= workflow.pbsid %> - <%= content_tag :i, nil, style: "display: inline", class: "fa fa-external-link-square-alt" %>&nbsp;XDMoD
                     <% end %>
+
+                    <%= content_tag :p, xdmod_url_warning_message(workflow), class: "bg-warning" if xdmod_url_warning_message(workflow) %>
                   <% else %>
                     <span title="<%= workflow.pbsid %>"><%= workflow.pbsid %></span>
                   <% end %>
@@ -113,6 +115,7 @@
       </div>
       <div class="panel-body">
         <h4 id="job-details-id"></h4>
+        <p id="job-details-xdmod-warning" class="bg-warning"></p>
         <p>Job Name: <h4 class="wrap-line"><strong><span id="job-details-name"></span></strong></h4></p>
         <div id="job-details-submit-to">
           <p>Submit to:</p>

--- a/apps/myjobs/app/views/workflows/show.json.jbuilder
+++ b/apps/myjobs/app/views/workflows/show.json.jbuilder
@@ -1,5 +1,6 @@
 json.extract! @workflow, :pbsid, :name, :batch_host, :script_path, :staged_script_name, :staged_dir, :created_at, :updated_at, :status, :account, :job_array_request
 json.extract! @workflow, :xdmod_url if @workflow.xdmod_url_available?
+json.set! 'xdmod_url_warning_message', xdmod_url_warning_message(@workflow) if xdmod_url_warning_message(@workflow)
 json.set! 'status_label', status_label(@workflow)
 json.set! 'active', @workflow.active?
 json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir) if @workflow.staged_dir

--- a/apps/myjobs/config/locales/en.yml
+++ b/apps/myjobs/config/locales/en.yml
@@ -36,3 +36,5 @@ en:
     options_script_title: "Specify job script"
     options_script_help: "Files larger than 65KB are omitted for the job script field"
     options_title: "Job Options"
+    xdmod_url_warning_message: "This job may not appear in XDMoD until 24 hours after the completion of the job."
+    xdmod_url_warning_message_seconds_after_job_completion: 86400

--- a/apps/myjobs/test/helpers/workflow_helper_test.rb
+++ b/apps/myjobs/test/helpers/workflow_helper_test.rb
@@ -1,4 +1,48 @@
 require 'test_helper'
 
 class WorkflowsHelperTest < ActionView::TestCase
+  test "xdmod url warning message for newly completed job" do
+    w = Workflow.new
+    w.stubs(:completed_at).returns(Time.now)
+
+    assert_equal I18n.t('jobcomposer.xdmod_url_warning_message'), xdmod_url_warning_message(w)
+  end
+
+
+  test "xdmod url warning message hidden for old job" do
+    t = Time.now
+    w = Workflow.new
+    w.stubs(:completed_at).returns(t)
+
+    Timecop.freeze(t.advance(days: 1)) do
+      refute xdmod_url_warning_message(w), "#{Time.now} is 48 hours after #{w.completed_at} so no warning message should display"
+    end
+  end
+
+  test "xdmod url warning message hidden if localization timespan set to 0" do
+    I18n.stubs(:t).with('jobcomposer.xdmod_url_warning_message_seconds_after_job_completion').returns(0)
+    I18n.stubs(:t).with('jobcomposer.xdmod_url_warning_message').returns('This message should never display.')
+
+    w = Workflow.new
+    w.stubs(:completed_at).returns(Time.now)
+    refute xdmod_url_warning_message(w)
+  end
+
+  test "xdmod url warning message timespan can be changed" do
+    message = 'Display till 9 seconds passed.'
+    I18n.stubs(:t).with('jobcomposer.xdmod_url_warning_message_seconds_after_job_completion').returns(9)
+    I18n.stubs(:t).with('jobcomposer.xdmod_url_warning_message').returns(message)
+
+    t = Time.now
+    w = Workflow.new
+    w.stubs(:completed_at).returns(t)
+
+    Timecop.freeze(t.advance(seconds: 8)) do
+      assert_equal message, xdmod_url_warning_message(w)
+    end
+
+    Timecop.freeze(t.advance(seconds: 9)) do
+      refute xdmod_url_warning_message(w)
+    end
+  end
 end

--- a/apps/myjobs/test/test_helper.rb
+++ b/apps/myjobs/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'climate_control'
+require 'timecop'
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
@@ -10,4 +12,9 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options, &block)
+  end
 end
+
+require 'mocha/minitest'


### PR DESCRIPTION
Fix xdmod widget layout when no motd:

![screen 2020-09-19 at 9 42 14 AM](https://user-images.githubusercontent.com/512333/93668780-e7233180-fa5c-11ea-952b-c40606b4a3b9.png)

TODO:

- [x] Warn user about XDMoD links in Job Composer that may be broken for 24 hours
- [x] Add analytics request on SSO failure

XDMoD links in Job Composer may be broken for 24 hours:

1. i18n key for the xdmod job link warning message 
2. i18n key for the xdmod job link warning timespan (number of seconds after job completes to warn user) - we will display this message after job composer recognizes that the job completed (which is not necessarily the same time/date as the job completing)
3. use modified date of completed job (hack) or add completed date to job when switching from running to completed
4. update view to use i18n keys (bg-warning on paragraph underneath link):
   - ![screen 2020-09-19 at 2 13 56 PM](https://user-images.githubusercontent.com/512333/93686174-8149a080-fa82-11ea-97ce-809f04d5219a.png)
   - ![screen 2020-09-19 at 2 14 03 PM](https://user-images.githubusercontent.com/512333/93686180-86a6eb00-fa82-11ea-83c4-c141e73e674a.png)
   - obviously we want to ensure when highlighted in datatables this doesn't render the text illegible
