### PR TITLE
fix HashAlignment rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,5 +10,5 @@ Style/WordArray:
 
 # layout
 Layout/HashAlignment:
-  EnforcedStyle: table
-
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table


### PR DESCRIPTION
This is a quick fix to the rubocop for `Layout/HashAlignment`. I can't replicate this output we see in our CI, so I'm not really sure what's going on (CI has a different version of rubocop?)

```text
Run bundle exec rake lint || true
  bundle exec rake lint || true
  shell: /usr/bin/bash -e {0}
Warning: Layout/HashAlignment does not support EnforcedStyle parameter.

Supported parameters are:

  - Enabled
  - AllowMultipleStyles
  - EnforcedHashRocketStyle
  - SupportedHashRocketStyles
  - EnforcedColonStyle
  - SupportedColonStyles
  - EnforcedLastArgumentHashStyle
  - SupportedLastArgumentHashStyles
apps/dashboard/config/initializers/browser.rb: Metrics/LineLength has the wrong namespace - should be Layout
apps/dashboard/config/initializers/browser.rb: Metrics/LineLength has the wrong namespace - should be Layout
Running RuboCop...
Inspecting 279 files
```

Also the CI says it's inspecting 279 and when I run it manually it's 4391.