### PR TITLE
Use OnDemand version specific build repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,10 @@
 before_script:
   - docker info
   - '[ -d tmp ] || mkdir tmp'
-  - git clone https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+  - MAJOR_VERSION=$(echo "$CI_COMMIT_TAG" | grep -v "v" | cut -d'.' -f1)
+  - MINOR_VERSION=$(echo "$CI_COMMIT_TAG" | grep -v "v" | cut -d'.' -f2)
+  - RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}"
+  - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
   - cp /systems/osc_certs/gpg/ondemand/.gpgpass $CI_PROJECT_DIR/tmp/ondemand-packaging/
   - cp /systems/osc_certs/gpg/ondemand/ondemand.sec $CI_PROJECT_DIR/tmp/ondemand-packaging/
 stages:
@@ -32,6 +35,13 @@ rpm-build-el8:
     paths:
       - tmp/output
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
+
+rpm-deploy-build:
+  stage: deploy
+  only:
+    - tags
+  script:
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./tmp/output/*
 
 rpm-deploy-ci:
   stage: deploy


### PR DESCRIPTION
This is to be able to build 1.8 RPMs using automated build tools while still building 2.0 on master branch.

The corresponding packaging changes: https://github.com/OSC/ondemand-packaging/pull/93

I will do similar changes to this repo and ondemand-packaging for 1.7.