### PR TITLE
add the ability to configure through ondemand.d/y*ml files

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -267,10 +267,11 @@ end
   end
 
   def read_config
-    files = Pathname.glob([config_directory.join("*.yml"), config_directory.join("*.yaml")])
+    files = Pathname.glob([config_directory.join("*.{yml,yaml}"), config_directory.join("*.{yml,yaml}.erb")])
     files.each_with_object({}) do |f, config|
       begin
-        yml = YAML.safe_load(File.open(f.to_s)) || {}
+        content = ERB.new(f.read, nil, "-").result(binding)
+        yml = YAML.safe_load(content) || {}
         config.deep_merge!(yml.deep_symbolize_keys)
       rescue => e
         Rails.logger.error("Can't read or parse #{f} because of error #{e}")

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -267,7 +267,7 @@ end
   end
 
   def read_config
-    files = Pathname.glob([config_directory.join("*.{yml,yaml}"), config_directory.join("*.{yml,yaml}.erb")])
+    files = Pathname.glob(config_directory.join("*.{yml,yaml,yml.erb,yaml.erb}"))
     files.each_with_object({}) do |f, config|
       begin
         content = ERB.new(f.read, nil, "-").result(binding)

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -292,4 +292,21 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       assert_equal ['four', 'five', 'six'], cfg[:test_hash][:another_array]
     end
   end
+
+  test "reads from good erb file" do
+    with_modified_env(config_fixtures) do
+      cfg = ConfigurationSingleton.new.send(:config)
+      assert_equal 42, cfg[:the_erb_answer]
+    end
+  end
+
+  test "logs read and parse errors" do
+    with_modified_env(config_fixtures) do
+      bad_erb_rex = /bad_erb.yml.erb because of error undefined local variable or method `wont_find_this_functon/
+      bad_yml_rex = /not_good_yml.yml because of error \(<unknown>\): did not find expected '-' indicator while parsing a block collection at line 2 column 3/
+      Rails.logger.expects(:error).with(regexp_matches(bad_erb_rex)).at_least_once
+      Rails.logger.expects(:error).with(regexp_matches(bad_yml_rex)).at_least_once
+      ConfigurationSingleton.new.send(:config)
+    end
+  end
 end

--- a/apps/dashboard/test/fixtures/config/ondemand.d/bad_erb.yml.erb
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/bad_erb.yml.erb
@@ -1,0 +1,1 @@
+<%= wont_find_this_functon %>

--- a/apps/dashboard/test/fixtures/config/ondemand.d/good_erb.yml.erb
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/good_erb.yml.erb
@@ -1,0 +1,1 @@
+the_erb_answer: <%= 40 + 2 %>

--- a/apps/dashboard/test/fixtures/config/ondemand.d/not_good_yml.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/not_good_yml.yml
@@ -1,0 +1,2 @@
+bad_hash:
+  - 'arrays should not have commas!',

--- a/apps/dashboard/test/fixtures/config/ondemand.d/pinned_apps.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/pinned_apps.yml
@@ -1,0 +1,4 @@
+pinned_apps:
+  - "sys/bc_osc_jupyter"
+  - "sys/bc_osc_rstudio_server"
+  - "sys/iqmol"

--- a/apps/dashboard/test/fixtures/config/ondemand.d/should_not_read.yml.bak
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/should_not_read.yml.bak
@@ -1,0 +1,1 @@
+key_in_bak_file: 'I should not have been read!'

--- a/apps/dashboard/test/fixtures/config/ondemand.d/test_keys.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/test_keys.yml
@@ -1,0 +1,12 @@
+test_key: 'test_value'
+test_array:
+  - 'one'
+  - 'two'
+  - 'three'
+
+test_hash:
+  some_key: 'some_value'
+  another_array:
+    - 'four'
+    - 'five'
+    - 'six'

--- a/apps/dashboard/test/fixtures/config/ondemand.d/yml_with_a.yaml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/yml_with_a.yaml
@@ -1,0 +1,1 @@
+key_from_yaml_file: 'I got read!'


### PR DESCRIPTION
add the ability to configure through ondemand.d/y*ml files. Still, only `pinned_apps` is exposed through the Configuration APIs, but arbitrary configurations are still read.