### PR TITLE
fix shell dropdown menu to correctly redirect to the shell app

### DIFF
--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -6,22 +6,19 @@
   <% if Configuration.login_clusters.count > 0 %>
     <button type="button" class="btn btn-sm btn-outline-dark dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
     <ul class="dropdown-menu" x-placement="right-start" id="shell-dropdown-items">
-      <% Configuration.login_clusters.each{ |cluster| %>
+      <% Configuration.login_clusters.each do |cluster| %>
         <%=
-          # <li>
-          #   <a href="" title="" target="_blank" class="dropdown-item"></a>
-          # </li>
           tag.li(
             tag.a(
               "#{cluster.metadata.title || cluster.id.to_s.titleize}",
-              href: OodAppkit::Urls::Shell.new(base_url: root_path).url(host: cluster.login.host, path: @path.to_s),
+              href: OodAppkit.shell.url(host: cluster.login.host, path: @path.to_s),
               title: "#{cluster.metadata.title || cluster.id.to_s.titleize}",
               target: '_blank',
               class: 'dropdown-item'
             )
           )
         %>
-      <% } %>
+      <% end %>
     </ul>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes #1315.

fix shell dropdown menu to correctly redirect to the shell app. This also slightly cleans that ERB becuase the `<% } %>` threw me off.