### PR TITLE
simplify all apps page links

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/apps.scss
@@ -44,14 +44,6 @@ tr.app {
   font-size: 14px;
 }
 
-.apps-table p {
-  display: inline-block;
-}
-
-.apps-table ul {
-  min-width: 210px;
-}
-
 // awesim colors - FIXME: aweful lot for a list of colors to cycle through
 // would be better to gave a default grey and then cycle based on a list in an
 // initializer

--- a/apps/dashboard/app/views/apps/_app_group_rows.html.erb
+++ b/apps/dashboard/app/views/apps/_app_group_rows.html.erb
@@ -3,8 +3,10 @@
     <tr id="<%= row_id(app.url) %>">
       <td>
         <div class="btn-group">
+          <%= link_to app.links.first.url, class: 'btn btn-primary', target: '_blank' do %>
+          <span title="FontAwesome icon specified: folder" aria-hidden="true" class="fas fa-folder fa-fw"></span> Files
+          <% end %>
           <button type="button" class="btn dropdown-toggle btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Files
             <span class="caret"></span>
           </button>
           <ul class="dropdown-menu">

--- a/apps/dashboard/app/views/apps/_link.html.erb
+++ b/apps/dashboard/app/views/apps/_link.html.erb
@@ -1,22 +1,3 @@
-<div>
-  <%=
-    link_to(
-      link.url.to_s,
-      data: {
-        toggle: "popover",
-        content: manifest_markdown(link.description),
-        html: true,
-        trigger: "hover",
-        title: link.title,
-        container: "body"
-      },
-      target: link.new_tab? ? "_blank" : nil
-    ) do
-  %>
-    <div class="center-block">
-      <%= icon_tag(link.icon_uri) %>
-      <%= content_tag(:p, link.title, class: "text-center") %>
-    </div>
-  <% end %>
-</div>
-
+<%= link_to(link.url.to_s, target: link.new_tab? ? "_blank" : nil) do %>
+  <%= icon_tag(link.icon_uri) %> <%= link.title %>
+<% end %>


### PR DESCRIPTION
app links are simplified which fixes the UI issues with the Files dropdown
and underline issues with the other app links

but omits the popovers which are probably misplaced on a table like this
(and not accessible anyways)

The files button is also a two-teir button now where the first link opens the
Files app to the first "favorite" found

The menu is still problematic because it doesn't scroll easily so this optional button
will avoid having to open the menu to just go to your home directory

![screen 2021-02-18 at 5 18 32 PM](https://user-images.githubusercontent.com/512333/108428977-63d55a00-720d-11eb-80d2-18466c2b9df7.png)

![screen 2021-02-18 at 5 18 41 PM](https://user-images.githubusercontent.com/512333/108428987-6768e100-720d-11eb-89bc-7634f1c99950.png)
