### PR TITLE
Add retry attempt counter to 404 loop to fix client side loop

### DIFF
--- a/apps/dashboard/app/controllers/transfers_controller.rb
+++ b/apps/dashboard/app/controllers/transfers_controller.rb
@@ -10,7 +10,7 @@ class TransfersController < ApplicationController
     else
       respond_to do |format|
         format.html
-        format.json { render json: {}, status: 404 }
+        format.json { render json:{ }, status: 404 }
       end
     end
   end

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -781,28 +781,35 @@ function reportTransfer(data){
   // 1. add the transfer label
   findAndUpdateTransferStatus(data);
 
+  let attempts = 0
+
   // 2. poll for the updates
-  var poll = function(){
-   $.getJSON(data.show_json_url, function(newdata){
-     findAndUpdateTransferStatus(newdata);
+  var poll = function() {
+    $.getJSON(data.show_json_url, function (newdata) {
+      findAndUpdateTransferStatus(newdata);
 
-     if(newdata.completed){
-       if(! newdata.error_message){
-         if(newdata.target_dir == history.state.currentDirectory){
-           reloadTable();
-         }
+      if(newdata.completed) {
+        if(! newdata.error_message) {
+          if(newdata.target_dir == history.state.currentDirectory) {
+            reloadTable();
+          }
 
-         // 3. fade out after 5 seconds
-         fadeOutTransferStatus(newdata)
-       }
-     }
-     else{
-       // not completed yet, so poll again
-       setTimeout(poll, 1000);
-     }
-   }).fail(function(){
-     setTimeout(poll, 1000);
-   });
+          // 3. fade out after 5 seconds
+          fadeOutTransferStatus(newdata)
+        }
+      }
+      else {
+        // not completed yet, so poll again
+        setTimeout(poll, 1000);
+      }
+    }).fail(function() {
+      if (attempts >= 3) {
+        Swal.fire('File operation failed after 3 attempts', 'Failed to delete file.', 'error');
+      } else {
+        setTimeout(poll, 1000);
+        attempts++
+      }
+    });
   }
 
   poll();

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -807,7 +807,7 @@ function reportTransfer(data){
         Swal.fire('Operation may not have happened', 'Failed to retrieve file operation status.', 'error');
       } else {
         setTimeout(poll, 1000);
-        attempts++
+        attempts++;
       }
     });
   }

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -804,7 +804,7 @@ function reportTransfer(data){
       }
     }).fail(function() {
       if (attempts >= 3) {
-        Swal.fire('File operation failed after 3 attempts', 'Failed to delete file.', 'error');
+        Swal.fire('Operation may not have happened', 'Failed to retrieve file operation status.', 'error');
       } else {
         setTimeout(poll, 1000);
         attempts++


### PR DESCRIPTION
To fix the 404 loop, stop transfer polling after 3 attempts to delete the file / directory and display an error message to user.

Error message: "Operation may not have happened. Failed to retrieve file operation status."