### PR TITLE
K8s dashboard

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -387,7 +387,7 @@ module BatchConnect
     # Whether job is running but still hasn't generated the connection file
     # @return [Boolean] whether starting
     def starting?
-      if native_host?
+      if native_connection_info?
         status.queued?
       else
         status.running? && !connect_file.file?
@@ -483,8 +483,8 @@ module BatchConnect
     # The connection information for this session (job must be running)
     # @return [OpenStruct] connection information
     def connect
-      if native_host?
-        OpenStruct.new info.native
+      if native_connection_info?
+        OpenStruct.new info.native.fetch(:ood_connection_info, {})
       else
         OpenStruct.new YAML.safe_load(connect_file.read)
       end
@@ -492,8 +492,8 @@ module BatchConnect
 
     # Whether the session info has native host fields.
     # @return [Boolean] whether there is host and port information in this session.
-    def native_host?
-      info&.native&.key?(:host) && info&.native&.key?(:port)
+    def native_connection_info?
+      info&.native&.key?(:ood_connection_info)
     end
 
     # A unique identifier that details the current state of a session

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -388,7 +388,7 @@ module BatchConnect
     # @return [Boolean] whether starting
     def starting?
       if native_connection_info?
-        status.queued?
+        status.queued? && !connect.to_h.compact.empty?
       else
         status.running? && !connect_file.file?
       end

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -388,7 +388,7 @@ module BatchConnect
     # @return [Boolean] whether starting
     def starting?
       if native_host?
-        !status.running?
+        status.queued?
       else
         status.running? && !connect_file.file?
       end

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -387,7 +387,11 @@ module BatchConnect
     # Whether job is running but still hasn't generated the connection file
     # @return [Boolean] whether starting
     def starting?
-      status.running? && !connect_file.file?
+      if native_host?
+        !status.running?
+      else
+        status.running? && !connect_file.file?
+      end
     end
 
     # Whether job is running and connection file is generated
@@ -479,7 +483,17 @@ module BatchConnect
     # The connection information for this session (job must be running)
     # @return [OpenStruct] connection information
     def connect
-      OpenStruct.new YAML.safe_load(connect_file.read)
+      if native_host?
+        OpenStruct.new info.native
+      else
+        OpenStruct.new YAML.safe_load(connect_file.read)
+      end
+    end
+
+    # Whether the session info has native host fields.
+    # @return [Boolean] whether there is host and port information in this session.
+    def native_host?
+      info&.native&.key?(:host) && info&.native&.key?(:port)
     end
 
     # A unique identifier that details the current state of a session

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -387,7 +387,7 @@ module BatchConnect
     # Whether job is running but still hasn't generated the connection file
     # @return [Boolean] whether starting
     def starting?
-      if native_connection_info?
+      if connection_in_info?
         status.queued? && !connect.to_h.compact.empty?
       else
         status.running? && !connect_file.file?
@@ -483,17 +483,17 @@ module BatchConnect
     # The connection information for this session (job must be running)
     # @return [OpenStruct] connection information
     def connect
-      if native_connection_info?
-        OpenStruct.new info.native.fetch(:ood_connection_info, {})
+      if connection_in_info?
+        OpenStruct.new(info.ood_connection_info || {})
       else
         OpenStruct.new YAML.safe_load(connect_file.read)
       end
     end
 
-    # Whether the session info has native host fields.
+    # Whether the session info has connection information
     # @return [Boolean] whether there is host and port information in this session.
-    def native_connection_info?
-      info&.native&.key?(:ood_connection_info)
+    def connection_in_info?
+      info.respond_to?(:ood_connection_info)
     end
 
     # A unique identifier that details the current state of a session


### PR DESCRIPTION
Host and password information are held in `script.native` attributes in kubernetes at the moment so this change is needed for the dashboard to recognize it's state and extract the information.