### PR TITLE
fix app card styles for bootstrap 4

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/apps.scss
@@ -67,13 +67,21 @@ tr.app {
   background-color: rgb(86, 44, 135);
 }
 
+.app-card {
+  @extend .card;
+  @extend .rounded;
+  @extend .p-2;
+  @extend .mb-3;
 
-a.thumbnail.app {
   color: black;
-  text-decoration: none;
+
+  // HACK: this happens to make the icons mostly fill space below & line up
+  height: 95%;
 
   &:hover {
     color: rgb(0, 95, 133);
+    border-color: rgb(0, 95, 133);
+
     text-decoration: none;
   }
 }

--- a/apps/dashboard/app/views/apps/_app.html.erb
+++ b/apps/dashboard/app/views/apps/_app.html.erb
@@ -3,7 +3,7 @@
     <%=
       link_to(
         link.url.to_s,
-        class: "thumbnail app",
+        class: "app-card",
         data: {
           toggle: "popover",
           content: manifest_markdown(link.description),

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -3,7 +3,7 @@
   <%- @pinned_apps.each_with_index do |app, index| %>
     <%- link = app.links.first -%>
     <div class="col-sm-3 col-md-3 text-center">
-      <a class="thumbnail app" href="<%= link.url %>">
+      <a class="app-card" href="<%= link.url %>">
         <div class="center-block">
           <%= icon_tag(link.icon_uri) %>
         </div>

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -82,11 +82,11 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    assert_select 'a.thumbnail.app', 4
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/apps/show/pseudofun']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
+    assert_select 'a.app-card', 4
+    assert_select "a.app-card[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
+    assert_select "a.app-card[href='/apps/show/pseudofun']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
   end
 
   test "does not create pinned apps when no configuration" do
@@ -98,7 +98,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    assert_select 'a.thumbnail.app', 0
+    assert_select 'a.app-card', 0
   end
 
   test "shows pinned apps when MOTD is present" do
@@ -122,11 +122,11 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
       get '/'
     end
 
-    assert_select 'a.thumbnail.app', 4
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/apps/show/pseudofun']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
+    assert_select 'a.app-card', 4
+    assert_select "a.app-card[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
+    assert_select "a.app-card[href='/apps/show/pseudofun']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
 
     assert_select 'h3', 2
     assert_equal I18n.t('dashboard.motd_title'), css_select('h3')[1].text
@@ -156,11 +156,11 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
       get '/'
     end
 
-    assert_select 'a.thumbnail.app', 4
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/apps/show/pseudofun']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
+    assert_select 'a.app-card', 4
+    assert_select "a.app-card[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
+    assert_select "a.app-card[href='/apps/show/pseudofun']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
 
     assert_select "div[class='xdmod']", 1
     assert_select "div[id='jobsEfficiencyReportPanelDiv']", 1
@@ -191,11 +191,11 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
       get '/'
     end
 
-    assert_select 'a.thumbnail.app', 4
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
-    assert_select "a.thumbnail.app[href='/apps/show/pseudofun']", 1
-    assert_select "a.thumbnail.app[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
+    assert_select 'a.app-card', 4
+    assert_select "a.app-card[href='/batch_connect/sys/bc_jupyter/session_contexts/new']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_paraview/session_contexts/new']", 1
+    assert_select "a.app-card[href='/apps/show/pseudofun']", 1
+    assert_select "a.app-card[href='/batch_connect/sys/bc_desktop/owens/session_contexts/new']", 1
 
     assert_select 'h3', 2
     assert_equal I18n.t('dashboard.motd_title'), css_select('h3')[1].text


### PR DESCRIPTION
Was the quickest solution but not sure about extending some of the helper classes (it spaces based on `$spacer`).

```
 .app-card {
  @extend .card;
  @extend .rounded;
  @extend .p-2;
  @extend .mb-3;
```