### PR TITLE
add _app partial back for shared apps

### DIFF
--- a/apps/dashboard/app/views/apps/_app.html.erb
+++ b/apps/dashboard/app/views/apps/_app.html.erb
@@ -1,0 +1,32 @@
+<% app.links.each do |link| %>
+  <div class="col-sm-3 col-md-3">
+    <%=
+      link_to(
+        link.url.to_s,
+        class: "thumbnail app",
+        data: {
+          toggle: "popover",
+          content: manifest_markdown(link.description),
+          html: true,
+          trigger: "hover",
+          title: link.title,
+          container: "body"
+        },
+        target: link.new_tab? ? "_blank" : nil
+      ) do
+    %>
+      <div class="center-block" style="text-align: center">
+        <%= icon_tag(link.icon_uri) %>
+        <%= content_tag(:p, link.title) %>
+        <%=
+          content_tag(
+            :p,
+            content_tag(:span, link.caption),
+            class: "text-muted",
+            style: "margin-top: 20px"
+          ) if link.caption
+        %>
+      </div>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
Looks like I accidentally removed this partial in #884 thinking it was a part of the apps table, but it is in fact a part of the main landing page when usr apps are enabled. So shared apps are broken.  I checked this file out from 01ef72e020f808768607b6bbaa85c4346d6f1ad3, our 2.0.0 tag.