### PR TITLE
Properly escape user input by using Open3 capture methods

### DIFF
--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -213,8 +213,8 @@ class OodApp
           #
           # This makes the execution of the setup-production script use the same ruby versions
           # that Passenger uses when launching the app.
-          output = `PATH=#{path.join('bin').to_s}:$PATH bundle exec #{setup} 2>&1`
-          unless $?.success?
+          output, status = Open3.capture2e({'PATH' => path.join('bin').to_s + ':'+ ENV['PATH']}, 'bundle','exec', setup)
+          unless status.success?
             msg = "Per user setup failed for script at #{path}/#{setup} "
             msg += "for user #{Etc.getpwuid.name} with output: #{output}"
             raise SetupScriptFailed, msg

--- a/apps/dashboard/app/models/product.rb
+++ b/apps/dashboard/app/models/product.rb
@@ -189,12 +189,6 @@ class Product
     permissions(:group)
   end
 
-  def active_users
-    @active_users ||= `ps -o uid= -p $(pgrep -f '^Passenger .*#{Regexp.quote(router.path.to_s)}') 2> /dev/null | sort | uniq`.split.map(&:to_i).map do |id|
-      OodSupport::User.new id
-    end
-  end
-
   def git_repo?
     router.path.join(".git", "HEAD").file?
   end

--- a/apps/dashboard/app/models/product.rb
+++ b/apps/dashboard/app/models/product.rb
@@ -235,13 +235,22 @@ class Product
     end
 
     def get_git_remote
-      `cd #{router.path} 2> /dev/null && HOME="" git config --get remote.origin.url 2> /dev/null`.strip
+      Dir.chdir(router.path) do
+        o, s = Open3.capture2({'HOME'=>''}, 'git', 'config', '--get', 'remote.origin.url')
+        o.to_s.strip
+      end
     end
 
     def set_git_remote
-      target = router.path
-      Dir.chdir(target) do
-        `HOME="" git config --get remote.origin.url 2>/dev/null && HOME="" git remote set-url origin #{git_remote} 2> /dev/null || HOME="" git remote add origin #{git_remote} 2> /dev/null`
+      Dir.chdir(router.path) do
+        o, s = Open3.capture2({'HOME'=>''}, 'git', 'config', '--get', 'remote.origin.url')
+        if s.success?
+          o, s = Open3.capture2({'HOME'=>''}, 'git', 'remote', 'set-url', 'origin', git_remote)
+
+          unless s.success?
+            o, s = Open3.capture2({'HOME'=>''}, 'git', 'remote', 'add', 'origin', git_remote)
+          end
+        end
       end
     end
 
@@ -292,7 +301,9 @@ class Product
     end
 
     def git_status
-      files = `cd #{router.path} 2> /dev/null && HOME="" git status --porcelain 2> /dev/null`.split("\n")
+      files = Dir.chdir(router.path) do
+        `HOME="" git status --porcelain 2> /dev/null`.split("\n")
+      end
       results = {}
       results[:unstaged]  = files.select {|v| /^\s\w .+$/ =~ v}
       results[:staged]    = files.select {|v| /^\w\s .+$/ =~ v}

--- a/apps/dashboard/app/views/products/_product.html.erb
+++ b/apps/dashboard/app/views/products/_product.html.erb
@@ -9,9 +9,6 @@
     <% if product.git_repo? %>
       <span class="text-muted">[<%= product.version %>]</span>
     <% end %>
-    <% unless product.active_users.empty? %>
-      <span class="label label-default pull-right"><%= pluralize product.active_users.size, "active user" %></span>
-    <% end %>
     <p>
       <%= manifest_markdown(product.description) %>
     </p>

--- a/apps/dashboard/app/views/products/show.html.erb
+++ b/apps/dashboard/app/views/products/show.html.erb
@@ -44,12 +44,6 @@
       <%= @product.app.title %>
     </p>
     <p>
-      <span data-toggle="popover" data-trigger="hover" data-placement="bottom" title="Active Users" data-content="<%= @product.active_users.join("<br />") %>" data-html="true">
-        <strong>Active users:</strong>
-        <%= @product.active_users.size %>
-      </span>
-    </p>
-    <p>
       <strong>Type:</strong>
       <%= app_type_title @product.app %>
     </p>

--- a/apps/myjobs/app/controllers/templates_controller.rb
+++ b/apps/myjobs/app/controllers/templates_controller.rb
@@ -24,7 +24,6 @@ class TemplatesController < ApplicationController
   # POST /templates
   # POST /templates.json
   def create
-
     @template = template_params[:path].blank? ? Template.default : Template.new(template_params[:path])
     @template.script = template_params[:script] if template_params[:script].present?
     @template.name = template_params[:name]
@@ -47,7 +46,7 @@ class TemplatesController < ApplicationController
 
     if @template.errors.empty?
       FileUtils.mkdir_p(data_location)
-      copy_dir(template_location, data_location)
+      Filesystem.new.copy_dir(template_location, data_location)
       @template.path = data_location.to_s
 
       yaml = { 'name' => @template.name, 'host' => @template.host, 'notes' => @template.notes, 'script' => @template.script }
@@ -94,17 +93,4 @@ class TemplatesController < ApplicationController
     def template_params
       params.require(:template).permit(:name, :path, :host, :notes, :script)
     end
-
-  # Copies the data in a Location to a destination path using rsync.
-  #
-  # @param [String, Pathname] dest The target location path.
-  # @return [Location] The target location path wrapped by Location instance.
-  def copy_dir(src, dest)
-    # @path has / auto-dropped, so we add it to make sure we copy everything
-    # in the old directory to the new
-    `rsync -r --exclude='.svn' --exclude='.git' --exclude='.gitignore' --filter=':- .gitignore' '#{src.to_s}/' '#{dest.to_s}'`
-
-    # return target location so we can chain method
-    dest
-  end
 end

--- a/apps/myjobs/app/models/filesystem.rb
+++ b/apps/myjobs/app/models/filesystem.rb
@@ -70,7 +70,7 @@ class Filesystem
   end
 
   def du(path, timeout)
-    Open3.capture3 "timeout", "#{timeout}s", "du", "-cbs", path
+    Open3.capture3("timeout", "#{timeout}s", "du", "-cbs", path)
   end
 
   # Copies the data in a Location to a destination path using rsync.
@@ -78,10 +78,13 @@ class Filesystem
   # @param [String, Pathname] dest The target location path.
   # @return [Pathname] The target location path as Pathname obj
   def copy_dir(src, dest)
-    Open3.capture3({}, 'rsync', "-r --exclude='.svn' --exclude='.git' --exclude='.gitignore' --filter=':- .gitignore", src.to_s + "/", dest.to_s)
-    # FIXME: error handling
-    #
-    Pathname.new(dest)
+    o, s = Open3.capture2e({}, 'rsync', "-r --exclude='.svn' --exclude='.git' --exclude='.gitignore' --filter=':- .gitignore", src.to_s + "/", dest.to_s)
+
+    if(s.success?)
+      Pathname.new(dest)
+    else
+      raise "rsync exited with error: #{o}"
+    end
   end
 
   # FIXME: some duplication here between du command above and this; we probably

--- a/apps/myjobs/app/models/filesystem.rb
+++ b/apps/myjobs/app/models/filesystem.rb
@@ -70,7 +70,18 @@ class Filesystem
   end
 
   def du(path, timeout)
-    Open3.capture3 "timeout #{timeout}s du -cbs #{Shellwords.escape(path)}"
+    Open3.capture3 "timeout", "#{timeout}s", "du", "-cbs", path
+  end
+
+  # Copies the data in a Location to a destination path using rsync.
+  #
+  # @param [String, Pathname] dest The target location path.
+  # @return [Pathname] The target location path as Pathname obj
+  def copy_dir(src, dest)
+    Open3.capture3({}, 'rsync', "-r --exclude='.svn' --exclude='.git' --exclude='.gitignore' --filter=':- .gitignore", src.to_s + "/", dest.to_s)
+    # FIXME: error handling
+    #
+    Pathname.new(dest)
   end
 
   # FIXME: some duplication here between du command above and this; we probably

--- a/apps/myjobs/app/models/filesystem.rb
+++ b/apps/myjobs/app/models/filesystem.rb
@@ -87,10 +87,11 @@ class Filesystem
   # FIXME: some duplication here between du command above and this; we probably
   # want to use the above
   #
-  # Get the disk usage of a path in bytes, nil if path is invalid
+  # Get the disk usage of a path in bytes, nil if path does not exist
   def path_size (path)
     if Dir.exist? path
-      Integer(`du -s -b #{path}`.split('/')[0])
+      o, e, s = Open3.capture3('du', '-s', '-b', path)
+      o.split('/')[0].to_i
     end
   end
 end

--- a/apps/myjobs/app/models/filesystem.rb
+++ b/apps/myjobs/app/models/filesystem.rb
@@ -73,18 +73,14 @@ class Filesystem
     Open3.capture3("timeout", "#{timeout}s", "du", "-cbs", path)
   end
 
-  # Copies the data in a Location to a destination path using rsync.
+  # Copies the data in a source to a destination path using rsync.
   #
-  # @param [String, Pathname] dest The target location path.
-  # @return [Pathname] The target location path as Pathname obj
+  # @param [String, Pathname] src The src path.
+  # @param [String, Pathname] dest The target path.
+  # @return array of the [output, status] of the command
   def copy_dir(src, dest)
-    o, s = Open3.capture2e({}, 'rsync', "-r --exclude='.svn' --exclude='.git' --exclude='.gitignore' --filter=':- .gitignore", src.to_s + "/", dest.to_s)
-
-    if(s.success?)
-      Pathname.new(dest)
-    else
-      raise "rsync exited with error: #{o}"
-    end
+    output = `rsync -r --exclude='.svn' --exclude='.git' --exclude='.gitignore' --filter=':- .gitignore' 2>&1 #{Shellwords.escape(src.to_s)}/ #{Shellwords.escape(dest.to_s)}`
+    [output, $?]
   end
 
   # FIXME: some duplication here between du command above and this; we probably

--- a/apps/myjobs/app/views/templates/_form.html.erb
+++ b/apps/myjobs/app/views/templates/_form.html.erb
@@ -3,12 +3,23 @@
 
     <script type="text/javascript">
       $( document ).ready(function() {
-        $(".has-error input").first().focus();
+          let inputs = $(".has-error input");
+          if(inputs.length > 0){
+            inputs.first().focus();
+          }
+          else{
+            $('#error_explanation').focus()
+          }
       });
     </script>
 
     <div id="error_explanation">
       <h4><%= pluralize(@template.errors.count, "error") %> prohibited this template from being saved:</h4>
+      <ul>
+        <% @template.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
     </div>
 
   <% end %>

--- a/apps/myjobs/test/models/configuration_singleton_test.rb
+++ b/apps/myjobs/test/models/configuration_singleton_test.rb
@@ -56,6 +56,10 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   end
 
   test "loading custom OSC external config in production env" do
+    # TypeError: incompatible marshal file format (can't be read)
+    #     format version 4.8 required; 32.32 given
+    skip
+
     config_root = Rails.root.join('config','examples','osc')
     config = config_via_runner(env: 'production', envvars: "OOD_APP_CONFIG_ROOT=#{config_root}")
 
@@ -65,6 +69,10 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   end
 
   test "loading custom AweSim external config in production env" do
+    # TypeError: incompatible marshal file format (can't be read)
+    #     format version 4.8 required; 32.32 given
+    skip
+
     config_root = Rails.root.join('config','examples','awesim')
     config = config_via_runner(env: 'production', envvars: "OOD_APP_CONFIG_ROOT=#{config_root}")
 

--- a/apps/myjobs/test/models/configuration_singleton_test.rb
+++ b/apps/myjobs/test/models/configuration_singleton_test.rb
@@ -56,10 +56,6 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   end
 
   test "loading custom OSC external config in production env" do
-    # TypeError: incompatible marshal file format (can't be read)
-    #     format version 4.8 required; 32.32 given
-    skip
-
     config_root = Rails.root.join('config','examples','osc')
     config = config_via_runner(env: 'production', envvars: "OOD_APP_CONFIG_ROOT=#{config_root}")
 
@@ -69,10 +65,6 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   end
 
   test "loading custom AweSim external config in production env" do
-    # TypeError: incompatible marshal file format (can't be read)
-    #     format version 4.8 required; 32.32 given
-    skip
-
     config_root = Rails.root.join('config','examples','awesim')
     config = config_via_runner(env: 'production', envvars: "OOD_APP_CONFIG_ROOT=#{config_root}")
 

--- a/apps/myjobs/test/models/filesystem_test.rb
+++ b/apps/myjobs/test/models/filesystem_test.rb
@@ -1,8 +1,27 @@
 require 'test_helper'
 
 class FilesystemTest < ActiveSupport::TestCase
+  test "copy_dir copies directories excluding .git .svn and files in gitignore" do
+    Dir.mktmpdir do |dir|
+      tmp = Pathname.new(dir).join('t')
+      tmp2 = Pathname.new(dir).join('t2')
+
+      Filesystem.new.copy_dir Rails.root.join('example_templates', 'default'), tmp
+
+      assert_equal 2, tmp.children.count, "job script and manifest should have been copied"
+
+      tmp.join('.gitignore').write('manifest.yml')
+      tmp.join('.git').mkpath
+      tmp.join('.svn').mkpath
+
+      Filesystem.new.copy_dir tmp, tmp2
+
+      assert_equal 1, tmp2.children.count, "only job template should exist cause the manifest.yml should have been ignored"
+    end
+  end
+
   test "copy_dir doesn't allow command injection" do
-    o,e,s = Filesystem.new.copy_dir("/dev/null';echo INJECTED;'", '/dev/null')
-    refute_match /INJECTED/, o
+    o,s = Filesystem.new.copy_dir("/dev/null';echo INJECTED;'", '/dev/null')
+    assert_equal 0, o.split("\n").grep(/^INJECTED$/).count, "expected not to find INJECTED in output: #{o}"
   end
 end

--- a/apps/myjobs/test/models/filesystem_test.rb
+++ b/apps/myjobs/test/models/filesystem_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class FilesystemTest < ActiveSupport::TestCase
+  test "copy_dir doesn't allow command injection" do
+    o,e,s = Filesystem.new.copy_dir("/dev/null';echo INJECTED;'", '/dev/null')
+    refute_match /INJECTED/, o
+  end
+end


### PR DESCRIPTION
Also remove 'active_users' from developer interface which was broken as of Passenger 6 (and not really used anyways).