### PR TITLE
Fix file deletion not working in files app

### DIFF
--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -915,7 +915,7 @@ function deleteFiles(files){
   .then((result) => {
     if(result.isConfirmed){
       loading('Deleting files...');
-      removeFiles(files.map(f => [history.state.currentDirectory, f].join('/')), csrf_token);
+      removeFiles(Object.fromEntries(files.map(f => [[history.state.currentDirectory, f].join('/'), [history.state.currentDirectory, f].join('/')])), csrf_token);
     }
   })
 }


### PR DESCRIPTION
This pull request fixes a bug we found in the files app causing file deletion to not work.

Attempting to delete a file in the files app gave an error.
```
App 16733 output: [2021-08-13 12:55:38 +0300 ] FATAL ""
App 16733 output: [2021-08-13 12:55:38 +0300 ] FATAL "TypeError (no implicit conversion of nil into String):"
App 16733 output: [2021-08-13 12:55:38 +0300 ] FATAL ""
App 16733 output: [2021-08-13 12:55:38 +0300 ] FATAL "app/models/allowlist_policy.rb:34:in `initialize'\napp/models/allowlist_policy.rb:34:in `new'\napp/models/allowlist_policy.rb:34:in `real_expanded_path'\napp/models/allowlist_policy.rb:19:in `block in
 permitted?'\napp/models/allowlist_policy.rb:19:in `any?'\napp/models/allowlist_policy.rb:19:in `permitted?'\napp/models/transfer.rb:18:in `block (2 levels) in <class:Transfer>'\napp/models/transfer.rb:16:in `each'\napp/models/transfer.rb:16:in `block in
 <class:Transfer>'\napp/controllers/transfers_controller.rb:21:in `create'"
```

The file delete request was sent to the server as an array of file to delete instead of an object, which is expected by `dashboard/app/models/transfer.rb`. This lead to `v` in `files.each do |k,v|` in `validates_each :files` being nil.

This PR changes the frontend to send the request file list as `{'/tmp/file1.txt': '/tmp/file1.txt', '/tmp/file2.txt': '/tmp/file2.txt'}`, which works as expected.
There may be better solutions to this bug as currently the error is logged twice. A simple nil check for `v` would also work but wouldn't match the current test cases for `transfer.rb` atleast.
