### PR TITLE
Pin apps by metadata

### DIFF
--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -35,24 +35,22 @@ class Router
   private
 
   def self.pinned_apps_from_token(token, all_apps)
-    all_apps.select do |app|
-      glob_match = File.fnmatch(token, app.token, File::FNM_EXTGLOB)
-      sub_app_match = token.start_with?(app.token) # find bc/desktop/pitzer from sys/bc_desktop
+    matcher = TokenMatcher.new(token)
 
-      glob_match || sub_app_match
+    all_apps.select do |app|
+      matcher.matches_app?(app)
     end.each_with_object([]) do |app, apps|
       if app.has_sub_apps?
-        apps.concat(featured_apps_from_sub_app(app, token))
+        apps.concat(featured_apps_from_sub_app(app, matcher))
       else
         apps.append(FeaturedApp.from_ood_app(app))
       end
     end
   end
 
-  def self.featured_apps_from_sub_app(app, token)
+  def self.featured_apps_from_sub_app(app, matcher)
     app.sub_app_list.each_with_object([]) do |sub_app, apps|
-      glob_match = File.fnmatch(token, sub_app.token, File::FNM_EXTGLOB)
-      apps.append(FeaturedApp.from_ood_app(app, token: sub_app.token)) if glob_match
+      apps.append(FeaturedApp.from_ood_app(app, token: sub_app.token)) if matcher.matches_app?(sub_app)
     end
   end
 end

--- a/apps/dashboard/app/apps/token_matcher.rb
+++ b/apps/dashboard/app/apps/token_matcher.rb
@@ -1,0 +1,34 @@
+# This class matches pinned apps configuration tokens to a given OodApp
+# Tokens can be globs like 'sys/*', specific apps like 'sys/jupyter'
+# or 'sys/bc_desktop/pitzer' for subapps
+class TokenMatcher
+
+  attr_reader :matchers, :token
+
+  # @param [String] token the token to match apps against
+  def initialize(token)
+    @matchers = []
+    @token = token
+
+    if token.is_a?(String)
+      matchers.append('glob_match?')
+    end
+  end
+
+  def matches_app?(app)
+    if matchers.empty?
+      false
+    else
+      matchers.all? { |matcher| method(matcher).call(app) }
+    end
+  end
+
+  private
+
+  def glob_match?(app)
+    glob_match = File.fnmatch(token, app.token, File::FNM_EXTGLOB)
+    sub_app_match = token.start_with?(app.token) # find sys/bc_desktop/pitzer from sys/bc_desktop
+
+    glob_match || sub_app_match
+  end
+end

--- a/apps/dashboard/app/apps/token_matcher.rb
+++ b/apps/dashboard/app/apps/token_matcher.rb
@@ -1,17 +1,24 @@
 # This class matches pinned apps configuration tokens to a given OodApp
-# Tokens can be globs like 'sys/*', specific apps like 'sys/jupyter'
-# or 'sys/bc_desktop/pitzer' for subapps
+# Tokens can either be strings that are globs like 'sys/*', specific apps like
+# 'sys/jupyter' or 'sys/bc_desktop/pitzer' for subapps. They can also be hashes
+# Hashes can be known attributes like category, subcategory, type to filter off
+# of those. And/or they can be arbitrary key value pairs to filter off of OodApp#metadata.
 class TokenMatcher
 
   attr_reader :matchers, :token
 
-  # @param [String] token the token to match apps against
+  # @param [String, Hash] token the token to match apps against
   def initialize(token)
     @matchers = []
     @token = token
 
     if token.is_a?(String)
       matchers.append('glob_match?')
+    elsif token.is_a?(Hash)
+      matchers.append('same_type?') unless token[:type].nil?
+      matchers.append('same_category?') unless token[:category].nil?
+      matchers.append('same_subcategory?') unless token[:subcategory].nil?
+      matchers.append('metadata_match?') if token_has_metadata?
     end
   end
 
@@ -30,5 +37,29 @@ class TokenMatcher
     sub_app_match = token.start_with?(app.token) # find sys/bc_desktop/pitzer from sys/bc_desktop
 
     glob_match || sub_app_match
+  end
+
+  def token_has_metadata?
+    token.to_h.reject do |k, _|
+      %i[type category subcategory].include?(k)
+    end.any?
+  end
+
+  def same_category?(app)
+    token[:category].to_s == app.category
+  end
+
+  def same_subcategory?(app)
+    token[:subcategory].to_s == app.subcategory
+  end
+
+  def same_type?(app)
+    token[:type].to_s.to_sym == app.type
+  end
+
+  def metadata_match?(app)
+    app.metadata.select do |key, value|
+      token[key.to_sym] == value
+    end.any?
   end
 end

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -10,6 +10,8 @@ module BatchConnect
     # @return [String, nil] sub app
     attr_accessor :sub_app
 
+    delegate :type, :category, :subcategory, :metadata, to: :ood_app
+
     # Raised when batch connect app components could not be found
     class AppNotFound < StandardError; end
 

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -255,6 +255,12 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       "sys/bc_osc_jupyter",
       "sys/bc_osc_rstudio_server",
       "sys/iqmol",
+      {
+        type: 'sys',
+        category: 'Interactive Apps',
+        subcategory: 'Servers',
+        field_of_science: 'Biology'
+      }
     ]
 
     with_modified_env(config_fixtures) do

--- a/apps/dashboard/test/fixtures/config/ondemand.d/pinned_apps.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/pinned_apps.yml
@@ -2,3 +2,7 @@ pinned_apps:
   - "sys/bc_osc_jupyter"
   - "sys/bc_osc_rstudio_server"
   - "sys/iqmol"
+  - type: sys
+    category: 'Interactive Apps'
+    subcategory: 'Servers'
+    field_of_science: 'Biology'

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/manifest.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/manifest.yml
@@ -4,3 +4,5 @@ category: Interactive Apps
 subcategory: Apps
 icon: fa://gear
 role: batch_connect
+metadata:
+  machine_learning: 'true'

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/pseudofun/manifest.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/pseudofun/manifest.yml
@@ -11,3 +11,5 @@ description: |-
 category: Gateway Apps
 subcategory: Biomedical Informatics
 icon: fa://search
+metadata:
+  field_of_science: 'biology'

--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -25,6 +25,23 @@ class RouterTest < ActiveSupport::TestCase
     DevRouter.apps + SysRouter.apps + UsrRouter.all_apps(owners: UsrRouter.owners)
   end
 
+  def sys_with_gateway_tokens
+    [
+      "sys/bc_jupyter",
+      "sys/activejobs",
+      "sys/bc_desktop/oakley", # picks up sub-apps instead of the main app
+      "sys/bc_desktop/owens",
+      "sys/bc_paraview",
+      "sys/dashboard",
+      "sys/file-editor",
+      "sys/files",
+      "sys/myjobs",
+      "sys/pseudofun",
+      "sys/shell",
+      "sys/systemstatus"
+    ]
+  end
+
   test "pinned apps returns at least empty" do
     UsrRouter.stubs(:base_path).returns(Pathname.new("/dev/null"))
     assert_equal [], Router.pinned_apps([], [])
@@ -43,9 +60,9 @@ class RouterTest < ActiveSupport::TestCase
       'sys/bc_desktop/doesnt_exist',
       'sys/should_get_filtered'
     ]
-    
+
     pinned_apps = Router.pinned_apps(tokens, all_apps)
-    assert_equal real_tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal real_tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with specific sys apps" do
@@ -62,30 +79,16 @@ class RouterTest < ActiveSupport::TestCase
       'sys/should_get_filtered'
     ]
 
-    pinned_apps = Router.pinned_apps(tokens, all_apps)    
-    assert_equal real_tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    pinned_apps = Router.pinned_apps(tokens, all_apps)
+    assert_equal real_tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with wildcarded sys apps" do
     SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
     DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
 
-    tokens = [
-      "sys/activejobs",
-      "sys/bc_desktop/oakley", # picks up sub-apps instead of the main app
-      "sys/bc_desktop/owens",
-      "sys/bc_jupyter",
-      "sys/bc_paraview",
-      "sys/dashboard",
-      "sys/file-editor",
-      "sys/files",
-      "sys/myjobs",
-      "sys/pseudofun",
-      "sys/shell",
-      "sys/systemstatus"
-    ]
-    pinned_apps = Router.pinned_apps(['sys/*'], all_apps)    
-    assert_equal tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    pinned_apps = Router.pinned_apps(['sys/*'], all_apps)
+    assert_equal sys_with_gateway_tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with wildcarded sys sub apps" do
@@ -104,7 +107,7 @@ class RouterTest < ActiveSupport::TestCase
     ]
 
     pinned_apps = Router.pinned_apps(cfg, all_apps)    
-    assert_equal tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with specific usr apps" do
@@ -126,7 +129,7 @@ class RouterTest < ActiveSupport::TestCase
     ]
 
     pinned_apps = Router.pinned_apps(tokens, all_apps)
-    assert_equal real_tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal real_tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with wildcarded usr apps" do
@@ -146,7 +149,7 @@ class RouterTest < ActiveSupport::TestCase
     ]
 
     pinned_apps = Router.pinned_apps(cfg, all_apps)
-    assert_equal tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with wildcarded usr sub apps apps" do
@@ -165,7 +168,7 @@ class RouterTest < ActiveSupport::TestCase
     ]
 
     pinned_apps = Router.pinned_apps(cfg, all_apps)
-    assert_equal tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps with usr sys and dev apps" do
@@ -205,7 +208,7 @@ class RouterTest < ActiveSupport::TestCase
     ]
 
     pinned_apps = Router.pinned_apps(cfg, all_apps)
-    assert_equal tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal tokens.to_set, pinned_apps.map(&:token).to_set
   end
 
   test "pinned apps wont duplicate entries" do
@@ -213,22 +216,7 @@ class RouterTest < ActiveSupport::TestCase
     DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
     cfg = ['sys/bc_jupyter', 'sys/*', 'sys/bc_jupyter', 'sys/pseudofun']
 
-    tokens = [
-      "sys/bc_jupyter",
-      "sys/activejobs",
-      "sys/bc_desktop/oakley", # picks up sub-apps instead of the main app
-      "sys/bc_desktop/owens",
-      "sys/bc_paraview",
-      "sys/dashboard",
-      "sys/file-editor",
-      "sys/files",
-      "sys/myjobs",
-      "sys/pseudofun",
-      "sys/shell",
-      "sys/systemstatus"
-    ]
-
     pinned_apps = Router.pinned_apps(cfg, all_apps)
-    assert_equal tokens.to_set, pinned_apps.map { |app| app.token }.to_set
+    assert_equal sys_with_gateway_tokens.to_set, pinned_apps.map(&:token).to_set
   end
 end


### PR DESCRIPTION
The final checkbox to fix #714, pinning apps by category, subcategory, type and/or metadata.