### PR TITLE
add workflow regularly update changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,42 @@
+name: Update Changelog
+
+on:
+  workflow_dispatch:
+  schedule:
+    # every Monday morning
+    - cron:  '0 2 * * 1'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update-dependencies:
+    strategy:
+      fail-fast: false
+    runs-on: 'ubuntu-latest'
+    name: Update Changelog
+
+    steps:
+      - name: Checkout ${{ github.sha	}}
+        uses: actions/checkout@v2
+
+      - name: Update changelog
+        run: |
+          UPDATES=$(git log --after=$(date -d '7 days ago' +%Y-%m-%dT%00:00:00) --pretty=format:%s)
+          PRE_PROCESSED=$(printf '%s\n' "$UPDATES" | sed 's/\\/&&/g;s/^[[:blank:]]/\\&/;s/$/\\/')
+          sed -i "/^## \[Unreleased\]/a\\$PRE_PROCESSED" CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
+          commit-message: update dependencies
+          committer: OSC ROBOT <osc-bot@gmail.com>
+          author: osc-bot <osc-bot@gmail.com>
+          branch: osc-bot/changelog-update
+          delete-branch: true
+          title: 'Update Dependencies'
+          body: |
+            Changelog updates from the last 7 days
+


### PR DESCRIPTION
fixes #1388 by add workflow regularly update changelog.

Now the output doesn't look super pretty, but most entries will be removed anyhow. The expectation is that this workflow will open a new pull request that we can then manually fix up.