### PR TITLE
short circuit based on clusters not configured_clusters.

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -358,7 +358,7 @@ module BatchConnect
       # add a widget for choosing the cluster if one doesn't already exist
       # and if users aren't defining they're own form.cluster and attributes.cluster
       def add_cluster_widget(attributes, attribute_list)
-        return unless configured_clusters.any?
+        return unless clusters.any?
 
         attribute_list.prepend("cluster") unless attribute_list.include?("cluster")
 

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -231,7 +231,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
   end
 
   test "staged root is available to the submit options" do
-    OodAppkit.stubs(:clusters).returns(good_clusters)
     r = PathRouter.new("test/fixtures/sys_with_interactive_apps/bc_jupyter")
     app = BatchConnect::App.new(router: r)
 

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -316,7 +316,6 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       )
     BatchConnect::Session.any_instance.stubs(:info).returns(info)
     OodCore::Job::Info.any_instance.stubs(:ood_connection_info).returns(connect)
-    OodAppkit.stubs(:clusters).returns([OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}})])
     session = BatchConnect::Session.new
     session.stage(app: bc_jupyter_app, context: bc_jupyter_app.build_session_context)
 
@@ -335,7 +334,6 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       BatchConnect::Session.stubs(:dataroot).returns(Pathname.new(dir))
       BatchConnect::Session.any_instance.stubs(:id).returns('test-id')
       BatchConnect::Session.any_instance.stubs(:info).returns(info)
-      OodAppkit.stubs(:clusters).returns([OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}})])
       session = BatchConnect::Session.new
       session.stage(app: bc_jupyter_app, context: bc_jupyter_app.build_session_context)
 
@@ -359,7 +357,6 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       BatchConnect::Session.stubs(:dataroot).returns(Pathname.new(dir.to_s))
       BatchConnect::Session.any_instance.stubs(:id).returns('test-id')
       BatchConnect::Session.any_instance.stubs(:info).returns(info)
-      OodAppkit.stubs(:clusters).returns([OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}})])
       session = BatchConnect::Session.new
       session.stage(app: bc_jupyter_app, context: bc_jupyter_app.build_session_context)
 


### PR DESCRIPTION
[Trey asked this question](https://github.com/OSC/bc_osc_jupyter/pull/61#discussion_r656458291) which reminded me of this bug I found while working on #1159.

They are unrelated but I ran into this stack trace during that PR while writing tests. This PR removes those stubs they're now no longer necessary, but the stack illustrates the point - you're referencing `clusters` in the logic of the method, but we have short circuit based on `configured_clusters`.

```text
Error:
BatchConnect::SessionTest#test_session_is_running?_when_info.running_and_connection.yml_exists:
NoMethodError: undefined method `id' for nil:NilClass
    app/models/batch_connect/app.rb:373:in `add_cluster_widget'
    app/models/batch_connect/app.rb:197:in `build_session_context'
    test/models/batch_connect/session_test.rb:361:in `block (2 levels) in <class:SessionTest>'
    /apps/ruby/2.7.1/lib/ruby/2.7.0/tmpdir.rb:89:in `mktmpdir'
    test/models/batch_connect/session_test.rb:346:in `block in <class:SessionTest>'
```

add_cluster_widget should check for clusters not configured_clusters
    
add_cluster_widget should check for clusters not configured_clusters because just because you've configured a cluster does not mean the user has access to it. Plus all the logic in the method is based off of clusters, not configured_clusters. This is a bug that can result in nils being thrown because there are configured_clusters, but no clusters (i.e., you're not allowed? or you've configured something that doesn't exist).