### PR TITLE
refactor some usr stubbing helpers

### DIFF
--- a/apps/dashboard/test/integration/apps_test.rb
+++ b/apps/dashboard/test/integration/apps_test.rb
@@ -2,25 +2,19 @@ require 'test_helper'
 
 class AppsTest < ActionDispatch::IntegrationTest
 
-  UserDouble = Struct.new(:name)
-
   def setup
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_interactive_apps"))
     DevRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/dev"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
 
     Router.instance_variable_set('@pinned_apps', nil)
-    OodSupport::Process.stubs(:user).returns(UserDouble.new('me'))
-    OodSupport::User.stubs(:new).returns(UserDouble.new('me'))
-    FileUtils.chmod 0000, 'test/fixtures/usr/cant_see/'
-    UsrRouter.stubs(:base_path).with(:owner => "me").returns(Pathname.new("test/fixtures/usr/me"))
-    UsrRouter.stubs(:base_path).with(:owner => 'shared').returns(Pathname.new("test/fixtures/usr/shared"))
-    UsrRouter.stubs(:base_path).with(:owner => 'cant_see').returns(Pathname.new("test/fixtures/usr/cant_see"))
-    UsrRouter.stubs(:owners).returns(['me', 'shared', 'cant_see'])
+
+    stub_usr_router
+    setup_usr_fixtures
   end
 
   def teardown
-    FileUtils.chmod 0755, 'test/fixtures/usr/cant_see/'
+    teardown_usr_fixtures
     Router.instance_variable_set('@pinned_apps', nil)
   end
 

--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -1,23 +1,16 @@
 require 'test_helper'
 
 class RouterTest < ActiveSupport::TestCase
-
-  UserDouble = Struct.new(:name)
   
   def setup
     Router.instance_variable_set('@pinned_apps', nil)
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    OodSupport::Process.stubs(:user).returns(UserDouble.new('me'))
-    FileUtils.chmod 0000, 'test/fixtures/usr/cant_see/'
-
-    UsrRouter.stubs(:base_path).with(:owner => "me").returns(Pathname.new("test/fixtures/usr/me"))
-    UsrRouter.stubs(:base_path).with(:owner => 'shared').returns(Pathname.new("test/fixtures/usr/shared"))
-    UsrRouter.stubs(:base_path).with(:owner => 'cant_see').returns(Pathname.new("test/fixtures/usr/cant_see"))
-    UsrRouter.stubs(:owners).returns(['me', 'shared', 'cant_see'])
+    stub_usr_router
+    setup_usr_fixtures
   end
 
   def teardown
-    FileUtils.chmod 0755, 'test/fixtures/usr/cant_see/'
+    teardown_usr_fixtures
     Router.instance_variable_set('@pinned_apps', nil)
   end
 

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -15,6 +15,8 @@ require 'timecop'
 class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 
+  UserDouble = Struct.new(:name)
+
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
   end
@@ -25,6 +27,24 @@ class ActiveSupport::TestCase
 
   def exit_failure(exit_status=1)
     OpenStruct.new(:success? => false, :exitstatus => exit_status)
+  end
+
+  def stub_usr_router
+    OodSupport::Process.stubs(:user).returns(UserDouble.new('me'))
+    OodSupport::User.stubs(:new).returns(UserDouble.new('me'))
+
+    UsrRouter.stubs(:base_path).with(:owner => "me").returns(Pathname.new("test/fixtures/usr/me"))
+    UsrRouter.stubs(:base_path).with(:owner => 'shared').returns(Pathname.new("test/fixtures/usr/shared"))
+    UsrRouter.stubs(:base_path).with(:owner => 'cant_see').returns(Pathname.new("test/fixtures/usr/cant_see"))
+    UsrRouter.stubs(:owners).returns(['me', 'shared', 'cant_see'])
+  end
+
+  def setup_usr_fixtures
+    FileUtils.chmod 0000, 'test/fixtures/usr/cant_see/'
+  end
+
+  def teardown_usr_fixtures
+    FileUtils.chmod 0755, 'test/fixtures/usr/cant_see/'
   end
 end
 


### PR DESCRIPTION
refactor some usr stubbing helpers because I'm working on #1243 and all usr routing tests seem to follow the same setup & teardown patterns.  I thought it'd be better to refactor in a separate PR to reduce complexity of any one given PR.