### PR TITLE
fix update changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout ${{ github.sha	}}
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Update changelog
         run: |
@@ -32,11 +34,11 @@ jobs:
         with:
           token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
           commit-message: update dependencies
-          committer: OSC ROBOT <osc-bot@gmail.com>
-          author: osc-bot <osc-bot@gmail.com>
+          committer: OSC ROBOT <osc.bot@gmail.com>
+          author: osc-bot <osc.bot@gmail.com>
           branch: osc-bot/changelog-update
           delete-branch: true
-          title: 'Update Dependencies'
+          title: 'Update Changelog'
           body: |
             Changelog updates from the last 7 days
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
-          commit-message: update dependencies
+          commit-message: update changelog
           committer: OSC ROBOT <osc.bot@gmail.com>
           author: osc-bot <osc.bot@gmail.com>
           branch: osc-bot/changelog-update


### PR DESCRIPTION
fix update changelog workflow. Sets the right PR title and commit user. Also grabs more commits so it can search through the history.