### PR TITLE
Add back ability to download directory as zip

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -80,3 +80,4 @@ gem "sinatra-contrib", require: false
 gem "erubi", require: false
 
 gem 'webpacker', '~> 5.2', '>= 5.2.1'
+gem 'zip_tricks', '~> 5.5'

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -246,6 +246,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    zip_tricks (5.5.0)
 
 PLATFORMS
   ruby
@@ -286,6 +287,7 @@ DEPENDENCIES
   turbolinks (~> 5.2.0)
   uglifier (>= 1.3.0)
   webpacker (~> 5.2, >= 5.2.1)
+  zip_tricks (~> 5.5)
 
 BUNDLED WITH
    2.1.4

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -19,8 +19,14 @@ class FilesController < ApplicationController
           render :index
         }
         format.json {
-          @files = Files.new.ls(@path.to_s)
-          render :index
+          if params[:can_download]
+            # check to see if this directory can be downloaded as a zip
+            can_download, error_message = Files.can_download_as_zip?(@path)
+            render json: { can_download: can_download, error_message: error_message }
+          else
+            @files = Files.new.ls(@path.to_s)
+            render :index
+          end
         }
         format.zip {
           zipname = @path.basename.to_s.gsub('"', '\"') + '.zip'

--- a/apps/dashboard/app/models/files.rb
+++ b/apps/dashboard/app/models/files.rb
@@ -6,6 +6,18 @@ class Files
     path.each_child.first
   end
 
+  #FIXME: a more generic name for this?
+  FileToZip = Struct.new(:path, :relative_path)
+
+  def self.files_to_zip(path)
+    path = path.expand_path
+
+    Pathname.new(path).glob('**/*').map {|p|
+      FileToZip.new(p.to_s, p.relative_path_from(path).to_s)
+    }
+  end
+
+
   def ls(dirpath)
     Pathname.new(dirpath).each_child.map do |path|
       Files.stat(path)

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -66,9 +66,7 @@
     <li><a href="{{data.edit_url}}" class="edit-file dropdown-item" target="_blank" data-row-index="{{row_index}}"><i class="fas fa-edit" aria-hidden="true"></i> Edit</a></li>
     {{/if}}
     <li><a href="#" class="rename-file dropdown-item" data-row-index="{{row_index}}"><i class="fas fa-font" aria-hidden="true"></i> Rename</a></li>
-    {{#if file}}
     <li><a href="{{data.download_url}}" class="download-file dropdown-item" data-row-index="{{row_index}}"><i class="fas fa-download" aria-hidden="true"></i> Download</a></li>
-    {{/if}}
     <li class="dropdown-divider mt-4"></li>
     <li><a href="#" class="delete-file dropdown-item text-danger" data-row-index="{{row_index}}"><i class="fas fa-trash" aria-hidden="true"></i> Delete</a></li>
   </ul>
@@ -400,10 +398,6 @@ $('#download-btn').on("click", () => {
   let selection = table.rows({selected: true}).data();
   if(selection.length != 1){
     Swal.fire('Select only 1 file to download', 'You have selected none or multiple rows', 'error')
-  }
-  else if(selection[0].type == "d"){
-    Swal.fire('Cannot download directory', 'Can only download files', 'error')
-    // TODO
   }
   else {
     downloadFile(selection[0]);

--- a/apps/dashboard/config/initializers/mime_types.rb
+++ b/apps/dashboard/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "application/zip", :zip


### PR DESCRIPTION
This PR is for adding back the feature from the cloud commander that let you download as a zip. Remaining work:

- [ ] 1. When downloading directory, first do an AJAX request to get the JSON for the `?can_download=1` to verify it is possible, and if not, report an error instead of starting the download
- [ ] 2. Use this method `Files.can_download_as_zip?` as the first step prior to actually downloading the zip (so user's cannot just bypass by changing the url)
- [ ] 3. Consider changing default timeout to 5 seconds, as 10 is quite a long time to wait
- [ ] 4. "download as zip check timeout" and "max download as zip byte size" both need to become configuration options
- [ ] 5. Internationalize all strings

This would complete the MVP of this feature.

Future work that can improve this includes (open new issues):

1. using zip utility which may be much faster than ZipTricks
2. possibly moving this to Transfers and supporting both the synchronous and async options