### PR TITLE
files app – enforce file size restrictions server side

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -114,7 +114,11 @@ class FilesController < ApplicationController
 
   def show_file
     if params[:download]
-      send_file @path
+      if Files.downloadable?(@path)
+        send_file @path
+      else
+        render json: { error_message: "#{@path} exceeds the maximum configured download size #{ ::Configuration.file_download_max } bytes" }, status: :forbidden
+      end
     else
       begin
         type = Files.mime_type_by_extension(@path).presence || Files.mime_type(@path)

--- a/apps/dashboard/app/models/files.rb
+++ b/apps/dashboard/app/models/files.rb
@@ -40,7 +40,7 @@ class Files
   #
   # @return [Boolean]
   def self.downloadable?(path)
-    path.stat.size < Configuration.file_download_max
+    Configuration.file_download_max ? (path.stat.size < Configuration.file_download_max) : true
   end
 
   # TODO: move to PosixFile

--- a/apps/dashboard/app/models/files.rb
+++ b/apps/dashboard/app/models/files.rb
@@ -36,6 +36,13 @@ class Files
     }
   end
 
+  # Returns if the File size exceeds Configuration.file_download_max
+  #
+  # @return [Boolean]
+  def self.downloadable?(path)
+    path.stat.size < Configuration.file_download_max
+  end
+
   # TODO: move to PosixFile
   def self.mime_type(path)
     path = Pathname.new(path.to_s)

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -376,6 +376,10 @@ $('#new-dir-btn').on("click", () => {
 });
 
 function downloadFile(file){
+  if (file.size > <%= Configuration.file_download_max %>) {
+    return Swal.fire('File size exceeds the maximum of <%= number_to_human_size(Configuration.file_download_max, precision: 0) %>', `"${file.name}" is ${file.human_size}`, 'warning')
+  }
+
   // creating the temporary iframe is exactly what the CloudCmd does
   // so this just repeats the status quo
 
@@ -520,7 +524,11 @@ function getFilesAndDirectoriesFromDirectory (directoryReader, oldEntries, logDr
   }
 
 
-  window.uppy = Uppy.Core();
+  window.uppy = Uppy.Core({
+    restrictions: {
+      maxFileSize: <%= Configuration.file_upload_max %>,
+    }
+  });
   uppy.use(EmptyDirCreator);
   uppy.use(Uppy.Dashboard, {
     trigger: '#upload-btn',

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -59,7 +59,7 @@ class ConfigurationSingleton
   #   file_download_max #=> "21474840000"
   # @return [String] Maximum download size for nginx.
   def file_download_max
-    (ENV['FILE_DOWNLOAD_MAX'].presence || 10737420000).to_i
+    ENV['FILE_DOWNLOAD_MAX'].presence.try(:to_i)
   end
 
   # @return [String, nil] version string from git describe, or nil if not git repo

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -36,9 +36,31 @@ class ConfigurationSingleton
     @ood_version ||= (ood_version_from_env || version_from_file('/opt/ood') || version_from_git('/opt/ood') || "Unknown").strip
   end
 
-def ood_bc_ssh_to_compute_node
-  to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
-end
+  def ood_bc_ssh_to_compute_node
+    to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
+  end
+
+  # Maximum file upload size that nginx will allow from clients in bytes
+  #
+  # @example No maximum upload size supplied.
+  #   file_upload_max #=> "10737420000"
+  # @example 20 gigabyte file size upload limit.
+  #   file_upload_max #=> "21474840000"
+  # @return [String] Maximum upload size for nginx.
+  def file_upload_max
+    (ENV['FILE_UPLOAD_MAX'].presence || 10737420000).to_i
+  end
+
+  # Maximum file download size that nginx will allow.
+  #
+  # @example No maximum upload size supplied.
+  #   file_download_max #=> "10737420000"
+  # @example 20 gigabyte file size upload limit.
+  #   file_download_max #=> "21474840000"
+  # @return [String] Maximum download size for nginx.
+  def file_download_max
+    (ENV['FILE_DOWNLOAD_MAX'].presence || 10737420000).to_i
+  end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
   def version_from_git(dir)


### PR DESCRIPTION
This PR adds upload / download limits in the Files App and a new ENV var `FILE_DOWNLOAD_MAX`

Limits used for demo:
```yml
FILE_UPLOAD_MAX=100
FILE_DOWNLOAD_MAX=499
```

**Demo**
<video src="https://user-images.githubusercontent.com/6081892/114775110-efb3c000-9d3e-11eb-86dd-deb49bf1acd3.mov
">
