### PR TITLE
Fix OnDemand logo broken link in Dashboard footer

### DIFF
--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-6 col-sm-6">
-        <%= link_to "https://osc.github.io/Open-OnDemand/" do %>
+        <%= link_to "https://openondemand.org" do %>
           <%= image_tag(
                 "OpenOnDemand_powered_by_RGB.svg",
                 class: "footer-logo",


### PR DESCRIPTION
This PR fixes the broken link in the footer of the Dashboard app. The OnDemand logo was linking to the old Open OnDemand repo.

![image](https://user-images.githubusercontent.com/6081892/108776463-706cf180-7530-11eb-950f-e689fda09aa4.png)

*Old link*
https://osc.github.io/Open-OnDemand/

*New link*
https://openondemand.org