### PR TITLE
rm duplicate yarn call in bin/setup

### DIFF
--- a/apps/dashboard/bin/setup
+++ b/apps/dashboard/bin/setup
@@ -64,11 +64,6 @@ chdir APP_ROOT do
     sh "bin/rake assets:precompile"
   end
 
-  # puts "\n== Preparing database =="
-  # system! 'bin/rails db:setup'
-  # Install JavaScript dependencies if using Yarn
-  system('bin/yarn')
-
   puts "\n== Removing old logs and tempfiles =="
   sh "bin/rake log:clear tmp:clear"
 


### PR DESCRIPTION
the choice to do bin/yarn without the --production flag should be up to developer but by default we should not exclude the --production flag