### PR TITLE
add development container and refactor lib/tasks/packaging slightly.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Checkout ${{ github.sha	}}
         uses: actions/checkout@v2
 
+      - name: Ensure tags exist for container packaging
+        run: git fetch --prune --unshallow --tags
+
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
         with:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM ood:latest
+
+ARG USER=ood
+ARG UID=1000
+ARG GID=1000
+
+RUN dnf reinstall -y httpd-tools && \
+    dnf install -y \
+        strace && \
+    dnf clean all && rm -rf /var/cache/dnf/*
+
+RUN groupadd -g $GID $USER && \
+    useradd -u $UID --create-home --gid $USER $USER && \
+    echo "$USER ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/$USER
+
+COPY docker/dev-entrypoint.sh /entrypoint.sh
+
+CMD [ "/entrypoint.sh" ]

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+set -e
+
+export USER=$(whoami) # $USER isn't set!?
+
+APP_DEV_DIR="/home/$USER/ondemand/dev"
+OOD_DEV_DIR="/var/www/ood/apps/dev/$USER"
+
+sudo su root <<MKDEV
+  mkdir -p $OOD_DEV_DIR 
+  chmod 755 $OOD_DEV_DIR
+  cd $OOD_DEV_DIR
+  ln -s $APP_DEV_DIR gateway
+MKDEV
+
+/opt/ood/ood-portal-generator/sbin/update_ood_portal
+
+if [ -n "$OOD_STATIC_USER" ] && [ -f "$OOD_STATIC_USER" ]; then
+  cat "$OOD_STATIC_USER" >>  /etc/ood/dex/config.yaml
+fi
+
+sudo runuser -u ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml &
+sudo /usr/sbin/httpd -DFOREGROUND

--- a/lib/tasks/build_utils.rb
+++ b/lib/tasks/build_utils.rb
@@ -1,6 +1,6 @@
 module BuildUtils
   def image_tag
-    tag? ? numeric_tag : git_hash
+    tag? ? numeric_tag : "#{numeric_tag}-#{git_hash}"
   end
 
   def ood_version
@@ -33,6 +33,10 @@ module BuildUtils
 
   def test_image_name
     "ood-test"
+  end
+
+  def dev_image_name
+    "ood-dev"
   end
 
   def image_name

--- a/lib/tasks/docker.rb
+++ b/lib/tasks/docker.rb
@@ -2,19 +2,14 @@ DOCKER_NAME = ENV["DOCKER_NAME"] || "ondemand-dev"
 
 namespace :docker do
     desc "Build Docker container"
-    task :build => ["package:latest_container"] do
-      file = "Dockerfile.test"
-      build_cmd = podman_runtime? ? buildah_build_cmd(file, DOCKER_NAME) : docker_build_cmd(file, DOCKER_NAME)
-      sh build_cmd unless image_exists?("#{DOCKER_NAME}:#{image_tag}")
-      sh tag_latest_container_cmd(DOCKER_NAME)
-    end
+    task :build => ["package:test_container"]
 
     desc "Run Docker container"
-    task :run do
+    task :run => :build do
       args = [ container_runtime, 'run', '-p 8080:8080', '-p 5556:5556', "--name #{DOCKER_NAME}" ]
       args.concat [ "--rm", "--detach", "-v '#{PROJ_DIR}:/ondemand'" ]
       args.concat mount_args
-      args.concat [ "#{DOCKER_NAME}:latest" ]
+      args.concat [ "#{test_image_name}:latest" ]
       sh args.join(' ')
     end
 


### PR DESCRIPTION
This is the development container that I use, so here's a rake task and some files to build it.

It really centers around the fact that I use podman and I can launch this container rootlessly me, so I can also then mount `$HOME/ondemand/dev:$HOME/ondemand/dev` directly into the container and edit the files as me on both sides and I don't have to worry about privilege escalation.

I get this nice ps tree where "root" (UID 100000) starts everything up, but I'm still me.
```text
4 S jeff      608338  607955  0  80   0 - 87066 -      15:30 ?        00:00:00 Passenger watchdog
0 S jeff      608341  608338  0  80   0 - 378633 -     15:30 ?        00:00:00 Passenger core
5 S 100000    608353  607955  0  80   0 - 23078 -      15:30 ?        00:00:00 nginx: master process (jeff) -c /var/lib/ondemand-nginx/config/puns/jeff.conf
5 S jeff      608358  608353  0  80   0 - 26720 -      15:30 ?        00:00:00 nginx: worker process
0 S jeff      608431  608341  2  80   0 - 93347 -      15:30 ?        00:00:02 ruby /opt/rh/ondemand/root/usr/share/passenger/helper-scripts/rack-loader.rb
```

There's this little hack in the entry point where I've mounted and `ood_portal.yml` that generated dex configs, but I need to add myself (`$USER` not `ood`) to the staticPasswords so I just append the file.
https://github.com/OSC/ondemand/blob/5513c30315865941185279caa8f17ac9893f2ae6/docker/dev-entrypoint.sh#L20-L22

There's also a little re-factoring to generate tags with the OOD version like `1.8.19-2-bc72f6f` instead of just the git commit hash `bc72f6f`. 

The `docker:*` tasks still use the test_container I just cleaned it up a smidge to be sure there's only 1 way to do a thing (build in this case).