### PR TITLE
small patch to redirect to sessions

### DIFF
--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -266,6 +266,8 @@ class OodApp
   def version_from_git
     o, e, s = Open3.capture3('git', 'describe', '--always', '--tags', chdir: path.to_s)
     s.success? ? o : nil
+  rescue
+    nil
   end
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -10,13 +10,13 @@ class BatchConnect::SessionContextsController < ApplicationController
     if @app.valid?
       # Read in context from cache file if cache is disabled and context.json exist
       begin
-       @session_context.update_with_cache(JSON.parse(cache_file.read))  if cache_file.file?
-      rescue => e
-        flash.now[:alert] = t('dashboard.batch_connect_form_attr_cache_error',error_message: e.message)
+        @session_context.update_with_cache(JSON.parse(cache_file.read)) if cache_file.file?
+      rescue StandardError => e
+        flash.now[:alert] = t('dashboard.batch_connect_form_attr_cache_error', error_message: e.message)
       end
     else
       @session_context = nil  # do not display session context form
-      flash.now[:alert] = @app.validation_reason
+      redirect_to batch_connect_sessions_url, alert: @app.validation_reason
     end
 
     set_app_groups


### PR DESCRIPTION
small patch to redirect to sessions if the bc app you're trying to access doesn't exist

fixes #659.

The token we get is like `sessions/<UUID>`, we could check for that regex. But this just catches the exception in finding the git version and since it's an invalid app, redirects back to your sessions page.