### PR TITLE
invalidate cached @pinned_apps from Router in tests

### DIFF
--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -18,6 +18,7 @@ class RouterTest < ActiveSupport::TestCase
 
   def teardown
     FileUtils.chmod 0755, 'test/fixtures/usr/cant_see/'
+    Router.instance_variable_set('@pinned_apps', nil)
   end
 
   def all_apps


### PR DESCRIPTION
Fix #908. I tracked that issue down to apps being returned in `@pinned_apps` that should not have been there.  They'd been cached during these test cases, but subsequently during the integration test did not meet `should_appear_in_nav?` requirements and should not have shown up at all.