### PR TITLE
add area/build labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,3 +30,6 @@ component/ood_auth_map:
 
 component/ood_portal_generator:
   - ood-portal-generator/**/*
+
+area/build:
+  - lib/tasks/**/*


### PR DESCRIPTION
A simple change to add `area/build` labels to PRs based on `lib/tasks` files changed.