### PR TITLE
Internationalize "Pinned Apps"

### DIFF
--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -8,7 +8,9 @@ class FeaturedApp < OodApp
     FeaturedApp.new(app.router, token: token)
   end
 
-  def initialize(router, category: "Apps", subcategory: "Pinned Apps", token: nil)
+  def initialize(router, category: "Apps", 
+                         subcategory: I18n.t('dashboard.pinned_apps_title'),
+                         token: nil)
     super(router)
     @category = category.to_s
     @subcategory = subcategory.to_s

--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -1,6 +1,8 @@
 class OodAppGroup
   attr_accessor :apps
-
+  
+  PINNED_APPS_TITLE = I18n.t('dashboard.pinned_apps_title')
+  
   def initialize(title: "", apps: [])
     @apps = apps
     @_title = title
@@ -17,11 +19,11 @@ class OodAppGroup
 
   def title
     @title ||= begin
-      if @_title == "Pinned Apps"
+      if @_title == PINNED_APPS_TITLE
         if apps.size > nav_limit
-          "Pinned Apps (showing #{nav_limit} of #{apps.size})"
+          "#{PINNED_APPS_TITLE} (showing #{nav_limit} of #{apps.size})"
         else
-          "Pinned Apps"
+          PINNED_APPS_TITLE
         end
       else
         @_title
@@ -31,7 +33,7 @@ class OodAppGroup
 
   def nav_limit
     @nav_limit ||= begin
-      if @_title == "Pinned Apps"
+      if @_title == PINNED_APPS_TITLE
         ::Configuration.pinned_apps_menu_length
       else
         apps.size

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -116,6 +116,8 @@ en:
 
     motd_title: "Message of the Day"
 
+    pinned_apps_title: "Pinned Apps"
+
     nav_all_apps: "All Apps"
     nav_develop_docs: "Developer Documentation"
     nav_develop_my_sandbox_apps_dev: "My Sandbox Apps (Development)"

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -29,7 +29,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [
-      { header: "Pinned Apps" },
+      { header: I18n.t('dashboard.pinned_apps_title') },
       "Owens Desktop",
       "Jupyter Notebook",
       "Paraview",
@@ -58,7 +58,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [
-      { header: "Pinned Apps (showing 2 of 4)" },
+      { header: "#{I18n.t('dashboard.pinned_apps_title')} (showing 2 of 4)" },
       "Owens Desktop",
       "Jupyter Notebook",
       :divider,


### PR DESCRIPTION
This fixes [#926](https://github.com/OSC/ondemand/issues/926). I added a constant variable to adjust the control flow instead of using an attribute. 