### PR TITLE
Fix docker dev builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY ood-portal-generator   /opt/ood/ood-portal-generator
 COPY ood_auth_map           /opt/ood/ood_auth_map
 COPY apps                   /opt/ood/apps
 COPY Rakefile               /opt/ood/Rakefile
+COPY lib                    /opt/ood/lib
 
 RUN  cd /opt/ood && \
     scl enable ondemand -- rake -mj4 build && \


### PR DESCRIPTION
The move to using `lib` for tasks needs to be copied into container for docker development builds.