### PR TITLE
fix #888

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -8,13 +8,12 @@ module OodPortalGenerator
   class Dex
     # @param opts [#to_h] the options describing the context used to render the Dex config
     def initialize(opts = {}, view)
-      opts = opts.to_h.each_with_object({}) { |(k, v), h| h[k.to_sym] = v unless v.nil? }
+      opts = opts.to_h.deep_symbolize_keys
       config = opts.fetch(:dex, {})
       if config.nil? || config == false
         @enable = false
         return
       else
-        config = config.to_h.each_with_object({}) { |(k, v), h| h[k.to_sym] = v unless v.nil? }
         @config = config
         @enable = true
       end
@@ -47,10 +46,7 @@ module OodPortalGenerator
           userID: '08a8684b-db88-4b73-90a9-3cd1661f5466',
         }]
       end
-      @dex_config[:frontend] = {
-        dir: '/usr/share/ondemand-dex/web',
-        theme: 'ondemand',
-      }.merge(frontend)
+      @dex_config[:frontend] = frontend
       # Pass values back to main ood-portal.conf view
       if enabled? && self.class.installed?
         view.update_oidc_attributes(oidc_attributes)
@@ -196,7 +192,10 @@ module OodPortalGenerator
     end
 
     def frontend
-      @config.fetch(:frontend, {})
+      {
+        dir: '/usr/share/ondemand-dex/web',
+        theme: 'ondemand',
+      }.merge(@config.fetch(:frontend, {}))
     end
 
     def copy_ssl_certs

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -184,6 +184,14 @@ describe OodPortalGenerator::Application do
         described_class.generate()
       end
 
+      it 'generates custom dex configs' do
+        with_modified_env CONFIG: 'spec/fixtures/ood_portal.dex.yaml' do
+          expected_dex_yaml = read_fixture('dex.custom.yaml').gsub('/etc/ood/dex', config_dir)
+          expect(described_class.dex_output).to receive(:write).with(expected_dex_yaml)
+          described_class.generate()
+        end
+      end
+
       it 'generates copies SSL certs' do
         certdir = Dir.mktmpdir
         cert = File.join(certdir, 'cert')

--- a/ood-portal-generator/spec/fixtures/dex.custom.yaml
+++ b/ood-portal-generator/spec/fixtures/dex.custom.yaml
@@ -1,0 +1,29 @@
+---
+issuer: http://example.com:5556
+storage:
+  type: sqlite3
+  config:
+    file: "/etc/ood/dex/dex.db"
+web:
+  http: 0.0.0.0:5556
+telemetry:
+  http: 0.0.0.0:5558
+staticClients:
+- id: example.com
+  redirectURIs:
+  - http://example.com/oidc
+  name: OnDemand
+  secret: 83bc78b7-6f5e-4010-9d80-22f328aa6550
+oauth2:
+  skipApprovalScreen: true
+enablePasswordDB: true
+staticPasswords:
+- email: ood@localhost
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  username: ood
+  userID: '08a8684b-db88-4b73-90a9-3cd1661f5466'
+frontend:
+  dir: "/etc/site/custom-dex-themes"
+  theme: custom-test-theme
+  extra:
+    loginButtonText: Test login Text

--- a/ood-portal-generator/spec/fixtures/ood_portal.dex.yaml
+++ b/ood-portal-generator/spec/fixtures/ood_portal.dex.yaml
@@ -1,0 +1,8 @@
+---
+dex:
+  frontend:
+    theme: "custom-test-theme"
+    dir: /etc/site/custom-dex-themes
+    extra:
+      loginButtonText: "Test login Text"
+


### PR DESCRIPTION
Just use the active_support deep_symbolize_keys to symbolize the config, that way we always symbolize nested hashes like dex.frontend.*

Same as #929 but for the 1.8 release branch.