### PR TITLE
Support nightly RPM builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,10 @@ rpm-build-nightly-el7:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
     - export SHA=$(git rev-parse --short HEAD)
+    - export LAST_TAG=$(git describe --tags --abbrev=0)
+    - export MAJOR_MINOR=${LAST_TAG%.*}
     - bundle install --path vendor/bundle --without test
-    - export VERSION="$(date +%Y%m%d)-0.${SHA}.nightly"
+    - export VERSION="${MAJOR_MINOR#v}.$(date +%Y%m%d)-1.${SHA}.nightly"
     - bundle exec rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el7 $CI_PROJECT_DIR/packaging
   artifacts:
@@ -35,8 +37,10 @@ rpm-build-nightly-el8:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
     - export SHA=$(git rev-parse --short HEAD)
+    - export LAST_TAG=$(git describe --tags --abbrev=0)
+    - export MAJOR_MINOR=${LAST_TAG%.*}
     - bundle install --path vendor/bundle --without test
-    - export VERSION="$(date +%Y%m%d)-0.${SHA}.nightly"
+    - export VERSION="${MAJOR_MINOR#v}.$(date +%Y%m%d)-1.${SHA}.nightly"
     - bundle exec rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el8 $CI_PROJECT_DIR/packaging
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - export LAST_TAG=$(git describe --tags --abbrev=0)
+    - export SHA=$(git rev-parse --short HEAD)
     - bundle install --path vendor/bundle --without test
-    - export VERSION="${LAST_TAG#v}-99.$(date +%Y%m%d).nightly"
+    - export VERSION="$(date +%Y%m%d)-0.${SHA}.nightly"
     - bundle exec rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el7 $CI_PROJECT_DIR/packaging
   artifacts:
@@ -34,9 +34,9 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - export LAST_TAG=$(git describe --tags --abbrev=0)
+    - export SHA=$(git rev-parse --short HEAD)
     - bundle install --path vendor/bundle --without test
-    - export VERSION="${LAST_TAG#v}-99.$(date +%Y%m%d).nightly"
+    - export VERSION="$(date +%Y%m%d)-0.${SHA}.nightly"
     - bundle exec rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el8 $CI_PROJECT_DIR/packaging
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,6 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - env
     - bundle exec rake package:rpm:nightly[el7,'-u -v -C']
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,10 +42,10 @@ rpm-build-el7:
   only:
     - tags
   script:
-    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $CI_COMMIT_TAG -u -v -C -d el7 $CI_PROJECT_DIR/packaging
+    - bundle exec rake package:rpm[el7,'-u -v -C']
   artifacts:
     paths:
-      - tmp/output
+      - dist
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
 
 rpm-build-el8:
@@ -53,10 +53,10 @@ rpm-build-el8:
   only:
     - tags
   script:
-    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $CI_COMMIT_TAG -u -v -C -d el8 $CI_PROJECT_DIR/packaging
+    - bundle exec rake package:rpm[el8,'-u -v -C']
   artifacts:
     paths:
-      - tmp/output
+      - dist
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
 
 rpm-deploy-nightly:
@@ -71,11 +71,11 @@ rpm-deploy-build:
   only:
     - tags
   script:
-    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./tmp/output/*
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./dist/*
 
 rpm-deploy:
   stage: deploy
   only:
     - tags
   script:
-    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ rpm-build-nightly-el7:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
     - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
+    - rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el7 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:
@@ -32,6 +33,7 @@ rpm-build-nightly-el8:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
     - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
+    - rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el8 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,10 +19,11 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
+    - export LAST_TAG=$(git describe --tags --abbrev=0)
     - bundle install --path vendor/bundle --without test
-    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
+    - export VERSION="${LAST_TAG#v}-99.$(date +%Y%m%d).nightly"
     - bundle exec rake package:tar
-    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el7 $CI_PROJECT_DIR/packaging
+    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el7 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:
       - tmp/output
@@ -33,10 +34,11 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
+    - export LAST_TAG=$(git describe --tags --abbrev=0)
     - bundle install --path vendor/bundle --without test
-    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
+    - export VERSION="${LAST_TAG#v}-99.$(date +%Y%m%d).nightly"
     - bundle exec rake package:tar
-    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el8 $CI_PROJECT_DIR/packaging
+    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el8 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:
       - tmp/output

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ before_script:
   - '[ -d tmp ] || mkdir tmp'
   - MAJOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f1)
   - MINOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f2)
-  - RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}"
+  - '[ "x$CI_COMMIT_TAG" != "x" ] && RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}" || RELEASE=master'
   - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
   - cp /systems/osc_certs/gpg/ondemand/.gpgpass $CI_PROJECT_DIR/tmp/ondemand-packaging/
   - cp /systems/osc_certs/gpg/ondemand/ondemand.sec $CI_PROJECT_DIR/tmp/ondemand-packaging/
@@ -13,6 +13,30 @@ stages:
 
 variables:
   GIT_STRATEGY: clone
+
+rpm-build-nightly-el7:
+  stage: build
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d)"
+    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el7 $CI_PROJECT_DIR/packaging
+  artifacts:
+    paths:
+      - tmp/output
+    name: "$CI_PROJECT_NAME-$CI_COMMIT_SHORT_SHA"
+
+rpm-build-nightly-el8:
+  stage: build
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d)"
+    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el8 $CI_PROJECT_DIR/packaging
+  artifacts:
+    paths:
+      - tmp/output
+    name: "$CI_PROJECT_NAME-$CI_COMMIT_SHORT_SHA"
 
 rpm-build-el7:
   stage: build
@@ -35,6 +59,13 @@ rpm-build-el8:
     paths:
       - tmp/output
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
+
+rpm-deploy-nightly:
+  stage: deploy
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c nightly ./tmp/output/*
 
 rpm-deploy-build:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,19 +84,9 @@ rpm-deploy-build:
   script:
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./tmp/output/*
 
-rpm-deploy-ci:
-  stage: deploy
-  only:
-    - tags
-  script:
-    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c ci ./tmp/output/*
-
 rpm-deploy:
   stage: deploy
   only:
     - tags
-  except:
-    variables:
-      - $CI_COMMIT_TAG =~ /.*_.*/
   script:
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ before_script:
   - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
   - cp /systems/osc_certs/gpg/ondemand/.gpgpass $CI_PROJECT_DIR/tmp/ondemand-packaging/
   - cp /systems/osc_certs/gpg/ondemand/ondemand.sec $CI_PROJECT_DIR/tmp/ondemand-packaging/
+  - bundle install --path vendor/bundle --without test
 stages:
   - build
   - deploy
@@ -19,16 +20,10 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - export SHA=$(git rev-parse --short HEAD)
-    - export LAST_TAG=$(git describe --tags --abbrev=0)
-    - export MAJOR_MINOR=${LAST_TAG%.*}
-    - bundle install --path vendor/bundle --without test
-    - export VERSION="${MAJOR_MINOR#v}.$(date +%Y%m%d)-1.${SHA}.nightly"
-    - bundle exec rake package:tar
-    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el7 $CI_PROJECT_DIR/packaging
+    - bundle exec rake package:rpm:nightly[el7,'-u -v -C']
   artifacts:
     paths:
-      - tmp/output
+      - dist
     name: "$CI_PROJECT_NAME-$CI_COMMIT_SHORT_SHA"
 
 rpm-build-nightly-el8:
@@ -36,16 +31,10 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - export SHA=$(git rev-parse --short HEAD)
-    - export LAST_TAG=$(git describe --tags --abbrev=0)
-    - export MAJOR_MINOR=${LAST_TAG%.*}
-    - bundle install --path vendor/bundle --without test
-    - export VERSION="${MAJOR_MINOR#v}.$(date +%Y%m%d)-1.${SHA}.nightly"
-    - bundle exec rake package:tar
-    - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V v${VERSION} -u -v -C -d el8 $CI_PROJECT_DIR/packaging
+    - bundle exec rake package:rpm:nightly[el7,'-u -v -C']
   artifacts:
     paths:
-      - tmp/output
+      - dist
     name: "$CI_PROJECT_NAME-$CI_COMMIT_SHORT_SHA"
 
 rpm-build-el7:
@@ -75,7 +64,7 @@ rpm-deploy-nightly:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c nightly ./tmp/output/*
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c nightly ./dist/*
 
 rpm-deploy-build:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,9 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
+    - bundle install --path vendor/bundle --without test
     - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
-    - rake package:tar
+    - bundle exec rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el7 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:
@@ -32,8 +33,9 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
+    - bundle install --path vendor/bundle --without test
     - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
-    - rake package:tar
+    - bundle exec rake package:tar
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el8 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d)"
+    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el7 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:
@@ -31,7 +31,7 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d)"
+    - export VERSION="$(git describe --tags --abbrev=0)-99.$(date +%Y%m%d).nightly"
     - ./tmp/ondemand-packaging/build.sh -w $CI_PROJECT_DIR/tmp/work -o $CI_PROJECT_DIR/tmp/output -V $VERSION -u -v -C -d el8 $CI_PROJECT_DIR/packaging
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
+    - env
     - bundle exec rake package:rpm:nightly[el7,'-u -v -C']
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - bundle exec rake package:rpm:nightly[el7,'-u -v -C']
+    - bundle exec rake package:rpm:nightly[el8,'-u -v -C']
   artifacts:
     paths:
       - dist

--- a/lib/tasks/lint.rb
+++ b/lib/tasks/lint.rb
@@ -1,4 +1,3 @@
-require 'rubocop/rake_task'
 require 'fileutils'
 
 desc "Lint OnDemand"
@@ -9,6 +8,7 @@ namespace :lint do
   include RakeHelper
 
   begin
+    require 'rubocop/rake_task'
     RuboCop::RakeTask.new(:rubocop, [:path]) do |t, args|
       t.options = ["--config=#{PROJ_DIR.join(".rubocop.yml")}"]
       default_patterns = [

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -117,10 +117,10 @@ namespace :package do
   namespace :rpm do
     desc "Build nightly RPM"
     task :nightly, [:dist, :extra_args] do |t, args|
-      last_tag = git_tag.gsub(/^v/, '').split('.')
+      version_major, version_minor, version_patch = git_tag.gsub(/^v/, '').split('.', 3)
       date = Time.now.strftime("%Y%m%d")
       id = ENV['CI_PIPELINE_ID'] || Time.now.strftime("%H%M%S")
-      ENV['VERSION'] = "#{last_tag[0]}.#{last_tag[1]}.#{date}-#{id}.#{git_hash}.nightly"
+      ENV['VERSION'] = "#{version_major}.#{version_minor}.#{date}-#{id}.#{git_hash}.nightly"
       Rake::Task['package:rpm'].invoke(args[:dist], args[:extra_args])
     end
   end

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -119,7 +119,7 @@ namespace :package do
     task :nightly, [:dist, :extra_args] do |t, args|
       last_tag = git_tag.gsub(/^v/, '').split('.')
       date = Time.now.strftime("%Y%m%d")
-      id = ENV['CI_JOB_ID'] || '1'
+      id = ENV['CI_PIPELINE_ID'] || Time.now.strftime("%H%M%S")
       ENV['VERSION'] = "#{last_tag[0]}.#{last_tag[1]}.#{date}-#{id}.#{git_hash}.nightly"
       Rake::Task['package:rpm'].invoke(args[:dist], args[:extra_args])
     end

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -113,4 +113,14 @@ namespace :package do
     sh git_clone_packaging("#{version_major}.#{version_minor}", packaging_dir) unless Dir.exist?(packaging_dir)
     sh rpm_build_cmd(packaging_dir, File.join(tmp_dir, "work"), dist_dir, dist, version, extra_args)
   end
+
+  namespace :rpm do
+    desc "Build nightly RPM"
+    task :nightly, [:dist, :extra_args] do |t, args|
+      last_tag = git_tag.gsub(/^v/, '').split('.')
+      date = Time.now.strftime("%Y%m%d")
+      ENV['VERSION'] = "#{last_tag[0]}.#{last_tag[1]}.#{date}-1.#{git_hash}.nightly"
+      Rake::Task['package:rpm'].invoke(args[:dist], args[:extra_args])
+    end
+  end
 end

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -102,7 +102,7 @@ namespace :package do
   desc "Build RPM"
   task :rpm, [:dist, :extra_args] => :tar do |t, args|
     version = ENV['VERSION'] || ENV['CI_COMMIT_TAG']
-    version.gsub!(/^v/, '') unless version.nil?
+    version = version.gsub(/^v/, '') unless version.nil?
     version_major, version_minor, version_patch = version.split('.', 3)
     dist = args[:dist]
     extra_args = args[:extra_args].nil? ? '' : args[:extra_args]

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -100,7 +100,7 @@ namespace :package do
 
   desc "Build RPM"
   task :rpm, [:dist, :extra_args] => :tar do |t, args|
-    version = ENV['VERSION']
+    version = ENV['VERSION'] || ENV['CI_COMMIT_TAG']
     version_major, version_minor, version_patch = version.split('.', 3)
     dist = args[:dist]
     extra_args = args[:extra_args].nil? ? '' : args[:extra_args]

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -60,7 +60,8 @@ namespace :package do
       tar = 'tar'
     end
 
-    version = ENV['VERSION']
+    version = ENV['VERSION'] || ENV['CI_COMMIT_TAG']
+    version.gsub!(/^v/, '') unless version.nil?
 
     if ! version
       latest_commit = `git rev-list --tags --max-count=1`.strip[0..6]

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -101,6 +101,7 @@ namespace :package do
   desc "Build RPM"
   task :rpm, [:dist, :extra_args] => :tar do |t, args|
     version = ENV['VERSION'] || ENV['CI_COMMIT_TAG']
+    version.gsub!(/^v/, '') unless version.nil?
     version_major, version_minor, version_patch = version.split('.', 3)
     dist = args[:dist]
     extra_args = args[:extra_args].nil? ? '' : args[:extra_args]

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -119,7 +119,8 @@ namespace :package do
     task :nightly, [:dist, :extra_args] do |t, args|
       last_tag = git_tag.gsub(/^v/, '').split('.')
       date = Time.now.strftime("%Y%m%d")
-      ENV['VERSION'] = "#{last_tag[0]}.#{last_tag[1]}.#{date}-1.#{git_hash}.nightly"
+      id = ENV['CI_JOB_ID'] || '1'
+      ENV['VERSION'] = "#{last_tag[0]}.#{last_tag[1]}.#{date}-#{id}.#{git_hash}.nightly"
       Rake::Task['package:rpm'].invoke(args[:dist], args[:extra_args])
     end
   end

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -61,7 +61,7 @@ namespace :package do
     end
 
     version = ENV['VERSION'] || ENV['CI_COMMIT_TAG']
-    version.gsub!(/^v/, '') unless version.nil?
+    version = version.gsub(/^v/, '') unless version.nil?
 
     if ! version
       latest_commit = `git rev-list --tags --max-count=1`.strip[0..6]


### PR DESCRIPTION
Fixes #1366 

The version of nightly RPM where latest OnDemand tag is `v2.0.15` would be `v2.0.15-99.20210825.nightly`.  So each days build will be seen as an upgrade by YUM/DNF.  

I think one way to test this is not merge, but leave in this branch and setup gitlab CI pipeline schedule to build off this branch to test with.

I already bootstrapped the nightly repos using ondemand-packaging scripts.