### PR TITLE
Add annotation to K8 namespace of when hook was last used

### DIFF
--- a/hooks/k8s-bootstrap/k8s-bootstrap-ondemand.sh
+++ b/hooks/k8s-bootstrap/k8s-bootstrap-ondemand.sh
@@ -20,6 +20,7 @@ export $(grep -Ev "^#" "$HOOK_ENV" | cut -d= -f1)
 
 export PATH=/usr/local/bin:/bin:$PATH
 export NAMESPACE="${NAMESPACE_PREFIX}${ONDEMAND_USERNAME}"
+export TIMESTAMP=$(date +%s)
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 YAML_DIR="${BASEDIR}/yaml"

--- a/hooks/k8s-bootstrap/k8s-bootstrap-ondemand.sh
+++ b/hooks/k8s-bootstrap/k8s-bootstrap-ondemand.sh
@@ -20,6 +20,7 @@ export $(grep -Ev "^#" "$HOOK_ENV" | cut -d= -f1)
 
 export PATH=/usr/local/bin:/bin:$PATH
 export NAMESPACE="${NAMESPACE_PREFIX}${ONDEMAND_USERNAME}"
+# shellcheck disable=SC2155
 export TIMESTAMP=$(date +%s)
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/hooks/k8s-bootstrap/yaml/namespace.yaml
+++ b/hooks/k8s-bootstrap/yaml/namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   labels:
     app.kubernetes.io/name: open-ondemand
   annotations:
-    last-hook-execution: "$TIMESTAMP"
+    openondemand.org/last-hook-execution: "$TIMESTAMP"

--- a/hooks/k8s-bootstrap/yaml/namespace.yaml
+++ b/hooks/k8s-bootstrap/yaml/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: "$NAMESPACE"
   labels:
     app.kubernetes.io/name: open-ondemand
+  annotations:
+    last-hook-execution: "$TIMESTAMP"


### PR DESCRIPTION
Right now I have https://github.com/OSC/k8-namespace-reaper that will reap unused K8 namespaces because at some point we will have the K8 hook run for all OnDemand users at OSC and I don't want an ever growing list of namespaces, most of which won't be used. The reaping happens on an interval but to avoid reaping a namespace of someone who is logged in I need some way to know the last time the K8 hook was executed so that the k8-namespace-reaper code can look at that timestamp and still only reap namespaces that are truly idle and unused.