### PR TITLE
system pinned apps

### DIFF
--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -1,0 +1,12 @@
+# A simple subclass of OodApp that overrides category
+# and subcategory to allow for groupings other than what's
+# provided in the app's manifest & definition.
+class FeaturedApp < OodApp
+  attr_reader :category, :subcategory
+
+  def initialize(router, category: "Apps", subcategory: "Pinned Apps")
+    super(router)
+    @category = category.to_s
+    @subcategory = subcategory.to_s
+  end
+end

--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -2,11 +2,32 @@
 # and subcategory to allow for groupings other than what's
 # provided in the app's manifest & definition.
 class FeaturedApp < OodApp
-  attr_reader :category, :subcategory
+  attr_reader :category, :subcategory, :token
 
-  def initialize(router, category: "Apps", subcategory: "Pinned Apps")
+  def initialize(router, category: "Apps", subcategory: "Pinned Apps", token: nil)
     super(router)
     @category = category.to_s
     @subcategory = subcategory.to_s
+    @token = token
+  end
+
+  protected
+
+  # A featured app is only 1 app, singular. So it _is_ the configured sub-app.
+  # As an example, we've configured sys/bc_desktop/pitzer.  Pitzer is a sub-app
+  # of bc_desktop. We don't care if there are multiple bc_desktops sub-apps, only
+  # pitzer is featured - so only _it_ should be returned in the sub-app list
+  def sub_app_list
+    if batch_connect.sub_app_list.size == 1
+      batch_connect.sub_app_list
+    else
+      batch_connect.sub_app_list.select { |app| app.sub_app == sub_app_name }
+    end
+  end
+
+  private
+
+  def sub_app_name
+    token.to_s.split("/").last
   end
 end

--- a/apps/dashboard/app/apps/nav_config.rb
+++ b/apps/dashboard/app/apps/nav_config.rb
@@ -3,6 +3,6 @@ class NavConfig
       attr_accessor :categories, :categories_whitelist
       alias_method :categories_whitelist?, :categories_whitelist
     end
-    self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
+    self.categories = ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"]
     self.categories_whitelist = false
 end

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -278,6 +278,12 @@ class OodApp
     @version ||= (version_from_file || version_from_git || "unknown").strip
   end
 
+  # test whether this object is equal to another.
+  # @return [Boolean]
+  def ==(other)
+    other.respond_to?(:url) ? url == other.url : false
+  end
+
   private
 
   # @return [String, nil] version string from git describe, or nil if not git repo

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -26,7 +26,7 @@ class OodApp
   end
 
   def invalid_batch_connect_app?
-    batch_connect_app? && batch_connect.sub_app_list.none?(&:valid?)
+    batch_connect_app? && sub_app_list.none?(&:valid?)
   end
 
   def should_appear_in_nav?
@@ -115,7 +115,7 @@ class OodApp
         end.sort_by { |lnk| lnk.title }
       end
     elsif role == "batch_connect"
-      batch_connect.sub_app_list.select(&:valid?).map(&:link)
+      sub_app_list.select(&:valid?).map(&:link)
     else
       [
         OodAppLink.new(
@@ -134,8 +134,8 @@ class OodApp
     # hack - but at least this hack is in a method next to the method it is
     # coupled with and this prevents control coupling from the outside by doing
     # something atrocious like links(validate: false)
-    if role == "batch_connect"
-      batch_connect.sub_app_list.map(&:link)
+    if batch_connect_app?
+      sub_app_list.map(&:link)
     else
       links
     end
@@ -282,6 +282,12 @@ class OodApp
   # @return [Boolean]
   def ==(other)
     other.respond_to?(:url) ? url == other.url : false
+  end
+
+  protected
+
+  def sub_app_list
+    batch_connect.sub_app_list
   end
 
   private

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -25,6 +25,6 @@ class Router
       next if router.nil?
 
       FeaturedApp.new(router, token: token)
-    end
+    end.reject { |app| !app.accessible? || app.hidden? || app.backup? || app.invalid_batch_connect_app? }
   end
 end

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -1,0 +1,33 @@
+class Router
+
+  # Return a Router [SysRouter, UsrRouter or DevRouter] based off
+  # of the input token. Returns nil if nothing is parsed correctly.
+  #
+  # return [SysRouter, UsrRouter or DevRouter]
+  def self.router_from_token(token)
+    type, *app = token.split("/")
+    case type
+    when "dev"
+      name, = app
+      DevRouter.new(name)
+    when "usr"
+      owner, name, = app
+      UsrRouter.new(name, owner)
+    when "sys"
+      name, = app
+      SysRouter.new(name)
+    end
+  end
+
+  def self.pinned_apps
+    # @pinned_apps ||= begin
+      Configuration.pinned_apps.to_a.map do |token|
+        router = router_from_token(token.to_s)
+        next if router.nil?
+
+        FeaturedApp.new(router)
+      end.reject(&:invalid_batch_connect_app?)
+    # end
+  end
+
+end

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -20,14 +20,11 @@ class Router
   end
 
   def self.pinned_apps
-    # @pinned_apps ||= begin
-      Configuration.pinned_apps.to_a.map do |token|
-        router = router_from_token(token.to_s)
-        next if router.nil?
+    Configuration.pinned_apps.to_a.map do |token|
+      router = router_from_token(token.to_s)
+      next if router.nil?
 
-        FeaturedApp.new(router)
-      end.reject(&:invalid_batch_connect_app?)
-    # end
+      FeaturedApp.new(router)
+    end
   end
-
 end

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -20,7 +20,7 @@ class Router
   end
 
   def self.pinned_apps
-    Configuration.pinned_apps.to_a.map do |token|
+    @pinned_apps ||= Configuration.pinned_apps.to_a.map do |token|
       router = router_from_token(token.to_s)
       next if router.nil?
 

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -24,7 +24,7 @@ class Router
       router = router_from_token(token.to_s)
       next if router.nil?
 
-      FeaturedApp.new(router)
+      FeaturedApp.new(router, token: token)
     end
   end
 end

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -17,11 +17,12 @@ class ApplicationController < ActionController::Base
   end
 
   def set_nav_groups
+    groups = sys_app_groups + pinned_app_group
     #TODO: for AweSim, what if we added the shared apps here?
     if NavConfig.categories_whitelist?
-        @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: sys_app_groups)
+      @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: groups)
     else
-        @nav_groups = OodAppGroup.order(titles: NavConfig.categories, groups: sys_app_groups)
+      @nav_groups = OodAppGroup.order(titles: NavConfig.categories, groups: groups)
     end
   end
 
@@ -51,6 +52,10 @@ class ApplicationController < ActionController::Base
 
   def sys_app_groups
     OodAppGroup.groups_for(apps: nav_sys_apps)
+  end
+
+  def pinned_app_group
+    OodAppGroup.groups_for(apps: Router.pinned_apps)
   end
 
   def set_announcements

--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -19,4 +19,8 @@ module DashboardHelper
   def invalid_clusters
     @invalid_clusters ||= OodCore::Clusters.new(OodAppkit.clusters.select { |c| not c.valid? })
   end
+
+  def pinned_apps?
+    !Router.pinned_apps.empty?
+  end
 end

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <%- Router.pinned_apps.each do |app| %>
+  <%- Router.pinned_apps.each_with_index do |app, index| %>
     <%- link = app.links.first -%>
     <div class="col-sm-3 col-md-3 text-center">
       <a class="thumbnail app" href="<%= link.url %>">
@@ -9,5 +9,6 @@
         <%= link.title %>
       </a>
     </div>
+    <%= tag.div class: %w(clearfix visible-lg-block visible-md-block visible-sm-block) if (index+1) % 4 == 0 %>
   <%- end %>
 </div>

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,12 +1,12 @@
 <div class="row">
   <%- Router.pinned_apps.each do |app| %>
     <%- link = app.links.first -%>
-    <div class="col-sm-3 col-md-3">
+    <div class="col-sm-3 col-md-3 text-center">
       <a class="thumbnail app" href="<%= link.url %>">
-        <div class="center-block" style="text-align: center">
-          <img class="app-icon" src="<%= link.icon_uri %>" alt="<%= link.title %>">
-          <p><%= link.title %></p>
+        <div class="center-block">
+          <%= icon_tag(link.icon_uri) %>
         </div>
+        <%= link.title %>
       </a>
     </div>
   <%- end %>

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,0 +1,13 @@
+<div class="row">
+  <%- Router.pinned_apps.each do |app| %>
+    <%- link = app.links.first -%>
+    <div class="col-sm-3 col-md-3">
+      <a class="thumbnail app" href="<%= link.url %>">
+        <div class="center-block" style="text-align: center">
+          <img class="app-icon" src="<%= link.icon_uri %>" alt="<%= link.title %>">
+          <p><%= link.title %></p>
+        </div>
+      </a>
+    </div>
+  <%- end %>
+</div>

--- a/apps/dashboard/app/views/dashboard/index.html.erb
+++ b/apps/dashboard/app/views/dashboard/index.html.erb
@@ -5,6 +5,7 @@
   <div class="row">
     <% if @motd %>
       <div class="col-md-8">
+        <%= render "pinned_apps" if pinned_apps? %>
         <%# This assumes @motd_file responds to `to_partial_path` %>
         <%= render @motd %>
       </div>
@@ -28,5 +29,6 @@
     <% end %>
   </div>
 <% else %>
+  <%= render "pinned_apps" if pinned_apps? %>
   <%= render @motd if @motd %>
 <% end %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -250,7 +250,29 @@ end
     ENV['OOD_NATIVE_VNC_LOGIN_HOST']
   end
 
+  # Set the global configuration file
+  def config_file
+    Pathname.new(ENV['OOD_CONFIG_FILE'] || "/etc/ood/config/ondemand.yml")
+  end
+
+  # The configured pinned apps
+  def pinned_apps
+    config.fetch(:pinned_apps, [])
+  end
+
   private
+
+  def config
+    @config ||= read_config
+  end
+
+  def read_config
+    f = Configuration.config_file
+    YAML.safe_load(File.open(f.to_s)).symbolize_keys
+  rescue => e
+    Rails.logger.error("Can't read or parse #{Configuration.config_file} because of error #{e}")
+    {}
+  end
 
   # The environment
   # @return [String] "development", "test", or "production"

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -124,6 +124,52 @@ class DashboardControllerTest < ActionController::TestCase
     end
   end
 
+  test "should create Apps dropdown when pinned apps are available" do
+      SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+      OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+      pinned_apps = [
+        FeaturedApp.new(SysRouter.new('bc_jupyter')),
+        FeaturedApp.new(SysRouter.new('bc_paraview')),
+        FeaturedApp.new(SysRouter.new('bc_desktop/oakley')),
+        FeaturedApp.new(SysRouter.new('pseudofun'))
+      ]
+      Router.stubs(:pinned_apps).returns(pinned_apps)
+
+      get :index
+
+      dd = dropdown_list('Apps')
+      dditems = dropdown_list_items(dd)
+      assert dditems.any?, "dropdown list items not found"
+      assert_equal [
+        { header: "Pinned Apps" },
+        "Bc Desktop/Oakley",
+        "Jupyter Notebook",
+        "Paraview",
+        "PseudoFuN"
+      ], dditems
+  end
+
+  test "should create Pinned app icons when pinned apps are available" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    Configuration.stubs(:pinned_apps).returns([
+      'sys/bc_jupyter',
+      'sys/bc_paraview',
+      'sys/bc_desktop/oakley',
+      'sys/pseduofun'
+    ])
+
+    get :index
+
+    assert_response :success
+
+    assert_select 'a.thumbnail.app', 4
+    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
+    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
+    assert_select "a.thumbnail.app[href='/batch_connect/sys/pseduofun/session_contexts/new']", 1
+    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/oakley/session_contexts/new']", 1
+  end
+
   test "should create My Interactive Apps link if Interactive Apps exist and not developer" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_interactive_apps"))
     Configuration.stubs(:app_development_enabled?).returns(false)

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -131,7 +131,8 @@ class DashboardControllerTest < ActionController::TestCase
         FeaturedApp.new(SysRouter.new('bc_jupyter')),
         FeaturedApp.new(SysRouter.new('bc_paraview')),
         FeaturedApp.new(SysRouter.new('bc_desktop/owens')),
-        FeaturedApp.new(SysRouter.new('pseudofun'))
+        FeaturedApp.new(SysRouter.new('pseudofun')),
+        FeaturedApp.new(SysRouter.new('should_get_filtered'))
       ]
       Router.stubs(:pinned_apps).returns(pinned_apps)
 
@@ -156,7 +157,8 @@ class DashboardControllerTest < ActionController::TestCase
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
-      'sys/pseudofun'
+      'sys/pseudofun',
+      'sys/should_get_filtered'
     ])
 
     get :index

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -127,14 +127,14 @@ class DashboardControllerTest < ActionController::TestCase
   test "should create Apps dropdown when pinned apps are available" do
       SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
       OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-      pinned_apps = [
-        FeaturedApp.new(SysRouter.new('bc_jupyter')),
-        FeaturedApp.new(SysRouter.new('bc_paraview')),
-        FeaturedApp.new(SysRouter.new('bc_desktop/owens')),
-        FeaturedApp.new(SysRouter.new('pseudofun')),
-        FeaturedApp.new(SysRouter.new('should_get_filtered'))
-      ]
-      Router.stubs(:pinned_apps).returns(pinned_apps)
+      Configuration.stubs(:pinned_apps).returns([
+        'sys/bc_jupyter',
+        'sys/bc_paraview',
+        'sys/bc_desktop/owens',
+        'sys/bc_desktop/doesnt_exist',
+        'sys/pseudofun',
+        'sys/should_get_filtered'
+      ])
 
       get :index
 
@@ -143,7 +143,7 @@ class DashboardControllerTest < ActionController::TestCase
       assert dditems.any?, "dropdown list items not found"
       assert_equal [
         { header: "Pinned Apps" },
-        "Bc Desktop/Owens",
+        "Owens Desktop",
         "Jupyter Notebook",
         "Paraview",
         "PseudoFuN"
@@ -157,6 +157,7 @@ class DashboardControllerTest < ActionController::TestCase
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
+      'sys/bc_desktop/doesnt_exist',
       'sys/pseudofun',
       'sys/should_get_filtered'
     ])

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -156,7 +156,7 @@ class DashboardControllerTest < ActionController::TestCase
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/oakley',
-      'sys/pseduofun'
+      'sys/pseudofun'
     ])
 
     get :index
@@ -166,7 +166,7 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select 'a.thumbnail.app', 4
     assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
     assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/pseduofun/session_contexts/new']", 1
+    assert_select "a.thumbnail.app[href='/apps/show/pseudofun']", 1
     assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/oakley/session_contexts/new']", 1
   end
 

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -4,6 +4,7 @@ class DashboardControllerTest < ActionController::TestCase
 
   def setup
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+    Router.instance_variable_set('@pinned_apps', nil)
   end
 
   def dropdown_list(title)

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -130,7 +130,7 @@ class DashboardControllerTest < ActionController::TestCase
       pinned_apps = [
         FeaturedApp.new(SysRouter.new('bc_jupyter')),
         FeaturedApp.new(SysRouter.new('bc_paraview')),
-        FeaturedApp.new(SysRouter.new('bc_desktop/oakley')),
+        FeaturedApp.new(SysRouter.new('bc_desktop/owens')),
         FeaturedApp.new(SysRouter.new('pseudofun'))
       ]
       Router.stubs(:pinned_apps).returns(pinned_apps)
@@ -142,7 +142,7 @@ class DashboardControllerTest < ActionController::TestCase
       assert dditems.any?, "dropdown list items not found"
       assert_equal [
         { header: "Pinned Apps" },
-        "Bc Desktop/Oakley",
+        "Bc Desktop/Owens",
         "Jupyter Notebook",
         "Paraview",
         "PseudoFuN"
@@ -155,7 +155,7 @@ class DashboardControllerTest < ActionController::TestCase
     Configuration.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
-      'sys/bc_desktop/oakley',
+      'sys/bc_desktop/owens',
       'sys/pseudofun'
     ])
 
@@ -167,7 +167,7 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
     assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
     assert_select "a.thumbnail.app[href='/apps/show/pseudofun']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/oakley/session_contexts/new']", 1
+    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
   end
 
   test "should create My Interactive Apps link if Interactive Apps exist and not developer" do

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_desktop/local/owens.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_desktop/local/owens.yml
@@ -1,0 +1,34 @@
+---
+title: "Owens Desktop"
+cluster: "owens"
+attributes:
+  desktop: "gnome"
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Oakley nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Oakley.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Oakley. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Oakley node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Oakley.
+      - **hugemem** - (*32 cores*) This Oakley node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Oakley. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -11,16 +11,6 @@ class ActiveSupport::TestCase
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
   end
-
-  def read_fixture(name)
-    File.read(fixture_file_path(name))
-  end
-
-  def fixture_file_path(name)
-    test_dir = File.dirname(__FILE__)
-    fixture_dir = File.join(test_dir, 'fixtures')
-    File.join(fixture_dir, name)
-  end
 end
 
 require 'mocha/minitest'

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -11,6 +11,16 @@ class ActiveSupport::TestCase
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
   end
+
+  def read_fixture(name)
+    File.read(fixture_file_path(name))
+  end
+
+  def fixture_file_path(name)
+    test_dir = File.dirname(__FILE__)
+    fixture_dir = File.join(test_dir, 'fixtures')
+    File.join(fixture_dir, name)
+  end
 end
 
 require 'mocha/minitest'


### PR DESCRIPTION
Fix for #714.  Currently in draft as it needs test for sure.

If you like the general structure, I'll move forward on tests.

Given a config file like

```yaml
pinned_apps:
  - 'sys/bc_osc_codeserver'
```

We'll generate pinned apps icons and navbar entry like so:
![image](https://user-images.githubusercontent.com/4874123/106515067-1c2ba000-64a3-11eb-8c3d-63f3f757835e.png)
