### PR TITLE
Added support for custom images to improve custom widgets look and feel

### DIFF
--- a/apps/dashboard/app/controllers/widgets_controller.rb
+++ b/apps/dashboard/app/controllers/widgets_controller.rb
@@ -1,0 +1,29 @@
+class WidgetsController < ApplicationController
+
+  SUPPORTED_TYPES = {
+    ".jpg" => "image/jpeg",
+    ".gif" => "image/gif",
+    ".png" => "image/png",
+    ".svg" => "image/svg+xml",
+  }
+
+  def image
+    return render plain: "Widget images not configured", content_type: 'text/plain', status: :bad_request unless ::Configuration.widget_images_path
+
+    image_file = Pathname.new(::Configuration.widget_images_path).join(params[:image_name])
+
+    return render plain: "Image type not supported: #{image_file.extname}", content_type: 'text/plain', status: :bad_request unless supported? image_file
+
+    if image_file.file? && image_file.readable?
+      send_file image_file, :type => SUPPORTED_TYPES[image_file.extname], :disposition => 'inline'
+    else
+      render plain: "Image not found", content_type: 'text/plain', status: :not_found
+    end
+  end
+
+  private
+
+  def supported?(image_file)
+    SUPPORTED_TYPES.has_key? image_file.extname
+  end
+end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -372,6 +372,10 @@ class ConfigurationSingleton
     end
   end
 
+  def widget_images_path
+    config.fetch(:widget_images_path, nil)
+  end
+
   private
 
   def can_access_core_app?(name)

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
   get "apps/icon/:name(/:type(/:owner))" => "apps#icon", as: "app_icon", defaults: { type: "sys" }
   get "apps/index" => "apps#index"
 
+  get "widgets/image/:image_name" => "widgets#image", constraints: { image_name: %r{[^\/]+} }
+
   if Configuration.app_sharing_enabled?
     get "apps/restart" => "apps#restart"
     get "apps/featured" => "apps#featured"

--- a/apps/dashboard/test/controllers/widgets_controller_test.rb
+++ b/apps/dashboard/test/controllers/widgets_controller_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'html_helper'
+
+class WidgetsControllerTest < ActionController::TestCase
+
+  def setup
+    Configuration.stubs(:widget_images_path).returns(nil)
+  end
+
+  test "should return 400 when widget_images_path is not configured" do
+    Configuration.stubs(:widget_images_path).returns(nil)
+    get :image, params: { image_name: "test.png" }
+    assert_response :bad_request
+  end
+
+  test "should return 400 when widget_images_path is configured and image type is not supported" do
+    Configuration.stubs(:widget_images_path).returns("#{Rails.root}/test/fixtures/widgets/images")
+    get :image, params: { image_name: "test.avi" }
+    assert_response :bad_request
+  end
+
+  test "should return 404 when widget_images_path is configured and image not installed" do
+    Configuration.stubs(:widget_images_path).returns("#{Rails.root}/test/fixtures/widgets/images")
+    get :image, params: { image_name: "test.png" }
+    assert_response :not_found
+  end
+
+end


### PR DESCRIPTION
IQSS Idea allow custom images from an external location to improve custom widgets look and feel.

An external directory can be added to the configuration under `widget_images_path:`. Images dropped in this directory will be available under:` /widgets/image/image_name.type`

This could be used for enhancing custom widgets with images without adding these to the dashboard application directory