### PR TITLE
redirect old activejobs url to new dashboard 

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -95,6 +95,9 @@ http {
       alias <%= default_html_root %>/$1;
     }
 
+    # redirect all the old apps to the dashboard
+    rewrite ^/pun/sys/activejobs(.*)$ /pun/sys/dashboard/activejobs$1 permanent;
+
     # Include all app configs user has access to
     <%- app_configs.each do |app_config| -%>
     include <%= app_config %>;

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -1,15 +1,47 @@
 require 'watir'
+require_relative 'e2e_helper'
 
 describe 'OnDemand browser test' do
-  let(:browser) { Watir::Browser.new :chrome, headless: true, options: {args: ['--disable-dev-shm-usage']} }
-  after(:each) { browser.close }
 
-  it 'successfully logs into OnDemand' do
-    browser.goto "http://localhost:8080"
-    browser.text_field(id: 'username').set "ood@localhost"
-    browser.text_field(id: 'password').set "password"
-    browser.button(id: 'submit-login').click
+  def browser
+    @browser ||= Watir::Browser.new :chrome, headless: true, options: { args: ['--disable-dev-shm-usage'] }
+  end
 
+  before(:all) do
+    # sometimes you need to retry to let the container start up, so retry to make the tests
+    # a little less flaky
+    [*1..3].each do |try|
+      begin
+        browser_login(browser)
+        break
+      rescue => e
+        raise e if try == 3
+
+        `sleep 1`
+      end
+    end
+  end
+
+  after(:all) do
+    browser.close
+  end
+
+  it 'successfully loads dashboard no path' do
+    browser.goto ctr_base_url
     expect(browser.title).to eq('Dashboard - Open OnDemand')
+  end
+
+  it 'succesfully redirects /pun/sys/activejobs' do
+    browser.goto "#{ctr_base_url}/pun/sys/activejobs"
+    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/activejobs")
+    expect(browser.title).to eq('Dashboard - Open OnDemand')
+    expect(browser.table(id: 'job_status_table').present?).to be true
+  end
+
+  it 'redirects from /pun/sys/activejobs preserve query params' do
+    browser.goto "#{ctr_base_url}/pun/sys/activejobs?jobcluster=all&jobfilter=all"
+    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/activejobs?jobcluster=all&jobfilter=all")
+    expect(browser.title).to eq('Dashboard - Open OnDemand')
+    expect(browser.table(id: 'job_status_table').present?).to be true
   end
 end

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -1,0 +1,10 @@
+def ctr_base_url
+  "http://localhost:8080"
+end
+
+def browser_login(browser)
+  browser.goto ctr_base_url
+  browser.text_field(id: 'username').set "ood@localhost"
+  browser.text_field(id: 'password').set "password"
+  browser.button(id: 'submit-login').click
+end


### PR DESCRIPTION
redirect old activejobs url to new dashboard activejobs url in the pun config instead of the apache config.

Note this also adds end to end tests for the same and slightly refactors the e2e tests to allow for multiple page hits without logging in every time.