### PR TITLE
only show app.links.first in the feature apps menu 

### DIFF
--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -5,8 +5,7 @@
     <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, nav_limit: group.nav_limit).each_with_index do |g, index| %>
       <%= content_tag "li", "", class: "dropdown-divider", role: "separator" if index > 0 %>
       <%= content_tag "li", g.title_with_nav_limit_caption, class: "dropdown-header" unless g.title_with_nav_limit_caption.empty? %>
-      <% g.apps.take(g.nav_limit).each do |app| %>
-        <%- link = app.links.first -%>
+      <% g.apps.take(g.nav_limit).map { |app| app.links.first }.compact.each do |link| %>
           <li>
             <%=
               link_to(

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -6,7 +6,7 @@
       <%= content_tag "li", "", class: "dropdown-divider", role: "separator" if index > 0 %>
       <%= content_tag "li", g.title_with_nav_limit_caption, class: "dropdown-header" unless g.title_with_nav_limit_caption.empty? %>
       <% g.apps.take(g.nav_limit).each do |app| %>
-        <% app.links.each do |link| %>
+        <%- link = app.links.first -%>
           <li>
             <%=
               link_to(
@@ -22,7 +22,6 @@
               <% end %>
             <% end %>
           </li>
-        <% end %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
Fix #953 by only showing 1 link/app. Meaning the files app only shows the home directory and not all of the favorite paths.