### PR TITLE
Hide NGINX and Passenger version information

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -34,6 +34,9 @@ http {
 
   <%- end -%>
 
+  server_tokens off;
+  passenger_show_version_in_header off;
+
   # Kill all apps after they idle timeout
   passenger_min_instances 0;
 


### PR DESCRIPTION
Before this change on OSC deployed OnDemand:

```
Server: nginx/1.18.0 + Phusion Passenger 6.0.7
X-Powered-By: Phusion Passenger 6.0.7
```

After this change logging into Docker based OnDemand:

```
Server: nginx + Phusion Passenger
X-Powered-By: Phusion Passenger
```