### PR TITLE
fix file editor opening files w ampersand in name

### DIFF
--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -11,7 +11,17 @@
       </h4>
       <div id="ajaxErrorResponse"></div>
     </div>
-    <pre id="editor"></pre>
+    <pre id="editor" data-path="<%= @pathname %>" data-api="<%= @file_api_url %>"></pre>
+
+    <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ace.js" %>" type="text/javascript" charset="utf-8"></script>
+    <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ext-modelist.js" %>" type="text/javascript" charset="utf-8"></script>
+    <script>
+      var editorContent = "";
+
+      const editorElement = document.querySelector('#editor');
+      const apiUrl = editorElement.dataset.api;
+      const filePath = editorElement.dataset.path
+    </script>
 
 <% elsif @directory_content %>
     <h3>Select a file to edit:</h3>
@@ -32,17 +42,10 @@
 <% elsif @not_found %>
     <h2><span class="label label-danger">File Not Found!</span></h2>
     <h3>The file or folder could not be found.</h3>
-    
+
 <% elsif @path_forbidden %>
     <h2><span class="label label-danger">Path Forbidden!</span></h2>
     <h3>The file or folder cannot be loaded.</h3>
     <h4><pre><%= @pathname %></pre></h4>
 <% end %>
 
-<script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ace.js" %>" type="text/javascript" charset="utf-8"></script>
-<script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ext-modelist.js" %>" type="text/javascript" charset="utf-8"></script>
-<script>
-  var editorContent = "";
-  var apiUrl = "<%= @file_api_url %>";
-  var filePath = "<%= @pathname %>";
-</script>


### PR DESCRIPTION
by rendering the file editor url and path in html data attributes
and then pulling those using JS we avoid issues with encoding of
characters like & resulting in a malformed url when it is used by JS