### PR TITLE
bugfix

### DIFF
--- a/apps/dashboard/app/views/active_jobs/_ganglia_graphs_table.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_ganglia_graphs_table.html.erb
@@ -1,14 +1,15 @@
-<table>
+
 <div class="panel panel-default">
 	<tr class="col-xs-12">
 		<div class="col-xs-12">
    			<tr><div class="job_data" data-jobid="<%= d.pbsid %>" ></div></tr>
   		</div>
     	</tr>
+	
 	<% if !d.nodes.nil? %>
 		<% d.nodes.each do |node| %>
 			<%= render partial: 'active_jobs/job_details_node_view.html.erb', :locals => {:data => d, :node => node } %>
 		<% end %>
 	<% end %>
+	
 </div>
-</table>

--- a/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
@@ -1,12 +1,15 @@
 <% if has_ganglia(data.cluster) || has_grafana(data.cluster) %>
+
 <div class="card ml-5 mt-3">
+
         <% if has_ganglia(data.cluster) %>
           <div class="card-header">Node: <%= node %> <span class="float-right">Job: <%= data.pbsid %> </span></div>
           <div class="card-body">
-            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'cpu_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'cpu_report', node, 'large'), data: { lightbox: "cpu-report", title: "CPU Report " + node } %>
-            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'load_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'load_report', node, 'large'), data: { lightbox: "load-report", title: "Load Report " + node } %>
-            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'mem_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'mem_report', node, 'large'), data: { lightbox: "mem-report", title: "Memory Report " + node } %>
-            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'network_report', node, 'small'), class:"img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" ), build_ganglia_link(data.cluster, data.starttime, 'network_report', node, 'large'), data: { lightbox: "network-report", title: "Network Report " + node } %>
+        
+            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'cpu_report', node, 'small'), class:"img-responsive col-lg-auto col-md-auto col-sm-auto col-xs-auto" ), build_ganglia_link(data.cluster, data.starttime, 'cpu_report', node, 'large'), data: { lightbox: "cpu-report", title: "CPU Report " + node } %>
+            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'load_report', node, 'small'), class:"img-responsive col-lg-auto col-md-auto col-sm-auto col-xs-auto" ), build_ganglia_link(data.cluster, data.starttime, 'load_report', node, 'large'), data: { lightbox: "load-report", title: "Load Report " + node } %>
+            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'mem_report', node, 'small'), class:"img-responsive col-lg-auto col-md-auto col-sm-auto col-xs-auto" ), build_ganglia_link(data.cluster, data.starttime, 'mem_report', node, 'large'), data: { lightbox: "mem-report", title: "Memory Report " + node } %>
+            <%= link_to  image_tag( build_ganglia_link(data.cluster, data.starttime, 'network_report', node, 'small'), class:"img-responsive col-lg-auto col-md-auto col-sm-auto col-xs-auto" ), build_ganglia_link(data.cluster, data.starttime, 'network_report', node, 'large'), data: { lightbox: "network-report", title: "Network Report " + node } %>
           </div>
         <% elsif has_grafana(data.cluster) %>
           <div class="card-header">
@@ -22,10 +25,10 @@
             <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'cpu', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
             <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'memory', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
           </div>
+         
         <% end %>
-        </div>
-      </div>
-    </td>
-  </tr>
+  
 </div>
+       
+
 <% end %>


### PR DESCRIPTION
### Implementation details: 

1. As referred from [archived active jobs](https://github.com/OSC/ood-activejobs/blob/master/app/views/jobs/_job_details_node_view.html.erb) plugin the semantic of the changes were in bad shape. There were incomplete ``` HTML <tr> <td> blocks in [ _job_details_node_view](apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb).
Hence this was rectified along with:
2. An additional table that was used but not required to render the ganglia graphs in [_ganglia_graphs_table](apps/dashboard/app/views/active_jobs/_ganglia_graphs_table.html.erb)

