### PR TITLE
don't use UUID as HTML id  in session card

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -1,6 +1,6 @@
 module BatchConnect::SessionsHelper
   def session_panel(session)
-    content_tag(:div, id: session.id, class: "card session-panel mb-4", data: { hash: session.to_hash }) do
+    content_tag(:div, id: "id_#{session.id}", class: "card session-panel mb-4", data: { id: session.id, hash: session.to_hash }) do
       concat(
         content_tag(:div, class: "card-heading") do
           content_tag(:h5, class: "card-header alert-#{status_context(session)}") do
@@ -201,19 +201,19 @@ module BatchConnect::SessionsHelper
       content_tag(:div) do
         # menu
         concat(
-          content_tag(:ul, class: "nav nav-tabs", id: id) do
+          content_tag(:ul, class: "nav nav-tabs") do
             tabs.map { |t| t[:title] }.map.with_index do |title, idx|
               content_tag(:li, class: "nav-item #{"active" if idx.zero?}") do
-                link_to title, "##{id}_#{idx}", data: { toggle: "tab" }, aria: { selected: (true if idx.zero?) }, class: "nav-link #{"active" if idx.zero?}"
+                link_to title, "#c_#{id}_#{idx}", data: { toggle: "tab" }, aria: { selected: (true if idx.zero?) }, class: "nav-link #{"active" if idx.zero?}"
               end
             end.join("\n").html_safe
           end
         )
         # content
         concat(
-          content_tag(:div, class: "tab-content", id: "#{id}Content") do
+          content_tag(:div, class: "tab-content") do
             tabs.map.with_index do |tab, idx|
-              content_tag(:div, id: "#{id}_#{idx}", class: "tab-pane ood-appkit markdown #{"active" if idx.zero?}", role: 'tabpanel') do
+              content_tag(:div, id: "c_#{id}_#{idx}", class: "tab-pane ood-appkit markdown #{"active" if idx.zero?}", role: 'tabpanel') do
                 render partial: "batch_connect/sessions/connections/#{tab[:partial]}", locals: tab[:locals]
               end
             end.join("\n").html_safe

--- a/apps/dashboard/app/views/batch_connect/sessions/index.js.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.js.erb
@@ -5,7 +5,7 @@
   <%# Replace sessions whose state has changed %>
   <% @sessions.each do |session| %>
     sessions.push('<%= session.id %>');
-    $target = $('#<%= session.id %>');
+    $target = $('#id_<%= session.id %>');
     if ( $target.data('hash') !== '<%= session.to_hash %>' ) {
       $target.replaceWith('<%= j render(partial: "panel", locals: { session: session }) %>');
     }
@@ -13,7 +13,7 @@
 
   <%# Remove sessions that don't exist anymore %>
   $('.session-panel').each(function () {
-    if ( $.inArray($(this).attr('id'), sessions) < 0 ) {
+    if ( $.inArray($(this).attr('data-id'), sessions) < 0 ) {
       $(this).remove();
     }
   });


### PR DESCRIPTION
CSS can only work with HTML id's that follow HTML4 rules, so the id must be prefixed by a letter
UUIDs may be prefixed with a number, and this causes problems when using UUID as an HTML id

in particular, the bootstrap 4 tab control doesn't work if the id's start with a number

The solution:

1. prefix session card id with "id_"
2. prefix connection tab ids with "c_"
3. remove unused ids that were also duplicates of card from tag content wrapper div and nav tabs ul
4. add data-id attribute to session card for convenience use by JS wanting quick access to session id