### PR TITLE
contain the navbar's logo height

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -35,7 +35,7 @@
   padding: 0px;
 }
 
-.navbar-brand.navbar-brand-logo img[src$=".svg"] {
+a.navbar-brand.navbar-brand-logo {
   height: 2em;
 }
 

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
   <header <%= 'data-turbolinks-permanent' if Configuration.turbolinks_enabled? %>>
     <nav class="navbar navbar-expand-md shadow-sm navbar-dark navbar-color" aria-label="Navigation">
     <% if ENV['OOD_DASHBOARD_HEADER_IMG_LOGO'].present? %>
-      <a class="navbar-brand navbar-brand-logo" href="<%= root_path %>"><img src="<%= ENV['OOD_DASHBOARD_HEADER_IMG_LOGO'] %>"></a>
+      <a class="navbar-brand navbar-brand-logo" href="<%= root_path %>"><img class="img-fluid" src="<%= ENV['OOD_DASHBOARD_HEADER_IMG_LOGO'] %>"></a>
     <% else %>
       <a class="navbar-brand" href="<%= root_path %>"><%= OodAppkit.dashboard.title.html_safe %></a>
     <% end %>


### PR DESCRIPTION
Could fix #962

Setting the navbar's height seems to be problematic. 962 says ".navbar-brand needs a height fixed to the desired height of the navbar".  

The height of the navbar is dynamic.  This PR has this look & feel, but these show the navbar height can't really be reliably known before everything is set in it.

Or maybe `2em` _is_ the desired height of the navar.

40px on my desktop

40px on mobile with awesim's PNG
![image](https://user-images.githubusercontent.com/4874123/111363310-43f75180-8666-11eb-9826-2094692116ba.png)

80px on mobile the OOD svg that's wider than awesim's PNG.  **maybe we need to control the width too?**
![image](https://user-images.githubusercontent.com/4874123/111363011-e236e780-8665-11eb-8c1b-4e905de6eef9.png)

When the dropdown is open it's 520!
![image](https://user-images.githubusercontent.com/4874123/111363081-f8dd3e80-8665-11eb-9bb2-28b0b570f504.png)
