### PR TITLE
add a rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+# style
+Style/MultilineBlockChain:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: 'no_mixed_keys'
+Style/ClassAndModuleChildren:
+  EnforcedStyle: 'compact'
+Style/WordArray:
+  EnforcedStyle: 'brackets'
+
+# layout
+Layout/HashAlignment:
+  EnforcedStyle: table
+


### PR DESCRIPTION
Here's an initial rubocop file taken from just what I've found is the style of the project so far.

I don't think we should symlink it around given how we move the subdirectories when we install, it'll just create a bunch of broken links. So, our vscode or similar settings should just look for this file wherever it is.