### PR TITLE
Improve dev tooling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,55 @@
+# Developing Open-OnDemand
+
+## Getting Started
+
+These are instructions to build and interact with a full stack
+development container.  This container will create a duplicate user
+with the same group and user id.  Starting the container will prompt  
+you to set a password.  This is only credentials for web access to the
+container.
+
+Pull down this source code and start the container. 
+
+```text
+mkdir -p ~/ondemand
+git clone ~/ondemand/src
+cd ~/ondemand/src
+rake dev:start
+```
+
+See `rake --tasks` for all the `dev:` related tasks.
+
+```
+rake dev:exec                               # Bash exec into the development container
+rake dev:restart                            # Restart development container
+rake dev:start                              # Start development container
+rake dev:stop                               # Stop development container
+```
+
+### Login to the container
+
+Here's the important bit about user mapping with containers. Let's use the
+example of `jessie` with `id` below. In creating the development container,
+we added a user with the same.  The password is for `dex` the IDP, and the
+web only. 
+
+```
+uid=1000(jessie) gid=1000(jessie) groups=1000(jessie)
+``` 
+
+Now you'll be able to access `http://localhost:8080/` where it'll redirect
+you to `dex` the OpenID Connect provider within the container. Use the email
+`<your username>@localhost`.
+
+
+### Configuring the container
+
+In starting the container, you may see the mount 
+`~/.config/ondemand/container:/etc/ood`.  This mount allows us to
+completely configure this Open-OnDemand container.
+
+Create and edit files in the host's home directory and to mount in
+new configurations. 
+
+Remove `~/.config/ondemand/container/static_user.yml` to reset your
+container's password.

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY ood_auth_map           /opt/ood/ood_auth_map
 COPY apps                   /opt/ood/apps
 COPY Rakefile               /opt/ood/Rakefile
 COPY lib                    /opt/ood/lib
+COPY Gemfile                /opt/ood/Gemfile
+
+RUN cd /opt/ood; bundle install
 
 RUN source /opt/rh/ondemand/enable && \
     rake -f /opt/ood/Rakefile -mj$CONCURRENCY build && \

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "rake"
+gem "bcrypt"
 
 group :test do
   gem "rspec"

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ PASSENGER_APP_ENV = ENV["PASSENGER_APP_ENV"] || "production"
 require "#{TASK_DIR}/packaging"
 require "#{TASK_DIR}/test"
 require "#{TASK_DIR}/docker"
+require "#{TASK_DIR}/development"
 
 def infrastructure
   [

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -9,12 +9,11 @@ APP_DEV_DIR="/home/$USER/ondemand/dev"
 OOD_DEV_DIR="/var/www/ood/apps/dev/$USER"
 
 sudo su root <<SETUP
-  mkdir -p $OOD_DEV_DIR 
-  chmod 755 $OOD_DEV_DIR
+  mkdir -p $OOD_DEV_DIR
   cd $OOD_DEV_DIR
   ln -s $APP_DEV_DIR gateway
 
-  /opt/ood/ood-portal-generator/sbin/update_ood_portal
+  /opt/ood/ood-portal-generator/sbin/update_ood_portal --force
 
   if [ -n "$OOD_STATIC_USER" ] && [ -f "$OOD_STATIC_USER" ]; then
     cat "$OOD_STATIC_USER" >>  /etc/ood/dex/config.yaml

--- a/lib/.rubocop.yml
+++ b/lib/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: 'sapps/dashboard/.rubocop.yml'

--- a/lib/tasks/build_utils.rb
+++ b/lib/tasks/build_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildUtils
   def image_tag
     tag? ? numeric_tag : "#{numeric_tag}-#{git_hash}"
@@ -41,5 +43,9 @@ module BuildUtils
 
   def image_name
     "ood"
+  end
+
+  def user
+    @user ||= Etc.getpwnam(Etc.getlogin)
   end
 end

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+namespace :dev do
+
+  require_relative 'build_utils'
+  require 'yaml'
+  require 'bcrypt'
+  include BuildUtils
+
+  def dev_container_name
+    'ood-dev' || "#{ENV['OOD_DEV_CONTAINER_NAME']}"
+  end
+
+  def init_ood_portal
+    file = "#{config_directory}/config/ood_portal.yml"
+    return if File.exists?(file)
+
+    FileUtils.mkdir_p("#{config_directory}/config")
+
+    File.open(file, File::WRONLY|File::CREAT|File::EXCL) do |f|
+      f.write({
+        'servername': 'localhost',
+        'port': 8080,
+        'listen_addr_port': 8080,
+        'oidc_remote_user_claim': 'email',
+        'dex': {
+          'connectors':  [{
+            'type': 'mockCallback',
+            'id': 'mock',
+            'name': 'Mock'
+          }]
+        }
+      }.to_yaml)
+    end
+  end
+
+  def init_ctr_user
+    file = "#{config_directory}/static_user.yml"
+    return if File.exists?(file)
+
+    require 'io/console'
+    puts 'Enter password:'
+    plain_password = STDIN.noecho(&:gets).chomp
+    bcrypted = BCrypt::Password.create(plain_password)
+
+    content = <<CONTENT
+enablePasswordDB: true
+staticPasswords:
+- email: "#{user.name}@localhost"
+  hash: "#{bcrypted}"
+  username: "#{user.name}"
+  userID: "71e63e31-7af3-41d7-add2-575568f4525f"
+CONTENT
+
+    File.open(file, File::WRONLY|File::CREAT|File::EXCL) do |f|
+      f.write(content)
+    end
+  end
+
+  def container_rt_args
+    podman_runtime? ? podman_rt_args : docker_rt_args
+  end
+
+  def docker_rt_args
+    [].freeze
+  end
+
+  def podman_rt_args
+    [
+      '--userns', 'keep-id',
+      '--cap-add', 'sys_ptrace',
+    ].freeze
+  end
+
+  def config_directory
+    @config_directory ||= begin
+      dir = "#{user.dir}/.config/ondemand/container"
+      FileUtils.mkdir_p(dir)
+      dir
+    end
+  end
+
+  def dev_mounts
+    [ 
+      '-v', "#{config_directory}:/etc/ood",
+      '-v', "#{user.dir}/ondemand:#{user.dir}/ondemand"
+    ]
+  end
+
+  desc 'Start development container'
+  task :start => ['package:dev_container', 'ensure_dev_files'] do
+    ctr_args = [ container_runtime, 'run', '-p 8080:8080', '-p 5556:5556' ]
+    ctr_args.concat ["--name #{dev_container_name}" ]
+    ctr_args.concat [ '--rm', '--detach' ]
+    ctr_args.concat [ '-e', 'OOD_STATIC_USER=/etc/ood/config/static_user.yml' ]
+    ctr_args.concat dev_mounts
+    ctr_args.concat container_rt_args
+
+    ctr_args.concat [ "#{dev_image_name}:latest" ]
+    sh ctr_args.join(' ')
+  end
+
+  desc 'Stop development container'
+  task :stop do
+    sh "#{container_runtime} stop #{dev_container_name}"
+  end
+
+  desc 'Restart development container'
+  task :restart => [:stop, :start]
+
+  desc 'Bash exec into the development container'
+  task :exec do
+    ctr_args = [ container_runtime, 'exec', '-it' ]
+    # home is set to /root? could be bug for me
+    ctr_args.concat [ '-e', "HOME=#{user.dir}" ]
+    ctr_args.concat [ '--workdir', user.dir.to_s ]
+    ctr_args.concat [ dev_container_name, '/bin/bash' ]
+
+    sh ctr_args.join(' ')
+  end
+
+  task :bash => [:exec]
+
+  # let advanced users know this, not --tasks
+  task :ensure_dev_files do
+      [
+        :init_ood_portal,
+        :init_ctr_user
+      ].each do |initer|
+        self.send(initer)
+      end
+  end
+end

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -57,8 +57,8 @@ namespace :package do
     sh "git ls-files | #{tar} -c --transform 's,^,ondemand-#{version}/,' -T - | gzip > packaging/v#{version}.tar.gz"
   end
 
-  desc "Build clean docker container from ood image"
-  task container: [:clean] do
+  desc "Build the ood image"
+  task :container do
     sh build_cmd("Dockerfile", image_name) unless image_exists?("#{image_name}:#{image_tag}")
   end
 
@@ -75,14 +75,9 @@ namespace :package do
 
   desc "Build container with Dockerfile.dev"
   task dev_container: [:latest_container] do
-    if ENV['OOD_KEEP_USERNS'].to_s.empty?
-      extra = []
-    else
-      username = Etc.getlogin
-      extra = ["--build-arg", "USER=#{username}"]
-      extra.concat ["--build-arg", "UID=#{Etc.getpwnam(username).uid}"]
-      extra.concat ["--build-arg", "GID=#{Etc.getpwnam(username).uid}"]
-    end
+    extra = ["--build-arg", "USER=#{user.name}"]
+    extra.concat ["--build-arg", "UID=#{user.uid}"]
+    extra.concat ["--build-arg", "GID=#{user.uid}"]
 
     sh build_cmd("Dockerfile.dev", dev_image_name, extra_args: extra) unless image_exists?("#{dev_image_name}:#{image_tag}")
     sh tag_latest_container_cmd(dev_image_name)


### PR DESCRIPTION
I went to make my development image on my personal machine over the weekend and found that what I ran at work was a far to much of a snowflake to replicate. So I put work into the `dev` namespace build/start/stop development containers.

Here's the progress made. Note that the develoment.md should explain things. 

- [x] creates a user with the same name & uid:gid inside the container
- [x] documentation
- [x] prompts to set a password
- [x] podman support
- [ ] docker support
- [ ] only build a container if there isn't `ood-dev:latest` already (but can rebuild through a parameter) 

