### PR TITLE
fix activejobs styles for Bootstrap 4

### DIFF
--- a/apps/dashboard/app/assets/javascripts/active_jobs.js
+++ b/apps/dashboard/app/assets/javascripts/active_jobs.js
@@ -202,7 +202,6 @@ function create_datatable(options){
             },
             {
                 data:               "pbsid",
-                className:          "small",
                 "autoWidth":        true,
                 render: function (data) {
                   var data = escapeHtml(data)
@@ -211,16 +210,14 @@ function create_datatable(options){
             },
             {
                 data:               "jobname",
-                className:          "small text-break",
                 width:              '25%',
                 render: function (data) {
                   var data = escapeHtml(data)
-                  return `<span title="${data}">${data}</span>`;
+                  return `<span title="${data}" class="text-break">${data}</span>`;
                 },
             },
             {
                 data:               "username",
-                className:          "small",
                 "autoWidth":        true,
                 render: function (data) {
                   var data = escapeHtml(data)
@@ -229,7 +226,6 @@ function create_datatable(options){
             },
             {
                 data:               "account",
-                className:          "small",
                 "autoWidth":        true,
                 render: function (data) {
                   var data = escapeHtml(data)
@@ -238,7 +234,7 @@ function create_datatable(options){
             },
             {
                 data:               "walltime_used",
-                className:          "small text-right",
+                className:          "text-right",
                 "autoWidth":        true,
                 render: function (data) {
                   return `
@@ -250,7 +246,6 @@ function create_datatable(options){
             },
             {
                 data:               "queue",
-                className:          "small text-break",
                 "autoWidth":        true,
                 "render":           function(data) {
                   var data = escapeHtml(data)
@@ -259,7 +254,7 @@ function create_datatable(options){
             },
             {
                 data:               "status",
-                className:          "small status-label",
+                className:          "status-label",
                 "autoWidth":        true,
                 "render":           function(data) {
                   return status_label(data);
@@ -267,12 +262,10 @@ function create_datatable(options){
             },
             {
                 data:               "cluster_title",
-                className:          "small",
                 "autoWidth":        true
             },
             {
                 data:               null,
-                className:          "small",
                 "autoWidth":        true,
                 render: function(data, type, row, meta) {
                   let { jobname, pbsid, delete_path } = data

--- a/apps/dashboard/app/helpers/active_jobs_helper.rb
+++ b/apps/dashboard/app/helpers/active_jobs_helper.rb
@@ -78,9 +78,9 @@ module ActiveJobsHelper
       labelclass = "badge-warning"
     else
       label = "Undetermined"
-      labelclass = "badge-default"
+      labelclass = "badge-secondary"
     end
-    "<div style='white-space: nowrap;'><span class='badge #{labelclass}'>#{label}</span></div>".html_safe
+    "<span class='badge #{labelclass}'>#{label}</span>".html_safe
   end
 
   def filters

--- a/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
@@ -3,55 +3,45 @@
     <%= data.error %>
   </div>
 <% else %>
-<div>
-  <div class="panel panel-default container-fluid">
-    <div class="panel-heading row clearfix">
-      <strong>
-        <div class="col-xs-1">
-          <div style="white-space: nowrap;">
-            <%= data.status %>
-          </div>
-        </div>
-        <div class="col-xs-11" style="word-wrap: break-word;"><%= data.jobname %>
-          <div><%= data.pbsid %></div>
-        </div>
-      </strong>
+<div class="card ml-5">
+  <div class="card-header">
+    <%# FIXME: ul/li with css %>
+    <strong>
+      <%= data.status %>
+      <span class="text-break ml-3"><%= data.jobname %></span>
+      <span class="ml-3"><%= data.pbsid %></span>
+    </strong>
+  </div>
+  <div class="card-body">
+    <table class="table table-sm table-striped">
+      <tbody>
+      <% data.native_attribs.each do |attrib| %>
+        <tr>
+          <!-- FIXME: col-xs-2... -->
+        <td class="col-xs-2"><strong><%= attrib.name %></strong></td>
+        <td class="col-xs-10"><%= attrib.value %></td>
+      </tr>
+    <% end %>
+      </tbody>
+    </table>
+  </div>
+    <% if data.submit_args %>
+    <div class="card-body">
+      <p class="card-text">Submit Args: <pre class="card bg-light p-2" style="white-space: pre-wrap;"><%= data.submit_args %></pre></p>
     </div>
-    <div class="panel-body">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <table class="table table-condensed table-striped">
-            <tbody>
-            <% data.native_attribs.each do |attrib| %>
-              <tr>
-                <td class="col-xs-2"><strong><%= attrib.name %></strong></td>
-                <td class="col-xs-10"><%= attrib.value %></td>
-              </tr>
-            <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
+    <% end %>
+    <% if data.output_path %>
+    <div class="card-body">
+      <%# FIXME: can use form element input with label and disabled %>
+      <p class="card-text">Output Location: <pre class="card bg-light p-2" style="white-space: pre-wrap;"><%= data.output_path %></pre></p>
     </div>
-      <% if data.submit_args %>
-      <div class="col-md-12">
-        <span class="col-md-2">Submit Args: </span>
-        <pre class="col-md-10" style="white-space: pre-wrap;"><%= data.submit_args %></pre>
-      </div>
+    <% end %>
+    <div class="card-body">
+      <% if ENV["USER"] == data.username %>
+          <%= link_to "#{icon("fas", "folder-open")} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-outline-black", :target => "_blank", :style => "margin: 10px;" if data.file_explorer_url %>
+          <%= link_to "#{icon("fas", "terminal")} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-outline-black", :target => "_blank", :style => "margin: 10px;" if data.shell_url %>
+          <%= link_to "#{icon("fas", "trash-o")} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-outline-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" } %>
       <% end %>
-      <% if data.output_path %>
-      <div class="col-md-12">
-        <span class="col-md-2">Output Location: </span>
-        <pre class="col-md-10" style="white-space: pre-wrap;"><%= data.output_path %></pre>
-      </div>
-      <% end %>
-      <div class="col-md-12">
-        <% if ENV["USER"] == data.username %>
-            <%= link_to "#{icon("fas", "folder-open")} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.file_explorer_url %>
-            <%= link_to "#{icon("fas", "terminal")} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.shell_url %>
-            <%= link_to "#{icon("fas", "trash-o")} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" } %>
-        <% end %>
-      </div>
     </div>
   </div>
 </div>

--- a/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
@@ -1,19 +1,24 @@
 <% if has_ganglia(data.cluster) || has_grafana(data.cluster) %>
-<div class="col-md-12">
-  <tr>
-    <td>
-      <div class="panel panel-default">
+<div class="card ml-5">
         <% if has_ganglia(data.cluster) %>
-          <div class="panel-heading"><h3 class="panel-title"> <%= node %> <span class="pull-right"> <%= data.pbsid %> </span></h3></div>
-          <div class="panel-body">
+          <div class="card-header">Node: <%= node %> <span class="float-right">Job: <%= data.pbsid %> </span></div>
+          <div class="card-body">
             <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'cpu_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'cpu_report', node, 'large'), data: { lightbox: "cpu-report", title: "CPU Report " + node } %>
             <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'load_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'load_report', node, 'large'), data: { lightbox: "load-report", title: "Load Report " + node } %>
             <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'mem_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'mem_report', node, 'large'), data: { lightbox: "mem-report", title: "Memory Report " + node } %>
             <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'network_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'network_report', node, 'large'), data: { lightbox: "network-report", title: "Network Report " + node } %>
           </div>
         <% elsif has_grafana(data.cluster) %>
-          <div class="panel-heading"><h3 class="panel-title"><%= node %> <span><a href="<%= build_grafana_link(data.cluster, data.starttime, 'node', node) %>" target="_blank">Detailed Metrics</a></span> <span class="pull-right"> <%= data.pbsid %> <a href="<%= build_grafana_link(data.cluster, data.starttime, 'job', node, data.pbsid) %>" target="_blank">Detailed Metrics</a></span></h3></div>
-          <div class="panel-body">
+          <div class="card-header">
+            Node: <%= node %>
+            <span class="ml-3">Job: <%= data.pbsid %></span>
+            <span class="ml-3">
+              <a href="<%= build_grafana_link(data.cluster, data.starttime, 'node', node) %>" target="_blank">
+                    <span class="fa fa-external-link-square-alt"></span> Detailed Metrics
+              </a>
+            </span>
+          </div>
+          <div class="card-body">
             <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'cpu', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
             <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'memory', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
           </div>

--- a/apps/dashboard/app/views/active_jobs/index.html.erb
+++ b/apps/dashboard/app/views/active_jobs/index.html.erb
@@ -38,7 +38,7 @@
 <div class="row">
   <div class="col-md-12 table-responsive">
     <h2>Active Jobs</h2>
-    <table id="job_status_table" class="table datatable table-striped table-bordered table-hover" cellspacing="0" width="100%">
+    <table id="job_status_table" class="table datatable table-hover" cellspacing="0" width="100%">
       <thead>
       <tr>
         <th></th>

--- a/apps/dashboard/app/views/layouts/active_jobs.html.erb
+++ b/apps/dashboard/app/views/layouts/active_jobs.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "layouts/application", locals: { layout_container_class: 'container-fluid' } %>


### PR DESCRIPTION
- avoid using small text on headers and body
- use fluid layout to expand entire space
- use Bootstrap 4 cards instead of Bootstrap 3 panels for the details view
- indent the details view cards
- remove bordered and striped table classes to be closer to previous styles (the new ones
  made it more difficult to view, especially with the striped view when expanding certain rows)

note:

- doesn't use <ul><li> which may be more semantically desirable
- doesn't fix ganglia table view partial