### PR TITLE
inner delete button to also use float-right

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -170,7 +170,7 @@ module BatchConnect::SessionsHelper
       icon("fas", "trash-alt", t('dashboard.batch_connect_sessions_delete_title'), class: "fa-fw"),
       session,
       method: :delete,
-      class: "btn btn-danger pull-right btn-delete",
+      class: "btn btn-danger float-right btn-delete",
       title: t('dashboard.batch_connect_sessions_delete_hover'),
       data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
     )


### PR DESCRIPTION
fix #977

Note that the element containing the button is already in a `float-right`, so it may not be needed. 
https://github.com/OSC/ondemand/blob/0d898a0937119d6f8ae082755ab2a661da4eea1f/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb#L39
