### PR TITLE
Files App – Fix iframe visibility

### DIFF
--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -383,7 +383,7 @@ function downloadFile(file){
       downloadUrl = `${history.state.currentDirectoryUrl}/${encodeURI(filename)}?download=${Date.now().toString()}`,
       iframe = document.createElement('iframe'),
       TIME = 30 * 1000;
-  iframe.setAttribute('class', 'hidden');
+  iframe.setAttribute('class', 'd-none');
   iframe.setAttribute('src', downloadUrl);
 
   document.body.appendChild(iframe);


### PR DESCRIPTION
The iframe was using `hidden` instead of `d-none` (Bootstrap visibility control) on the iframe when you're downloading a file.

This PR prevents the iframe container from being shown:
![image](https://user-images.githubusercontent.com/6081892/114903485-dbc29980-9de4-11eb-973c-dcf8858a46c7.png)
