### PR TITLE
add optional dalli gem for ihpc apps to use

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -78,5 +78,6 @@ gem 'pbs', '~> 2.2.1'
 gem "sinatra", require: false
 gem "sinatra-contrib", require: false
 gem "erubi", require: false
+gem "dalli", require: false
 
 gem 'webpacker', '~> 5.2', '>= 5.2.1'

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    dalli (2.7.11)
     data-confirm-modal (1.6.3)
       railties (>= 3.0)
     dotenv (2.7.6)
@@ -259,6 +260,7 @@ DEPENDENCIES
   capybara
   climate_control (~> 0.2)
   coffee-rails (~> 4.2)
+  dalli
   data-confirm-modal (~> 1.2)
   dotenv-rails (~> 2.1)
   dotiw


### PR DESCRIPTION
Fixes #1079

dalli gem for using memcached is provided as an optional gem to status apps or ihpc apps 