### PR TITLE
Added support for API key and secret to Apache for API clients

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -102,9 +102,13 @@ module OodPortalGenerator
       @oidc_cookie_same_site            = opts.fetch(:oidc_cookie_same_site, @ssl ? 'Off' : 'On')
       @oidc_settings                    = opts.fetch(:oidc_settings, {})
 
-      # CORS setup
+      # API setup
+      @api_uri                          = opts.fetch(:api_cors_uri, "#{@pun_uri}/sys/dashboard/api")
+      # API auth
+      @api_auth_enabled                 = opts.fetch(:api_auth_enabled, false)
+      @api_auth_root                    = opts.fetch(:api_auth_root, "/opt/ood/api")
+      # CORS
       @api_cors_enabled                 = opts.fetch(:api_cors_enabled, false)
-      @api_cors_uri                     = opts.fetch(:api_cors_uri, "#{@pun_uri}/sys/dashboard/api")
       @api_cors_origin                  = opts.fetch(:api_cors_origin, nil)
     end
 

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -106,7 +106,7 @@ module OodPortalGenerator
       @api_uri                          = opts.fetch(:api_cors_uri, "#{@pun_uri}/sys/dashboard/api")
       # API auth
       @api_auth_enabled                 = opts.fetch(:api_auth_enabled, false)
-      @api_auth_root                    = opts.fetch(:api_auth_root, "/opt/ood/api")
+      @api_auth_root                    = opts.fetch(:api_auth_root, "/etc/ood/api")
       # CORS
       @api_cors_enabled                 = opts.fetch(:api_cors_enabled, false)
       @api_cors_origin                  = opts.fetch(:api_cors_origin, nil)

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -195,11 +195,19 @@ Listen 8080
     LuaHookLog analytics.lua analytics_handler
   </Location>
 
-  # CORS setup for API requests
-  <Location "/pun/sys/application/api">
+  # Setup for API requests
+  <Location "/my_pun_apps/sys/dashboard/api">
+    RewriteEngine On
+    # Client API auth check
+    RewriteCond "%{HTTP:X-OOD-API-ID}" !^[a-z0-9-]+$ [NC,OR]
+    RewriteCond "%{HTTP:X-OOD-API-CLIENT-SECRET}" !^[a-z0-9-]+$ [NC,OR]
+    RewriteCond "/opt/ood/api/clients/%{HTTP:X-OOD-API-ID}.%{HTTP:X-OOD-API-CLIENT-SECRET}" !-f
+    RewriteRule ^.*$ - [R=401,L]
+
+    # CORS setup
     Header always set Access-Control-Allow-Origin "https://test.com:8080"
     Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
-    Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token"
+    Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token, x-ood-api-id, x-ood-api-client-secret"
     Header always set Access-Control-Expose-Headers "Content-Security-Policy, Location"
     Header always set Access-Control-Allow-Credentials "false"
     Header always set Access-Control-Max-Age "600"
@@ -210,7 +218,6 @@ Listen 8080
       Satisfy Any
     </Limit>
 
-    RewriteEngine On
     RewriteCond %{REQUEST_METHOD} OPTIONS
     RewriteRule ^(.*)$ $1 [R=204,L]
   </Location>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -201,7 +201,7 @@ Listen 8080
     # Client API auth check
     RewriteCond "%{HTTP:X-OOD-API-ID}" !^[a-z0-9-]+$ [NC,OR]
     RewriteCond "%{HTTP:X-OOD-API-CLIENT-SECRET}" !^[a-z0-9-]+$ [NC,OR]
-    RewriteCond "/opt/ood/api/clients/%{HTTP:X-OOD-API-ID}.%{HTTP:X-OOD-API-CLIENT-SECRET}" !-f
+    RewriteCond "/etc/ood/api/clients/%{HTTP:X-OOD-API-ID}.%{HTTP:X-OOD-API-CLIENT-SECRET}" !-f
     RewriteRule ^.*$ - [R=401,L]
 
     # CORS setup

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -202,7 +202,7 @@ Listen 8080
     RewriteCond "%{HTTP:X-OOD-API-ID}" !^[a-z0-9-]+$ [NC,OR]
     RewriteCond "%{HTTP:X-OOD-API-CLIENT-SECRET}" !^[a-z0-9-]+$ [NC,OR]
     RewriteCond "/etc/ood/api/clients/%{HTTP:X-OOD-API-ID}.%{HTTP:X-OOD-API-CLIENT-SECRET}" !-f
-    RewriteRule ^.*$ - [R=401,L]
+    RewriteRule ^.*$ - [F,L]
 
     # CORS setup
     Header always set Access-Control-Allow-Origin "https://test.com:8080"

--- a/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
+++ b/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
@@ -429,6 +429,7 @@ register_root: '/var/www/ood/register'
 #  frontend:
 #    theme: ondemand
 #    dir: /usr/share/ondemand-dex/web
+api_uri: "/pun/sys/application/api"
+api_auth_enabled: true
 api_cors_enabled: true
-api_cors_uri: "/pun/sys/application/api"
 api_cors_origin: "https://test.com:8080"

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -267,12 +267,23 @@ Listen <%= addr_port %>
     <%- end -%>
   </Location>
 
-  <%- if @api_cors_enabled -%>
-  # CORS setup for API requests
-  <Location "<%= @api_cors_uri %>">
+  <%- if @api_auth_enabled || @api_cors_enabled -%>
+  # Setup for API requests
+  <Location "<%= @api_uri %>">
+    RewriteEngine On
+    <%- if @api_auth_enabled -%>
+    # Client API auth check
+    RewriteCond "%{HTTP:X-OOD-API-ID}" !^[a-z0-9-]+$ [NC,OR]
+    RewriteCond "%{HTTP:X-OOD-API-CLIENT-SECRET}" !^[a-z0-9-]+$ [NC,OR]
+    RewriteCond "<%= @api_auth_root %>/clients/%{HTTP:X-OOD-API-ID}.%{HTTP:X-OOD-API-CLIENT-SECRET}" !-f
+    RewriteRule ^.*$ - [R=401,L]
+    <%- end -%>
+
+    <%- if @api_cors_enabled -%>
+    # CORS setup
     Header always set Access-Control-Allow-Origin "<%= @api_cors_origin %>"
     Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
-    Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token"
+    Header always set Access-Control-Allow-Headers "x-requested-with, content-type, origin, authorization, accept, client-security-token, x-ood-api-id, x-ood-api-client-secret"
     Header always set Access-Control-Expose-Headers "Content-Security-Policy, Location"
     Header always set Access-Control-Allow-Credentials "false"
     Header always set Access-Control-Max-Age "600"
@@ -283,9 +294,9 @@ Listen <%= addr_port %>
       Satisfy Any
     </Limit>
 
-    RewriteEngine On
     RewriteCond %{REQUEST_METHOD} OPTIONS
     RewriteRule ^(.*)$ $1 [R=204,L]
+    <%- end -%>
   </Location>
 
   <%- end -%>

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -276,7 +276,7 @@ Listen <%= addr_port %>
     RewriteCond "%{HTTP:X-OOD-API-ID}" !^[a-z0-9-]+$ [NC,OR]
     RewriteCond "%{HTTP:X-OOD-API-CLIENT-SECRET}" !^[a-z0-9-]+$ [NC,OR]
     RewriteCond "<%= @api_auth_root %>/clients/%{HTTP:X-OOD-API-ID}.%{HTTP:X-OOD-API-CLIENT-SECRET}" !-f
-    RewriteRule ^.*$ - [R=401,L]
+    RewriteRule ^.*$ - [F,L]
     <%- end -%>
 
     <%- if @api_cors_enabled -%>


### PR DESCRIPTION
This is a proposal to add API client authorization using an API key and secret. This is on top of the existing end user authentication. For API requests, both will be needed.

This model is compatible and with OOD current user authentication and Apache configuration.
It used mod_rewrite to check the HTTP headers: `X-OOD-API-ID` and `X-OOD-API-CLIENT-SECRET`.

The combination of the two header values form a filename that if created in the configured directory, access is granted.
These files will be managed by system administrators.

It is a simple implementation, easy to understand and has the following benefits:
- All clients will have to register to obtain credentials.
- Client credentials can be revoked by sys admins at any time.
- Client secrets can be rotated periodically to improve security.