### PR TITLE
Fix component/dashboard labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@ component/bc_desktop:
   - apps/bc_desktop/**/*
 
 component/dashboard:
-  - apps/activejobs/**/*
+  - apps/dashboard/**/*
 
 component/file_editor:
   - apps/file-editor/**/*


### PR DESCRIPTION
`component/dashboard` label was being incorrectly applied to `activejobs`