### PR TITLE
(mainline) deleting clusters needs to account for form defined clusters too

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -85,10 +85,17 @@ class BatchConnect::SessionContextsController < ApplicationController
     # Read in context from cache file if cache is disabled and context.json exist
     def update_session_with_cache
       cache = cache_file.file? ? JSON.parse(cache_file.read) : {}
+      cache.delete('cluster') if delete_cached_cluster?(cache['cluster'].to_s)
 
-      # you could be trying to use a cluster that no longer exists or the app
-      # was changed to a different cluster (and does not provide the user with a choice)
-      cache.delete('cluster') unless @app.clusters.include?(cache['cluster'].to_s)
       @session_context.update_with_cache(cache)
+    end
+
+    def delete_cached_cluster?(cached_cluster)
+
+      # if you've cached a cluster that no longer exists
+      !OodAppkit.clusters.include?(cached_cluster) ||
+        # OR the app only has 1 cluster, and it's changed since the previous cluster was cached.
+        # I.e., admin wants to override what you've cached.
+        (@app.clusters.size == 1 && @app.clusters[0] != cached_cluster)
     end
 end

--- a/apps/dashboard/test/controllers/batch_connect/session_contexts_controller_test.rb
+++ b/apps/dashboard/test/controllers/batch_connect/session_contexts_controller_test.rb
@@ -72,4 +72,49 @@ class BatchConnect::SessionContextsControllerTest < ActionController::TestCase
       assert_select "input[type=hidden][id='batch_connect_session_context_cluster'][value=?]", "new"
     end
   end
+
+  test "keep cached cluster when cluster is defined in form" do
+    Dir.mktmpdir("session_context_controller_test") do |tmpdir|
+
+      cache_json = File.new("#{tmpdir}/cache.json", 'w+')
+      cache_json.write({cluster: 'second'}.to_json) # 'second' cluster is cached
+      cache_json.close
+
+      app_yml = File.new("/#{tmpdir}/form.yml", 'w+')
+      app_yml.write({
+        'form': [
+          'some_input_string',
+          'cluster'
+        ],
+        'attributes': {
+          'cluster': {
+            'widget': 'select',
+            'options': [
+              'first',
+              'second'
+            ]
+          }.transform_keys(&:to_s)
+        }.transform_keys(&:to_s)
+      }.transform_keys(&:to_s).to_yaml)
+      app_yml.close
+
+      # read form.yml and cache.json from the tmp directory
+      BatchConnect::App.any_instance.stubs(:version).returns("1.0.0")
+      BatchConnect::App.any_instance.stubs(:root).returns(Pathname(tmpdir.to_s))
+      @controller.stubs(:cache_file).returns(Pathname(cache_json.path))
+
+      # old and new clusters both enabled (read from clusters.d)
+      OodAppkit.stubs(:clusters).returns([
+        OodCore::Cluster.new({ id: 'first', job: { some: 'job config' }}),
+        OodCore::Cluster.new({ id: 'second', job: { some: 'job config' }})
+      ])
+
+
+      get :new, params: { token: 'dev/test' }
+      assert_response :success
+
+      assert_select "div .alert", 1 # OnDemand requires a newer version of the browser
+      assert_select "select#batch_connect_session_context_cluster option[selected][value=?]", "second"
+    end
+  end
 end


### PR DESCRIPTION
The original logic in was right because it accounts for clusters defined in the form/attributes. 

https://github.com/OSC/ondemand/pull/748/commits