### PR TITLE
fix locale fallbacks so they actually fallback

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -3,15 +3,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :set_user, :set_pinned_apps, :set_nav_groups, :set_announcements, :set_locale
+  before_action :set_user, :set_pinned_apps, :set_nav_groups, :set_announcements
   before_action :set_my_balances, only: [:index, :new, :featured]
   before_action :set_featured_group
-
-  def set_locale
-    I18n.locale = ::Configuration.locale
-  rescue I18n::InvalidLocale => e
-    logger.warn "I18n::InvalidLocale #{::Configuration.locale}: #{e.message}"
-  end
 
   def set_user
     @user = User.new

--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -32,7 +32,7 @@ module Dashboard
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # locale's are handled in config/initializers/locales.rb
+    # Locales are handled in config/initializers/locales.rb.
 
     # Custom error pages
     config.exceptions_app = self.routes

--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -32,9 +32,7 @@ module Dashboard
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    # locale's are handled in config/initializers/locales.rb
 
     # Custom error pages
     config.exceptions_app = self.routes

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -264,7 +264,7 @@ class ConfigurationSingleton
   end
 
   def locale
-    (ENV['OOD_LOCALE'] || I18n.default_locale).to_sym
+    (ENV['OOD_LOCALE'] || 'en').to_sym
   end
 
   def locales_root

--- a/apps/dashboard/config/environments/production.rb
+++ b/apps/dashboard/config/environments/production.rb
@@ -64,9 +64,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  # Locales are handled in config/initializers/locales.rb.
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/apps/dashboard/config/initializers/locales.rb
+++ b/apps/dashboard/config/initializers/locales.rb
@@ -1,11 +1,9 @@
-# load the fallbacks backend module
-require "i18n/backend/fallbacks"
+# Setup locales by adding to the locale path, setting the default and setting fallbacks
 
-# clear the Railtie config to allow our config_root to have higher precedence
-Rails.application.config.i18n = {}
+extra_locales = ::Configuration.locales_root.join('*.{yml,rb}')
+base_locales = Rails.application.config.root.join('config', 'locales', '*.{yml,rb}')
 
-# replace the backend to allow missing translations to default to OOD-supplied ones
-I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 
-# load the local translations and any translations from config_root
-I18n.load_path += Dir[Rails.application.config.root.join('config', 'locales', '*.{yml,rb}'), ::Configuration.locales_root.join('*.{yml,rb}')]
+Rails.application.config.i18n.load_path += Dir[base_locales, extra_locales]
+Rails.application.config.i18n.default_locale = ::Configuration.locale
+Rails.application.config.i18n.fallbacks = [:en]

--- a/apps/dashboard/config/initializers/locales.rb
+++ b/apps/dashboard/config/initializers/locales.rb
@@ -3,7 +3,6 @@
 extra_locales = ::Configuration.locales_root.join('*.{yml,rb}')
 base_locales = Rails.application.config.root.join('config', 'locales', '*.{yml,rb}')
 
-
 Rails.application.config.i18n.load_path += Dir[base_locales, extra_locales]
 Rails.application.config.i18n.default_locale = ::Configuration.locale
 Rails.application.config.i18n.fallbacks = [:en]


### PR DESCRIPTION
Fixes #1252. 

I can really only test this manually - but here's the test where Cluster dropdown _could_ be in `zh-CN`, but there's no translation for them so they're in english. I.e., the fallback to english worked.

![image](https://user-images.githubusercontent.com/4874123/128201060-fad182be-58a7-43e1-ae2f-12cd2e1dd539.png)

There's not clean way to test in system or integration tests because the system boots up and sets defaults (english) that, even if you override in a test case, everything's already setup, you can't reset it. So looks like we'll have to add some end-to-end coverage for locales.