### PR TITLE
activejobs: use button for details disclosure

### DIFF
--- a/apps/activejobs/app/assets/javascripts/application.js
+++ b/apps/activejobs/app/assets/javascripts/application.js
@@ -37,12 +37,21 @@ function human_time(seconds_total) {
 }
 
 function fetch_job_data(tr, row, options) {
+  let btn = tr.find('button.details-control');
   if (row.child.isShown()) {
     // This row is already open - close it
     row.child.hide();
     tr.removeClass("shown");
+
+    btn.removeClass("fa-chevron-down");
+    btn.addClass("fa-chevron-right");
+    btn.attr("aria-expanded", false);
   } else {
     tr.addClass("shown");
+
+    btn.removeClass("fa-chevron-right");
+    btn.addClass("fa-chevron-down");
+    btn.attr("aria-expanded", true);
 
     let data = {
       pbsid: row.data().pbsid,
@@ -168,8 +177,6 @@ function create_datatable(options){
             "sSearch": "Filter: "
         },
         "fnCreatedRow": function( nRow, aData, iDataIndex ) {
-          $(nRow).attr("tabindex", 0);
-          
           $(nRow).children("td").css("overflow", "hidden");
           $(nRow).children("td").css("white-space", "nowrap");
           $(nRow).children("td").css("text-overflow", "ellipsis");
@@ -196,13 +203,8 @@ function create_datatable(options){
                 "defaultContent":   '',
                 "width":            "20px",
                 "searchable":       false,
-                "fnCreatedCell":    function(nTd, data) {
-                                        if (data) {
-                                            $(nTd).addClass('details-control');
-                                        }
-                                    },
-                render: function () {
-                  return "";
+                render: function (data, type, row, meta) {
+                  return '<button class="details-control fa fa-chevron-right btn btn-default" aria-expanded="false" aria-label="Toggle visibility of job details row"></button>';
                 },
             },
             {

--- a/apps/activejobs/app/assets/stylesheets/jobs.scss
+++ b/apps/activejobs/app/assets/stylesheets/jobs.scss
@@ -9,16 +9,6 @@ table td {
   word-wrap:break-word;
 }
 
-td.details-control {
-  background: url(image_path('arrowright.png')) no-repeat center center;
-  background-size: 75%;
-  cursor: pointer;
-}
-tr.shown td.details-control {
-  background: url(image_path('arrowdown.png')) no-repeat center center;
-  background-size: 75%;
-}
-
 .job_label_data {
   word-wrap: break-word;
   bottom: 0;


### PR DESCRIPTION
use actual button for job details show/hide, so that it is controllable
using a keyboard

add aria attribute expanded expected by disclosure control
add aria label for button

This results in a slight change in look and feel:

![screen 2020-11-10 at 10 48 30 AM](https://user-images.githubusercontent.com/512333/98697063-7dc7ec80-2342-11eb-9ef1-6cda673d370b.png)

But now since we use a button, you can activate using Enter or Space as expected by https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure and focus on the button:

![screen 2020-11-10 at 10 48 47 AM](https://user-images.githubusercontent.com/512333/98697171-9cc67e80-2342-11eb-89a0-25882ce0a779.png)
