### PR TITLE
Changed cookies to be secure in production

### DIFF
--- a/apps/activejobs/config/initializers/session_store.rb
+++ b/apps/activejobs/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_job_status_session'
+Rails.application.config.session_store :cookie_store, key: '_job_status_session', secure: Rails.env.production?

--- a/apps/dashboard/config/initializers/session_store.rb
+++ b/apps/dashboard/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_dashboard_session'
+Rails.application.config.session_store :cookie_store, key: '_dashboard_session', secure: Rails.env.production?

--- a/apps/file-editor/config/initializers/session_store.rb
+++ b/apps/file-editor/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_ood_app_session'
+Rails.application.config.session_store :cookie_store, key: '_ood_app_session', secure: Rails.env.production?

--- a/apps/files/lib/cloudcmd/lib/client/ood.js
+++ b/apps/files/lib/cloudcmd/lib/client/ood.js
@@ -113,7 +113,7 @@ function setCookie(cname, cvalue, exdays) {
     var d = new Date();
     d.setTime(d.getTime() + (exdays*24*60*60*1000));
     var expires = "expires="+d.toUTCString();
-    document.cookie = cname + "=" + cvalue + "; " + expires + "; path=" + CloudCmd.PREFIX;
+    document.cookie = cname + "=" + cvalue + "; " + expires + "; path=" + CloudCmd.PREFIX + ";secure;"
 }
 
 // getCookie and setCookie methods borrowed from

--- a/apps/myjobs/config/initializers/session_store.rb
+++ b/apps/myjobs/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_job_constructor_session'
+Rails.application.config.session_store :cookie_store, key: '_job_constructor_session', secure: Rails.env.production?


### PR DESCRIPTION
This adds the secure flag to session cookies:


- _dashboard_session (dashboard)
- _job_constructor_session (job composer)
- _job_status_session (activejobs)
- _ood_app_session (file-editor)
- ownermode (files app)

For all apps except files app:

The secure cookie was set in `config/initializers/session_store.rb`

For files app:

The secure cookie was set in `lib/cloudcmd/lib/client/ood.js` in the `setCookie()` function
