### PR TITLE
parity for the accessability of the current master branch

### DIFF
--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -1,7 +1,7 @@
 <li class="nav-item dropdown" title="<%= group.title %>" >
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 
-  <ul class="dropdown-menu" role="menu">
+  <ul class="dropdown-menu">
     <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory).each_with_index do |g, index| %>
       <%= content_tag "li", "", class: "divider", role: "separator" if index > 0 %>
       <%= content_tag "li", g.title, class: "dropdown-header" unless g.title.empty? %>

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -1,12 +1,13 @@
 <li class="nav-item dropdown" title="<%= group.title %>">
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 
-  <ul class="dropdown-menu" role="menu">
+  <ul class="dropdown-menu">
     <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory).each_with_index do |g, index| %>
       <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
       <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
       <% g.apps.each do |app| %>
         <% app.links.each do |link| %>
+          <li>
             <%=
               link_to(
                 link.url.to_s,
@@ -21,6 +22,7 @@
               <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
             <% end %>
           <% end %>
+          </li>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
This brings the branch up to parity in terms of navbar navigation. The `"role=menu"` seem to make things worse. But in looking at this, I do believe we need to create a follow up ticket for navbar accessability as we use no roles.  So I think clearly there's a need to add roles, it's just not clear where and I don't think the bootstrap upgrade is the place for it anyhow. So this just brings the bootstrap PR to parity with what we currently have. No better, but no worse.

Also the `_featured_apps` partial was just an .erb extension and not an `.html.erb`. I guess it didn't seem to matter to rails, but even so, we should be consistent.