### PR TITLE
Manifest files now support metadata maps

### DIFF
--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -58,6 +58,7 @@ category: OSC
   # @option opts [String] :icon The icon used on the dashboard, optionally a Font Awesome tag
   # @option opts [String] :role Dashboard categorization
   # @option opts [String] :url An optional redirect URL
+  # @option opts [Hash]   :metadata An optional hash of key value pairs
   def initialize(opts)
     raise InvalidContentError.new unless(opts && opts.respond_to?(:to_h))
 
@@ -111,6 +112,13 @@ category: OSC
   # @return [String] role as string
   def role
     @manifest_options[:role] || ""
+  end
+
+  # Return the app metadata
+  #
+  # @return [Hash] metadata as a hash
+  def metadata
+    @manifest_options[:metadata] || {}
   end
 
   # Manifest objects are valid

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -173,6 +173,10 @@ class OodApp
     manifest.role
   end
 
+  def metadata
+    manifest.metadata
+  end
+
   def manifest
     @manifest ||= Manifest.load(manifest_path)
   end

--- a/apps/dashboard/test/fixtures/files/manifest_valid
+++ b/apps/dashboard/test/fixtures/files/manifest_valid
@@ -9,3 +9,6 @@ category: Desktops
 subcategory: Virtual Desktop Interface
 role: vdi
 url: /pun/sys/vncsim/%{app_token}/sessions
+metadata:
+  tags: test
+  field_of_science: CS

--- a/apps/dashboard/test/models/manifest_test.rb
+++ b/apps/dashboard/test/models/manifest_test.rb
@@ -93,4 +93,36 @@ class ManifestTest < ActiveSupport::TestCase
     assert_equal "", manifest_three.role, "nil role should return empty string"
   end
 
+  test "keys are read correctly" do
+    manifest = Manifest.load("test/fixtures/files/manifest_valid")
+    metadata = {
+      "tags" => 'test',
+      "field_of_science" => 'CS'
+    }
+    description = "**Ruby VDI** provides a remote desktop on an Ruby shared node at the Ohio\n" +
+      "Supercomputer Center (OSC). Care must be taken to avoid heavy computation as\n" +
+      "the resources are shared with many users."
+
+    assert_equal "Ruby VDI", manifest.name
+    assert_equal description, manifest.description
+    assert_equal "vdi", manifest.role
+    assert_equal "fa://desktop", manifest.icon
+    assert_equal "Desktops", manifest.category
+    assert_equal "Virtual Desktop Interface", manifest.subcategory
+    assert_equal "/pun/sys/vncsim/%{app_token}/sessions", manifest.url
+    assert_equal metadata, manifest.metadata
+  end
+
+  test "default keys are safe" do
+    manifest = Manifest.load("test/fixtures/files/manifest_invalid")
+
+    assert_equal "", manifest.name
+    assert_equal "", manifest.description
+    assert_equal "", manifest.role
+    assert_equal "", manifest.icon
+    assert_equal "", manifest.category
+    assert_equal "", manifest.subcategory
+    assert_equal "", manifest.url
+    assert_equal({}, manifest.metadata)
+  end
 end


### PR DESCRIPTION
This is a step to support different filtering types in #714 and #715. It only adds the ability to add metadata, other PRs should build on it to start to use it in different ways.