### PR TITLE
Remove mobile browser warning banner in Dashboard

### DIFF
--- a/apps/dashboard/app/views/layouts/_browser_warning.html.erb
+++ b/apps/dashboard/app/views/layouts/_browser_warning.html.erb
@@ -8,13 +8,3 @@
       Current browser requirements include IE Edge, Firefox 19+, Chrome 34+, Safari 8+.
     </div>
 <% end %>
-
-<% if browser.device.mobile? %>
-    <div class="alert alert-danger alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert">
-        <span aria-hidden="true">&times;</span>
-        <span class="sr-only">Close</span>
-      </button>
-      OnDemand is not yet optimized for mobile use.
-    </div>
-<% end %>


### PR DESCRIPTION
Removes the browser warning banner:

<img src="https://user-images.githubusercontent.com/6081892/119174275-6034b780-ba36-11eb-83e5-27a73b2cf742.jpg" width=400>