### PR TITLE
dev container setup in sudo context

### DIFF
--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -8,18 +8,18 @@ export USER=$(whoami) # $USER isn't set!?
 APP_DEV_DIR="/home/$USER/ondemand/dev"
 OOD_DEV_DIR="/var/www/ood/apps/dev/$USER"
 
-sudo su root <<MKDEV
+sudo su root <<SETUP
   mkdir -p $OOD_DEV_DIR 
   chmod 755 $OOD_DEV_DIR
   cd $OOD_DEV_DIR
   ln -s $APP_DEV_DIR gateway
-MKDEV
 
-/opt/ood/ood-portal-generator/sbin/update_ood_portal
+  /opt/ood/ood-portal-generator/sbin/update_ood_portal
 
-if [ -n "$OOD_STATIC_USER" ] && [ -f "$OOD_STATIC_USER" ]; then
-  cat "$OOD_STATIC_USER" >>  /etc/ood/dex/config.yaml
-fi
+  if [ -n "$OOD_STATIC_USER" ] && [ -f "$OOD_STATIC_USER" ]; then
+    cat "$OOD_STATIC_USER" >>  /etc/ood/dex/config.yaml
+  fi
+SETUP
 
 sudo runuser -u ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml &
 sudo /usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
I updated to podman 2.2.1 and kernel `5.10.8-100.fc32.x86_64` yesterday and this started to fail for me today.  Apparently mount points with `--userns=keep-id` are much more strict so I can't these files and init the contianers correctly as my regular user.