### PR TITLE
Update job details and delete button aria-labels

### DIFF
--- a/apps/activejobs/app/assets/javascripts/application.js
+++ b/apps/activejobs/app/assets/javascripts/application.js
@@ -277,7 +277,9 @@ function create_datatable(options){
                 data:               null,
                 className:          "small",
                 "autoWidth":        true,
-                "render":           function(data){
+                render: function(data, type, row, meta) {
+                  let { jobname, pbsid } = row
+
                   if(data.delete_path == "" || data.status == "completed"){
                     return ""
                   } else {
@@ -288,7 +290,7 @@ function create_datatable(options){
                           data-method="delete"
                           data-confirm="Are you sure you want to delete ${data.jobname} - ${data.pbsid}"
                           href="${data.delete_path}"
-                          aria-labeled-by"title"
+                          aria-label="Delete job ${jobname} with ID ${pbsid}"
                           data-toggle="tooltip"
                           title="Delete Job"
                         >

--- a/apps/activejobs/app/assets/javascripts/application.js
+++ b/apps/activejobs/app/assets/javascripts/application.js
@@ -204,7 +204,8 @@ function create_datatable(options){
                 "width":            "20px",
                 "searchable":       false,
                 render: function (data, type, row, meta) {
-                  return '<button class="details-control fa fa-chevron-right btn btn-default" aria-expanded="false" aria-label="Toggle visibility of job details row"></button>';
+                  let { cluster_title, jobname, } = row
+                  return `<button class="details-control fa fa-chevron-right btn btn-default" aria-expanded="false" aria-label="Toggle visibility of job details for job ${jobname} on ${cluster_title}"></button>`;
                 },
             },
             {


### PR DESCRIPTION
This PR updates the `aria-label` for toggle job details and delete job buttons in Active Jobs. I tested this with NVDA Screen Reader and it works as expected.

**Show details** `aria-label`:
```
Toggle visibility of job details for job ondemand/sys/dashboard/sys/bc_osc_rstudio_server on Pitzer
```

**Delete button** `aria-label`:
```
Delete job ondemand/sys/dashboard/sys/bc_osc_rstudio_server with ID 2141764
```