### PR TITLE
Fix ood-portal-generator to work with Oracle Linux

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator.rb
+++ b/ood-portal-generator/lib/ood_portal_generator.rb
@@ -26,7 +26,7 @@ module OodPortalGenerator
     def scl_apache?
       return true if os_release_file.nil?
       env = Dotenv.parse(os_release_file)
-      return false if ("#{env['ID']} #{env['ID_LIKE']}" =~ /rhel/ && env['VERSION_ID'] =~ /^8/)
+      return false if ("#{env['ID']} #{env['ID_LIKE']}" =~ /(rhel|fedora)/ && env['VERSION_ID'] =~ /^8/)
       true
     end
 


### PR DESCRIPTION
In response to https://discourse.osc.edu/t/ood-portal-generator-support-oracle-linux-8/1427