### PR TITLE
Add default MOTD

### DIFF
--- a/apps/dashboard/app/models/motd_file.rb
+++ b/apps/dashboard/app/models/motd_file.rb
@@ -7,9 +7,9 @@ class MotdFile
   # Initialize the Motd Controller object based on the current user.
   #
   # @param [String] path The path to the motd file as a URI
-  def initialize(path = ENV['MOTD_PATH'])
+  def initialize(path = ENV['MOTD_PATH'] || Rails.root.join("default_motd").to_s)
     @motd_path = path
-    @content = load(path)
+    @content   = load(path)
   end
 
   # Checks the path URI to see if it can be opened
@@ -17,7 +17,7 @@ class MotdFile
   # Uses open-uri to check local or remote path for contents
   # @return [String] the motd raw content as string
   def content
-    @content || ""
+    @content || "" 
   end
 
   # A title for the message of the day.
@@ -46,7 +46,11 @@ class MotdFile
       when 'text_erb'
         @motd = MotdFormatterPlaintextErb.new(self)
       else
-        @motd = MotdFormatterPlaintext.new(self)
+        if self.motd_path.include?("default_motd")
+          @motd = MotdFormatterMarkdownErb.new(self)
+        else
+          @motd = MotdFormatterPlaintext.new(self)
+        end
     end if self.exist?
   end
 
@@ -72,6 +76,3 @@ class MotdFile
     nil
   end
 end
-
-
-

--- a/apps/dashboard/default_motd
+++ b/apps/dashboard/default_motd
@@ -1,0 +1,7 @@
+Development of Open OnDemand is supported through the [National Science Foundation](https://www.nsf.gov/) 
+under grant numbers [1534949](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1534949) and 
+[1835725](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1835725). 
+
+- For Questions \- Visit Open Ondemand's [Discourse](https://discourse.osc.edu/) page.
+- Source Code \- Visit Open Ondemand's [GitHub](https://github.com/OSC/ondemand) page.
+- Documentation \- Visit Open Ondemand's [Documentation](https://osc.github.io/ood-documentation/latest/) page.


### PR DESCRIPTION
I added the default motd file in the root of the dashboard app for now. I wasn't sure where the most apt place for it would be.  I also have a question, for the default motd, do we want that to be markdown_erb or just markdown?   