### PR TITLE
Support custom passenger options for NGINX PUN

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -69,7 +69,12 @@ module NginxStage
 
     # Hash of Passenger configuration options
     # @return [Hash] Hash of Passenger configuration options
-    attr_accessor :passenger_options
+    attr_writer :passenger_options
+
+    def passenger_options
+      # Ensure that all options begin with passenger_
+      @passenger_options.select { |key, value| key.to_s.starts_with?('passenger_') }
+    end
 
     #
     # per-user NGINX configuration options

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -67,6 +67,10 @@ module NginxStage
     # @return [Integer] the value for passenger_pool_idle_time
     attr_accessor :passenger_pool_idle_time
 
+    # Hash of Passenger configuration options
+    # @return [Hash] Hash of Passenger configuration options
+    attr_accessor :passenger_options
+
     #
     # per-user NGINX configuration options
     #
@@ -422,6 +426,7 @@ module NginxStage
       self.passenger_python = "#{root}/bin/python"
 
       self.passenger_pool_idle_time = 300
+      self.passenger_options = {}
 
       self.pun_custom_env      = {}
       self.pun_custom_env_declarations = []

--- a/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
+++ b/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
@@ -67,6 +67,12 @@ module NginxStage
       NginxStage.passenger_pool_idle_time
     end
 
+    # Hash of Passenger configuration options
+    # @return [Hash] Hash of Passenger configuration options
+    def passenger_options
+      NginxStage.passenger_options
+    end
+
     # Max file upload size in bytes (e.g., 10737420000)
     # @return [String] the max file size clients can upload
     def nginx_file_upload_max

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -96,7 +96,7 @@
 #passenger_pool_idle_time: 300
 
 # Hash of Passenger configuration options
-# Leave off the 'passenger_' prefix, this is added automatically
+# Keys without passenger_ prefix will be ignored
 #
 #passenger_options: {}
 

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -95,6 +95,11 @@
 #
 #passenger_pool_idle_time: 300
 
+# Hash of Passenger configuration options
+# Leave off the 'passenger_' prefix, this is added automatically
+#
+#passenger_options: {}
+
 # Max file upload size in bytes (e.g., 10737420000)
 #
 #nginx_file_upload_max: '10737420000'

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -54,10 +54,9 @@ http {
   passenger_pool_idle_time <%= passenger_pool_idle_time %>;
 
   <%- end -%>
-
-  <%- passenger_options.to_h.each_pair do |key, value| -%>
-    passenger_<%= key %> <%= value %>;
-  <%- end -%>
+<%- passenger_options.to_h.each_pair do |key, value| -%>
+  <%= key %> <%= value %>;
+<%- end -%>
 
   # Set an array of temp and cache file options for the per-user environment
   client_body_temp_path   <%= tmp_root %>/client_body;

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -54,6 +54,11 @@ http {
   passenger_pool_idle_time <%= passenger_pool_idle_time %>;
 
   <%- end -%>
+
+  <%- passenger_options.to_h.each_pair do |key, value| -%>
+    passenger_<%= key %> <%= value %>;
+  <%- end -%>
+
   # Set an array of temp and cache file options for the per-user environment
   client_body_temp_path   <%= tmp_root %>/client_body;
   proxy_temp_path         <%= tmp_root %>/proxy_temp;


### PR DESCRIPTION
Fixes #1210

If we don't auto set the `passenger_` prefix then we are essentially allowing any NGINX options, which might be better to change config option name.