### PR TITLE
changelog workflow use right email

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
           commit-message: update changelog
-          committer: OSC ROBOT <osc.bot@gmail.com>
-          author: osc-bot <osc.bot@gmail.com>
+          committer: OSC ROBOT <osc.robot@gmail.com>
+          author: osc-bot <osc.robot@gmail.com>
           branch: osc-bot/changelog-update
           delete-branch: true
           title: 'Update Changelog'


### PR DESCRIPTION
OK - I looked this up in PAM now instead of just relying on my memory of the email address for the osc-bot user.