### PR TITLE
Staged_root & partition in submit.yml.erb render

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -216,12 +216,28 @@ module BatchConnect
     # @param session_context [SessionContext] object with attributes
     # @param fmt [String, nil] formatting used for attributes in submit hash
     # @return [Hash] hash of submission options
-    def submit_opts(session_context, fmt: nil)
+    def submit_opts(session_context, staged_root: staged_root, fmt: nil)
       hsh = {}
       session_context.each do |attribute|
         hsh = hsh.deep_merge attribute.submit(fmt: fmt)
       end
-      hsh = hsh.deep_merge submit_config(binding: session_context.get_binding)
+
+      # rendering context should be attribute values AND staged_root
+      # so we convert the array of Attribute objects to a Hash of id => value pairs
+      # and convert that to an OpenStruct, which gives the same "attribute_name as method" experience,
+      # lets us add staged_root, and avoids conflicts with other predefined methods like partition
+      # (OpenStruct has very few)
+      context_attrs = Hash[*(session_context.map {|a| [a.id, a.value] }.flatten)]
+      illegal_attrs = OpenStruct.new.methods & context_attrs.keys
+
+      raise '#{illegal_attrs.inspect} are keywords that cannot be used as attr names' unless illegal_attrs.empty?
+
+      rendering_context = OpenStruct.new(context_attrs)
+      rendering_context.staged_root = staged_root
+
+      rendering_context.define_singleton_method(:get_binding) { binding }
+
+      hsh = hsh.deep_merge submit_config(binding: rendering_context.get_binding)
     end
 
     # View used for session if it exists

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -216,7 +216,7 @@ module BatchConnect
     # @param session_context [SessionContext] object with attributes
     # @param fmt [String, nil] formatting used for attributes in submit hash
     # @return [Hash] hash of submission options
-    def submit_opts(session_context, staged_root: staged_root, fmt: nil)
+    def submit_opts(session_context, staged_root: nil, fmt: nil)
       hsh = {}
       session_context.each do |attribute|
         hsh = hsh.deep_merge attribute.submit(fmt: fmt)

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -411,7 +411,7 @@ module BatchConnect
     # Root directory where a job is staged and run in
     # @return [Pathname] staged root directory
     def staged_root
-      self.class.dataroot(token).join("output", id)
+      self.class.dataroot(token).join("output", id).tap { |p| p.mkpath unless p.exist? }
     end
 
     # List of template files that need to be rendered


### PR DESCRIPTION
**This is an alternative to https://github.com/OSC/ondemand/pull/915 and has not yet been tested**

Rendering context should be attribute name & values AND staged_root
So we convert the array of Attribute objects to a Hash of id => value pairs (Attribute's name is returned by method id)
and convert that to an OpenStruct, which gives the same "attribute_name as method" experience,
lets us add staged_root, and avoids conflicts with other predefined methods like partition

we have to define a method on the OpenStruct instance we create 'get_binding'