### PR TITLE
Bugfix/update workflow

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -137,7 +137,7 @@ task :update do
   ruby_apps.each do |app|
     chdir app.path
     Bundler.with_unbundled_env do
-      sh "bundle install"
+      sh "bundle update"
     end
   end
 


### PR DESCRIPTION
Well this is what I get for pulling in #1355 without review. `rake update` needs to invoke bundle update, not bundle install.