### PR TITLE
Removed Audible Bell by Default in Shell

### DIFF
--- a/apps/shell/views/index.hbs
+++ b/apps/shell/views/index.hbs
@@ -90,7 +90,8 @@
           "brightWhite"
         ]
       ),
-      'cursor-color': theme.cursorColor
+      'cursor-color': theme.cursorColor,
+      'audible-bell-sound': ''
     }
   });
   themes["default"] = {
@@ -98,6 +99,7 @@
     'ctrl-v-paste': true,
     'ctrl-c-copy': true,
     'cursor-blink': false,
+    'audible-bell-sound': ''
   }
 
   // Set backing store that hterm uses to read/write preferences


### PR DESCRIPTION
In reference to this discussion on Discourse: https://discourse.osc.edu/t/shell-app-configuration-disable-bell/1455/1