### PR TITLE
Fix cacheable flag bug

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -184,7 +184,7 @@ module BatchConnect
         ""
       end
     end
-       
+
     # The session context described by this batch connect app
     # @return [SessionContext] the session context
     def build_session_context

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -1,4 +1,4 @@
- require "smart_attributes"
+require "smart_attributes"
 
 module BatchConnect
   class App
@@ -150,7 +150,6 @@ module BatchConnect
         (self.clusters.size == 1 && self.clusters[0] != cached_cluster)
     end
 
-
     # The clusters that the batch connect app can use. It's a combination
     # of what the app is configured to use and what the user is allowed
     # to use.
@@ -185,7 +184,7 @@ module BatchConnect
         ""
       end
     end
-    
+       
     # The session context described by this batch connect app
     # @return [SessionContext] the session context
     def build_session_context
@@ -205,8 +204,12 @@ module BatchConnect
         SmartAttributes::AttributeFactory.build(attribute_id, attribute_opts)
       end
 
-     BatchConnect::SessionContext.new(attributes, form_config.fetch(:cacheable, nil)  ) #form_config.fetch(:cacheable, nil)  
+     BatchConnect::SessionContext.new(attributes, get_cacheable_value(local_attribs))  
        
+    end
+
+    def cacheable_val
+      get_cacheable_value(form_config.fetch(:attributes, {}))
     end
 
     #
@@ -367,6 +370,12 @@ module BatchConnect
             widget: "hidden_field"
           }
         end
+      end
+
+      # grab the cluster attrib's cacheable field value 
+      def get_cacheable_value(local_attribs)
+        cluster_attrib = local_attribs.fetch(:cluster, {})
+        cluster_attrib.fetch(:cacheable, nil)
       end
   end
 end


### PR DESCRIPTION
The method that builds the session_context in batch_connect/app.rb was not fetching the flag correctly. I added a private method to fetch the cacheable flag and called it from there. 