### PR TITLE
Files App - Open in Terminal Dropdown

### DIFF
--- a/apps/dashboard/app/assets/javascripts/files.js
+++ b/apps/dashboard/app/assets/javascripts/files.js
@@ -31,7 +31,9 @@ function reloadTable(url){
 
   return fetch(request_url, {headers: {'Accept':'application/json'}})
     .then(response => dataFromJsonResponse(response))
-    .then(function(data){
+    .then(function(data) {
+      $('#shell-wrapper').replaceWith((data.shell_dropdown_html))
+
       table.clear();
       table.rows.add(data.files);
       table.draw();

--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -1,0 +1,27 @@
+<div id="shell-wrapper" class="btn-group dropright">
+  <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm', target: '_blank' do %>
+    <i class="fas fa-terminal" aria-hidden="true"></i>
+    Open in Terminal
+  <% end %>
+  <% if Configuration.login_clusters.count > 0 %>
+    <button type="button" class="btn btn-sm btn-outline-dark dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
+    <ul class="dropdown-menu" x-placement="right-start" id="shell-dropdown-items">
+      <% Configuration.login_clusters.each{ |cluster| %>
+        <%=
+          # <li>
+          #   <a href="" title="" target="_blank" class="dropdown-item"></a>
+          # </li>
+          tag.li(
+            tag.a(
+              "#{cluster.metadata.title || cluster.id.to_s.titleize}",
+              href: OodAppkit::Urls::Shell.new(base_url: root_path).url(host: cluster.login.host, path: @path.to_s),
+              title: "#{cluster.metadata.title || cluster.id.to_s.titleize}",
+              target: '_blank',
+              class: 'dropdown-item'
+            )
+          )
+        %>
+      <% } %>
+    </ul>
+  <% end %>
+</div>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -1,7 +1,7 @@
 <%# z-index:999 cause dropdowns are 1000 default sticky-top is 1020 https://getbootstrap.com/docs/4.6/layout/overview/#z-index %>
 <div class="text-right sticky-top bg-white border-bottom p-2 m-3" style="z-index: 999">
   <!-- terminal button href is set via JavaScript because the URL is based on the current directory -->
-  <a id="open-in-terminal-btn" class="btn btn-outline-dark btn-sm disabled" href="#" target="_blank"><i class="fas fa-terminal" aria-hidden="true"></i> Open in Terminal</a>
+  <%= render partial: 'shell_dropdown' %>
 
   <button id="new-file-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-plus" aria-hidden="true"></i> New File</button>
   <button id="new-dir-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-folder-plus" aria-hidden="true"></i> New Directory</button>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -19,6 +19,8 @@ json.files @files do |f|
   json.owner f[:owner]
   json.mode f[:mode]
 end
+
 json.breadcrumbs_html render partial: 'breadcrumb.html.erb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path }
+json.shell_dropdown_html render partial: 'shell_dropdown.html.erb'
 json.time Time.now.to_i
 json.error_message alert if alert

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -36,9 +36,9 @@ class ConfigurationSingleton
     @ood_version ||= (ood_version_from_env || version_from_file('/opt/ood') || version_from_git('/opt/ood') || "Unknown").strip
   end
 
-def ood_bc_ssh_to_compute_node
-  to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
-end
+  def ood_bc_ssh_to_compute_node
+    to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
+  end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
   def version_from_git(dir)
@@ -48,6 +48,15 @@ end
     end
   rescue Errno::ENOENT
     nil
+  end
+
+  def login_clusters
+    OodCore::Clusters.new(
+      OodAppkit.clusters
+        .select(&:allow?)
+        .reject { |c| c.metadata.hidden }
+        .select(&:login_allow?)
+    )
   end
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail


### PR DESCRIPTION
If there are no valid clusters, the default Shell URL is provided by `OodAppkit::ShellUrl`

<img src="https://user-images.githubusercontent.com/6081892/113926338-09db2480-97ba-11eb-9387-2e36841d41d4.png" width=350>

If there are valid clusters, then the dropdown turns into this:

<img src="https://user-images.githubusercontent.com/6081892/113926338-09db2480-97ba-11eb-9387-2e36841d41d4.png" width=350>