### PR TITLE
upgrade balance warnings to bootstrap 4

### DIFF
--- a/apps/dashboard/app/views/shared/_insufficient_balance_resource.html.erb
+++ b/apps/dashboard/app/views/shared/_insufficient_balance_resource.html.erb
@@ -1,7 +1,7 @@
 <h4>
   <%= t('dashboard.balance_warning_prefix_html', units_balance: balance.units_balance, unit: balance.unit) %>
   <strong><%= balance.project_type %> <%= balance.balance_object %></strong>
-  <small class="pull-right hidden-xs hidden-sm">
+  <small class="float-right text-muted d-none d-md-block">
     <%= t('dashboard.balance_reload_message_html', last_update: local_time(balance.updated_at, format: '%Y/%m/%d at %l:%M%p')) %>
   </small>
 </h4>


### PR DESCRIPTION
Fixes #970. 

There is more that we could do in this PR, but I'd like to create a follow up ticket to fix the accessibility with using `h4`s into perhaps using lists instead.  We could also then tweak the font sizes as you can see they went up a little.

mainline:
![image](https://user-images.githubusercontent.com/4874123/111491892-9db55580-8712-11eb-91e4-8f2ea2f9e70f.png)

this PR:
![image](https://user-images.githubusercontent.com/4874123/111491947-a7d75400-8712-11eb-9977-a0a8295e5c78.png)
