### PR TITLE
Prepend XDMoD with word 'Open'

### DIFF
--- a/apps/myjobs/app/assets/javascripts/workflows.js.coffee
+++ b/apps/myjobs/app/assets/javascripts/workflows.js.coffee
@@ -105,7 +105,7 @@ $(window).focus ->
     update_missing_data_script_view()
     if(data.xdmod_url)
       # details external url
-      $("#job-details-id").html('<a target="_blank" href="'+data.xdmod_url+'">'+data.pbsid+' - <i style="display: inline" class="fa fa-external-link-square-alt"></i>&nbsp;XDMoD</a>')
+      $("#job-details-id").html('<a target="_blank" href="'+data.xdmod_url+'">'+data.pbsid+' - <i style="display: inline" class="fa fa-external-link-square-alt"></i>&nbsp;Open&nbsp;XDMoD</a>')
       if(data.xdmod_url_warning_message)
         $("#job-details-xdmod-warning").text(data.xdmod_url_warning_message)
       else

--- a/apps/myjobs/app/views/workflows/index.html.erb
+++ b/apps/myjobs/app/views/workflows/index.html.erb
@@ -87,7 +87,7 @@
                 <td>
                   <% if workflow.xdmod_url_available? %>
                     <%= link_to(workflow.xdmod_url, target: "_blank")  do %>
-                      <%= workflow.pbsid %> - <%= content_tag :i, nil, style: "display: inline", class: "fa fa-external-link-square-alt" %>&nbsp;XDMoD
+                      <%= workflow.pbsid %> - <%= content_tag :i, nil, style: "display: inline", class: "fa fa-external-link-square-alt" %>&nbsp;Open&nbsp;XDMoD
                     <% end %>
 
                     <%= content_tag :p, xdmod_url_warning_message(workflow), class: "bg-warning" if xdmod_url_warning_message(workflow) %>


### PR DESCRIPTION
To match the dashboard widgets, where we change "XDMoD" to "Open XDMoD"