### PR TITLE
Add GitHub action to automatically assign new PRs to their authors

### DIFF
--- a/.github/workflows/pr-assign-author.yml
+++ b/.github/workflows/pr-assign-author.yml
@@ -1,0 +1,15 @@
+# This action runs when a new PR is opened or repoened and automatically
+# assigns the PR to the author.
+name: Assign to author PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.2.0
+        with:
+          repo-token: ${{ secrets.OSCWIAG_ISSUE_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub action to automatically update assign the new and reopened pull requests to the author.

**Plugin used:**
https://github.com/toshimaru/auto-author-assign