### PR TITLE
don't always use cached clusters 

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -8,9 +8,8 @@ class BatchConnect::SessionContextsController < ApplicationController
     set_session_context
 
     if @app.valid?
-      # Read in context from cache file if cache is disabled and context.json exist
       begin
-       @session_context.update_with_cache(JSON.parse(cache_file.read))  if cache_file.file?
+        update_session_with_cache
       rescue => e
         flash.now[:alert] = t('dashboard.batch_connect_form_attr_cache_error',error_message: e.message)
       end
@@ -81,5 +80,22 @@ class BatchConnect::SessionContextsController < ApplicationController
     # Store session context into a cache file
     def cache_file
       BatchConnect::Session.dataroot(@app.token).tap { |p| p.mkpath unless p.exist? }.join("context.json")
-    end 
+    end
+
+    # Read in context from cache file if cache is disabled and context.json exist
+    def update_session_with_cache
+      cache = cache_file.file? ? JSON.parse(cache_file.read) : {}
+      cache.delete('cluster') if delete_cached_cluster?(cache['cluster'].to_s)
+
+      @session_context.update_with_cache(cache)
+    end
+
+    def delete_cached_cluster?(cached_cluster)
+
+      # if you've cached a cluster that no longer exists
+      !OodAppkit.clusters.include?(cached_cluster) ||
+        # OR the app only has 1 cluster, and it's changed since the previous cluster was cached.
+        # I.e., admin wants to override what you've cached.
+        (@app.clusters.size == 1 && @app.clusters[0] != cached_cluster)
+    end
 end

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -85,17 +85,10 @@ class BatchConnect::SessionContextsController < ApplicationController
     # Read in context from cache file if cache is disabled and context.json exist
     def update_session_with_cache
       cache = cache_file.file? ? JSON.parse(cache_file.read) : {}
-      cache.delete('cluster') if delete_cached_cluster?(cache['cluster'].to_s)
 
+      # you could be trying to use a cluster that no longer exists or the app
+      # was changed to a different cluster (and does not provide the user with a choice)
+      cache.delete('cluster') unless @app.clusters.include?(cache['cluster'].to_s)
       @session_context.update_with_cache(cache)
-    end
-
-    def delete_cached_cluster?(cached_cluster)
-
-      # if you've cached a cluster that no longer exists
-      !OodAppkit.clusters.include?(cached_cluster) ||
-        # OR the app only has 1 cluster, and it's changed since the previous cluster was cached.
-        # I.e., admin wants to override what you've cached.
-        (@app.clusters.size == 1 && @app.clusters[0] != cached_cluster)
     end
 end

--- a/apps/dashboard/test/controllers/batch_connect/session_contexts_controller_test.rb
+++ b/apps/dashboard/test/controllers/batch_connect/session_contexts_controller_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+# OodAppKit = OodAppKit
+
+class BatchConnect::SessionContextsControllerTest < ActionController::TestCase
+
+  test "create new session when cached cluster is no longer exists" do
+    Dir.mktmpdir("session_context_controller_test") do |tmpdir|
+
+      cache_json = File.new("#{tmpdir}/cache.json", 'w+')
+      cache_json.write({cluster: 'old'}.to_json) # 'old' cluster is cached
+      cache_json.close
+
+      app_yml = File.new("#{tmpdir}/form.yml", 'w+')
+      app_yml.write({
+        'cluster': 'new',
+        'form': [
+          'some_input_string'
+        ]
+      }.transform_keys(&:to_s).to_yaml)
+      app_yml.close
+
+      # read form.yml and cache.json from the tmp directory
+      BatchConnect::App.any_instance.stubs(:version).returns("1.0.0")
+      BatchConnect::App.any_instance.stubs(:root).returns(Pathname(tmpdir.to_s))
+      @controller.stubs(:cache_file).returns(Pathname(cache_json.path))
+
+      # only the 'new' cluster is enabled (read from clusters.d)
+      OodAppkit.stubs(:clusters).returns([
+        OodCore::Cluster.new({ id: 'new', job: { some: 'job config' }})
+      ])
+
+
+      get :new, params: { token: 'dev/test' }
+      assert_response :success
+      assert_select "div .alert", 1 # OnDemand requires a newer version of the browser
+      assert_select "input[type=hidden][id='batch_connect_session_context_cluster'][value=?]", "new"
+    end
+  end
+
+  test "create new session when cached cluster exists, but is no longer wanted" do
+    Dir.mktmpdir("session_context_controller_test") do |tmpdir|
+
+      cache_json = File.new("#{tmpdir}/cache.json", 'w+')
+      cache_json.write({cluster: 'old'}.to_json) # 'old' cluster is cached
+      cache_json.close
+
+      app_yml = File.new("#{tmpdir}/form.yml", 'w+')
+      app_yml.write({
+        'cluster': 'new',
+        'form': [
+          'some_input_string'
+        ]
+      }.transform_keys(&:to_s).to_yaml)
+      app_yml.close
+
+      # read form.yml and cache.json from the tmp directory
+      BatchConnect::App.any_instance.stubs(:version).returns("1.0.0")
+      BatchConnect::App.any_instance.stubs(:root).returns(Pathname(tmpdir.to_s))
+      @controller.stubs(:cache_file).returns(Pathname(cache_json.path))
+
+      # old and new clusters both enabled (read from clusters.d)
+      OodAppkit.stubs(:clusters).returns([
+        OodCore::Cluster.new({ id: 'new', job: { some: 'job config' }}),
+        OodCore::Cluster.new({ id: 'old', job: { some: 'job config' }})
+      ])
+
+
+      get :new, params: { token: 'dev/test' }
+      assert_response :success
+      assert_select "div .alert", 1 # OnDemand requires a newer version of the browser
+      assert_select "input[type=hidden][id='batch_connect_session_context_cluster'][value=?]", "new"
+    end
+  end
+end


### PR DESCRIPTION
don't use cached clusters when the cached cluster value conflicts with the current form

As the comment in delete_cached_cluster? says, it's possible to (a) have a cached
cluster value that no longer exists OR the app has simply reconfigured a different
cluster to use.

This is problematic for apps with only 1 cluster because the form presented to the
user does not give an option to change the value. So if you've cached a bad value,
they're stuck with it.

The tests will show the erroneous behavior by checking out app/ to the previous commit.