### PR TITLE
Make RPM package tests verbose for easier debugging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           bundler-cache: true
 
       - name: Build package
-        run: bundle exec rake package:rpm[${{ matrix.dist }}]
+        run: bundle exec rake package:rpm[${{ matrix.dist }},'-v']
         env:
           VERSION: "${{ matrix.version }}.0"
 


### PR DESCRIPTION
There was a failure in #1335 and was impossible to know what broke without adding `-v` flag to print mock RPM build output.