### PR TITLE
Fix ssh_to_compute_node? to not error on non-existant cluster

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -510,6 +510,8 @@ module BatchConnect
     # @return [Boolean]
     def cluster_ssh_to_compute_node?
       cluster.batch_connect_ssh_allow?
+    rescue ClusterNotFound
+      return nil
     end
 
     # @return [Boolean]

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -409,4 +409,11 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
     Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
     assert session.ssh_to_compute_node?
   end
+
+  test "ssh_to_compute_node? handles non-existant cluster and disabled globally" do
+    session = BatchConnect::Session.new
+    session.stubs(:cluster).raises(BatchConnect::Session::ClusterNotFound, "Session specifies nonexistent")
+    Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
+    refute session.ssh_to_compute_node?
+  end
 end


### PR DESCRIPTION
Fixes #1273