### PR TITLE
Control open_apps_in_new_window? using manifest

### DIFF
--- a/apps/activejobs/manifest.yml
+++ b/apps/activejobs/manifest.yml
@@ -5,3 +5,4 @@ description: |-
   View jobs currently running on available clusters configured for OnDemand.
 icon: fa://clock-o
 url: activejobs
+new_window: false

--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -121,6 +121,13 @@ category: OSC
     @manifest_options[:metadata] || {}
   end
 
+  # Return the app's hint of whether to open app in new window
+  #
+  # @return [Boolean, nil] if set, Boolean value, otherwise nil
+  def new_window
+    @manifest_options[:new_window]
+  end
+
   # Manifest objects are valid
   #
   # @return [true] Always return true

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -41,6 +41,14 @@ class OodApp
     manifest.name.empty? ? name.titleize : manifest.name
   end
 
+  def open_in_new_window?
+    if manifest.new_window.nil?
+      Configuration.open_apps_in_new_window?
+    else
+      manifest.new_window
+    end
+  end
+
   def url
     if manifest.url.empty?
       if batch_connect_app?
@@ -78,7 +86,7 @@ class OodApp
           url: OodAppkit::Urls::Files.new(base_url: url).url(path: Dir.home),
           icon_uri: "fas://home",
           caption: caption,
-          new_tab: true
+          new_tab: open_in_new_window?
         )
       ].concat(
         OodFilesApp.new.favorite_paths.map do |favorite_path|
@@ -89,7 +97,7 @@ class OodApp
             url: OodAppkit::Urls::Files.new(base_url: url).url(path: favorite_path.path.to_s),
             icon_uri: "fas://folder",
             caption: caption,
-            new_tab: true
+            new_tab: open_in_new_window?
           )
         end
       )
@@ -108,7 +116,7 @@ class OodApp
             url: OodAppkit::Urls::Shell.new(base_url: url).url,
             icon_uri: "fas://terminal",
             caption: caption,
-            new_tab: true
+            new_tab: open_in_new_window?
           )
         ]
       else
@@ -119,7 +127,7 @@ class OodApp
             url: OodAppkit::Urls::Shell.new(base_url: url).url(host: cluster.login.host),
             icon_uri: "fas://terminal",
             caption: caption,
-            new_tab: true
+            new_tab: open_in_new_window?
           )
         end.sort_by { |lnk| lnk.title }
       end
@@ -133,7 +141,7 @@ class OodApp
           url: (type == :sys && owner == :sys) ? app_path(name, nil, nil) : app_path(name, type, owner),
           icon_uri: icon_uri,
           caption: caption,
-          new_tab: true
+          new_tab: open_in_new_window?
         )
       ]
     end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -334,6 +334,19 @@ end
     (ENV['OOD_ALLOWLIST_PATH'] || ENV['WHITELIST_PATH'] || "").split(':').map{ |s| Pathname.new(s) }
   end
 
+  # default value for opening apps in new window
+  # that is used if app's manifest doesn't specify
+  # if not set default is true
+  #
+  # @return [Boolean] true if by default open apps in new window
+  def open_apps_in_new_window?
+    if ENV['OOD_OPEN_APPS_IN_NEW_WINDOW']
+      to_bool(ENV['OOD_OPEN_APPS_IN_NEW_WINDOW'])
+    else
+      true
+    end
+  end
+
   private
 
   def can_access_core_app?(name)

--- a/apps/dashboard/test/integration/nav_test.rb
+++ b/apps/dashboard/test/integration/nav_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class NavTest < ActionDispatch::IntegrationTest
+ test "default for app to open in new window" do
+   SysRouter.stubs(:base_path).returns(Rails.root.parent)
+   Configuration.stubs(:open_apps_in_new_window?).returns(true)
+
+   get '/'
+
+   link = css_select('a[title="Job Composer"]').first
+
+   assert link, "Job Composer link not found on index page"
+   assert_equal '_blank', link['target'], 'Job Composer link should be set to open in new window'
+ end
+
+ test "default for app to open in same window" do
+   SysRouter.stubs(:base_path).returns(Rails.root.parent)
+   Configuration.stubs(:open_apps_in_new_window?).returns(false)
+
+   get '/'
+
+   link = css_select('a[title="Job Composer"]').first
+
+   assert link, 'Job Composer link not found on index page'
+   refute link['target'], 'Job Composer link should be set to open in same window'
+ end
+end

--- a/apps/file-editor/manifest.yml
+++ b/apps/file-editor/manifest.yml
@@ -4,3 +4,4 @@ description: |-
   A text editor for files on OSC systems
 documentation: |-
 url: files/edit
+new_window: true

--- a/apps/files/manifest.yml
+++ b/apps/files/manifest.yml
@@ -6,3 +6,4 @@ category: Files
 icon: fa://folder
 role: files
 url: files
+new_window: false

--- a/apps/shell/manifest.yml
+++ b/apps/shell/manifest.yml
@@ -5,3 +5,4 @@ icon: fa://terminal
 description: |-
   Open OnDemand web-based terminal
 role: shell
+new_window: true


### PR DESCRIPTION
when default is to open in new window,
any OodApp will open in a new window unless the
manifest of that app specifies otherwise
using new_window: true or new_window: false

set activejobs and files to always open in same window using manifest
set file-editor and shell to always open in new window using manifest

specified default via Configuration.open_apps_in_new_window?
default is true (unless default is changed using OOD_OPEN_APPS_IN_NEW_WINDOW)