### PR TITLE
Gracefully fail while parsing YAML cluster configurations in Shell app

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -4,7 +4,6 @@ const path      = require('path');
 const WebSocket = require('ws');
 const express   = require('express');
 const pty       = require('node-pty');
-const hbs       = require('hbs');
 const dotenv    = require('dotenv');
 const Tokens    = require('csrf');
 const url       = require('url');

--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -10,7 +10,7 @@ const Tokens    = require('csrf');
 const url       = require('url');
 const port      = 3000;
 const helpers   = require('./utils/helpers');
-const HostAllowlist = require('./utils/HostAllowlist');
+const HostAllowlist = require('./utils/host-allowlist');
 
 // Read in environment variables
 dotenv.config({path: '.env.local'});

--- a/apps/shell/test/allowlist.test.js
+++ b/apps/shell/test/allowlist.test.js
@@ -2,7 +2,7 @@
  * Allowlist helper function tests
  */
 const helpers = require('../utils/helpers')
-const HostAllowlist = require('../utils/HostAllowlist')
+const HostAllowlist = require('../utils/host-allowlist')
 
 /**
  * Constants used during test

--- a/apps/shell/test/allowlist.test.js
+++ b/apps/shell/test/allowlist.test.js
@@ -49,8 +49,17 @@ describe('Helper function hostAndDirFromURL()', () => {
   })
 }) 
 
-describe('Class HostAllowlist', () => {
-  let cluster_path = "./test/clusters.d"
+describe('test host-allowlist class', () => {
+  let cluster_path = "./test/clusters.d";
+
+  // Mute console error during test runs
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterAll(() => {
+    console.error.mockRestore();
+  });
 
   test('generates allowlist and default_sshhost correctly', () => {
     let ood_default_sshhost = "owens.osc.edu"
@@ -59,7 +68,6 @@ describe('Class HostAllowlist', () => {
 
     expect(host_allowlist.allowlist).toMatchObject(new Set(['owens.osc.edu', 'pitzer.osc.edu', 'ruby.osc.edu', "*.ten.osc.edu"]))
     expect(host_allowlist.default_sshhost).toBe("owens.osc.edu")
-
   })
 
   test('if default_sshhost is not declared', () => {
@@ -80,4 +88,19 @@ describe('Class HostAllowlist', () => {
     expect(host_allowlist.default_sshhost).toBe("armstrong.osc.edu")
   })
 
+  test('gracefully fail if invalid cluster configs with default_sshhost defined', () => {
+    let ood_default_sshhost = 'owens.osc.edu';
+    let ood_sshhost_allowlist;
+    let host_allowlist = new HostAllowlist(ood_sshhost_allowlist, './test/clusters.d/invalid', ood_default_sshhost);
+
+    expect(host_allowlist.allowlist).toMatchObject(new Set(['owens.osc.edu']));
+    expect(host_allowlist.default_sshhost).toBe('owens.osc.edu');
+  })
+
+  test('gracefully fail if invalid cluster configs without default_sshhost defined', () => {
+    let host_allowlist = new HostAllowlist(null, './test/clusters.d/invalid', null);
+
+    expect(host_allowlist.allowlist).toMatchObject(new Set());
+    expect(host_allowlist.default_sshhost).toBe(undefined);
+  })
 })

--- a/apps/shell/test/clusters.d/invalid/owens-invalid.yml
+++ b/apps/shell/test/clusters.d/invalid/owens-invalid.yml
@@ -1,0 +1,60 @@
+---
+v2: INVALID
+  metadata:
+    title: "Owens"
+    url: "https://www.osc.edu/supercomputing/computing/owens"
+    hidden: false
+  login:
+    host: "owens.osc.edu"
+    default: true
+  job:
+    adapter: "torque"
+    host: "owens-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "owens-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "owens-batch.ten.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "owens-batch.ten.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "owens-batch.ten.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysall"
+            - "sappall"
+            - "clntall"
+          type: "blacklist"
+    grafana:
+      host: "https://grafana-test.osc.edu"
+      orgId: 1
+      dashboard:
+        name: "ondemand-clusters"
+        uid: "aaba6Ahbauquag"
+        panels:
+          cpu: 20
+          memory: 24
+      labels:
+        cluster: "cluster"
+        host: "host"
+        jobid: "jobid"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/apps/shell/test/clusters.d/invalid/pitzer-invalid.yml
+++ b/apps/shell/test/clusters.d/invalid/pitzer-invalid.yml
@@ -1,0 +1,60 @@
+---
+v2: INVALID
+  metadata:
+    title: "Pitzer"
+    url: "https://www.osc.edu/supercomputing/computing/pitzer"
+    hidden: false
+  login:
+    host: "pitzer.osc.edu"
+    default: false
+  job:
+    adapter: "torque"
+    host: "pitzer-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "pitzer-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "pitzer-batch.ten.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "pitzer-batch.ten.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "pitzer-batch.ten.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysall"
+            - "sappall"
+            - "clntall"
+          type: "blacklist"
+    grafana:
+      host: "https://grafana-test.osc.edu"
+      orgId: 1
+      dashboard:
+        name: "ondemand-clusters"
+        uid: "aaba6Ahbauquag"
+        panels:
+          cpu: 20
+          memory: 24
+      labels:
+        cluster: "cluster"
+        host: "host"
+        jobid: "jobid"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/apps/shell/test/clusters.d/invalid/ruby-invalid.yml
+++ b/apps/shell/test/clusters.d/invalid/ruby-invalid.yml
@@ -1,0 +1,63 @@
+---
+v2: INVALID
+  metadata:
+    title: "Ruby"
+    url: "https://www.osc.edu/supercomputing/computing/ruby"
+    hidden: false
+  acls:
+    - adapter: "group"
+      groups:
+        - "ruby"
+      type: "whitelist"
+  login:
+    host: "ruby.osc.edu"
+  job:
+    adapter: "torque"
+    host: "ruby-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "ruby-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "ruby-batch.ten.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "ruby-batch.ten.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "ruby-batch.ten.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysall"
+            - "sappall"
+            - "clntall"
+          type: "blacklist"
+    grafana:
+      host: "https://grafana-test.osc.edu"
+      orgId: 1
+      dashboard:
+        name: "ondemand-clusters"
+        uid: "aaba6Ahbauquag"
+        panels:
+          cpu: 10
+          memory: 4
+      labels:
+        cluster: "cluster"
+        host: "host"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/apps/shell/test/clusters.d/owens-invalid.yml
+++ b/apps/shell/test/clusters.d/owens-invalid.yml
@@ -1,0 +1,60 @@
+---
+v2: INVALID
+  metadata:
+    title: "Owens"
+    url: "https://www.osc.edu/supercomputing/computing/owens"
+    hidden: false
+  login:
+    host: "owens.osc.edu"
+    default: true
+  job:
+    adapter: "torque"
+    host: "owens-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "owens-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "owens-batch.ten.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "owens-batch.ten.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "owens-batch.ten.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysall"
+            - "sappall"
+            - "clntall"
+          type: "blacklist"
+    grafana:
+      host: "https://grafana-test.osc.edu"
+      orgId: 1
+      dashboard:
+        name: "ondemand-clusters"
+        uid: "aaba6Ahbauquag"
+        panels:
+          cpu: 20
+          memory: 24
+      labels:
+        cluster: "cluster"
+        host: "host"
+        jobid: "jobid"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -38,7 +38,7 @@ class HostAllowlist {
 
   getClusterConfigs() {
     const clusterConfigs = path.join((this.clusters_d_path || '/etc/ood/config/clusters.d'))
-    let yamlFiles = glob.sync(path.join(clusterConfigs, '*.y*ml'))
+    let yamlFiles = glob.sync(path.join(clusterConfigs + '/**', '*.y*ml'))
 
     let data = yamlFiles
       .map(location => {

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -5,27 +5,50 @@ const yaml      = require('js-yaml');
 const fs        = require('fs');
 
 class HostAllowlist {
-  constructor(ood_sshhost_allowlist, clusters_d_path, ood_default_sshhost){
-    this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set();
+  constructor(ood_sshhost_allowlist, clusters_d_path, ood_default_sshhost) {
+    this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set()
+    this.clusters = new Array()
 
-    //Filter through cluster configs, return array of hashes with host and default
-    let cluster_sshhosts = glob.sync(path.join((clusters_d_path || '/etc/ood/config/clusters.d'), '*.y*ml'))
-    .map(yml => yaml.safeLoad(fs.readFileSync(yml)))
-    .filter(config => (config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
-    .map(config => {
-      return { host: config.v2.login.host, default: config.v2.login.default ? true : false }
-    })
+    const directory = path.join((clusters_d_path || '/etc/ood/config/clusters.d'))
+    let yamlFiles = glob.sync(path.join(directory, '*.y*ml'))
+  
+    while (yamlFiles.length > 0) {
+      try {
+        // Destructure "v2" property out of yaml configuration.
+        let { v2: version } = yaml.safeLoad(fs.readFileSync(yamlFiles.shift(), 'utf-8'))
+  
+        // Destructure "login" and "metadata" properties out of cluster configuration.
+        let {
+          login: {
+            default: isDefault = version.login.default === undefined ? false : version.login.default, // If cluster configuration does not contain "default" property, set false.
+            host = version.login.host === undefined ? 'localhost' : version.login.host // If host is not defined, set to "localhost".
+          },
+          metadata: {
+            hidden = version.metadata.hidden === undefined ? true : version.metadata.hidden // If cluster configuration does not set "hidden" property, set true.
+          }
+        } = version
+ 
+        this.clusters.push(version)
 
-    //Add to allowlist
-    if (ood_default_sshhost) { 
-      this.addToAllowlist(ood_default_sshhost);
+        if (isDefault) this.default_sshhost = host // Set cluster as default if "login.default" is true.
+        if (!hidden) { // If the cluster is not hidden, add the host to the allowlist.
+          this.addToAllowlist(host)
+        }
+      } catch (err) {
+        const { name, reason, message } = err
+        if (name === 'YAMLException', reason, message) {
+          console.error(name, reason, message)
+        }
+      }
     }
-    cluster_sshhosts.forEach(cluster => {
-      this.addToAllowlist(cluster.host);
-    });
 
-    var cluster = cluster_sshhosts.find(cluster => cluster.default) || cluster_sshhosts[0];
-    this.default_sshhost = ood_default_sshhost || cluster.host;
+    // Find default cluster configuration.
+    let { login: { host } } = this.clusters.find(cluster => cluster.default) || this.clusters.shift() // Find cluster with "login.default", if not found then use first cluster found.
+    this.default_sshhost = ood_default_sshhost || host // ood_default_sshhost takes precedence over default cluster found.
+
+    if (ood_default_sshhost) {
+      this.addToAllowlist(ood_default_sshhost)
+    }
   }
 
   default_sshhost() {

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -13,13 +13,9 @@ class HostAllowlist {
         .map(yml => yaml.safeLoad(fs.readFileSync(yml)))
         .filter(config => (config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
         .map(config => {
-            let isDefault = false;
-            if (config.v2.login.default){ // a catch in case the default is undefined for cluster configs
-                isDefault = true
-            }
-            return { host: config.v2.login.host, default: isDefault }
+            return { host: config.v2.login.host, default: config.v2.login.default ? true : false }
         })
-    
+
         //Add to allowlist
         if (ood_default_sshhost) { 
             this.addToAllowlist(ood_default_sshhost);

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -8,6 +8,7 @@ class HostAllowlist {
   constructor(ood_sshhost_allowlist, clusters_d_path, ood_default_sshhost) {
     this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set();
     this.clusters = new Array();
+    this.default_sshhost = ood_default_sshhost || undefined;
 
     const clusterConfigs = path.join((clusters_d_path || '/etc/ood/config/clusters.d'));
     let yamlFiles = glob.sync(path.join(clusterConfigs, '*.y*ml'));
@@ -42,8 +43,6 @@ class HostAllowlist {
           default: isDefault,
         };
       });
-
-    this.default_sshhost = ood_default_sshhost || undefined; // ood_default_sshhost takes precedence over default cluster found.
 
     // Find default cluster configuration.
     if (this.clusters.length > 0) {

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -5,45 +5,45 @@ const yaml      = require('js-yaml');
 const fs        = require('fs');
 
 class HostAllowlist {
-    constructor(ood_sshhost_allowlist, clusters_d_path, ood_default_sshhost){
-        this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set();
-  
-        //Filter through cluster configs, return array of hashes with host and default
-        let cluster_sshhosts = glob.sync(path.join((clusters_d_path || '/etc/ood/config/clusters.d'), '*.y*ml'))
-        .map(yml => yaml.safeLoad(fs.readFileSync(yml)))
-        .filter(config => (config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
-        .map(config => {
-            return { host: config.v2.login.host, default: config.v2.login.default ? true : false }
-        })
+  constructor(ood_sshhost_allowlist, clusters_d_path, ood_default_sshhost){
+    this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set();
 
-        //Add to allowlist
-        if (ood_default_sshhost) { 
-            this.addToAllowlist(ood_default_sshhost);
-        }
-        cluster_sshhosts.forEach(cluster => {
-            this.addToAllowlist(cluster.host);
-        });
+    //Filter through cluster configs, return array of hashes with host and default
+    let cluster_sshhosts = glob.sync(path.join((clusters_d_path || '/etc/ood/config/clusters.d'), '*.y*ml'))
+    .map(yml => yaml.safeLoad(fs.readFileSync(yml)))
+    .filter(config => (config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
+    .map(config => {
+      return { host: config.v2.login.host, default: config.v2.login.default ? true : false }
+    })
 
-        var cluster = cluster_sshhosts.find(cluster => cluster.default) || cluster_sshhosts[0];
-        this.default_sshhost = ood_default_sshhost || cluster.host;
+    //Add to allowlist
+    if (ood_default_sshhost) { 
+      this.addToAllowlist(ood_default_sshhost);
     }
-  
-    default_sshhost() {
-        return this.default_sshhost;
-    }
-  
-    allowlist() {
-        return this.allowlist;
-    }
+    cluster_sshhosts.forEach(cluster => {
+      this.addToAllowlist(cluster.host);
+    });
 
-    addToAllowlist(host) {
-        this.allowlist.add(host);
-    }
+    var cluster = cluster_sshhosts.find(cluster => cluster.default) || cluster_sshhosts[0];
+    this.default_sshhost = ood_default_sshhost || cluster.host;
+  }
 
-    hostInAllowlist(host) {
-        var arrAllowlist = Array.from(this.allowlist);
-        return arrAllowlist.some((value) => minimatch(host, value))
-    }
+  default_sshhost() {
+    return this.default_sshhost;
+  }
+
+  allowlist() {
+    return this.allowlist;
+  }
+
+  addToAllowlist(host) {
+    this.allowlist.add(host);
+  }
+
+  hostInAllowlist(host) {
+    var arrAllowlist = Array.from(this.allowlist);
+    return arrAllowlist.some((value) => minimatch(host, value))
+  }
 }
 
 module.exports = HostAllowlist

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -6,57 +6,57 @@ const fs        = require('fs');
 
 class HostAllowlist {
   constructor(ood_sshhost_allowlist, clusters_d_path, ood_default_sshhost) {
-    this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set()
-    this.clusters = new Array()
-    this.clusters_d_path = clusters_d_path
+    this.allowlist = ood_sshhost_allowlist ? new Set(ood_sshhost_allowlist.split(':')) : new Set();
+    this.clusters = new Array();
+    this.clusters_d_path = clusters_d_path;
 
     this.clusters = this.getClusterConfigs()
       .filter(config => (config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
       .map(config => {
-        let hidden = config.v2.login.hidden
-        let host = config.v2.login.host || 'localhost'
-        let isDefault = config.v2.login.default || false
+        let hidden = config.v2.login.hidden;
+        let host = config.v2.login.host || 'localhost';
+        let isDefault = config.v2.login.default || false;
 
         if (!hidden) { // If the cluster is not hidden, add the host to the allowlist.
-          this.addToAllowlist(host)
-        }
+          this.addToAllowlist(host);
+        };
 
         return {
           host,
           default: isDefault,
-        }
+        };
       })
 
     // Find default cluster configuration.
-    let found = this.clusters.find(cluster => cluster.default) || this.clusters.shift() // Find cluster with "default", if not found then use first cluster in array.
-    this.default_sshhost = ood_default_sshhost || found.host // ood_default_sshhost takes precedence over default cluster found.
+    let found = this.clusters.find(cluster => cluster.default) || this.clusters.shift(); // Find cluster with "default", if not found then use first cluster in array.
+    this.default_sshhost = ood_default_sshhost || found.host; // ood_default_sshhost takes precedence over default cluster found.
 
     if (ood_default_sshhost) {
-      this.addToAllowlist(ood_default_sshhost)
+      this.addToAllowlist(ood_default_sshhost);
     }
   }
 
   getClusterConfigs() {
-    const clusterConfigs = path.join((this.clusters_d_path || '/etc/ood/config/clusters.d'))
-    let yamlFiles = glob.sync(path.join(clusterConfigs + '/**', '*.y*ml'))
+    const clusterConfigs = path.join((this.clusters_d_path || '/etc/ood/config/clusters.d'));
+    let yamlFiles = glob.sync(path.join(clusterConfigs + '/**', '*.y*ml'));
 
     let data = yamlFiles
       .map(location => {
         // Attempt to parse yaml file.
         try {
-          let parsed = yaml.safeLoad(fs.readFileSync(location, 'utf-8'))
+          let parsed = yaml.safeLoad(fs.readFileSync(location, 'utf-8'));
 
-          return parsed
+          return parsed;
         } catch (err) {
-          const { name } = err
+          const { name } = err;
 
           if (name === 'YAMLException') {
-            return err
+            return err;
           }
         }
       })
 
-    return data
+    return data;
   }
 
   default_sshhost() {

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -22,7 +22,7 @@ class HostAllowlist {
         } catch (err) {
           const { name, reason, message } = err
 
-          if (name === 'YAMLException', reason, message) {
+          if (name === 'YAMLException') {
             console.error(name, reason, message)
           }
         }

--- a/apps/shell/utils/host-allowlist.js
+++ b/apps/shell/utils/host-allowlist.js
@@ -44,14 +44,14 @@ class HostAllowlist {
       .map(location => {
         // Attempt to parse yaml file.
         try {
-          let data = yaml.safeLoad(fs.readFileSync(location, 'utf-8'))
+          let parsed = yaml.safeLoad(fs.readFileSync(location, 'utf-8'))
 
-          return data
+          return parsed
         } catch (err) {
-          const { name, reason, message } = err
+          const { name } = err
 
           if (name === 'YAMLException') {
-            console.error(name, reason, message)
+            return err
           }
         }
       })


### PR DESCRIPTION
This PR brings improvements to the Shell app.

* Gracefully fail if there is an invalid cluster configuration.
* Rename `utils/HostAllowList.js` to `host-allowlist.js`

**Tests passing:**
![image](https://user-images.githubusercontent.com/6081892/97477672-490d6b80-1926-11eb-8c2c-431d49d037ce.png)
