### PR TITLE
Redirect active jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN cp /opt/ood/ood-portal-generator/share/ood_portal_example.yml    /etc/ood/co
 
 # make some misc directories & files
 RUN mkdir -p /var/lib/ondemand-nginx/config/apps/{sys,dev,usr}
-RUN touch /var/lib/ondemand-nginx/config/apps/sys/{dashboard,shell,files,file-editor,activejobs,myjobs}.conf
+RUN touch /var/lib/ondemand-nginx/config/apps/sys/{dashboard,shell,files,file-editor,myjobs}.conf
 
 # setup sudoers for apache
 RUN echo -e 'Defaults:apache !requiretty, !authenticate \n\

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -66,6 +66,9 @@ Listen 8080
   RewriteCond %{HTTP_HOST} !^(test.proxy.name(:8080)?)?$ [NC]
   RewriteRule ^(.*) https://test.proxy.name:8080$1 [R=301,NE,L]
 
+  RewriteEngine On
+  RewriteRule "^/my_pun_apps/sys/activejobs"  "/my_pun_apps/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/configured/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.default
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.default
@@ -48,6 +48,9 @@
   CustomLog "logs/access.log" combined
 
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -48,6 +48,9 @@
   CustomLog "logs/access.log" combined
 
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -60,6 +60,9 @@
   RewriteCond %{HTTP_HOST} !^(example.com(:443)?)?$ [NC]
   RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -60,6 +60,9 @@
   RewriteCond %{HTTP_HOST} !^(example.com(:443)?)?$ [NC]
   RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -48,6 +48,9 @@
   CustomLog "logs/access.log" combined
 
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -48,6 +48,9 @@
   CustomLog "logs/access.log" combined
 
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 
   # Lua configuration

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -52,6 +52,9 @@
   RewriteCond %{HTTP_HOST} !^(ondemand.example.com(:80)?)?$ [NC]
   RewriteRule ^(.*) http://ondemand.example.com:80$1 [R=301,NE,L]
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -60,6 +60,9 @@
   RewriteCond %{HTTP_HOST} !^(ondemand.example.com(:443)?)?$ [NC]
   RewriteRule ^(.*) https://ondemand.example.com:443$1 [R=301,NE,L]
 
+  RewriteEngine On
+  RewriteRule "^/pun/sys/activejobs"  "/pun/sys/dashboard/activejobs"  [R=301,L]
+
   # Support maintenance page during outages of OnDemand
   RewriteEngine On
   RewriteCond /var/www/ood/public/maintenance/index.html -f

--- a/ood-portal-generator/spec/fixtures/sum.default
+++ b/ood-portal-generator/spec/fixtures/sum.default
@@ -1,1 +1,1 @@
-051c639f68c21bf54d6dfe1ee3df3da0726dae906322a03137b51d34a5064a79 /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf
+46bbc78b5c542b1def21a0d01f6f5eaaf5a1f1cfa0cbbf689bf948bf986ca207 /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -81,6 +81,11 @@ Listen <%= addr_port %>
   RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @proxy_server %>:<%= @port %>$1 [R=301,NE,L]
   <%- end -%>
 
+  <%- if @use_rewrites && @pun_uri -%>
+  RewriteEngine On
+  RewriteRule "^<%= @pun_uri %>/sys/activejobs"  "<%= @pun_uri %>/sys/dashboard/activejobs"  [R=301,L]
+  <%- end -%>
+
   <%- if @use_rewrites && @use_maintenance -%>
   # Support maintenance page during outages of OnDemand
   RewriteEngine On


### PR DESCRIPTION
Partial fix for #1035 for just activejobs

This adds a redirect from `/pun/sys/activejobs` -> `/pun/sys/dashboard/activejobs` the new correct url. 