### PR TITLE
show metadata columns in the all apps table

### DIFF
--- a/apps/dashboard/app/controllers/apps_controller.rb
+++ b/apps/dashboard/app/controllers/apps_controller.rb
@@ -6,6 +6,7 @@ class AppsController < ApplicationController
     @sys_apps = sys_app_groups
     @dev_apps = OodAppGroup.groups_for(apps: nav_dev_apps)
     @usr_apps = OodAppGroup.groups_for(apps: nav_usr_apps)
+    set_metadata_columns
   end
 
   def featured
@@ -81,6 +82,14 @@ class AppsController < ApplicationController
     else
       #FIXME: app type doesn't exit
       raise ActionController::RoutingError.new('Not Found')
+    end
+  end
+
+  def set_metadata_columns
+    @metadata_columns = nav_all_apps.each_with_object([]) do |app, columns|
+      app.metadata.each do |k,v|
+        columns.append(k.to_s)
+      end
     end
   end
 end

--- a/apps/dashboard/app/controllers/apps_controller.rb
+++ b/apps/dashboard/app/controllers/apps_controller.rb
@@ -86,9 +86,13 @@ class AppsController < ApplicationController
   end
 
   def set_metadata_columns
-    @metadata_columns = nav_all_apps.each_with_object([]) do |app, columns|
-      app.metadata.each do |k,v|
-        columns.append(k.to_s)
+    @metadata_columns = begin
+      nav_all_apps.each_with_object([]) do |app, columns|
+        app.metadata.each do |k,v|
+          columns.append(k.to_s)
+        end
+      end.sort_by do |column|
+        column.to_s
       end
     end
   end

--- a/apps/dashboard/app/views/apps/_app_group_rows.html.erb
+++ b/apps/dashboard/app/views/apps/_app_group_rows.html.erb
@@ -19,6 +19,9 @@
       <td><%= install_location(app) %></td>
       <td><%= app.category %></td>
       <td><%= app.subcategory %></td>
+      <%- @metadata_columns.each do |column| -%>
+      <td><%= app.metadata.fetch(column, "") %></td>
+      <%- end -%>
     </tr>
   <%- else -%>
     <%- app.links.each do |link| -%>
@@ -27,6 +30,9 @@
         <td><%= install_location(app) %></td>
         <td><%= app.category %></td>
         <td><%= app.subcategory %></td>
+        <%- @metadata_columns.each do |column| -%>
+        <td><%= app.metadata.fetch(column, "") %></td>
+        <%- end -%>
       </tr>
     <%- end -%>
   <%- end -%>

--- a/apps/dashboard/app/views/apps/index.html.erb
+++ b/apps/dashboard/app/views/apps/index.html.erb
@@ -14,6 +14,9 @@
       <th scope="col"><%= t('dashboard.all_apps_table_install_column') %></th>
       <th scope="col"><%= t('dashboard.all_apps_table_category_column') %></th>
       <th scope="col"><%= t('dashboard.all_apps_table_sub_category_column') %></th>
+      <%- @metadata_columns.each do |column| -%>
+      <th scope="col"><%= column.to_s.titleize %></th>
+      <%- end -%>
     </tr>
   </thead>
   <tbody>

--- a/apps/dashboard/test/integration/apps_test.rb
+++ b/apps/dashboard/test/integration/apps_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class AppsTest < ActionDispatch::IntegrationTest
+
+  test "index table adds metadata columns" do
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    Configuration.stubs(:app_development_enabled?).returns(true)
+    Configuration.stubs(:app_sharing_enabled?).returns(true)
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+  
+    get "/apps/index"
+    assert_response :success
+  
+    headers = css_select('tr[id="all-apps-table-header"] th')
+  
+    assert_equal 6, headers.size
+    assert_equal 'Machine Learning', headers[4].text
+    assert_equal 'Field Of Science', headers[5].text
+
+    rows_test_data = {
+      "pun-sys-shell-ssh-owens.osc.edu": ["", ""],
+      "pun-sys-shell-ssh-oakley.osc.edu": ["", ""],
+      "apps-show-systemstatus": ["", ""],
+      "pun-sys-files": ["", ""],
+      "apps-show-activejobs": ["", ""],
+      "apps-show-myjobs": [ "", "" ],
+      "batch_connect-sys-bc_paraview-session_contexts-new": ["", ""],
+      "batch_connect-sys-bc_jupyter-session_contexts-new": ["true", ""], # machine learning metadata
+      "batch_connect-sys-bc_desktop-owens-session_contexts-new": ["", ""],
+      "batch_connect-sys-bc_desktop-oakley-session_contexts-new": ["", ""],
+      "apps-show-pseudofun": ["", "biology"] # field of science metadata
+    }
+
+    rows_test_data.each do |row_id, data|
+      assert_select "tr[id='#{row_id}']", 1
+      meta0 = css_select("tr[id='#{row_id}']").xpath('./td[5]').text
+      meta1 = css_select("tr[id='#{row_id}']").xpath('./td[6]').text
+      
+      assert_equal data[0], meta0
+      assert_equal data[1], meta1
+    end
+  end
+end

--- a/apps/dashboard/test/integration/apps_test.rb
+++ b/apps/dashboard/test/integration/apps_test.rb
@@ -14,8 +14,8 @@ class AppsTest < ActionDispatch::IntegrationTest
     headers = css_select('tr[id="all-apps-table-header"] th')
   
     assert_equal 6, headers.size
-    assert_equal 'Machine Learning', headers[4].text
-    assert_equal 'Field Of Science', headers[5].text
+    assert_equal 'Field Of Science', headers[4].text
+    assert_equal 'Machine Learning', headers[5].text
 
     rows_test_data = {
       "pun-sys-shell-ssh-owens.osc.edu": ["", ""],
@@ -25,10 +25,10 @@ class AppsTest < ActionDispatch::IntegrationTest
       "apps-show-activejobs": ["", ""],
       "apps-show-myjobs": [ "", "" ],
       "batch_connect-sys-bc_paraview-session_contexts-new": ["", ""],
-      "batch_connect-sys-bc_jupyter-session_contexts-new": ["true", ""], # machine learning metadata
+      "batch_connect-sys-bc_jupyter-session_contexts-new": ["", "true"], # machine learning metadata
       "batch_connect-sys-bc_desktop-owens-session_contexts-new": ["", ""],
       "batch_connect-sys-bc_desktop-oakley-session_contexts-new": ["", ""],
-      "apps-show-pseudofun": ["", "biology"] # field of science metadata
+      "apps-show-pseudofun": ["biology", ""] # field of science metadata
     }
 
     rows_test_data.each do |row_id, data|


### PR DESCRIPTION
Last thing to fix #715. This adds extra columns to 

There's currently no limitation on how many columns we'd add, so I'm not sure if want to make that configurable or if at all.

Here's what 2 additional columns would look like
![image](https://user-images.githubusercontent.com/4874123/109836463-2c55ad00-7c12-11eb-8a9a-65a49f21e307.png)
