### PR TITLE
(Release 1.8) Hide NGINX and Passenger version information

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -34,6 +34,9 @@ http {
 
   <%- end -%>
 
+  server_tokens off;
+  passenger_show_version_in_header off;
+
   # Kill all apps after they idle timeout
   passenger_min_instances 0;
 


### PR DESCRIPTION
See #891 for before/after.