### PR TITLE
add 1.8.20 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#743](https://github.com/OSC/ondemand/pull/743) [#747](https://github.com/OSC/ondemand/pull/747)
 - move JOSS publication to OSC/ondemand repo
 
+## [1.8.20] - 2020-04-14
+### Fixed
+- Ensure that LOGNAME is set correctly in the PUN in [837](https://github.com/OSC/ondemand/pull/837).
+- Remove unused SELinux dependencies in [853](https://github.com/OSC/ondemand/pull/853).
+- Fixed specifiying dex custom frontend themes in [930](https://github.com/OSC/ondemand/pull/930).
+
+### Changed
+- Hide Nginx and Passenger versions in the http headers in [892](https://github.com/OSC/ondemand/pull/892).
+- Update to Rails 5.2.5 to avoid broken mimemagic dependency in [1028](https://github.com/OSC/ondemand/pull/1028).
+
 ## [1.8.19] - 2020-12-14
 ### Fixed
  - don't use cached cluster value if it's not available [#748](https://github.com/OSC/ondemand/pull/748)
@@ -641,6 +651,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/OSC/ondemand/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/OSC/ondemand/compare/v1.8.19...v2.0.0
+[1.8.20]: https://github.com/OSC/ondemand/compare/v1.8.19...v1.8.20
 [1.8.19]: https://github.com/OSC/ondemand/compare/v1.8.18...v1.8.19
 [1.8.18]: https://github.com/OSC/ondemand/compare/v1.8.17...v1.8.18
 [1.8.17]: https://github.com/OSC/ondemand/compare/v1.8.16...v1.8.17


### PR DESCRIPTION
add 1.8.20 to the changelog. Note that this is sorted by version not date, so it's below 2.0.0. Not sure what we want to standardize on as this is the first time it's come up.