### PR TITLE
group pinned apps 

### DIFF
--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -2,6 +2,9 @@
 # and subcategory to allow for groupings other than what's
 # provided in the app's manifest & definition.
 class FeaturedApp < OodApp
+  alias_method :original_category, :category
+  alias_method :original_subcategory, :subcategory
+
   attr_reader :category, :subcategory, :token
 
   def self.from_ood_app(app, token: nil)
@@ -10,6 +13,7 @@ class FeaturedApp < OodApp
 
   def initialize(router, category: "Apps", subcategory: I18n.t('dashboard.pinned_apps_title'), token: nil)
     super(router)
+
     @category = category.to_s
     @subcategory = subcategory.to_s
     @token = token || router.token

--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -42,9 +42,9 @@ class OodAppGroup
   # specified by 'group_by', sorting both groups and apps arrays by title
   def self.groups_for(apps: [], group_by: :category, nav_limit: nil)
     apps.group_by { |app|
-      app.send(group_by)
+      app.try(group_by)
     }.map { |k,v|
-      OodAppGroup.new(title: k, apps: v.sort_by { |a| a.title }, nav_limit: nav_limit)
+      OodAppGroup.new(title: k || I18n.t('dashboard.not_grouped'), apps: v.sort_by { |a| a.title }, nav_limit: nav_limit)
     }.sort_by { |g| g.title }
   end
 

--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -44,7 +44,7 @@ class OodAppGroup
     apps.group_by { |app|
       app.try(group_by)
     }.map { |k,v|
-      OodAppGroup.new(title: k || I18n.t('dashboard.not_grouped'), apps: v.sort_by { |a| a.title }, nav_limit: nav_limit)
+      OodAppGroup.new(title: k, apps: v.sort_by { |a| a.title }, nav_limit: nav_limit)
     }.sort_by { |g| g.title }
   end
 

--- a/apps/dashboard/app/assets/stylesheets/apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/apps.scss
@@ -16,6 +16,7 @@ tr.app {
 
   color: #fff;
   font-weight: 300;
+  width: 100%;
 
   padding-left: 105px;
   padding-top: 5px;

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,3 +1,11 @@
 <h3><%= t('dashboard.pinned_apps_title') %> <small><%= t('dashboard.pinned_apps_caption_html', all_apps_url: apps_index_path) %></small></h3>
 
-<%= render(partial: "/dashboard/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: :original_category))  %>
+<%- group_by = Configuration.pinned_apps_group_by.to_sym -%>
+
+<%- if group_by.present? -%>
+  <%= render(partial: "/dashboard/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: group_by))  %>
+<%- else -%>
+  <div class="row">
+    <%= render partial: "/dashboard/pinned_apps/app", collection: @pinned_apps %>
+  </div>
+<%- end -%>

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,15 +1,3 @@
 <h3><%= t('dashboard.pinned_apps_title') %> <small><%= t('dashboard.pinned_apps_caption_html', all_apps_url: apps_index_path) %></small></h3>
-<div class="row">
-  <%- @pinned_apps.each_with_index do |app, index| %>
-    <%- link = app.links.first -%>
-    <div class="col-sm-3 col-md-3 text-center">
-      <a class="app-card" href="<%= link.url %>">
-        <div class="center-block">
-          <%= icon_tag(link.icon_uri) %>
-        </div>
-        <%= link.title %>
-      </a>
-    </div>
-    <%= tag.div class: %w(clearfix visible-lg-block visible-md-block visible-sm-block) if (index+1) % 4 == 0 %>
-  <%- end %>
-</div>
+
+<%= render(partial: "/dashboard/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: :original_category))  %>

--- a/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/dashboard/_pinned_apps.html.erb
@@ -1,9 +1,7 @@
 <h3><%= t('dashboard.pinned_apps_title') %> <small><%= t('dashboard.pinned_apps_caption_html', all_apps_url: apps_index_path) %></small></h3>
 
-<%- group_by = Configuration.pinned_apps_group_by.to_sym -%>
-
-<%- if group_by.present? -%>
-  <%= render(partial: "/dashboard/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: group_by))  %>
+<%- if Configuration.pinned_apps_group_by.present? -%>
+  <%= render(partial: "/dashboard/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: Configuration.pinned_apps_group_by.to_sym))  %>
 <%- else -%>
   <div class="row">
     <%= render partial: "/dashboard/pinned_apps/app", collection: @pinned_apps %>

--- a/apps/dashboard/app/views/dashboard/pinned_apps/_app.html.erb
+++ b/apps/dashboard/app/views/dashboard/pinned_apps/_app.html.erb
@@ -1,0 +1,31 @@
+<%- link = app.links.first -%>
+<div class="col-sm-3 col-md-3">
+  <%=
+    link_to(
+      link.url.to_s,
+      class: "app-card",
+      data: {
+        toggle: "popover",
+        content: manifest_markdown(link.description),
+        html: true,
+        trigger: "hover",
+        title: link.title,
+        container: "body"
+      },
+      target: link.new_tab? ? "_blank" : nil
+    ) do
+  %>
+    <div class="center-block text-center">
+      <%= icon_tag(link.icon_uri) %>
+      <%= content_tag(:p, link.title) %>
+      <%=
+        content_tag(
+          :p,
+          content_tag(:span, link.caption),
+          class: "text-muted",
+          style: "margin-top: 20px"
+        ) if link.caption
+      %>
+    </div>
+  <% end %>
+</div>

--- a/apps/dashboard/app/views/dashboard/pinned_apps/_app.html.erb
+++ b/apps/dashboard/app/views/dashboard/pinned_apps/_app.html.erb
@@ -4,14 +4,6 @@
     link_to(
       link.url.to_s,
       class: "app-card",
-      data: {
-        toggle: "popover",
-        content: manifest_markdown(link.description),
-        html: true,
-        trigger: "hover",
-        title: link.title,
-        container: "body"
-      },
       target: link.new_tab? ? "_blank" : nil
     ) do
   %>

--- a/apps/dashboard/app/views/dashboard/pinned_apps/_group.html.erb
+++ b/apps/dashboard/app/views/dashboard/pinned_apps/_group.html.erb
@@ -1,0 +1,5 @@
+<h4 class="apps-section-header-blue"><%= group.title %></h4>
+
+<div class="row">
+  <%= render partial: "/dashboard/pinned_apps/app", collection: group.apps %>
+</div>

--- a/apps/dashboard/app/views/dashboard/pinned_apps/_group.html.erb
+++ b/apps/dashboard/app/views/dashboard/pinned_apps/_group.html.erb
@@ -1,4 +1,4 @@
-<h4 class="apps-section-header-blue"><%= group.title %></h4>
+<h4 class="apps-section-header-blue"><%= group.title || I18n.t('dashboard.not_grouped') %></h4>
 
 <div class="row">
   <%= render partial: "/dashboard/pinned_apps/app", collection: group.apps %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -278,6 +278,16 @@ end
     config.fetch(:pinned_apps_menu_length, 6)
   end
 
+  # What to group pinned apps by
+  def pinned_apps_group_by
+    group_by = config.fetch(:pinned_apps_group_by, "")
+    if group_by == 'category' || group_by == 'subcategory'
+      "original_#{group_by}"
+    else
+      group_by
+    end
+  end
+
   private
 
   def config

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -281,6 +281,11 @@ end
   # What to group pinned apps by
   def pinned_apps_group_by
     group_by = config.fetch(:pinned_apps_group_by, "")
+
+    # FIXME: the configuration_singleton shouldn't really know the API of
+    # OodApp or subclasses. This is a hack because subclasses of OodApp overload
+    # the category and subcategory to something new while saving the original.
+    # The fix would be to move this knowledge to somewhere more appropriate than here.
     if group_by == 'category' || group_by == 'subcategory'
       "original_#{group_by}"
     else

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
     all_apps_table_sub_category_column: "Sub Category"
 
     unknown: "Unknown"
+    not_grouped: "Not Grouped"
 
     nav_limit_caption: 'showing %{subset_count} of %{total_count}'
     pinned_apps_title: 'Pinned Apps'

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -157,7 +157,7 @@ en:
     all_apps_table_sub_category_column: "Sub Category"
 
     unknown: "Unknown"
-    not_grouped: "Not Grouped"
+    not_grouped: "Other Apps"
 
     nav_limit_caption: 'showing %{subset_count} of %{total_count}'
     pinned_apps_title: 'Pinned Apps'

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -315,4 +315,22 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       ConfigurationSingleton.new.send(:config)
     end
   end
+
+  test "pinned_apps_group_by returns original category when configured with category" do
+    cfg = ConfigurationSingleton.new
+    cfg.stubs(:config).returns({pinned_apps_group_by: "category"})
+    assert_equal "original_category", cfg.pinned_apps_group_by
+  end
+
+  test "pinned_apps_group_by returns original subcategory when configured with subcategory" do
+    cfg = ConfigurationSingleton.new
+    cfg.stubs(:config).returns({pinned_apps_group_by: "subcategory"})
+    assert_equal "original_subcategory", cfg.pinned_apps_group_by
+  end
+
+  test "pinned_apps_group_by returns an empty string by default" do
+    cfg = ConfigurationSingleton.new
+    cfg.stubs(:config).returns({})
+    assert_equal "", cfg.pinned_apps_group_by
+  end
 end

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -277,4 +277,24 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
     assert_select "div[id='coreHoursEfficiencyReportPanelDiv']", 1
     assert_select "div[id='jobsPanelDiv']", 1
   end
+
+  test "groups the apps by categories" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    Configuration.stubs(:pinned_apps).returns([
+      'sys/bc_jupyter',
+      'sys/bc_paraview',
+      'sys/pseudofun',
+    ])
+
+    env = {}
+
+    with_modified_env(env) do
+      get '/'
+    end
+
+    assert_select "h4[class='apps-section-header-blue']", 2
+    assert_equal "Gateway Apps", css_select("h4[class='apps-section-header-blue']")[0].text
+    assert_equal "Interactive Apps", css_select("h4[class='apps-section-header-blue']")[1].text
+  end
 end

--- a/apps/dashboard/test/models/ood_app_group_test.rb
+++ b/apps/dashboard/test/models/ood_app_group_test.rb
@@ -45,6 +45,7 @@ class OodAppGroupTest < ActiveSupport::TestCase
     assert_equal nav_group_titles, groups2.map(&:title)
   end
 
+
   test "group by subcategory" do
     apps = []
     apps.concat(build_apps("Desktops", "IHPC", ["Abaqus/CAE", "ANSYS Workbench", "COMSOL", "Oakley Desktop", "Ruby Desktop"] ))
@@ -83,4 +84,21 @@ class OodAppGroupTest < ActiveSupport::TestCase
     apps.concat(build_apps("Desktops", "VDI", ["Oakley VDI", "Ruby VDI", "Paraview"] ))
     assert_equal 6, OodAppGroup.groups_for(apps: apps, nav_limit: 6).first.nav_limit
   end
+
+  test "ungroupable apps" do
+    apps = []
+    apps.concat(build_apps("Desktops", "IHPC", ["Abaqus/CAE", "ANSYS Workbench", "COMSOL", "Oakley Desktop", "Ruby Desktop"] ))
+    apps.concat(build_apps("Desktops", "VDI", ["Oakley VDI", "Ruby VDI", "Paraview"] ))
+    apps.concat(build_apps("Clusters", "", ["Shell Access", "System Status"]))
+    apps.concat(build_apps("Jobs", "", ["My Jobs", "Active Jobs"] ))
+    apps.concat(build_apps("Files", "", ["Files"] ))
+    apps.concat(build_apps("OSC WIAG", "", ["Container Fill Sim"] ))
+    apps.shuffle!
+
+    groups = OodAppGroup.groups_for(apps: apps, group_by: :user_defined_field)
+    assert_equal 1, groups.size
+    assert_equal 14, groups.first.apps.size
+    assert_equal I18n.t('dashboard.not_grouped'), groups.first.title
+  end
+
 end

--- a/apps/dashboard/test/models/ood_app_group_test.rb
+++ b/apps/dashboard/test/models/ood_app_group_test.rb
@@ -45,7 +45,6 @@ class OodAppGroupTest < ActiveSupport::TestCase
     assert_equal nav_group_titles, groups2.map(&:title)
   end
 
-
   test "group by subcategory" do
     apps = []
     apps.concat(build_apps("Desktops", "IHPC", ["Abaqus/CAE", "ANSYS Workbench", "COMSOL", "Oakley Desktop", "Ruby Desktop"] ))
@@ -98,7 +97,7 @@ class OodAppGroupTest < ActiveSupport::TestCase
     groups = OodAppGroup.groups_for(apps: apps, group_by: :user_defined_field)
     assert_equal 1, groups.size
     assert_equal 14, groups.first.apps.size
-    assert_equal I18n.t('dashboard.not_grouped'), groups.first.title
+    assert_equal nil, groups.first.title
   end
 
 end


### PR DESCRIPTION
Fixes #920

group pinned apps  by their original category and add a heading for each section.  This is essentially making the `dashboard#index` with pinned apps the same as `apps#featured` (i.e., shared apps). 

It is slightly different in the way the widgets are arranged (how they interact with the MOTD and the XDMOD panels) but the partials to generate the rows in `app/views/dashboard/pinned_apps` are basically carbon copies of similar partials in `app/views/apps/`. (only these headings are `h4` instead of `h2`)

`apps#featured`
![image](https://user-images.githubusercontent.com/4874123/111829927-b3b64800-88c3-11eb-82d6-4991a495b23b.png)

`dashboard#index`
![image](https://user-images.githubusercontent.com/4874123/111830006-c9c40880-88c3-11eb-9614-723f43e24df8.png)
