### PR TITLE
fix xdmod bootstrap4 widget style/header

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/_custom.scss.erb
+++ b/apps/dashboard/app/assets/stylesheets/_custom.scss.erb
@@ -19,3 +19,8 @@ table.dataTable > thead .sorting:before, table.dataTable > thead .sorting_asc:be
     padding: 1rem;
   }
 }
+
+.card-header h3{
+  font-size: 16px;
+  font-weight: bold;
+}

--- a/apps/dashboard/app/views/dashboard/_xdmod_widget_job_efficiency.html.erb
+++ b/apps/dashboard/app/views/dashboard/_xdmod_widget_job_efficiency.html.erb
@@ -4,10 +4,10 @@
 <script id="job-efficiency-template" type="text/x-handlebars-template">
 <div class="card mt-3">
 
-  <h6 class="card-header">
-    {{title}}
+  <div class="card-header">
     <a href="{{xdmod_url}}" class="float-right">Open XDMoD <span class="fa fa-external-link-square-alt"></span></a>
-  </h6>
+    <h3>{{title}} - {{date_range}}</h3>
+  </div>
 
   <div class="card-body">
     {{#if error}}
@@ -28,10 +28,6 @@
       </p>
       {{/if}}
     {{/if}}
-  </div>
-
-  <div class="card-footer">
-    <small class="text-muted">{{date_range}}</small>
   </div>
 </div>
 </script>

--- a/apps/dashboard/app/views/dashboard/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/dashboard/_xdmod_widget_jobs.html.erb
@@ -3,10 +3,10 @@
 <script id="jobs-template" type="text/x-handlebars-template">
 <div class="card mt-3">
 
-  <h6 class="card-header">
-    {{title}}
+  <div class="card-header">
     <a href="{{xdmod_url}}" class="float-right">Open XDMoD <span class="fa fa-external-link-square-alt"></span></a>
-  </h6>
+    <h3>{{title}} - {{date_range}}</h3>
+  </div>
 
   {{#if error}}
     <div class="card-body">
@@ -50,10 +50,6 @@
     </div>
     {{/if}}
   {{/if}}
-
-  <div class="card-footer">
-    <small class="text-muted">{{date_range}}</small>
-  </div>
 </div>
 </script>
 


### PR DESCRIPTION
- xdmod header should be h3 not h6 for accessibility
- fixed h3 sizing to be similar to the original bootstrap 3 widgets
- removed header and collocate date with title as in original widgets


NOTE: The efficency report title and the XDMoD links are very close together. This is due to the font size increase in bootstrap 4. Not sure what to do with that yet...

original bootstrap 3 widgets:

![screen 2021-03-15 at 3 26 49 PM](https://user-images.githubusercontent.com/512333/111209848-ebab4b80-85a2-11eb-83af-fda185955306.png)

after these changes, bootstrap 4:

![screen 2021-03-15 at 3 27 36 PM](https://user-images.githubusercontent.com/512333/111209910-ffef4880-85a2-11eb-90b3-31f4aa682292.png)


