### PR TITLE
Support Dex local users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ Defaults:apache env_keep += "NGINX_STAGE_* OOD_*" \n\
 apache ALL=(ALL) NOPASSWD: /opt/ood/nginx_stage/sbin/nginx_stage' >/etc/sudoers.d/ood
 
 # run the OOD executables to setup the env
-RUN /opt/ood/ood-portal-generator/sbin/update_ood_portal
+RUN /opt/ood/ood-portal-generator/sbin/update_ood_portal --insecure
 RUN /opt/ood/nginx_stage/sbin/update_nginx_stage
 RUN echo $VERSION > /opt/ood/VERSION
 # this one bc centos:8 doesn't generate localhost cert

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "rake"
-gem "bcrypt"
 
 group :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
   specs:
     ansi (1.5.0)
     ast (2.4.2)
-    bcrypt (3.1.16)
     beaker (4.30.0)
       beaker-hostgenerator
       hocon (~> 1.0)
@@ -185,7 +184,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt
   beaker
   beaker-docker!
   beaker-rspec

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -13,11 +13,7 @@ sudo su root <<SETUP
   cd $OOD_DEV_DIR
   ln -s $APP_DEV_DIR gateway
 
-  /opt/ood/ood-portal-generator/sbin/update_ood_portal --force
-
-  if [ -n "$OOD_STATIC_USER" ] && [ -f "$OOD_STATIC_USER" ]; then
-    cat "$OOD_STATIC_USER" >>  /etc/ood/dex/config.yaml
-  fi
+  /opt/ood/ood-portal-generator/sbin/update_ood_portal --force --insecure
 SETUP
 
 sudo runuser -u ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml &

--- a/docker/launch-ood
+++ b/docker/launch-ood
@@ -2,6 +2,6 @@
 
 set -e
 
-/opt/ood/ood-portal-generator/sbin/update_ood_portal
+/opt/ood/ood-portal-generator/sbin/update_ood_portal --force --insecure
 runuser -u ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml &
 /usr/sbin/httpd -DFOREGROUND

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -24,6 +24,11 @@ namespace :dev do
         'listen_addr_port': 8080,
         'oidc_remote_user_claim': 'email',
         'dex': {
+          'connectors': [{
+            'type': 'mockCallback',
+            'id': 'mock',
+            'name': 'Mock'
+          }],
           'static_passwords': [{
             'email': "#{user.name}@localhost",
             'password': plain_password,

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -24,11 +24,6 @@ namespace :dev do
         'listen_addr_port': 8080,
         'oidc_remote_user_claim': 'email',
         'dex': {
-          'connectors': [{
-            'type': 'mockCallback',
-            'id': 'mock',
-            'name': 'Mock'
-          }],
           'static_passwords': [{
             'email': "#{user.name}@localhost",
             'password': plain_password,

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -68,7 +68,8 @@ namespace :dev do
   def dev_mounts
     [
       '-v', "#{config_directory}:/etc/ood/config",
-      '-v', "#{user.dir}/ondemand:#{user.dir}/ondemand"
+      '-v', "#{user.dir}/ondemand:#{user.dir}/ondemand",
+      '-v', "#{proj_root}:/ondemand"
     ]
   end
 

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -68,8 +68,7 @@ namespace :dev do
   def dev_mounts
     [
       '-v', "#{config_directory}:/etc/ood/config",
-      '-v', "#{user.dir}/ondemand:#{user.dir}/ondemand",
-      '-v', "#{proj_root}:/ondemand"
+      '-v', "#{user.dir}/ondemand:#{user.dir}/ondemand"
     ]
   end
 

--- a/lib/tasks/lint.rb
+++ b/lib/tasks/lint.rb
@@ -1,4 +1,3 @@
-require 'rubocop/rake_task'
 require 'fileutils'
 
 desc "Lint OnDemand"
@@ -9,6 +8,7 @@ namespace :lint do
   include RakeHelper
 
   begin
+    require 'rubocop/rake_task'
     RuboCop::RakeTask.new(:rubocop, [:path]) do |t, args|
       t.options = ["--config=#{PROJ_DIR.join(".rubocop.yml")}"]
       default_patterns = [

--- a/ood-portal-generator/Gemfile
+++ b/ood-portal-generator/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activesupport', '5.2.4.3'
 gem 'dotenv', '~> 2.1'
+gem "bcrypt"
 
 group :development, :test do
   gem "rake"

--- a/ood-portal-generator/Gemfile.lock
+++ b/ood-portal-generator/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    bcrypt (3.1.16)
     climate_control (0.2.0)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
@@ -36,6 +37,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (= 5.2.4.3)
+  bcrypt
   climate_control
   dotenv (~> 2.1)
   rake

--- a/ood-portal-generator/lib/ood_portal_generator/application.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/application.rb
@@ -59,6 +59,10 @@ module OodPortalGenerator
         detailed_exitcodes ? 4 : 0
       end
 
+      def insecure
+        @insecure.nil? ? false : @insecure
+      end
+
       def apache
         ENV['APACHE'] || (OodPortalGenerator.scl_apache? ? '/opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf' : '/etc/httpd/conf.d/ood-portal.conf')
       end
@@ -140,7 +144,7 @@ module OodPortalGenerator
 
       def generate()
         view = View.new(context)
-        dex = Dex.new(context, view)
+        dex = Dex.new(context, view, insecure)
         rendered_template = view.render(template.read)
         output.write(rendered_template)
         if Dex.installed? && dex.enabled?
@@ -305,6 +309,10 @@ module OodPortalGenerator
 
         parser.on("-t", "--template TEMPLATE", String, "ERB template that is rendered") do |v|
           @template = v
+        end
+
+        parser.on("-i", "--insecure", TrueClass, "Generate insecure configs if configured") do |v|
+          @insecure = v
         end
 
         parser.on("-v", "--version", "Print current version") do

--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -8,7 +8,7 @@ module OodPortalGenerator
   # A view class that renders a Dex configuration
   class Dex
     # @param opts [#to_h] the options describing the context used to render the Dex config
-    def initialize(opts = {}, view)
+    def initialize(opts = {}, view = nil, insecure = false)
       opts = opts.to_h.deep_symbolize_keys
       config = opts.fetch(:dex, {})
       if config.nil? || config == false
@@ -35,9 +35,9 @@ module OodPortalGenerator
       @dex_config[:staticClients] = static_clients
       @dex_config[:connectors] = connectors unless connectors.nil?
       @dex_config[:oauth2] = { skipApprovalScreen: true }
-      if connectors.nil?
+      if insecure
         @dex_config[:enablePasswordDB] = true
-        @dex_config[:staticPasswords] = static_passwords(@config.fetch(:static_passwords, nil))
+        @dex_config[:staticPasswords] = static_passwords
       else
         @dex_config[:enablePasswordDB] = false
       end
@@ -197,8 +197,9 @@ module OodPortalGenerator
       BCrypt::Password.create(password).to_s
     end
 
-    def static_passwords(configured = nil)
+    def static_passwords
       passwords = []
+      configured = @config.fetch(:static_passwords, nil)
       if configured.nil?
         default = {
           email: 'ood@localhost',

--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -35,10 +35,9 @@ module OodPortalGenerator
       @dex_config[:staticClients] = static_clients
       @dex_config[:connectors] = connectors unless connectors.nil?
       @dex_config[:oauth2] = { skipApprovalScreen: true }
-      configured_static_passwords = @config.fetch(:static_passwords, nil)
-      if (connectors.nil? || !configured_static_passwords.nil?)
+      if connectors.nil?
         @dex_config[:enablePasswordDB] = true
-        @dex_config[:staticPasswords] = static_passwords(configured_static_passwords)
+        @dex_config[:staticPasswords] = static_passwords(@config.fetch(:static_passwords, nil))
       else
         @dex_config[:enablePasswordDB] = false
       end

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -156,6 +156,25 @@ describe OodPortalGenerator::Application do
         described_class.generate()
       end
 
+      it 'generates default dex configs with custom static password' do
+        allow_any_instance_of(OodPortalGenerator::Dex).to receive(:hash_password).with('secret').and_return('$2a$12$iKLecAIN9MrxOZ0UltRb.OQOms/bgQbs5F.qCehq15oc3CvGFYzLy')
+        allow(described_class).to receive(:context).and_return({
+          dex: {
+            static_passwords: [{
+              'email'    => 'username@localhost',
+              'password' => 'secret',
+              'username' => 'username',
+              'userID'   => 'D642A38C-402F-47AA-879B-FEC95745F5BA',
+            }]
+          },
+        })
+        expected_rendered = read_fixture('ood-portal.conf.dex')
+        expect(described_class.output).to receive(:write).with(expected_rendered)
+        expected_dex_yaml = read_fixture('dex.yaml.static_passwords').gsub('/etc/ood/dex', config_dir)
+        expect(described_class.dex_output).to receive(:write).with(expected_dex_yaml)
+        described_class.generate()
+      end
+
       it 'generates full dex configs with SSL using proxy' do
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -157,6 +157,7 @@ describe OodPortalGenerator::Application do
       end
 
       it 'generates default dex configs with custom static password' do
+        allow(described_class).to receive(:insecure).and_return(true)
         allow_any_instance_of(OodPortalGenerator::Dex).to receive(:hash_password).with('secret').and_return('$2a$12$iKLecAIN9MrxOZ0UltRb.OQOms/bgQbs5F.qCehq15oc3CvGFYzLy')
         allow(described_class).to receive(:context).and_return({
           dex: {
@@ -176,6 +177,7 @@ describe OodPortalGenerator::Application do
       end
 
       it 'generates full dex configs with SSL using proxy' do
+        allow(described_class).to receive(:insecure).and_return(true)
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           proxy_server: 'example-proxy.com',
@@ -194,6 +196,7 @@ describe OodPortalGenerator::Application do
       end
 
       it 'generates full dex configs with SSL' do
+        allow(described_class).to receive(:insecure).and_return(true)
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           port: '443',
@@ -211,6 +214,7 @@ describe OodPortalGenerator::Application do
       end
 
       it 'generates full dex configs with SSL and multiple redirect URIs' do
+        allow(described_class).to receive(:insecure).and_return(true)
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           port: '443',
@@ -233,6 +237,7 @@ describe OodPortalGenerator::Application do
 
       it 'generates custom dex configs' do
         with_modified_env CONFIG: 'spec/fixtures/ood_portal.dex.yaml' do
+          allow(described_class).to receive(:insecure).and_return(true)
           expected_dex_yaml = read_fixture('dex.custom.yaml').gsub('/etc/ood/dex', config_dir)
           expect(described_class.dex_output).to receive(:write).with(expected_dex_yaml)
           described_class.generate()
@@ -306,6 +311,7 @@ describe OodPortalGenerator::Application do
       end
 
       it 'generates Dex config using secure secret' do
+        allow(described_class).to receive(:insecure).and_return(true)
         secret = Tempfile.new('secret')
         File.write(secret.path, "supersecret\n")
         allow(described_class).to receive(:context).and_return({

--- a/ood-portal-generator/spec/fixtures/dex.yaml.default
+++ b/ood-portal-generator/spec/fixtures/dex.yaml.default
@@ -16,12 +16,7 @@ staticClients:
   secret: 83bc78b7-6f5e-4010-9d80-22f328aa6550
 oauth2:
   skipApprovalScreen: true
-enablePasswordDB: true
-staticPasswords:
-- email: ood@localhost
-  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-  username: ood
-  userID: '08a8684b-db88-4b73-90a9-3cd1661f5466'
+enablePasswordDB: false
 frontend:
   dir: "/usr/share/ondemand-dex/web"
   theme: ondemand

--- a/ood-portal-generator/spec/fixtures/dex.yaml.static_passwords
+++ b/ood-portal-generator/spec/fixtures/dex.yaml.static_passwords
@@ -1,0 +1,27 @@
+---
+issuer: http://example.com:5556
+storage:
+  type: sqlite3
+  config:
+    file: "/etc/ood/dex/dex.db"
+web:
+  http: 0.0.0.0:5556
+telemetry:
+  http: 0.0.0.0:5558
+staticClients:
+- id: example.com
+  redirectURIs:
+  - http://example.com/oidc
+  name: OnDemand
+  secret: 83bc78b7-6f5e-4010-9d80-22f328aa6550
+oauth2:
+  skipApprovalScreen: true
+enablePasswordDB: true
+staticPasswords:
+- email: username@localhost
+  username: username
+  userID: D642A38C-402F-47AA-879B-FEC95745F5BA
+  hash: "$2a$12$iKLecAIN9MrxOZ0UltRb.OQOms/bgQbs5F.qCehq15oc3CvGFYzLy"
+frontend:
+  dir: "/usr/share/ondemand-dex/web"
+  theme: ondemand

--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -125,7 +125,6 @@ set -x
 set -e
 export GEM_HOME=$(pwd)/gems-build
 export GEM_PATH=$(pwd)/gems-build:$GEM_PATH
-bundle install
 rake --trace -mj%{ncpus} build
 EOS
 

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -131,7 +131,7 @@ def upload_portal_config(file)
 end
 
 def update_ood_portal
-  on hosts, '/opt/ood/ood-portal-generator/sbin/update_ood_portal'
+  on hosts, '/opt/ood/ood-portal-generator/sbin/update_ood_portal --insecure'
 end
 
 def restart_apache

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -123,6 +123,9 @@ def install_ondemand
                      end
     on hosts, "#{config_manager} --save --setopt ondemand-web.exclude='ondemand ondemand-gems* ondemand-selinux'"
     install_packages(['ondemand', 'ondemand-dex', 'ondemand-selinux'])
+    # Avoid 'update_ood_portal --rpm' so that --insecure can be used
+    on hosts, "sed -i 's|--rpm|--rpm --insecure|g' /etc/systemd/system/#{apache_service}.service.d/ood-portal.conf"
+    on hosts, "systemctl daemon-reload"
   end
 end
 


### PR DESCRIPTION
Fixes #1318 

Also mount ondemand repo local path to container at `/ondemand` so don't have to rebuild entire container over and over to test small changes, can mount code and reinstall code into running container without full rebuild.  This is what `docker` namespace tasks do which I figured the `dev` namespace would replace.