### PR TITLE
use pull_request_target so PRs from forks can create labels

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,7 +4,7 @@ name: Pull Request Labeler
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 jobs:
   triage:


### PR DESCRIPTION
use `pull_request_target` so PRs from forks can securely apply labels on the PRs they create.