### PR TITLE
Update link to ood-portal-generator configuration documentation page

### DIFF
--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -19,7 +19,7 @@
 #    You can find more information about the ood-portal-generator configuration
 #    at:
 #
-#      https://osc.github.io/ood-documentation/master/infrastructure/ood-portal-generator.html
+#      https://osc.github.io/ood-documentation/latest/reference/commands/ood-portal-generator.html
 #
 # 2. Then build/install the updated Apache config with:
 #


### PR DESCRIPTION
The link in this template is broken and results in a 404 error. The link I updated it to is the closest page I could find to the original