### PR TITLE
gitlab ci use bash variable expansion instead of grep to remove v

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 before_script:
   - docker info
   - '[ -d tmp ] || mkdir tmp'
-  - MAJOR_VERSION=$(echo "$CI_COMMIT_TAG" | grep -v "v" | cut -d'.' -f1)
-  - MINOR_VERSION=$(echo "$CI_COMMIT_TAG" | grep -v "v" | cut -d'.' -f2)
+  - MAJOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f1)
+  - MINOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f2)
   - RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}"
   - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
   - cp /systems/osc_certs/gpg/ondemand/.gpgpass $CI_PROJECT_DIR/tmp/ondemand-packaging/


### PR DESCRIPTION
gitlab ci use bash variable expansion instead of grep to remove v