### PR TITLE
make breadcrumb dividers purely visual for accessability

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/_breadcrumb.scss
+++ b/apps/dashboard/app/assets/stylesheets/_breadcrumb.scss
@@ -1,0 +1,10 @@
+
+.breadcrumb-item + .breadcrumb-item::before {
+  display: inline-block;
+  margin: 0.15em 1em 0 0;
+  transform: rotate(25deg);
+  border-right: 0.1em solid currentColor;
+  padding-right: 0.5em;
+  height: 75%;
+}
+

--- a/apps/dashboard/app/assets/stylesheets/_breadcrumb.scss
+++ b/apps/dashboard/app/assets/stylesheets/_breadcrumb.scss
@@ -1,10 +1,10 @@
 
 .breadcrumb-item + .breadcrumb-item::before {
   display: inline-block;
-  margin: 0.15em 1em 0 0;
+  margin: 0.25em 1em 0 0;
   transform: rotate(25deg);
   border-right: 0.1em solid currentColor;
   padding-right: 0.5em;
-  height: 75%;
+  height: 0.8em;
 }
 

--- a/apps/dashboard/app/assets/stylesheets/_variables.scss.erb
+++ b/apps/dashboard/app/assets/stylesheets/_variables.scss.erb
@@ -41,3 +41,6 @@ $grid-breakpoints: (
 
 // Navigation bar link gutter spacing x-axis.
 $navbar-nav-link-padding-x: 0.75rem;
+
+// breadcrumbs are purely visual for accessability
+$breadcrumb-divider: '';

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -127,3 +127,4 @@ pre.motd-monospaced {
 @import "insufficient_balance";
 @import "fa_shims";
 @import "fontawesome-iconpicker";
+@import "breadcrumb";


### PR DESCRIPTION
Carried over from this conversation https://github.com/OSC/ondemand/pull/927#discussion_r590646363

This makes breadcrumb dividers purely visual for accessibility.  I'm happy to tweak the scss as they look slightly different.

Before:
![image](https://user-images.githubusercontent.com/4874123/110970811-1ccc1780-8328-11eb-88e2-a63bf3a5bdd2.png)


After (initial):
![image](https://user-images.githubusercontent.com/4874123/110970706-02923980-8328-11eb-9074-8a7cd050cfb5.png)

After (using `0.8em` instead of %)
![image](https://user-images.githubusercontent.com/4874123/110990115-dfc04f00-8340-11eb-9012-09ba492ce6d2.png)
