### PR TITLE
pinned apps to support wildcard globs

### DIFF
--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -4,11 +4,15 @@
 class FeaturedApp < OodApp
   attr_reader :category, :subcategory, :token
 
+  def self.from_ood_app(app, token: nil)
+    FeaturedApp.new(app.router, token: token)
+  end
+
   def initialize(router, category: "Apps", subcategory: "Pinned Apps", token: nil)
     super(router)
     @category = category.to_s
     @subcategory = subcategory.to_s
-    @token = token
+    @token = token || router.token
   end
 
   protected

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -289,7 +289,7 @@ class OodApp
   end
 
   # The subapp list may only be of size 1 and actually contains
-  # this appp. This returns true if there are indeed sub apps that
+  # this app. This returns true if there are indeed sub apps that
   # that differ from this object.
   def has_sub_apps?
     if batch_connect_app?

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -284,10 +284,19 @@ class OodApp
     other.respond_to?(:url) ? url == other.url : false
   end
 
-  protected
-
   def sub_app_list
-    batch_connect.sub_app_list
+    batch_connect_app? ? batch_connect.sub_app_list : []
+  end
+
+  # The subapp list may only be of size 1 and actually contains
+  # this appp. This returns true if there are indeed sub apps that
+  # that differ from this object.
+  def has_sub_apps?
+    if batch_connect_app?
+      sub_app_list.size > 1 || sub_app_list[0] != batch_connect
+    else
+      false
+    end
   end
 
   private

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -1,5 +1,25 @@
 class Router
 
+  # All the system install apps
+  def self.sys_apps
+    @sys_apps ||= SysRouter.apps
+  end
+
+  # All the developer apps
+  def self.dev_apps
+    @dev_apps ||= DevRouter.apps
+  end
+
+  # All the shared apps, from all possible owners
+  def self.usr_apps
+    @usr_apps ||= UsrRouter.all_apps(owners: UsrRouter.owners)
+  end
+
+  # A combination of all sys, dev and usr apps
+  def self.apps
+    @apps ||= sys_apps + usr_apps + dev_apps
+  end
+
   # Return a Router [SysRouter, UsrRouter or DevRouter] based off
   # of the input token. Returns nil if nothing is parsed correctly.
   #
@@ -19,12 +39,42 @@ class Router
     end
   end
 
+  # All the configured "Pinned Apps". Returns an array of unique and already rejected apps
+  # that may be problematic (inaccessible or idden and so on). Should at least return an
+  # an empty array.
+  #
+  # @return [FeaturedApp]
   def self.pinned_apps
-    @pinned_apps ||= Configuration.pinned_apps.to_a.map do |token|
-      router = router_from_token(token.to_s)
-      next if router.nil?
+    @pinned_apps ||= Configuration.pinned_apps.to_a.each_with_object([]) do |token, apps|
+      apps.concat pinned_apps_from_token(token)
+    end.uniq do |app|
+      app.token.to_s
+    end.reject do |app|
+      !app.accessible? || app.hidden? || app.backup? || app.invalid_batch_connect_app?
+    end
+  end
 
-      FeaturedApp.new(router, token: token)
-    end.reject { |app| !app.accessible? || app.hidden? || app.backup? || app.invalid_batch_connect_app? }
+  private
+
+  def self.pinned_apps_from_token(token)
+    apps.select do |app|
+      glob_match = File.fnmatch(token, app.token, File::FNM_EXTGLOB)
+      sub_app_match = token.start_with?(app.token) # find bc/desktop/pitzer from sys/bc_desktop
+
+      glob_match || sub_app_match
+    end.each_with_object([]) do |app, apps|
+      if app.has_sub_apps?
+        apps.concat(featured_apps_from_sub_app(app, token))
+      else
+        apps.append(FeaturedApp.from_ood_app(app))
+      end
+    end
+  end
+
+  def self.featured_apps_from_sub_app(app, token)
+    app.sub_app_list.each_with_object([]) do |sub_app, apps|
+      glob_match = File.fnmatch(token, sub_app.token, File::FNM_EXTGLOB)
+      apps.append(FeaturedApp.from_ood_app(app, token: sub_app.token)) if glob_match
+    end
   end
 end

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -30,7 +30,7 @@ class Router
     end.uniq do |app|
       app.token.to_s
     end.reject do |app|
-      !app.accessible? || app.hidden? || app.backup? || app.invalid_batch_connect_app?
+      app.invalid_batch_connect_app?
     end
   end
 

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -1,25 +1,5 @@
 class Router
 
-  # All the system install apps
-  def self.sys_apps
-    @sys_apps ||= SysRouter.apps
-  end
-
-  # All the developer apps
-  def self.dev_apps
-    @dev_apps ||= DevRouter.apps
-  end
-
-  # All the shared apps, from all possible owners
-  def self.usr_apps
-    @usr_apps ||= UsrRouter.all_apps(owners: UsrRouter.owners)
-  end
-
-  # A combination of all sys, dev and usr apps
-  def self.apps
-    @apps ||= sys_apps + usr_apps + dev_apps
-  end
-
   # Return a Router [SysRouter, UsrRouter or DevRouter] based off
   # of the input token. Returns nil if nothing is parsed correctly.
   #
@@ -44,9 +24,9 @@ class Router
   # an empty array.
   #
   # @return [FeaturedApp]
-  def self.pinned_apps
-    @pinned_apps ||= Configuration.pinned_apps.to_a.each_with_object([]) do |token, apps|
-      apps.concat pinned_apps_from_token(token)
+  def self.pinned_apps(tokens, all_apps)
+    @pinned_apps ||= tokens.to_a.each_with_object([]) do |token, pinned_apps|
+      pinned_apps.concat pinned_apps_from_token(token, all_apps)
     end.uniq do |app|
       app.token.to_s
     end.reject do |app|
@@ -56,8 +36,8 @@ class Router
 
   private
 
-  def self.pinned_apps_from_token(token)
-    apps.select do |app|
+  def self.pinned_apps_from_token(token, all_apps)
+    all_apps.select do |app|
       glob_match = File.fnmatch(token, app.token, File::FNM_EXTGLOB)
       sub_app_match = token.start_with?(app.token) # find bc/desktop/pitzer from sys/bc_desktop
 

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -29,8 +29,6 @@ class Router
       pinned_apps.concat pinned_apps_from_token(token, all_apps)
     end.uniq do |app|
       app.token.to_s
-    end.reject do |app|
-      app.invalid_batch_connect_app?
     end
   end
 

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :set_user, :set_nav_groups, :set_announcements, :set_locale
+  before_action :set_user, :set_pinned_apps, :set_nav_groups, :set_announcements, :set_locale
   before_action :set_my_balances, only: [:index, :new, :featured]
   before_action :set_featured_group
 
@@ -38,6 +38,10 @@ class ApplicationController < ActionController::Base
     @usr_apps ||= ::Configuration.app_sharing_enabled? ? UsrRouter.all_apps(owners: UsrRouter.owners) : []
   end
 
+  def all_apps
+    @all_apps ||= sys_apps + usr_apps + dev_apps
+  end
+
   def nav_sys_apps
     sys_apps.select(&:should_appear_in_nav?)
   end
@@ -55,7 +59,11 @@ class ApplicationController < ActionController::Base
   end
 
   def pinned_app_group
-    OodAppGroup.groups_for(apps: Router.pinned_apps)
+    OodAppGroup.groups_for(apps: @pinned_apps)
+  end
+
+  def set_pinned_apps
+    @pinned_apps ||= Router.pinned_apps(::Configuration.pinned_apps, all_apps)
   end
 
   def set_announcements

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -38,8 +38,8 @@ class ApplicationController < ActionController::Base
     @usr_apps ||= ::Configuration.app_sharing_enabled? ? UsrRouter.all_apps(owners: UsrRouter.owners) : []
   end
 
-  def all_apps
-    @all_apps ||= sys_apps + usr_apps + dev_apps
+  def nav_all_apps
+    @nav_all_apps ||= nav_sys_apps + nav_usr_apps + nav_dev_apps
   end
 
   def nav_sys_apps
@@ -63,7 +63,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_pinned_apps
-    @pinned_apps ||= Router.pinned_apps(::Configuration.pinned_apps, all_apps)
+    @pinned_apps ||= Router.pinned_apps(::Configuration.pinned_apps, nav_all_apps)
   end
 
   def set_announcements

--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -19,8 +19,4 @@ module DashboardHelper
   def invalid_clusters
     @invalid_clusters ||= OodCore::Clusters.new(OodAppkit.clusters.select { |c| not c.valid? })
   end
-
-  def pinned_apps?
-    !Router.pinned_apps.empty?
-  end
 end

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <%- Router.pinned_apps.each_with_index do |app, index| %>
+  <%- @pinned_apps.each_with_index do |app, index| %>
     <%- link = app.links.first -%>
     <div class="col-sm-3 col-md-3 text-center">
       <a class="thumbnail app" href="<%= link.url %>">

--- a/apps/dashboard/app/views/dashboard/index.html.erb
+++ b/apps/dashboard/app/views/dashboard/index.html.erb
@@ -5,7 +5,7 @@
   <div class="row">
     <% if @motd %>
       <div class="col-md-8">
-        <%= render "pinned_apps" if pinned_apps? %>
+        <%= render "pinned_apps" unless @pinned_apps.empty? %>
         <%# This assumes @motd_file responds to `to_partial_path` %>
         <%= render @motd %>
       </div>
@@ -29,6 +29,6 @@
     <% end %>
   </div>
 <% else %>
-  <%= render "pinned_apps" if pinned_apps? %>
+  <%= render "pinned_apps" unless @pinned_apps.empty? %>
   <%= render @motd if @motd %>
 <% end %>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
       </div>
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-9">
         <ul class="nav navbar-nav">
-          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if pinned_apps? %>
+          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } unless @pinned_apps.empty? %>
           <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
           <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
           <%= render partial: 'layouts/nav/all_apps' if Configuration.show_all_apps_link? %>

--- a/apps/dashboard/test/fixtures/usr/cant_see/app_one/manifest.yml
+++ b/apps/dashboard/test/fixtures/usr/cant_see/app_one/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: App One
+description: |-
+  The first app that you can't see
+category: CantSee
+icon: fa://tachometer

--- a/apps/dashboard/test/fixtures/usr/cant_see/app_two/manifest.yml
+++ b/apps/dashboard/test/fixtures/usr/cant_see/app_two/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: App two
+description: |-
+  The second app you can't see
+category: CantSee
+icon: fa://tachometer

--- a/apps/dashboard/test/fixtures/usr/me/my_shared_app/manifest.yml
+++ b/apps/dashboard/test/fixtures/usr/me/my_shared_app/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: My Shared App
+description: |-
+  Some App I'm sharing
+category: Me
+icon: fa://tachometer

--- a/apps/dashboard/test/fixtures/usr/shared/bc_app/form.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_app/form.yml
@@ -1,0 +1,6 @@
+---
+title: "Oakley Usr App"
+cluster: "oakley"
+form:
+  first_item
+submit: submit/pbs.yml.erb

--- a/apps/dashboard/test/fixtures/usr/shared/bc_app/manifest.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_app/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: "Oakley Usr App"
+category: Interactive Apps
+subcategory: Servers
+icon: fa://desktop
+role: batch_connect

--- a/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/form.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/form.yml
@@ -1,0 +1,23 @@
+---
+description: |
+  This app will launch an interactive desktop on one or more compute nodes. You
+  will have full access to the resources these nodes provide. This is analogous
+  to an interctive batch job.
+
+attributes:
+  desktop: "mate"
+  bc_vnc_idle: 0
+  bc_vnc_resolution:
+    required: true
+  node_type: null
+
+form:
+  - bc_vnc_idle
+  - desktop
+  - bc_num_hours
+  - bc_num_slots
+  - node_type
+  - bc_account
+  - bc_queue
+  - bc_vnc_resolution
+  - bc_email_on_started

--- a/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/oakley.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/oakley.yml
@@ -1,0 +1,34 @@
+---
+title: "Oakley Desktop"
+cluster: "oakley"
+attributes:
+  desktop: "gnome"
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Oakley nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Oakley.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Oakley. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Oakley node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Oakley.
+      - **hugemem** - (*32 cores*) This Oakley node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Oakley. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/owens.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/owens.yml
@@ -1,0 +1,34 @@
+---
+title: "Owens Desktop"
+cluster: "owens"
+attributes:
+  desktop: "gnome"
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Oakley nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Oakley.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Oakley. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Oakley node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Oakley.
+      - **hugemem** - (*32 cores*) This Oakley node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Oakley. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/manifest.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: Desktops
+category: Interactive Apps
+subcategory: Desktops
+icon: fa://desktop
+role: batch_connect

--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -1,0 +1,254 @@
+require 'test_helper'
+
+class RouterTest < ActiveSupport::TestCase
+
+  UserDouble = Struct.new(:name)
+  
+  def setup
+    Router.instance_variable_set('@pinned_apps', nil)
+    Router.instance_variable_set('@sys_apps', nil)
+    Router.instance_variable_set('@dev_apps', nil)
+    Router.instance_variable_set('@usr_apps', nil)
+    Router.instance_variable_set('@apps', nil)
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    OodSupport::Process.stubs(:user).returns(UserDouble.new('me'))
+    FileUtils.chmod 0000, 'test/fixtures/usr/cant_see/'
+
+    UsrRouter.stubs(:base_path).with(:owner => "me").returns(Pathname.new("test/fixtures/usr/me"))
+    UsrRouter.stubs(:base_path).with(:owner => 'shared').returns(Pathname.new("test/fixtures/usr/shared"))
+    UsrRouter.stubs(:base_path).with(:owner => 'cant_see').returns(Pathname.new("test/fixtures/usr/cant_see"))
+    UsrRouter.stubs(:owners).returns(['me', 'shared', 'cant_see'])
+  end
+
+  def teardown
+    FileUtils.chmod 0755, 'test/fixtures/usr/cant_see/'
+  end
+
+  test "all apps apis return at least empty arrays" do
+    UsrRouter.stubs(:base_path).returns(Pathname.new("/dev/null"))
+    assert_equal [], Router.sys_apps
+    assert_equal [], Router.dev_apps
+    assert_equal [], Router.usr_apps
+    assert_equal [], Router.apps
+  end
+
+  test "all apps apis return correct apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    sys_apps = [
+      "sys/activejobs",
+      "sys/bc_desktop", # just the main app!
+      "sys/bc_jupyter",
+      "sys/bc_paraview",
+      "sys/dashboard",
+      "sys/file-editor",
+      "sys/files",
+      "sys/myjobs",
+      "sys/pseudofun",
+      "sys/shell",
+      "sys/systemstatus"
+    ]
+
+    dev_apps = sys_apps.map { |app| "dev/#{app.split("/")[1]}"}
+    usr_apps = ["usr/me/my_shared_app", "usr/shared/bc_with_subapps", "usr/shared/bc_app"]
+
+    assert_equal sys_apps, Router.sys_apps.map { |app| app.token }
+    assert_equal dev_apps, Router.dev_apps.map { |app| app.token }
+    assert_equal usr_apps, Router.usr_apps.map { |app| app.token }
+    assert_equal sys_apps + usr_apps + dev_apps, Router.apps.map { |app| app.token }
+  end
+
+  test "pinned apps with specific dev apps" do
+    DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    real_apps = [
+      'dev/bc_jupyter',
+      'dev/bc_paraview',
+      'dev/bc_desktop/owens',
+      'dev/pseudofun'
+    ]
+    Configuration.stubs(:pinned_apps).returns(real_apps + [
+      'sys/bc_desktop/doesnt_exist',
+      'sys/should_get_filtered'
+    ])
+    
+    assert_equal real_apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with specific sys apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    real_apps = [
+      'sys/bc_jupyter',
+      'sys/bc_paraview',
+      'sys/bc_desktop/owens',
+      'sys/pseudofun'
+    ]
+
+    Configuration.stubs(:pinned_apps).returns(real_apps + [
+      'sys/bc_desktop/doesnt_exist',
+      'sys/should_get_filtered'
+    ])
+    
+    assert_equal real_apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with wildcarded sys apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+
+    all_apps = [
+      "sys/activejobs",
+      "sys/bc_desktop/oakley", # picks up sub-apps instead of the main app
+      "sys/bc_desktop/owens",
+      "sys/bc_jupyter",
+      "sys/bc_paraview",
+      "sys/dashboard",
+      "sys/file-editor",
+      "sys/files",
+      "sys/myjobs",
+      "sys/pseudofun",
+      "sys/shell",
+      "sys/systemstatus"
+    ]
+    Configuration.stubs(:pinned_apps).returns(['sys/*'])
+    
+    assert_equal all_apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with wildcarded sys sub apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    apps = [
+      "sys/bc_desktop/oakley",
+      "sys/bc_desktop/owens",
+      "sys/bc_jupyter",
+      "sys/pseudofun"
+    ]
+
+    Configuration.stubs(:pinned_apps).returns([
+      "sys/bc_desktop/*",
+      "sys/bc_jupyter",
+      "sys/pseudofun"
+    ])
+    
+    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with specific usr apps" do
+    UsrRouter.stubs(:base_path).with(:owner => "me").returns(Pathname.new("test/fixtures/usr/me"))
+    UsrRouter.stubs(:base_path).with(:owner => 'shared').returns(Pathname.new("test/fixtures/usr/shared"))
+    UsrRouter.stubs(:base_path).with(:owner => 'cant_see').returns(Pathname.new("test/fixtures/usr/cant_see"))
+    UsrRouter.stubs(:owners).returns(['me', 'shared', 'cant_see'])
+
+    real_apps = [
+      'usr/shared/bc_with_subapps/owens',
+      'usr/me/my_shared_app',
+    ]
+
+    Configuration.stubs(:pinned_apps).returns(real_apps + [
+      'usr/doesnt_exist/some_app',
+      'usr/should_get_filtered',
+      'usr/cant_see/app_one',
+      'usr/cant_see/app_two',
+    ])
+
+    assert_equal real_apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with wildcarded usr apps" do
+    apps = [
+      'usr/shared/bc_with_subapps/oakley',
+      'usr/shared/bc_with_subapps/owens',
+      'usr/shared/bc_app',
+      'usr/me/my_shared_app'
+    ]
+
+    Configuration.stubs(:pinned_apps).returns([
+      'usr/shared/*',
+      'usr/me/*',
+      'usr/cant_see/*',
+      'usr/doesnt_exist/some_app',
+      'usr/should_get_filtered'
+    ])
+
+    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with wildcarded usr sub apps apps" do
+    apps = [
+      'usr/shared/bc_with_subapps/oakley',
+      'usr/shared/bc_with_subapps/owens',
+      'usr/me/my_shared_app'
+    ]
+
+    Configuration.stubs(:pinned_apps).returns([
+      'usr/shared/bc_with_subapps/*', # subapps/* here. usr/shared/bc_app not included
+      'usr/me/*',
+      'usr/cant_see/*',
+      'usr/doesnt_exist/some_app',
+      'usr/should_get_filtered'
+    ])
+
+    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps with usr sys and dev apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_interactive_apps"))
+
+    apps = [  
+      "usr/shared/bc_with_subapps/oakley", 
+      "usr/shared/bc_with_subapps/owens", 
+      "usr/me/my_shared_app", 
+      "sys/bc_paraview", 
+      "sys/bc_desktop/oakley", 
+      "sys/bc_desktop/owens", 
+      "sys/bc_jupyter", 
+      "sys/pseudofun", 
+      "dev/activejobs", 
+      "dev/bc_desktop/oakley",  # dev/* gives the 1 subapp, not the main app
+      "dev/bc_jupyter", 
+      "dev/bc_paraview", 
+      "dev/dashboard", 
+      "dev/file-editor", 
+      "dev/files", 
+      "dev/myjobs", 
+      "dev/shell", 
+      "dev/systemstatus"
+    ]
+
+    Configuration.stubs(:pinned_apps).returns([
+      'usr/shared/bc_with_subapps/*',
+      'usr/me/*',
+      'usr/shared/cant_see',
+      'sys/bc_paraview',
+      'sys/bc_desktop/*',
+      'sys/bc_jupyter',
+      'sys/pseudofun',
+      'dev/*'
+    ])
+
+    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+  end
+
+  test "pinned apps wont duplicate entries" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
+    Configuration.stubs(:pinned_apps).returns(['sys/bc_jupyter', 'sys/*', 'sys/bc_jupyter', 'sys/pseudofun'])
+
+    all_apps = [
+      "sys/bc_jupyter", # sys/bc_jupyter configured first
+      "sys/activejobs",
+      "sys/bc_desktop/oakley", # picks up sub-apps instead of the main app
+      "sys/bc_desktop/owens",
+      "sys/bc_paraview",
+      "sys/dashboard",
+      "sys/file-editor",
+      "sys/files",
+      "sys/myjobs",
+      "sys/pseudofun",
+      "sys/shell",
+      "sys/systemstatus"
+    ]
+
+    assert_equal all_apps, Router.pinned_apps.map { |app| app.token }
+  end
+end

--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -52,10 +52,10 @@ class RouterTest < ActiveSupport::TestCase
     dev_apps = sys_apps.map { |app| "dev/#{app.split("/")[1]}"}
     usr_apps = ["usr/me/my_shared_app", "usr/shared/bc_with_subapps", "usr/shared/bc_app"]
 
-    assert_equal sys_apps, Router.sys_apps.map { |app| app.token }
-    assert_equal dev_apps, Router.dev_apps.map { |app| app.token }
-    assert_equal usr_apps, Router.usr_apps.map { |app| app.token }
-    assert_equal sys_apps + usr_apps + dev_apps, Router.apps.map { |app| app.token }
+    assert_equal sys_apps.to_set, Router.sys_apps.map { |app| app.token }.to_set
+    assert_equal dev_apps.to_set, Router.dev_apps.map { |app| app.token }.to_set
+    assert_equal usr_apps.to_set, Router.usr_apps.map { |app| app.token }.to_set
+    assert_equal (sys_apps + usr_apps + dev_apps).to_set, Router.apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with specific dev apps" do
@@ -71,7 +71,7 @@ class RouterTest < ActiveSupport::TestCase
       'sys/should_get_filtered'
     ])
     
-    assert_equal real_apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal real_apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with specific sys apps" do
@@ -88,7 +88,7 @@ class RouterTest < ActiveSupport::TestCase
       'sys/should_get_filtered'
     ])
     
-    assert_equal real_apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal real_apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with wildcarded sys apps" do
@@ -111,7 +111,7 @@ class RouterTest < ActiveSupport::TestCase
     ]
     Configuration.stubs(:pinned_apps).returns(['sys/*'])
     
-    assert_equal all_apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal all_apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with wildcarded sys sub apps" do
@@ -129,7 +129,7 @@ class RouterTest < ActiveSupport::TestCase
       "sys/pseudofun"
     ])
     
-    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with specific usr apps" do
@@ -150,7 +150,7 @@ class RouterTest < ActiveSupport::TestCase
       'usr/cant_see/app_two',
     ])
 
-    assert_equal real_apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal real_apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with wildcarded usr apps" do
@@ -169,7 +169,7 @@ class RouterTest < ActiveSupport::TestCase
       'usr/should_get_filtered'
     ])
 
-    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with wildcarded usr sub apps apps" do
@@ -187,7 +187,7 @@ class RouterTest < ActiveSupport::TestCase
       'usr/should_get_filtered'
     ])
 
-    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps with usr sys and dev apps" do
@@ -226,7 +226,7 @@ class RouterTest < ActiveSupport::TestCase
       'dev/*'
     ])
 
-    assert_equal apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 
   test "pinned apps wont duplicate entries" do
@@ -235,7 +235,7 @@ class RouterTest < ActiveSupport::TestCase
     Configuration.stubs(:pinned_apps).returns(['sys/bc_jupyter', 'sys/*', 'sys/bc_jupyter', 'sys/pseudofun'])
 
     all_apps = [
-      "sys/bc_jupyter", # sys/bc_jupyter configured first
+      "sys/bc_jupyter",
       "sys/activejobs",
       "sys/bc_desktop/oakley", # picks up sub-apps instead of the main app
       "sys/bc_desktop/owens",
@@ -249,6 +249,7 @@ class RouterTest < ActiveSupport::TestCase
       "sys/systemstatus"
     ]
 
-    assert_equal all_apps, Router.pinned_apps.map { |app| app.token }
+    assert_equal all_apps.size, Router.pinned_apps.size
+    assert_equal all_apps.to_set, Router.pinned_apps.map { |app| app.token }.to_set
   end
 end


### PR DESCRIPTION
Router#pinned_apps now supports glob style wildcards like sys/* and
sys/bc_desktop/* (usr/ and dev/ included). This also adds public Router#apps
methods to be possibly useful in the future.

This also adds a OodApp#has_sub_apps? api to determine if an app
in fact has valid sub apps for showing the subapp in the pinned
apps menus.

I can comment in the tickets where behaviour is defined more specifically, but basically here are a few common use cases for this:
```yaml
pinned_apps
   # get all the system and usr apps
   - "sys/*"
   - "usr/*"

   # show all the subapps for sys/bc_desktop
   - "sys/bc_desktop/*"

   # get all the apps from a specific usr share location
   - "usr/some_user/*"
```