### PR TITLE
Fix #951 (Pinned apps crash)

### DIFF
--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
 
       <div class="collapse navbar-collapse" id="navbar">
         <ul class="navbar-nav mr-auto">
-          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } unless @pinned_apps.empty? %>
+          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
           <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
           <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
           <%= render partial: 'layouts/nav/all_apps' if Configuration.show_all_apps_link? %>


### PR DESCRIPTION
This fixes #951 by only showing the 'Apps' navbar menu item when @featured_group is present because @featured_group is a part of the NavConfig.categories when @pinned_apps isn't.

So `@featured_group` - what's passed into the partial - is nil because it was filtered when `@pinned_apps` is still valid and will be shown on the landing page.

I'd say we put this on hold until we get bootstrap sorted because it may have a conflict after that.