### PR TITLE
Dynamic branding colors

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/_variables.scss.erb
+++ b/apps/dashboard/app/assets/stylesheets/_variables.scss.erb
@@ -17,16 +17,6 @@ $primary: #337ab7;
 $danger: #d9534f;
 $info: #5bc0de;
 
-// Navigation bar
-$nav-link-disabled-color: $blue-gray;
-
-// Link color
-$navbar-dark-color: <%= Configuration.brand_link_active_bg_color || "$warm-gray" %>;
-$navbar-dark-active-color: <%= Configuration.brand_link_active_bg_color || "$warm-gray" %>;
-
-// Navbar dark link text-muted disabled color.
-$navbar-dark-disabled-color: color-yiq($warm-gray);
-
 // Grid layout
 $container-max-widths: (
   xs: 0,

--- a/apps/dashboard/app/views/layouts/nav/_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_link.html.erb
@@ -7,7 +7,7 @@ target - optional, default "_self" - link target
 role - optional, default ""
 %>
 
-<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:target, '_self'), class: "dropdown-item #{local_assigns.fetch(:role, nil)}" do %>
+<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:target, '_self'), class: "dropdown-item m-auto #{local_assigns.fetch(:role, nil)}" do %>
   <%= tag.i class: "fas fa-fw fa-#{local_assigns.fetch(:faicon, 'cog')}" %>
   <%= tag.span do %>
     <%= local_assigns.fetch(:title, 'No title') %>

--- a/apps/dashboard/app/views/layouts/nav/_styles.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_styles.html.erb
@@ -1,23 +1,25 @@
 <style>
+.navbar-color {
+  background-color: <%= Configuration.brand_bg_color || "#334155" %> !important;
+}
+
 <% if bg_color %>
 .navbar-inverse {
-  background-color: <%= bg_color %>;
-}
-.navbar-color {
-  background-color: <%= Configuration.brand_bg_color || "#334155" %>;
+  background-color: <%= bg_color %> !important;
 }
 <% end %>
 
 <% if link_active_color %>
-.navbar-inverse {
-  border-color: <%= link_active_color %>;
-}
-
 .navbar-inverse .navbar-nav > .active > a, .navbar-inverse .navbar-nav > .active > a:hover, .navbar-inverse .navbar-nav > .active > a:focus {
   background-color: <%= link_active_color %>;
 }
 
-.navbar-inverse .navbar-nav > .open > a, .navbar-inverse .navbar-nav > .open > a:hover, .navbar-inverse .navbar-nav > .open > a:focus {
+#navbar > ul.navbar-nav > li.nav-item > a:hover {
+  background-color: <%= link_active_color %>;
+  border-radius: 0.25em;
+}
+
+.navbar > .dropdown-menu {
   background-color: <%= link_active_color %>;
 }
 


### PR DESCRIPTION
- [x] OOD_NAVBAR_TYPE (Creating config option for it) 

**Config used in demo:**

```env
OOD_BRAND_BG_COLOR='#0000ff'
OOD_BRAND_LINK_ACTIVE_BG_COLOR='#ff0000'
```

With branding environment set:
<video src="https://user-images.githubusercontent.com/6081892/111368465-4eb4e500-866c-11eb-99e2-f64d85ee6e1f.mov">

**Default:**

![image](https://user-images.githubusercontent.com/6081892/111368584-7310c180-866c-11eb-9196-6816f0e78f6c.png)

<img src="https://user-images.githubusercontent.com/6081892/111369457-78bad700-866d-11eb-80e4-e5f72480ef2d.png" width=400>
