### PR TITLE
rm spec.executables from nginx_stage

### DIFF
--- a/nginx_stage/nginx_stage.gemspec
+++ b/nginx_stage/nginx_stage.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Remove these files because installing this will put a 'ruby' file in your PATH which will create a recursive call back to that file.
Then anything trying to build or run ruby will inevitably have many many calls to this file resulting in "/usr/bin/env: 'ruby': Argument list too long" errors.

I came across this this week while refreshing my system to use `rvm` which puts the `GEM_HOME/bin` in the PATH, something I didn't have previously.

Now our builds https://travis-ci.org/github/OSC/ondemand/jobs/739295820#L308 are starting to fail, so it's come to a head.

The `ruby` file in this `bin` directory causes issues when it's dropped into `$GEM_HOME/bin`.  It's not clear why it was initially added, maybe to help development with different versions of ruby? In any case, it's now problematic even for our CI so we have to deal with it.

To replicate I think all you need to do is have `$GEM_HOME/bin` in your `PATH` and step to the nginx_stage directory and run `bundle install --with development test`. This will drop a `ruby` file in bin and now you'll have recursive calls to that file.