### PR TITLE
refactor fa icon info into a webpack

### DIFF
--- a/apps/dashboard/app/javascript/packs/fa/faIconInfo.js
+++ b/apps/dashboard/app/javascript/packs/fa/faIconInfo.js
@@ -1,3 +1,5 @@
+// TODO: I wonder how to update these fa icon lists?
+
 FA5iconinfo = [{
     "title": "fab fa-500px",
     "searchTerms": []
@@ -2966,6 +2968,7 @@ FA5iconinfo = [{
     "title": "fab fa-youtube-square",
     "searchTerms": []
 }];
+
 FA4iconinfo = [{
     "title": "fa fa-glass",
     "searchTerms": ["martini", "drink", "bar", "alcohol", "liquor"]

--- a/apps/dashboard/app/javascript/packs/fa/faIconPicker.js
+++ b/apps/dashboard/app/javascript/packs/fa/faIconPicker.js
@@ -1,0 +1,41 @@
+import 'fa/faIconInfo';
+
+jQuery(function() {
+
+  function faClassToURI(classname) {
+    var re = /^(fa[bsrl]?) fa-(.*)/;
+    var result = re.exec(classname);
+    if (result) {
+      return result[1] + "://" + result[2];
+    } else {
+      return classname;
+    }
+  };
+
+  var stdConfig = {placement: "inline", templates: {iconpickerItem: '<div role="button" class="iconpicker-item"><i></i></div>'}};
+  var usesOld = $('#product-icon').hasClass("fa");
+  var iconSetting = usesOld ? $.extend({icons: FA4iconinfo}, stdConfig) : $.extend({icons: FA5iconinfo, placement: "inline"}, stdConfig);
+  $('#icp').iconpicker(iconSetting);
+  $('#alias').prop('checked', usesOld);
+
+  $('#icp').on('iconpickerSelected', function(event) {
+    classname = event.iconpickerInstance.options.fullClassFormatter(event.iconpickerValue);
+    $('#product-icon').get(0).className = 'app-icon fa-fw ' + classname;
+    $('#uri-box').val(faClassToURI(classname));
+  });
+
+  $('#uri-box').on('change', function(event) {
+    if ($('#uri-box').val() === "") {
+      $('#product-icon').get(0).className = 'app-icon fa-fw fas fa-cog';
+    }
+  });
+
+  $('#alias').on('change', function() {
+    $('#icp').data('iconpicker').destroy();
+    if ($('#alias').is(":checked")) {
+      $('#icp').iconpicker($.extend({icons: FA4iconinfo, placement: "inline"}, stdConfig));
+    } else {
+      $('#icp').iconpicker($.extend({icons: FA5iconinfo, placement: "inline"}, stdConfig));
+    }
+  })
+});

--- a/apps/dashboard/app/views/products/_form_icon.html.erb
+++ b/apps/dashboard/app/views/products/_form_icon.html.erb
@@ -1,49 +1,11 @@
+<%= javascript_pack_tag 'fa/faIconPicker' %>
+
 <style>
   .iconpicker .iconpicker-items {
     max-height: 98px;
   }
 </style>
-<script>
-  $(document).ready(function() {
 
-    function faClassToURI(classname) {
-      var re = /^(fa[bsrl]?) fa-(.*)/;
-      var result = re.exec(classname);
-      if (result) {
-        return result[1] + "://" + result[2];
-      } else {
-        return classname;
-      }
-    };
-
-    var stdConfig = {placement: "inline", templates: {iconpickerItem: '<div role="button" class="iconpicker-item"><i></i></div>'}};
-    var usesOld = $('#product-icon').hasClass("fa");
-    var iconSetting = usesOld ? $.extend({icons: FA4iconinfo}, stdConfig) : $.extend({icons: FA5iconinfo, placement: "inline"}, stdConfig);
-    $('#icp').iconpicker(iconSetting);
-    $('#alias').prop('checked', usesOld);
-
-    $('#icp').on('iconpickerSelected', function(event) {
-      classname = event.iconpickerInstance.options.fullClassFormatter(event.iconpickerValue);
-      $('#product-icon').get(0).className = 'app-icon fa-fw ' + classname;
-      $('#uri-box').val(faClassToURI(classname));
-    });
-
-    $('#uri-box').on('change', function(event) {
-      if ($('#uri-box').val() === "") {
-        $('#product-icon').get(0).className = 'app-icon fa-fw fas fa-cog';
-      }
-    });
-
-    $('#alias').on('change', function() {
-      $('#icp').data('iconpicker').destroy();
-      if ($('#alias').is(":checked")) {
-        $('#icp').iconpicker($.extend({icons: FA4iconinfo, placement: "inline"}, stdConfig));
-      } else {
-        $('#icp').iconpicker($.extend({icons: FA5iconinfo, placement: "inline"}, stdConfig));
-      }
-    })
-  });
-</script>
 <% if product.app.image_icon? %>
   <p class="text-center">
     <%= image_tag product.app.icon_uri, class: 'app-icon', title: product.app.icon_path %>

--- a/apps/dashboard/config/webpack/environment.js
+++ b/apps/dashboard/config/webpack/environment.js
@@ -1,8 +1,9 @@
-const { environment } = require('@rails/webpacker')
-const config = environment.toWebpackConfig()
+const { environment } = require('@rails/webpacker');
+const config = environment.toWebpackConfig();
 
 config.resolve.alias = {
- jquery: 'jquery/src/jquery'
+ jquery: 'jquery/src/jquery',
+ fa: '/app/javascript/packs/fa',
 }
 
 module.exports = environment


### PR DESCRIPTION
refactor fa icon info into a webpack.

The `_form_icon.html.erb` in this change was dos encoded and I switched it to unix so that's why it looks as if it's changed more than it has. What has _really_ changed in it is only removing the `script` element to a pack and adding the pack_tag.