### PR TITLE
remove rails_12factor gem

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -61,7 +61,6 @@ gem 'addressable', '~> 2.4'
 gem 'bootstrap_form', '~> 4.0'
 gem 'jquery-datatables-rails', '~> 3.4'
 gem 'data-confirm-modal', '~> 1.2'
-gem 'rails_12factor', group: :production
 gem 'mocha', '~> 1.1', group: :test
 gem 'autoprefixer-rails', '~> 9.1'
 gem 'dotiw'

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -167,11 +167,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.5)
       actionpack (= 5.2.5)
       activesupport (= 5.2.5)
@@ -276,7 +271,6 @@ DEPENDENCIES
   ood_support (~> 0.0.2)
   pbs (~> 2.2.1)
   rails (= 5.2.5)
-  rails_12factor
   redcarpet (~> 3.3)
   sass-rails (~> 5.0)
   sdoc

--- a/apps/dashboard/app/controllers/transfers_controller.rb
+++ b/apps/dashboard/app/controllers/transfers_controller.rb
@@ -22,12 +22,14 @@ class TransfersController < ApplicationController
       # error
       render json: { error_message: @transfer.errors.full_messages.join('. ') }
     elsif @transfer.synchronous?
+      logger.info "files: executing synchronous commmand in directory #{@transfer.from.to_s}: #{@transfer.command_str}"
       @transfer.perform
 
       respond_to do |format|
         format.json { render :show }
       end
     else
+      logger.info "files: initiating asynchronous commmand in directory #{@transfer.from.to_s}: #{@transfer.command_str}"
       @transfer.perform_later
 
       respond_to do |format|

--- a/apps/dashboard/app/models/transfer.rb
+++ b/apps/dashboard/app/models/transfer.rb
@@ -171,6 +171,10 @@ class Transfer
     args
   end
 
+  def command_str
+    command.join(" ")
+  end
+
   def update_percent(step)
     self.percent = steps == 0 ? 100 : (100.0*((step).to_f/steps)).to_i
   end

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -60,7 +60,6 @@ gem "local_time", "~> 1.0.3"
 gem 'dotenv-rails', '~> 2.1'
 gem 'jquery-datatables-rails', '~> 3.4'
 gem "js-routes", "~> 1.2.4"
-gem "rails_12factor", group: :production
 gem 'osc_machete_rails', '~> 1.3.0'
 gem 'pbs', '~> 2.2.1'
 gem 'ood_appkit', '~> 1.1.4'

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -159,11 +159,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.5)
       actionpack (= 5.2.5)
       activesupport (= 5.2.5)
@@ -236,7 +231,6 @@ DEPENDENCIES
   pbs (~> 2.2.1)
   rails (= 5.2.5)
   rails-controller-testing
-  rails_12factor
   sass-rails (~> 5.0)
   sdoc
   sqlite3 (= 1.3.13)

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -140,7 +140,8 @@ module NginxStage
       "OOD_DEV_APPS_ROOT" => apps_root(env: :dev, owner: user),
       "OOD_FILES_URL" => "/pun/sys/dashboard/files",
       # this is not a typo => the editor is /edit off of the base url
-      "OOD_EDITOR_URL" => "/pun/sys/dashboard/files"
+      "OOD_EDITOR_URL" => "/pun/sys/dashboard/files",
+      "RAILS_LOG_TO_STDOUT" => "true"
     }.merge(pun_custom_env)
   end
 


### PR DESCRIPTION
the 12factor gem pulled in two gem dependencies that changed two
configuration values:

1. rails_serve_static_assets set serve static assets to true
2. rails_stdout_logging created a default logger that connected to
   STDOUT

in Rails 5, these can be controlled using env vars, so we set
RAILS_LOG_TO_STDOUT in NGINX stage

furthermore, we don't want to enable "serve static assets" from Rails,
since NGINX already serves static assets

when enabled, Rails tries to serve a missing static asset for 404 request,
which includes executing Webpacker::Compiler#compile though that just
pollutes the log file with lines like "[Webpacker] Everything's
up-to-date. Nothing to do"
(https://github.com/rails/webpacker/issues/2392).

So ensuring we disable "serve static assets" from Rails solves this
problem as well.


ALSO log cp, rm, mv statements:

https://github.com/OSC/ondemand/issues/1080