### PR TITLE
Fix OOD_NAVBAR_TYPE=light not working

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -214,9 +214,9 @@ class ConfigurationSingleton
   # See more about Bootstrap color schemes: https://getbootstrap.com/docs/4.6/components/navbar/#color-schemes
   # @return [String, 'dark'] Default to dark
   def navbar_type
-    if ENV['OOD_NAVBAR_TYPE'] == ('inverse' || 'dark')
+    if ENV['OOD_NAVBAR_TYPE'] == 'inverse' || ENV['OOD_NAVBAR_TYPE'] == 'dark'
       'dark'
-    elsif ENV['OOD_NAVBAR_TYPE'] == ('default' || 'light')
+    elsif ENV['OOD_NAVBAR_TYPE'] == 'default' || ENV['OOD_NAVBAR_TYPE'] == 'light'
       'light'
     else
       'dark'

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -391,4 +391,28 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     cfg.stubs(:config).returns({})
     assert_equal "", cfg.pinned_apps_group_by
   end
+
+  test "inverse navbar is dark" do
+    with_modified_env(OOD_NAVBAR_TYPE: 'inverse') do
+      assert_equal 'dark', ConfigurationSingleton.new.navbar_type
+    end
+  end
+
+  test "dark navbar is dark" do
+    with_modified_env(OOD_NAVBAR_TYPE: 'dark') do
+      assert_equal 'dark', ConfigurationSingleton.new.navbar_type
+    end
+  end
+
+  test "default navbar is light" do
+    with_modified_env(OOD_NAVBAR_TYPE: 'default') do
+      assert_equal 'light', ConfigurationSingleton.new.navbar_type
+    end
+  end
+
+  test "light navbar is light" do
+    with_modified_env(OOD_NAVBAR_TYPE: 'light') do
+      assert_equal 'light', ConfigurationSingleton.new.navbar_type
+    end
+  end
 end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -415,4 +415,8 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       assert_equal 'light', ConfigurationSingleton.new.navbar_type
     end
   end
+
+  test "no navbar environment variable is dark" do
+    assert_equal 'dark', ConfigurationSingleton.new.navbar_type
+  end
 end


### PR DESCRIPTION
Fixed a small bug that caused setting environmental variable OOD_NAVBAR_TYPE to light to not work as expected.