### PR TITLE
Added support for CORS to the Apache configuration

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -101,6 +101,11 @@ module OodPortalGenerator
       @oidc_state_max_number_of_cookies = opts.fetch(:oidc_state_max_number_of_cookies, '10 true')
       @oidc_cookie_same_site            = opts.fetch(:oidc_cookie_same_site, @ssl ? 'Off' : 'On')
       @oidc_settings                    = opts.fetch(:oidc_settings, {})
+
+      # CORS setup
+      @api_cors_enabled                 = opts.fetch(:api_cors_enabled, false)
+      @api_cors_uri                     = opts.fetch(:api_cors_uri, '/pun/sys/dashboard/api')
+      @api_cors_origin                  = opts.fetch(:api_cors_origin, '*')
     end
 
     # Helper method to set the filename and path for access and error logs

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -104,8 +104,8 @@ module OodPortalGenerator
 
       # CORS setup
       @api_cors_enabled                 = opts.fetch(:api_cors_enabled, false)
-      @api_cors_uri                     = opts.fetch(:api_cors_uri, '/pun/sys/dashboard/api')
-      @api_cors_origin                  = opts.fetch(:api_cors_origin, '*')
+      @api_cors_uri                     = opts.fetch(:api_cors_uri, "#{@pun_uri}/sys/dashboard/api")
+      @api_cors_origin                  = opts.fetch(:api_cors_origin, nil)
     end
 
     # Helper method to set the filename and path for access and error logs

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -196,15 +196,15 @@ Listen 8080
   </Location>
 
   # CORS setup for API requests
-  <Location "/pun/test">
-    Header always set Access-Control-Allow-Origin "test:8080"
+  <Location "/pun/sys/application/api">
+    Header always set Access-Control-Allow-Origin "https://test.com:8080"
     Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
     Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token"
     Header always set Access-Control-Expose-Headers "Content-Security-Policy, Location"
     Header always set Access-Control-Allow-Credentials "false"
     Header always set Access-Control-Max-Age "600"
 
-    # CORS PREFLIGHT REQUESTS ARE NOT AUTHENTICATED.
+    # CORS preflight requests are not authenticated as per specification
     <Limit OPTIONS>
       allow from all
       Satisfy Any

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -195,6 +195,26 @@ Listen 8080
     LuaHookLog analytics.lua analytics_handler
   </Location>
 
+  # CORS setup for API requests
+  <Location "/pun/test">
+    Header always set Access-Control-Allow-Origin "test:8080"
+    Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
+    Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token"
+    Header always set Access-Control-Expose-Headers "Content-Security-Policy, Location"
+    Header always set Access-Control-Allow-Credentials "false"
+    Header always set Access-Control-Max-Age "600"
+
+    # CORS PREFLIGHT REQUESTS ARE NOT AUTHENTICATED.
+    <Limit OPTIONS>
+      allow from all
+      Satisfy Any
+    </Limit>
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_METHOD} OPTIONS
+    RewriteRule ^(.*)$ $1 [R=204,L]
+  </Location>
+
   # Control backend PUN for authenticated user:
   # NB: See mod_ood_proxy for more details.
   #

--- a/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
+++ b/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
@@ -430,5 +430,5 @@ register_root: '/var/www/ood/register'
 #    theme: ondemand
 #    dir: /usr/share/ondemand-dex/web
 api_cors_enabled: true
-api_cors_uri: "/pun/test"
-api_cors_origin: "test:8080"
+api_cors_uri: "/pun/sys/application/api"
+api_cors_origin: "https://test.com:8080"

--- a/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
+++ b/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
@@ -429,3 +429,6 @@ register_root: '/var/www/ood/register'
 #  frontend:
 #    theme: ondemand
 #    dir: /usr/share/ondemand-dex/web
+api_cors_enabled: true
+api_cors_uri: "/pun/test"
+api_cors_origin: "test:8080"

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -277,7 +277,7 @@ Listen <%= addr_port %>
     Header always set Access-Control-Allow-Credentials "false"
     Header always set Access-Control-Max-Age "600"
 
-    # CORS PREFLIGHT REQUESTS ARE NOT AUTHENTICATED.
+    # CORS preflight requests are not authenticated as per specification
     <Limit OPTIONS>
       allow from all
       Satisfy Any

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -287,8 +287,8 @@ Listen <%= addr_port %>
     RewriteCond %{REQUEST_METHOD} OPTIONS
     RewriteRule ^(.*)$ $1 [R=204,L]
   </Location>
-  <%- end -%>
 
+  <%- end -%>
   # Control backend PUN for authenticated user:
   # NB: See mod_ood_proxy for more details.
   #

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -267,6 +267,28 @@ Listen <%= addr_port %>
     <%- end -%>
   </Location>
 
+  <%- if @api_cors_enabled -%>
+  # CORS setup for API requests
+  <Location "<%= @api_cors_uri %>">
+    Header always set Access-Control-Allow-Origin "<%= @api_cors_origin %>"
+    Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
+    Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token"
+    Header always set Access-Control-Expose-Headers "Content-Security-Policy, Location"
+    Header always set Access-Control-Allow-Credentials "false"
+    Header always set Access-Control-Max-Age "600"
+
+    # CORS PREFLIGHT REQUESTS ARE NOT AUTHENTICATED.
+    <Limit OPTIONS>
+      allow from all
+      Satisfy Any
+    </Limit>
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_METHOD} OPTIONS
+    RewriteRule ^(.*)$ $1 [R=204,L]
+  </Location>
+  <%- end -%>
+
   # Control backend PUN for authenticated user:
   # NB: See mod_ood_proxy for more details.
   #


### PR DESCRIPTION
These changes are to add CORS support to the Apache server.

CORS is needed to access the dashboard API from a front end application in a different domain.
This is a proposal that have worked for us while doing the API prototyping.