### PR TITLE
Add RPM packaging tests and RPM packaging rake task

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,9 +110,10 @@ jobs:
         run: git fetch --prune --unshallow --tags
 
       - name: Set version
+        id: version
         run: |
           version=$(git describe --tags --abbrev=0)
-          echo ::set-env name=VERSION::$(echo ${version#v})
+          echo ::set-output name=version::${version#v}
 
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
@@ -123,6 +124,10 @@ jobs:
 
       - name: Package EL7
         run: bundle exec rake package:rpm[el7]
+        env:
+          VERSION: "${{ steps.version.outputs.version }}"
 
       - name: Package EL8
         run: bundle exec rake package:rpm[el8]
+        env:
+          VERSION: "${{ steps.version.outputs.version }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,9 +98,9 @@ jobs:
   rpm-packaging-tests:
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
-    name: RPM packaging tests
+        dist: ["el7", "el8"]
+    runs-on: "ubuntu-latest"
+    name: RPM packaging tests ${{ matrix.dist }}
 
     steps:
       - name: Checkout ${{ github.sha	}}
@@ -122,12 +122,7 @@ jobs:
           bundler: "2.1.4"
           bundler-cache: true
 
-      - name: Package EL7
-        run: bundle exec rake package:rpm[el7]
-        env:
-          VERSION: "${{ steps.version.outputs.version }}"
-
-      - name: Package EL8
-        run: bundle exec rake package:rpm[el8]
+      - name: Build package
+        run: bundle exec rake package:rpm[${{ matrix.dist }}]
         env:
           VERSION: "${{ steps.version.outputs.version }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,3 +94,35 @@ jobs:
           kubectl cluster-info
       - name: Test k8s-bootstrap
         run: /bin/bash hooks/k8s-bootstrap/k8s-bootstrap-ondemand.sh test hooks/hook.env.example
+
+  rpm-packaging-tests:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
+    name: RPM packaging tests
+
+    steps:
+      - name: Checkout ${{ github.sha	}}
+        uses: actions/checkout@v2
+
+      - name: Ensure tags exist for packaging
+        run: git fetch --prune --unshallow --tags
+
+      - name: Set version
+        run: |
+          version=$(git describe --tags --abbrev=0)
+          echo ::set-env name=VERSION::$(echo ${version#v})
+
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.1"
+          bundler: "2.1.4"
+          bundler-cache: true
+
+      - name: Package EL7
+        run: bundle exec rake package:rpm[el7]
+
+      - name: Package EL8
+        run: bundle exec rake package:rpm[el8]

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ tags
 
 # Ignore files downloaded for testing
 /tests/*.zip
+
+# Ignore temporary files
+/tmp


### PR DESCRIPTION
Example execution:

```
rake package:rpm[el7] VERSION=2.0.15
```

The Github action just takes latest tag in git repo and uses that since the package isn't getting used, just need some version to use for building tar and passing to build script to match tar file.

Fixes #1265 