### PR TITLE
Notifications API and Document Title Dynamic Update for Interactive Sessions

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -1,4 +1,121 @@
 <% content_for :title, "#{t('dashboard.breadcrumbs_my_sessions')} - #{OodAppkit.dashboard.title}" %>
+<% content_for :js do %>
+  <script>
+    var tabNotInFocus = false;
+    var hidden, visibilityChange;
+    if (typeof document.hidden !== "undefined") {
+        hidden = "hidden";
+        visibilityChange = "visibilitychange";
+        state = "visibilityState";
+    } else if (typeof document.mozHidden !== "undefined") {
+        hidden = "mozHidden";
+        visibilityChange = "mozvisibilitychange";
+        state = "mozVisibilityState";
+    } else if (typeof document.msHidden !== "undefined") {
+        hidden = "msHidden";
+        visibilityChange = "msvisibilitychange";
+        state = "msVisibilityState";
+    } else if (typeof document.webkitHidden !== "undefined") {
+        hidden = "webkitHidden";
+        visibilityChange = "webkitvisibilitychange";
+        state = "webkitVisibilityState";
+    }
+
+    window.notifiedSessions = {};
+
+    <% @sessions.each do |session| %>
+    var notified = false
+    if ('<%= session.running? %>' === 'true') {
+    notified = true;
+    }
+
+
+    window.notifiedSessions['<%= session.id %>'] = {
+      didNotify: notified,
+      date: Date(),
+      info: {
+        status: '',
+        title: '',
+        jobId: ''
+      }
+
+    };
+    window.notifiedSessions['<%= session.id %>'].date = parseInt('<%= session.created_at %>');
+    window.notifiedSessions['<%= session.id %>'].info = {
+      status: '<%= session.status %>',
+      title: '<%= session.title %>',
+      jobId: '<%= session.job_id %>',
+      starting: false
+    }
+
+    if ('<%= session.starting? %>' === 'true') {
+      window.notifiedSessions['<%= session.id %>'].info.starting = true;
+    } else {
+      window.notifiedSessions['<%= session.id %>'].info.starting = false;
+    }
+    <% end %>
+    document.addEventListener(visibilityChange, function() {
+      if (document[hidden]) {
+        tabNotInFocus = true;
+      } else {
+        tabNotInFocus = false;
+      }
+    });
+
+    if (Notification.permission !== "denied" && Notification.permission !== "granted") {
+      Notification.requestPermission();
+    }
+
+    function getTitle(sessionId) {
+    var sessionObject = window.notifiedSessions[sessionId]
+    var status = sessionObject.info.status;
+    var state = status.charAt(0).toUpperCase() + status.slice(1);
+    var jobId = sessionObject.info.jobId;
+    var sessionTitle = sessionObject.info.title;
+
+    if (sessionObject.info.starting) {
+      state = "Starting";
+    }
+
+    return state + ' ' + sessionTitle + ' (' + jobId + ') ' + ` - ${getActiveSessions()} active sessions - My Interactive Sessions`;
+
+    }
+
+    function getLatestSession() {
+      const keys = Object.keys(window.notifiedSessions);
+      var initialDate = null;
+      var sessionId = '';
+
+      for (var i = 0; i < keys.length; i++) {
+        var id = keys[i];
+                if (initialDate === null || (window.notifiedSessions[id].date > initialDate) ) {
+          initialDate = window.notifiedSessions[id].date;
+          sessionId = id; 
+        }
+      }
+
+      return sessionId;
+    }
+
+    function getActiveSessions() {
+      var num = 0;
+      <% @sessions.each do |session| %>
+      if ('<%= session.running? %>' === 'true') {
+        num++;
+      }
+      <% end %>
+
+      return num;
+    }
+      <% if !(@sessions.empty?) %>
+      
+      document.title = getTitle('<%= @sessions[0].id %>');
+
+      <% end %>
+    
+  </script>
+<% end %>
+
 <%-
   any_apps = (@sys_app_groups + @usr_app_groups + @dev_app_groups).any?
 -%>

--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -24,36 +24,38 @@
     window.notifiedSessions = {};
 
     <% @sessions.each do |session| %>
-    var notified = false
-    if ('<%= session.running? %>' === 'true') {
-    notified = true;
-    }
-
-
-    window.notifiedSessions['<%= session.id %>'] = {
-      didNotify: notified,
-      date: Date(),
-      info: {
-        status: '',
-        title: '',
-        jobId: ''
+      var notified = false
+      if ('<%= session.running? %>' === 'true') {
+        notified = true;
       }
 
-    };
-    window.notifiedSessions['<%= session.id %>'].date = parseInt('<%= session.created_at %>');
-    window.notifiedSessions['<%= session.id %>'].info = {
-      status: '<%= session.status %>',
-      title: '<%= session.title %>',
-      jobId: '<%= session.job_id %>',
-      starting: false
-    }
 
-    if ('<%= session.starting? %>' === 'true') {
-      window.notifiedSessions['<%= session.id %>'].info.starting = true;
-    } else {
-      window.notifiedSessions['<%= session.id %>'].info.starting = false;
-    }
+      window.notifiedSessions['<%= session.id %>'] = {
+        didNotify: notified,
+        date: Date(),
+        info: {
+          status: '',
+          title: '',
+          jobId: ''
+        }
+      };
+      
+      window.notifiedSessions['<%= session.id %>'].date = parseInt('<%= session.created_at %>');
+      window.notifiedSessions['<%= session.id %>'].info = {
+        status: '<%= session.status %>',
+        title: '<%= session.title %>',
+        jobId: '<%= session.job_id %>',
+        starting: false
+      }
+
+      if ('<%= session.starting? %>' === 'true') {
+        window.notifiedSessions['<%= session.id %>'].info.starting = true;
+      } else {
+        window.notifiedSessions['<%= session.id %>'].info.starting = false;
+      }
+
     <% end %>
+    
     document.addEventListener(visibilityChange, function() {
       if (document[hidden]) {
         tabNotInFocus = true;
@@ -67,17 +69,17 @@
     }
 
     function getTitle(sessionId) {
-    var sessionObject = window.notifiedSessions[sessionId]
-    var status = sessionObject.info.status;
-    var state = status.charAt(0).toUpperCase() + status.slice(1);
-    var jobId = sessionObject.info.jobId;
-    var sessionTitle = sessionObject.info.title;
+      var sessionObject = window.notifiedSessions[sessionId]
+      var status = sessionObject.info.status;
+      var state = status.charAt(0).toUpperCase() + status.slice(1);
+      var jobId = sessionObject.info.jobId;
+      var sessionTitle = sessionObject.info.title;
 
-    if (sessionObject.info.starting) {
-      state = "Starting";
-    }
+      if (sessionObject.info.starting) {
+        state = "Starting";
+      }
 
-    return state + ' ' + sessionTitle + ' (' + jobId + ') ' + ` - ${getActiveSessions()} active sessions - My Interactive Sessions`;
+      return state + ' ' + sessionTitle + ' (' + jobId + ') ' + ` - ${getActiveSessions()} active sessions - My Interactive Sessions`;
 
     }
 
@@ -88,7 +90,7 @@
 
       for (var i = 0; i < keys.length; i++) {
         var id = keys[i];
-                if (initialDate === null || (window.notifiedSessions[id].date > initialDate) ) {
+        if (initialDate === null || (window.notifiedSessions[id].date > initialDate) ) {
           initialDate = window.notifiedSessions[id].date;
           sessionId = id; 
         }
@@ -100,18 +102,19 @@
     function getActiveSessions() {
       var num = 0;
       <% @sessions.each do |session| %>
-      if ('<%= session.running? %>' === 'true') {
-        num++;
-      }
+        if ('<%= session.running? %>' === 'true') {
+          num++;
+        }
       <% end %>
 
       return num;
     }
-      <% if !(@sessions.empty?) %>
+    
+    <% if !(@sessions.empty?) %>
       
       document.title = getTitle('<%= @sessions[0].id %>');
 
-      <% end %>
+    <% end %>
     
   </script>
 <% end %>

--- a/apps/dashboard/app/views/batch_connect/sessions/index.js.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.js.erb
@@ -1,14 +1,44 @@
+
 (function() {
   var sessions = [];
   var $target;
 
   <%# Replace sessions whose state has changed %>
   <% @sessions.each do |session| %>
+    var starting = false;
     sessions.push('<%= session.id %>');
     $target = $('#<%= session.id %>');
     if ( $target.data('hash') !== '<%= session.to_hash %>' ) {
       $target.replaceWith('<%= j render(partial: "panel", locals: { session: session }) %>');
+
+      if ('<%= session.starting? %>' === 'true') {
+        starting = true;
+      }
+
+      window.notifiedSessions['<%= session.id %>'].info = {
+        status: '<%= session.status %>',
+        title: '<%= session.title %>',
+        jobId: '<%= session.job_id %>',
+        starting: starting
+      }
+
+      if ('<%= session.running? %>' === 'true') {
+        if (("Notification" in window)) {
+          if (Notification.permission === "granted") {
+              if (window.notifiedSessions["<%= session.id %>"].didNotify !== true && tabNotInFocus) {
+                console.log("Session notified via Notification")
+                var options = {
+                  body: "Job ID: <%= session.job_id %>"
+                }
+                var notify = new Notification("<%= session.title %> is Running", options);
+              }
+
+            window.notifiedSessions["<%= session.id %>"].didNotify = true;
+          }
+        }
+      }
     }
+    document.title = getTitle(getLatestSession());
   <% end %>
 
   <%# Remove sessions that don't exist anymore %>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -7,16 +7,15 @@
   <!-- Webpacker -->
   <%= javascript_pack_tag 'application' %>
   <%= stylesheet_pack_tag 'application', media: 'all' %>
+  <%= yield :js %>
 
   <!-- (Legacy) Sprockets -->
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_include_tag 'application' %>
   <%= javascript_include_tag 'turbolinks' if Configuration.turbolinks_enabled? %>
-
   <%= csrf_meta_tags %>
-
-  <%= yield :head %>
-
+  <%= yield :head %> 
+  
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <% if Configuration.turbolinks_enabled? %>
     <meta name="turbolinks-root" content="<%= ENV['RAILS_RELATIVE_URL_ROOT'] || "/" %>">
@@ -31,7 +30,6 @@
     <% else %>
       <a class="navbar-brand" href="<%= root_path %>"><%= OodAppkit.dashboard.title.html_safe %></a>
     <% end %>
-      
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Added:
- window.notifiedSessions - Object used to keep client-side and server-side synced with interactive jobs state.
- Event and Listener to see if browser tab is in focus.
- Notifications via Notifications API (Only if browser tab is not in focus).
- document.title updated to latest Interactive Job Card and amount of sessions currently active.

Permission for notifications asked on page load.