### PR TITLE
Allow ondemand serviceaccount to cleanup ondemand namespaces

### DIFF
--- a/hooks/k8s-bootstrap/ondemand.yaml
+++ b/hooks/k8s-bootstrap/ondemand.yaml
@@ -15,6 +15,11 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
+  verbs:
+  - list
+- apiGroups: [""]
+  resources:
+  - namespaces
   - serviceaccounts
   verbs:
   - get
@@ -50,6 +55,18 @@ rules:
   - create
   - update
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ondemand-clean-namespaces
+  namespace: ondemand
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - delete
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/hooks/k8s-bootstrap/ondemand.yaml
+++ b/hooks/k8s-bootstrap/ondemand.yaml
@@ -17,6 +17,7 @@ rules:
   - namespaces
   verbs:
   - list
+  - delete
 - apiGroups: [""]
   resources:
   - namespaces
@@ -55,18 +56,6 @@ rules:
   - create
   - update
   - patch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: ondemand-clean-namespaces
-  namespace: ondemand
-rules:
-- apiGroups: [""]
-  resources:
-  - namespaces
-  verbs:
-  - delete
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/hooks/k8s-bootstrap/yaml/rolebinding.yaml
+++ b/hooks/k8s-bootstrap/yaml/rolebinding.yaml
@@ -28,3 +28,18 @@ subjects:
   - kind: User
     name: "$ONDEMAND_USERNAME"
     namespace: "$NAMESPACE"
+---
+# give the ondemand serviceaccount ability to cleanup ondemand namespaces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: "$NAMESPACE"
+  name: "ondemand-clean-namespaces"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "ondemand-clean-namespaces"
+subjects:
+  - kind: ServiceAccount
+    name: "ondemand"
+    namespace: "ondemand"

--- a/hooks/k8s-bootstrap/yaml/rolebinding.yaml
+++ b/hooks/k8s-bootstrap/yaml/rolebinding.yaml
@@ -28,18 +28,3 @@ subjects:
   - kind: User
     name: "$ONDEMAND_USERNAME"
     namespace: "$NAMESPACE"
----
-# give the ondemand serviceaccount ability to cleanup ondemand namespaces
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  namespace: "$NAMESPACE"
-  name: "ondemand-clean-namespaces"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "ondemand-clean-namespaces"
-subjects:
-  - kind: ServiceAccount
-    name: "ondemand"
-    namespace: "ondemand"


### PR DESCRIPTION
This will allow the `ondemand` serviceacocunt to also delete namespaces it creates. This is necessary to facilitate the cleanup of old namespaces to avoid Kubernetes namespaces always growing and never accounting for things like users who have been disabled or namespaces that have never been used after X days.  The approach in this pull request ensures that the only namespaces that ondemand can delete are those bootstrapped for ondemand.  Example where I bound the ClusterRole to namespace `user-zyou` but not my own namespace.

```
[root@webdev02 ~]# kubectl delete namespace user-zyou
namespace "user-zyou" deleted
[root@webdev02 ~]# kubectl delete namespace user-tdockendorf
Error from server (Forbidden): namespaces "user-tdockendorf" is forbidden: User "system:serviceaccount:ondemand:ondemand" cannot delete resource "namespaces" in API group "" in the namespace "user-tdockendorf"
```

The purpose of the `list` is to allow a script to list available namespaces that actually exist.  The plan for how I will clean things up is query Prometheus for most recent active pod by namespace and any namespaces without an active pod in last X days will be cleaned, so need to compare that list with list of namespaces that actually exist still.