### PR TITLE
Address some obvious performance issues

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -40,6 +40,9 @@ http {
   # Kill all apps after they idle timeout
   passenger_min_instances 0;
 
+  # Limit app instances to 1 so apps can safely utilize in memory session data
+  passenger_max_instances_per_app 1;
+
   # Take advantage of Ruby preloader
   #passenger_spawn_method smart;
   #passenger_max_preloader_idle_time 0;


### PR DESCRIPTION
Limit app instances to 1 so apps can safely utilize in memory session data which could actually break functionality with the dashboard app (the node.js apps don't expand to multiple instances by default which is why we didn't have this problem till now).