### PR TITLE
Update pinned apps menu

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_user, :set_nav_groups, :set_announcements, :set_locale
   before_action :set_my_balances, only: [:index, :new, :featured]
+  before_action :set_featured_group
 
   def set_locale
     I18n.locale = ::Configuration.locale
@@ -17,13 +18,12 @@ class ApplicationController < ActionController::Base
   end
 
   def set_nav_groups
-    groups = sys_app_groups + pinned_app_group
     #TODO: for AweSim, what if we added the shared apps here?
-    if NavConfig.categories_whitelist?
-      @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: groups)
-    else
-      @nav_groups = OodAppGroup.order(titles: NavConfig.categories, groups: groups)
-    end
+    @nav_groups = filter_groups(sys_app_groups)
+  end
+
+  def set_featured_group
+    @featured_group = filter_groups(pinned_app_group).first # 1 single group called 'Apps'
   end
 
   def sys_apps
@@ -79,5 +79,15 @@ class ApplicationController < ActionController::Base
     @my_balances = []
     ::Configuration.balance_paths.each { |path| @my_balances += Balance.find(path, OodSupport::User.new.name) }
     @my_balances
+  end
+
+  private
+
+  def filter_groups(groups)
+    if NavConfig.categories_whitelist?
+      OodAppGroup.select(titles: NavConfig.categories, groups: groups)
+    else
+      OodAppGroup.order(titles: NavConfig.categories, groups: groups)
+    end
   end
 end

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -36,6 +36,7 @@
       </div>
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-9">
         <ul class="nav navbar-nav">
+          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if pinned_apps? %>
           <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
           <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
           <%= render partial: 'layouts/nav/all_apps' if Configuration.show_all_apps_link? %>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
@@ -11,8 +11,7 @@
 
       <%= content_tag "li", "", class: "divider", role: "separator" if index > 0 %>
       <%= content_tag "li", title, class: "dropdown-header" unless g.title.empty? %>
-      <% g.apps.each_with_index do |app, app_index| %>
-        <%- break if rendering_pinned_apps && app_index >= Configuration.pinned_apps_menu_length -%>
+      <% g.apps.take(Configuration.pinned_apps_menu_length).each do |app| %>
         <% app.links.each do |link| %>
           <li>
             <%=

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
@@ -4,7 +4,9 @@
     <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory).each_with_index do |g, index| %>
       <%= content_tag "li", "", class: "divider", role: "separator" if index > 0 %>
       <%= content_tag "li", g.title, class: "dropdown-header" unless g.title.empty? %>
-      <% g.apps.each do |app| %>
+      <% g.apps.each_with_index do |app, app_index| %>
+        <%- rendering_pinned_apps = app.subcategory == "Pinned Apps" -%>
+        <%- break if rendering_pinned_apps && app_index >= Configuration.pinned_apps_menu_length -%>
         <% app.links.each do |link| %>
           <li>
             <%=
@@ -14,6 +16,9 @@
                 target: link.new_tab? ? "_blank" : nil
               ) do
             %>
+              <%- if rendering_pinned_apps && g.apps.size > Configuration.pinned_apps_menu_length -%>
+                </span>(<%= app_index+1 %>/<%= g.apps.size %>)</span>
+              <%- end -%>
               <%= icon_tag(link.icon_uri) %> <%=link.title %>
               <% if link.subtitle.present? %>
                 <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
@@ -2,10 +2,16 @@
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
   <ul class="dropdown-menu">
     <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory).each_with_index do |g, index| %>
+      <%- rendering_pinned_apps = g.apps.first.subcategory == "Pinned Apps" -%>
+      <%- if rendering_pinned_apps && g.apps.size > Configuration.pinned_apps_menu_length -%>
+        <%- title = "#{g.title} (showing #{Configuration.pinned_apps_menu_length} of #{g.apps.size})" %>
+      <%- else -%>
+        <%- title = g.title.to_s -%>
+      <%- end -%>
+
       <%= content_tag "li", "", class: "divider", role: "separator" if index > 0 %>
-      <%= content_tag "li", g.title, class: "dropdown-header" unless g.title.empty? %>
+      <%= content_tag "li", title, class: "dropdown-header" unless g.title.empty? %>
       <% g.apps.each_with_index do |app, app_index| %>
-        <%- rendering_pinned_apps = app.subcategory == "Pinned Apps" -%>
         <%- break if rendering_pinned_apps && app_index >= Configuration.pinned_apps_menu_length -%>
         <% app.links.each do |link| %>
           <li>
@@ -16,9 +22,6 @@
                 target: link.new_tab? ? "_blank" : nil
               ) do
             %>
-              <%- if rendering_pinned_apps && g.apps.size > Configuration.pinned_apps_menu_length -%>
-                <%= content_tag(:small, "(#{app_index+1}/#{g.apps.size})", style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
-              <%- end -%>
               <%= icon_tag(link.icon_uri) %> <%=link.title %>
               <% if link.subtitle.present? %>
                 <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
@@ -23,5 +23,8 @@
         <% end %>
       <% end %>
     <% end %>
+
+    <%= content_tag "li", "", class: "divider", role: "separator" %>
+    <%= render partial: 'layouts/nav/all_apps' %>
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
@@ -1,0 +1,27 @@
+<li class="dropdown" title="<%= group.title %>" >
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
+  <ul class="dropdown-menu">
+    <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory).each_with_index do |g, index| %>
+      <%= content_tag "li", "", class: "divider", role: "separator" if index > 0 %>
+      <%= content_tag "li", g.title, class: "dropdown-header" unless g.title.empty? %>
+      <% g.apps.each do |app| %>
+        <% app.links.each do |link| %>
+          <li>
+            <%=
+              link_to(
+                link.url.to_s,
+                title: link.title,
+                target: link.new_tab? ? "_blank" : nil
+              ) do
+            %>
+              <%= icon_tag(link.icon_uri) %> <%=link.title %>
+              <% if link.subtitle.present? %>
+                <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
+              <% end %>
+            <% end %>
+          </li>
+        <% end %>
+      <% end %>
+    <% end %>
+  </ul>
+</li>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.erb
@@ -17,7 +17,7 @@
               ) do
             %>
               <%- if rendering_pinned_apps && g.apps.size > Configuration.pinned_apps_menu_length -%>
-                </span>(<%= app_index+1 %>/<%= g.apps.size %>)</span>
+                <%= content_tag(:small, "(#{app_index+1}/#{g.apps.size})", style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
               <%- end -%>
               <%= icon_tag(link.icon_uri) %> <%=link.title %>
               <% if link.subtitle.present? %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -260,6 +260,11 @@ end
     config.fetch(:pinned_apps, [])
   end
 
+  # The length of the "Pinned Apps" navbar menu
+  def pinned_apps_menu_length
+    config.fetch(:pinned_apps_menu_length, 6)
+  end
+
   private
 
   def config

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -24,7 +24,7 @@ class DashboardControllerTest < ActionController::TestCase
       elsif item['class'] && item['class'].include?("dropdown-header")
         { :header => item.text.strip }
       else
-        item.text.squish
+        item.text.strip
       end
     end
   end
@@ -172,9 +172,9 @@ class DashboardControllerTest < ActionController::TestCase
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [
-      { header: "Pinned Apps" },
-      "(1/4) Owens Desktop",
-      "(2/4) Jupyter Notebook",
+      { header: "Pinned Apps (showing 2 of 4)" },
+      "Owens Desktop",
+      "Jupyter Notebook",
       :divider,
       "All Apps"
     ], dditems

--- a/apps/dashboard/test/controllers/dashboard_controller_test.rb
+++ b/apps/dashboard/test/controllers/dashboard_controller_test.rb
@@ -24,7 +24,7 @@ class DashboardControllerTest < ActionController::TestCase
       elsif item['class'] && item['class'].include?("dropdown-header")
         { :header => item.text.strip }
       else
-        item.text.strip
+        item.text.squish
       end
     end
   end
@@ -147,9 +147,38 @@ class DashboardControllerTest < ActionController::TestCase
         "Owens Desktop",
         "Jupyter Notebook",
         "Paraview",
-        "PseudoFuN"
+        "PseudoFuN",
+        :divider,
+        "All Apps"
       ], dditems
   end
+
+  test "should limit list of Pinned Apps in dropdown" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    Configuration.stubs(:pinned_apps).returns([
+      'sys/bc_jupyter',
+      'sys/bc_paraview',
+      'sys/bc_desktop/owens',
+      'sys/bc_desktop/doesnt_exist',
+      'sys/pseudofun',
+      'sys/should_get_filtered'
+    ])
+    Configuration.stubs(:pinned_apps_menu_length).returns(2)
+
+    get :index
+
+    dd = dropdown_list('Apps')
+    dditems = dropdown_list_items(dd)
+    assert dditems.any?, "dropdown list items not found"
+    assert_equal [
+      { header: "Pinned Apps" },
+      "(1/4) Owens Desktop",
+      "(2/4) Jupyter Notebook",
+      :divider,
+      "All Apps"
+    ], dditems
+end
 
   test "should create Pinned app icons when pinned apps are available" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))


### PR DESCRIPTION
Partial fix for #715.  This adds the 'All Apps' link to the 'Apps' menu and limits the pinned apps based off of a configuration.

Limiting pinned apps looks like this:
![image](https://user-images.githubusercontent.com/4874123/108243445-1c22d580-711c-11eb-99d6-85d68f957e12.png)

Where, if you're not limiting pinned apps (your limit is higher than the current configuration) it doesn't have the `(currrent/limit)` notation.
![image](https://user-images.githubusercontent.com/4874123/108243840-88053e00-711c-11eb-8805-139578ff1024.png)
