### PR TITLE
rename landing_page_layout to dashboard_layout

### DIFF
--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -32,9 +32,9 @@ module DashboardHelper
     @motd.present?
   end
 
-  def landing_page_layout
+  def dashboard_layout
     #FIXME: should sanitize the landing_page_layout or cast somethings to Array in the upper layers
-    Configuration.landing_page_layout || default_landing_page_layout
+    Configuration.dashboard_layout || default_dashboard_layout
   end
 
   def render_widget(widget)
@@ -47,7 +47,7 @@ module DashboardHelper
 
   private
 
-  def default_landing_page_layout
+  def default_dashboard_layout
     if xdmod?
       if pinned_apps? || motd?
         left_column = { width: 8, widgets: ['pinned_apps', 'motd'] }

--- a/apps/dashboard/app/views/dashboard/index.html.erb
+++ b/apps/dashboard/app/views/dashboard/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'shared/welcome' %>
 
-<%- landing_page_layout.fetch(:rows, []).each do |row| -%>
+<%- dashboard_layout.fetch(:rows, []).each do |row| -%>
 <div class="row">
   <%- row.fetch(:columns, []).each do |col| -%>
   <div class='<%= "col-md-#{col[:width]}" %>'> <%# FIXME: what if width is not specified!? %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -302,9 +302,9 @@ end
     end
   end
 
-  # The landing page layout. Defaults to nil.
-  def landing_page_layout
-    config.fetch(:landing_page_layout, nil)
+  # The dashboard's landing page layout. Defaults to nil.
+  def dashboard_layout
+    config.fetch(:dashboard_layout, nil)
   end
 
   def can_access_activejobs?

--- a/apps/dashboard/test/integration/dashboard_layout_test.rb
+++ b/apps/dashboard/test/integration/dashboard_layout_test.rb
@@ -1,12 +1,12 @@
 require 'html_helper'
 require 'test_helper'
 
-# Test the feature for configuring landing pages through ConfigurationSingleton#landing_page_layout.
+# Test the feature for configuring landing pages through ConfigurationSingleton#dashboard_layout.
 
-# Note that the default layout (having no ConfigurationSingleton#landing_page_layout set)
+# Note that the default layout (having no ConfigurationSingleton#dashboard_layout set)
 # and variants (MOTD enabled/disabled, XDMOD & MOTD enabled/disabled and so on) are handled
 # by pinned_apps_test.rb.
-class LandingPageTest < ActionDispatch::IntegrationTest
+class DashboardLayoutTest < ActionDispatch::IntegrationTest
 
   def setup
     Router.instance_variable_set('@pinned_apps', nil)
@@ -27,7 +27,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
 
   test "should show nothing when nothing is given" do
     # XDMOD here isn't really 
-    Configuration.stubs(:landing_page_layout).returns({})
+    Configuration.stubs(:dashboard_layout).returns({})
 
     get '/'
 
@@ -35,7 +35,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
   end
 
   test "nil MOTD and pinned apps render empty elements" do
-    Configuration.stubs(:landing_page_layout).returns({
+    Configuration.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -70,7 +70,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
   end
 
   test "shows MOTD a single row, single column" do
-    Configuration.stubs(:landing_page_layout).returns({
+    Configuration.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -97,7 +97,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
   end
 
   test "shows widgets with one row and two columns" do
-    Configuration.stubs(:landing_page_layout).returns({
+    Configuration.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -178,7 +178,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
       'sys/bc_desktop/owens',
       'sys/pseudofun',
     ])
-    Configuration.stubs(:landing_page_layout).returns({
+    Configuration.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -230,7 +230,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
   end
 
   test "bad widgets don't throw errors" do
-    Configuration.stubs(:landing_page_layout).returns({
+    Configuration.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -261,7 +261,7 @@ class LandingPageTest < ActionDispatch::IntegrationTest
   end
 
   test "should render brand new widgets with shipped widgets" do
-    Configuration.stubs(:landing_page_layout).returns({
+    Configuration.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [


### PR DESCRIPTION
Fix #1092

Renames are in external configurations as well as internal usage for consistency.