### PR TITLE
reject invalid subapps in pinned_apps

### DIFF
--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -29,6 +29,10 @@ class Router
       pinned_apps.concat pinned_apps_from_token(token, all_apps)
     end.uniq do |app|
       app.token.to_s
+    end.reject do |app|
+      # subapps are featured apps and this is the easiest way to tell if it's valid.
+      # instead of say app.send(:sub_app_list).first.valid?
+      app.links.empty?
     end
   end
 

--- a/apps/dashboard/test/fixtures/sys_with_interactive_apps/bc_desktop/local/bad_sub_app.yml.erb
+++ b/apps/dashboard/test/fixtures/sys_with_interactive_apps/bc_desktop/local/bad_sub_app.yml.erb
@@ -1,0 +1,5 @@
+# this subapp is invalid because module BatchConnect::App will throw an error while reading it.
+# note that if it were empty yml, it would be valid because it inhereted the parent's data.
+# FIXME: also note that if there's a syntax error here, it's not caught.
+
+throw_error: <%= throw_an_error_bc_its_not_defined %>


### PR DESCRIPTION
This fixes a bug found by UCCBR where the `submit.yml.erb`'s were being counted as a subapp and causing errors because it was an invalid sub app and had no links.