### PR TITLE
Open in Terminal Dropdown

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,7 @@ ARG GID=1000
 
 RUN dnf reinstall -y httpd-tools && \
     dnf install -y \
-        strace lua && \
+        strace lua python3 && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
 RUN groupadd -g $GID $USER && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,6 +4,12 @@ ARG USER=ood
 ARG UID=1000
 ARG GID=1000
 
+RUN dnf install -y \
+        python3 && \
+    dnf clean all && rm -rf /var/cache/dnf/* && \
+    python3 -m pip \
+        install flask
+
 RUN groupadd -g $GID $USER && \
     useradd -u $UID --create-home --gid $USER $USER
 

--- a/apps/dashboard/app/assets/javascripts/files.js
+++ b/apps/dashboard/app/assets/javascripts/files.js
@@ -31,7 +31,9 @@ function reloadTable(url){
 
   return fetch(request_url, {headers: {'Accept':'application/json'}})
     .then(response => dataFromJsonResponse(response))
-    .then(function(data){
+    .then(function(data) {
+      $('#shell-wrapper').replaceWith((data.shell_dropdown_html))
+
       table.clear();
       table.rows.add(data.files);
       table.draw();

--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -1,5 +1,5 @@
 <div class="shell-wrapper btn-group dropright">
-  <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm disabled', target: '_blank' do %>
+  <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm', target: '_blank' do %>
     <i class="fas fa-terminal" aria-hidden="true"></i>
     Open in Terminal
   <% end %>

--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div class="shell-wrapper btn-group dropright">
+<div id="shell-wrapper" class="btn-group dropright">
   <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm', target: '_blank' do %>
     <i class="fas fa-terminal" aria-hidden="true"></i>
     Open in Terminal
@@ -13,11 +13,9 @@
           # </li>
           tag.li(
             tag.a(
-              cluster.title,
-              href: OodAppLink.new(
-                url: OodAppkit::Urls::Shell.new().url(host: cluster.title.downcase),
-              ).url,
-              title: cluster.title,
+              "#{cluster.metadata.title || cluster.id.to_s.titleize}",
+              href: OodAppkit::Urls::Shell.new(base_url: root_path).url(host: cluster.login.host, path: @path.to_s),
+              title: "#{cluster.metadata.title || cluster.id.to_s.titleize}",
               target: '_blank',
               class: 'dropdown-item'
             )

--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -1,0 +1,29 @@
+<div class="shell-wrapper btn-group dropright">
+  <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm disabled', target: '_blank' do %>
+    <i class="fas fa-terminal" aria-hidden="true"></i>
+    Open in Terminal
+  <% end %>
+  <% if Configuration.login_clusters.count > 0 %>
+    <button type="button" class="btn btn-sm btn-outline-dark dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <ul class="dropdown-menu" x-placement="right-start" id="shell-dropdown-items">
+      <% Configuration.login_clusters.each{ |cluster| %>
+        <%=
+          # <li>
+          #   <a href="" title="" target="_blank" class="dropdown-item"></a>
+          # </li>
+          tag.li(
+            tag.a(
+              cluster.title,
+              href: OodAppLink.new(
+                url: OodAppkit::Urls::Shell.new().url(host: cluster.title.downcase),
+              ).url,
+              title: cluster.title,
+              target: '_blank',
+              class: 'dropdown-item'
+            )
+          )
+        %>
+      <% } %>
+    </ul>
+  <% end %>
+</div>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -1,7 +1,7 @@
 <%# z-index:999 cause dropdowns are 1000 default sticky-top is 1020 https://getbootstrap.com/docs/4.6/layout/overview/#z-index %>
 <div class="text-right sticky-top bg-white border-bottom p-2 m-3" style="z-index: 999">
   <!-- terminal button href is set via JavaScript because the URL is based on the current directory -->
-  <a id="open-in-terminal-btn" class="btn btn-outline-dark btn-sm disabled" href="#" target="_blank"><i class="fas fa-terminal" aria-hidden="true"></i> Open in Terminal</a>
+  <%= render partial: 'shell_dropdown' %>
 
   <button id="new-file-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-plus" aria-hidden="true"></i> New File</button>
   <button id="new-dir-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-folder-plus" aria-hidden="true"></i> New Directory</button>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -19,6 +19,8 @@ json.files @files do |f|
   json.owner f[:owner]
   json.mode f[:mode]
 end
+
 json.breadcrumbs_html render partial: 'breadcrumb.html.erb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path }
+json.shell_dropdown_html render partial: 'shell_dropdown.html.erb'
 json.time Time.now.to_i
 json.error_message alert if alert

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -36,9 +36,9 @@ class ConfigurationSingleton
     @ood_version ||= (ood_version_from_env || version_from_file('/opt/ood') || version_from_git('/opt/ood') || "Unknown").strip
   end
 
-def ood_bc_ssh_to_compute_node
-  to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
-end
+  def ood_bc_ssh_to_compute_node
+    to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
+  end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
   def version_from_git(dir)
@@ -48,6 +48,15 @@ end
     end
   rescue Errno::ENOENT
     nil
+  end
+
+  def login_clusters
+    OodCore::Clusters.new(
+      OodAppkit.clusters
+        .select(&:allow?)
+        .reject { |c| c.metadata.hidden }
+        .select(&:login_allow?)
+    )
   end
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail

--- a/mod_ood_proxy/lib/node_proxy.lua
+++ b/mod_ood_proxy/lib/node_proxy.lua
@@ -37,7 +37,7 @@ function node_proxy_handler(r)
   conn.uri = uri and (r.args and (uri .. "?" .. r.args) or uri) or r.unparsed_uri
 
   -- last ditch effort to ensure that the uri is at least something
-  -- because the readline of an HTTP request _has_ have something for a URL
+  -- because the request-line of an HTTP request _has_ to have something for a URL
   if conn.uri == '' then
     conn.uri = '/'
   end

--- a/mod_ood_proxy/lib/node_proxy.lua
+++ b/mod_ood_proxy/lib/node_proxy.lua
@@ -36,6 +36,12 @@ function node_proxy_handler(r)
   conn.server = host .. ":" .. port
   conn.uri = uri and (r.args and (uri .. "?" .. r.args) or uri) or r.unparsed_uri
 
+  -- last ditch effort to ensure that the uri is at least something
+  -- because the readline of an HTTP request _has_ have something for a URL
+  if conn.uri == '' then
+    conn.uri = '/'
+  end
+
   -- setup request for reverse proxy
   proxy.set_reverse_proxy(r, conn)
 

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -32,6 +32,10 @@ def portal_fixture(file)
   "#{File.expand_path('.')}/spec/fixtures/config/ood_portal/#{file}"
 end
 
+def extra_fixtures
+  "#{File.expand_path('.')}/spec/fixtures/extras"
+end
+
 def container_exec(cmd)
   `#{container_runtime} exec #{test_image_name} #{cmd}`.to_s
 end

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -1,0 +1,72 @@
+require 'watir'
+require_relative 'e2e_helper'
+
+describe 'Node and Rnode proxies' do
+
+  def browser
+    @browser ||= new_browser
+  end
+
+  before(:all) do
+    mnts = ["-v", "#{extra_fixtures}:/opt/extras"]
+    mnts.concat ["-v", "#{portal_fixture('portal_with_proxies.yml')}:/etc/ood/config/ood_portal.yml"]
+    Rake::Task['test:start_test_container'].execute(mount_args: mnts)
+
+    container_exec("/bin/bash -c '/opt/extras/simple_origin_server.py >/tmp/rnode.out 2>&1 &'")
+    container_exec("/bin/bash -c 'FLASK_PORT=5001 FLASK_BASE_URL=/node/localhost/5001 /opt/extras/simple_origin_server.py >/tmp/node.out 2>&1 &'")
+    browser_login(browser)
+  end
+
+  after(:all) do
+    Rake::Task['test:stop_test_container'].execute
+    browser.close
+  end
+
+  it 'rnode proxies directly to the origin' do
+    browser.goto "#{ctr_base_url}/rnode/localhost/5000/simple-page"
+    expect(browser.url).to eq("#{ctr_base_url}/rnode/localhost/5000/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'rnode redirects to the origin' do
+    browser.goto "#{ctr_base_url}/rnode/localhost/5000/simple-redirect"
+    expect(browser.url).to eq("#{ctr_base_url}/rnode/localhost/5000/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'rnode redirects to the origin when no path is given' do
+    browser.goto "#{ctr_base_url}/rnode/localhost/5000"
+    expect(browser.url).to eq("#{ctr_base_url}/rnode/localhost/5000/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'rnode redirects to the origin when only root is given' do
+    browser.goto "#{ctr_base_url}/rnode/localhost/5000/"
+    expect(browser.url).to eq("#{ctr_base_url}/rnode/localhost/5000/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'node proxies directly to the origin' do
+    browser.goto "#{ctr_base_url}/node/localhost/5001/simple-page"
+    expect(browser.url).to eq("#{ctr_base_url}/node/localhost/5001/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'rnode redirects to the origin' do
+    browser.goto "#{ctr_base_url}/node/localhost/5001/simple-redirect"
+    expect(browser.url).to eq("#{ctr_base_url}/node/localhost/5001/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'node redirects to the origin with nothing extra in the path' do
+    browser.goto "#{ctr_base_url}/node/localhost/5001"
+    expect(browser.url).to eq("#{ctr_base_url}/node/localhost/5001/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+
+  it 'node redirects to the origin when only root is given' do
+    browser.goto "#{ctr_base_url}/node/localhost/5001/"
+    expect(browser.url).to eq("#{ctr_base_url}/node/localhost/5001/simple-page")
+    expect(browser.div(id: "test-div").present?).to be true
+  end
+end

--- a/spec/fixtures/config/ood_portal/portal_with_proxies.yml
+++ b/spec/fixtures/config/ood_portal/portal_with_proxies.yml
@@ -1,0 +1,11 @@
+---
+#
+# Portal configuration
+#
+
+listen_addr_port: 8080
+servername: localhost
+port: 8080
+
+rnode_uri: '/rnode'
+node_uri: '/node'

--- a/spec/fixtures/extras/simple_origin_server.py
+++ b/spec/fixtures/extras/simple_origin_server.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+from flask import Flask, redirect, request, Blueprint, url_for
+
+app = Blueprint('app', 'simple_origin_server_blueprint')
+
+@app.route("/one/two/three/relative-redirect")
+def relative_redirect():
+    return redirect(url_for('app.one_level_down'), code=302)
+
+@app.route("/one/one-level-down")
+def one_level_down():
+    simple_page()
+
+@app.route("/simple-redirect")
+def simple_redirect():
+    return redirect(url_for('app.simple_page'), code=302)
+
+@app.route('/')
+def root():
+    return redirect(url_for('app.simple_page'), code=302)
+
+@app.route("/simple-page")
+def simple_page():
+    return "<html><body><div id='test-div'>A very simple page for testing</div></body></html>"
+
+if __name__ == '__main__':
+    super_app = Flask(__name__)
+
+    if os.environ.get('FLASK_BASE_URL'):
+        print('app root is ' + os.environ.get('FLASK_BASE_URL'))
+        super_app.register_blueprint(app, url_prefix=os.environ.get('FLASK_BASE_URL'))
+    else:
+        super_app.register_blueprint(app, url_prefix='/')
+    
+    if os.environ.get('FLASK_PORT'):
+        port = int(os.environ.get('FLASK_PORT'))
+    else:
+        port = 5000
+    
+    print(super_app.url_map)
+    super_app.run(host='127.0.0.1', port=port, debug=True)


### PR DESCRIPTION
Remake of https://github.com/OSC/ondemand/pull/1030

This PR adds a partial to generate the dropdown item HTML for Open in Terminal based on the users current path in the Files App. The dropdown is re-rendered whenever `goto()` is used around the Files App.

If there are no valid clusters, the default Shell URL is provided by `OodAppkit::ShellUrl`

![image](https://user-images.githubusercontent.com/6081892/113926046-b7016d00-97b9-11eb-8b7d-59e320d2a18e.png)

If there are valid clusters, then the dropdown turns into this:

![image](https://user-images.githubusercontent.com/6081892/113926338-09db2480-97ba-11eb-9387-2e36841d41d4.png)
