### PR TITLE
eval dbus-launch 

### DIFF
--- a/apps/bc_desktop/template/desktops/xfce.sh
+++ b/apps/bc_desktop/template/desktops/xfce.sh
@@ -36,5 +36,9 @@ else
     "${TERM_CONFIG}"
 fi
 
+# launch dbus first through eval becuase it can conflict with a conda environment
+# see https://github.com/OSC/ondemand/issues/700
+eval $(dbus-launch --sh-syntax)
+
 # Start up xfce desktop (block until user logs out of desktop)
 xfce4-session


### PR DESCRIPTION
fixes #700 to eval dbus-launch in xfce so that it can start cleanly with or without a conda environment.