### PR TITLE
fix #692 by using #all instead of #preload

### DIFF
--- a/apps/myjobs/app/controllers/workflows_controller.rb
+++ b/apps/myjobs/app/controllers/workflows_controller.rb
@@ -13,7 +13,7 @@ class WorkflowsController < ApplicationController
 
     @selected_id = session[:selected_id]
     session[:selected_id] = nil
-    @workflows = Workflow.preload(:jobs)
+    @workflows = Workflow.eager_load(:jobs)
   end
 
   # GET /workflows/1


### PR DESCRIPTION
Fixes #692 

ActiveRecord#preload uses a 'where in ...' clause and sqlite3 has limitations of 1000 variables in that 'in' portion. So just get all
workflows.