### PR TITLE
configure pinned_apps through metadata fields

### DIFF
--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -42,10 +42,10 @@ class OodAppGroup
   # specified by 'group_by', sorting both groups and apps arrays by title
   def self.groups_for(apps: [], group_by: :category, nav_limit: nil)
     apps.group_by { |app|
-      app.try(group_by)
+      app.respond_to?(group_by) ? app.send(group_by) : app.metadata[group_by]
     }.map { |k,v|
       OodAppGroup.new(title: k, apps: v.sort_by { |a| a.title }, nav_limit: nav_limit)
-    }.sort_by { |g| g.title }
+    }.sort_by { |g| [ g.title.nil? ? 1 : 0, g.title ] } # make sure that the ungroupable app is always last
   end
 
   # select a subset of groups by the specified array of titles

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -342,4 +342,27 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
     assert_select "a.app-card", 3
     assert_equal I18n.t('dashboard.not_grouped'), css_select("h4[class='apps-section-header-blue']")[0].text
   end
+
+  test "group by metadata fields works" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    Configuration.stubs(:pinned_apps).returns([
+      'sys/bc_jupyter',
+      'sys/bc_paraview',
+      'sys/pseudofun',
+    ])
+    Configuration.stubs(:pinned_apps_group_by).returns("languages")
+
+    env = {}
+
+    with_modified_env(env) do
+      get '/'
+    end
+
+    assert_select "h4[class='apps-section-header-blue']", 3
+    assert_select "a.app-card", 3
+    assert_equal "go erLANG python", css_select("h4[class='apps-section-header-blue']")[0].text
+    assert_equal "python julia R Ruby", css_select("h4[class='apps-section-header-blue']")[1].text
+    assert_equal I18n.t('dashboard.not_grouped'), css_select("h4[class='apps-section-header-blue']")[2].text
+  end
 end

--- a/apps/dashboard/test/models/ood_app_group_test.rb
+++ b/apps/dashboard/test/models/ood_app_group_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class OodAppGroupTest < ActiveSupport::TestCase
 
   def app(title, category, subcategory)
-    OpenStruct.new(title: title, category: category, subcategory: subcategory)
+    OpenStruct.new(title: title, category: category, subcategory: subcategory, metadata: {})
   end
 
   def build_apps(category, subcategory, titles)
@@ -44,6 +44,7 @@ class OodAppGroupTest < ActiveSupport::TestCase
     assert_equal 4, groups2.count
     assert_equal nav_group_titles, groups2.map(&:title)
   end
+
 
   test "group by subcategory" do
     apps = []
@@ -98,6 +99,23 @@ class OodAppGroupTest < ActiveSupport::TestCase
     assert_equal 1, groups.size
     assert_equal 14, groups.first.apps.size
     assert_nil groups.first.title
+  end
+
+  test "group by metadata field" do
+    app_dir = Pathname.new("#{Rails.root}/test/fixtures/sys_with_gateway_apps")
+    apps = app_dir.children.map { |d| OodApp.new PathRouter.new(d) }
+
+    groups = OodAppGroup.groups_for(apps: apps, group_by: :languages)
+
+    assert_equal 3, groups.size
+    assert_equal "go erLANG python", groups[0].title
+    assert_equal 1, groups[0].apps.count
+    assert_equal "python julia R Ruby", groups[1].title
+    assert_equal 1, groups[1].apps.count
+
+    # groups with a nil title are last
+    assert_nil groups[2].title
+    assert_equal 9, groups[2].apps.count
   end
 
 end


### PR DESCRIPTION
This allows for pinned_apps to be grouped by metadata fields. To accommodate that a few things had to change. First is that OodAppGroup#groups_for should guarantee that the group with a nil title is always last. This also adds metadata keys as attr_accessor methods to the OodApp, expanding it's interface based off of configuration. Manfiest#metadata keys are now sanitized for a bit of safety for this.