### PR TITLE
Adjust Dashboard branding colors #967

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/_custom.scss.erb
+++ b/apps/dashboard/app/assets/stylesheets/_custom.scss.erb
@@ -1,9 +1,5 @@
 // Bootstrap custom CSS
 
-.navbar-color {
-  background-color: <%= Configuration.brand_bg_color || "map-get($theme-colors, 'blue-gray')" %>;
-}
-
 table.dataTable > thead .sorting:before, table.dataTable > thead .sorting_asc:before, table.dataTable > thead .sorting_desc:before, table.dataTable > thead .sorting_asc_disabled:before, table.dataTable > thead .sorting_desc_disabled:before {
   right: 1.25em !important;
 }
@@ -14,13 +10,7 @@ table.dataTable > thead .sorting:before, table.dataTable > thead .sorting_asc:be
   }
 }
 
-.sessions-panel {
-  .card-body {
-    padding: 1rem;
-  }
-}
-
-.card-header h3{
+.card-header h3 {
   font-size: 16px;
   font-weight: bold;
 }

--- a/apps/dashboard/app/assets/stylesheets/_variables.scss.erb
+++ b/apps/dashboard/app/assets/stylesheets/_variables.scss.erb
@@ -4,27 +4,29 @@
 // Miscellaneous
 $enable-responsive-font-sizes: "true";
 $enable-shadows: "true";
+$font-size-base: 0.95rem;
 
 // Colors
+$green: #639e0f;
+$blue-gray: #334155;
+$warm-gray: #FAFAF9;
+
 $body-bg: #FFF;
 $body-color: #111827;
 
-// $blue: #0e99e9f1;
-
-$blue: #0284C7;
-$green: #639e0f;
-
-$theme-colors: ("blue-gray": #334155, "warm-gray": #FAFAF9);
+$primary: #337ab7;
+$danger: #d9534f;
+$info: #5bc0de;
 
 // Navigation bar
-$nav-link-disabled-color: map-get($theme-colors, "blue-gray");
+$nav-link-disabled-color: $blue-gray;
 
 // Link color
-$navbar-dark-color: <%= Configuration.brand_link_active_bg_color || "map-get($theme-colors, 'warm-gray')" %>;
-$navbar-dark-active-color: <%= Configuration.brand_link_active_bg_color || "map-get($theme-colors, 'warm-gray')" %>;
+$navbar-dark-color: <%= Configuration.brand_link_active_bg_color || "$warm-gray" %>;
+$navbar-dark-active-color: <%= Configuration.brand_link_active_bg_color || "$warm-gray" %>;
 
 // Navbar dark link text-muted disabled color.
-$navbar-dark-disabled-color: color-yiq(map-get($theme-colors, 'warm-gray'));
+$navbar-dark-disabled-color: color-yiq($warm-gray);
 
 // Grid layout
 $container-max-widths: (

--- a/apps/dashboard/app/views/layouts/nav/_styles.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_styles.html.erb
@@ -3,6 +3,9 @@
 .navbar-inverse {
   background-color: <%= bg_color %>;
 }
+.navbar-color {
+  background-color: <%= Configuration.brand_bg_color || "#334155" %>;
+}
 <% end %>
 
 <% if link_active_color %>


### PR DESCRIPTION
This PR includes a better default for the font size. https://github.com/OSC/ondemand/blob/de6439b24ffac7ea52ae98b87c3500f1cb3bb448/apps/dashboard/app/assets/stylesheets/_variables.scss.erb#L7

`$primary` color comes from the [Bootstrap 3 SASS variables](https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss#L18)