### PR TITLE
batch connect apps to use a per cluster dataroot

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -411,7 +411,8 @@ module BatchConnect
     # Root directory where a job is staged and run in
     # @return [Pathname] staged root directory
     def staged_root
-      self.class.dataroot(token, cluster: cluster_id).join("output", id)
+      c = Configuration.per_cluster_dataroot? ? cluster_id : nil
+      self.class.dataroot(token, cluster: c).join("output", id)
     end
 
     # List of template files that need to be rendered

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -94,8 +94,7 @@ module BatchConnect
       # @param token [#to_s] The data root directory for a given app token
       # @return [Pathname] data root directory
       def dataroot(token = "", cluster: nil)
-        root = cluster.present? ? OodAppkit.dataroot.join(cluster.to_s) : OodAppkit.dataroot
-        root.join("batch_connect", token.to_s)
+        OodAppkit.dataroot.join('batch_connect').join(cluster.to_s).join(token.to_s)
       end
 
       # Root directory for file system database

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -537,7 +537,7 @@ module BatchConnect
       def job_name
         [
           ENV["OOD_PORTAL"],    # the OOD portal id
-          ENV["RAILS_RELATIVE_URL_ROOT"].sub(/^\/[^\/]+\//, ""),  # the OOD app
+          ENV["RAILS_RELATIVE_URL_ROOT"].to_s.sub(/^\/[^\/]+\//, ""),  # the OOD app
           token                 # the Batch Connect app
         ].reject(&:blank?).join("/")
       end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -386,6 +386,14 @@ class ConfigurationSingleton
     end
   end
 
+  def per_cluster_dataroot?
+    if ENV['OOD_PER_CLUSTER_DATAROOT']
+      to_bool(ENV['OOD_PER_CLUSTER_DATAROOT'])
+    else
+      to_bool(config.fetch(:per_cluster_dataroot, false))
+    end
+  end
+
   private
 
   def can_access_core_app?(name)

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -431,6 +431,8 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       base_dir = Pathname.new("#{dir}/batch_connect/owens/bc_jupyter/output")
       assert base_dir.directory?
       assert_equal 1, base_dir.children.size
+      `ls -lrt #{dir}`
+      `ls -lrt #{dir}/batch_connect`
       refute File.directory?("#{dir}/batch_connect/oakley/bc_jupyter/output")
 
       # now let's switch to the oakley cluster

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class BatchConnect::SessionTest < ActiveSupport::TestCase
 
   def bc_jupyter_app
-    r = PathRouter.new("test/fixtures/sys_with_interactive_apps/bc_jupyter")
+    r = PathRouter.new("test/fixtures/sys_with_gateway_apps/bc_jupyter")
     BatchConnect::App.new(router: r)
   end
 

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -429,10 +429,11 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
 
       assert session.save(app: bc_jupyter_app, context: ctx)
       base_dir = Pathname.new("#{dir}/batch_connect/owens/bc_jupyter/output")
+      puts `ls -lrt #{dir}`
+      puts `ls -lrt #{dir}/batch_connect/owens`
+      puts `ls -lrt #{base_dir}/..`
       assert base_dir.directory?
       assert_equal 1, base_dir.children.size
-      puts `ls -lrt #{dir}`
-      puts `ls -lrt #{dir}/batch_connect`
       refute File.directory?("#{dir}/batch_connect/oakley/bc_jupyter/output")
 
       # now let's switch to the oakley cluster

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -431,8 +431,8 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       base_dir = Pathname.new("#{dir}/batch_connect/owens/bc_jupyter/output")
       assert base_dir.directory?
       assert_equal 1, base_dir.children.size
-      `ls -lrt #{dir}`
-      `ls -lrt #{dir}/batch_connect`
+      puts `ls -lrt #{dir}`
+      puts `ls -lrt #{dir}/batch_connect`
       refute File.directory?("#{dir}/batch_connect/oakley/bc_jupyter/output")
 
       # now let's switch to the oakley cluster
@@ -440,6 +440,11 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       assert session.save(app: bc_jupyter_app, context: ctx)
       base_dir = Pathname.new("#{dir}/batch_connect/oakley/bc_jupyter/output")
       assert base_dir.directory?
+      puts `ls -lrt #{dir}`
+      puts `ls -lrt #{dir}/batch_connect`
+      puts `ls -lrt #{dir}/batch_connect/oakley`
+      puts `ls -lrt #{dir}/batch_connect/oakley/bc_jupyter`
+      puts `ls -lrt #{dir}/batch_connect/oakley/bc_jupyter/output`
       assert_equal 1, base_dir.children.size
     end
   end

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -427,11 +427,8 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       ctx = bc_jupyter_app.build_session_context
       ctx.attributes = { 'cluster' => 'owens' }
 
-      assert session.save(app: bc_jupyter_app, context: ctx)
+      assert session.save(app: bc_jupyter_app, context: ctx), "#{session.errors.each do |e| e.to_s end }"
       base_dir = Pathname.new("#{dir}/batch_connect/owens/bc_jupyter/output")
-      puts `ls -lrt #{dir}`
-      puts `ls -lrt #{dir}/batch_connect/owens`
-      puts `ls -lrt #{base_dir}/..`
       assert base_dir.directory?
       assert_equal 1, base_dir.children.size
       refute File.directory?("#{dir}/batch_connect/oakley/bc_jupyter/output")
@@ -441,11 +438,6 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
       assert session.save(app: bc_jupyter_app, context: ctx)
       base_dir = Pathname.new("#{dir}/batch_connect/oakley/bc_jupyter/output")
       assert base_dir.directory?
-      puts `ls -lrt #{dir}`
-      puts `ls -lrt #{dir}/batch_connect`
-      puts `ls -lrt #{dir}/batch_connect/oakley`
-      puts `ls -lrt #{dir}/batch_connect/oakley/bc_jupyter`
-      puts `ls -lrt #{dir}/batch_connect/oakley/bc_jupyter/output`
       assert_equal 1, base_dir.children.size
     end
   end


### PR DESCRIPTION
Fixes #1328

Batch connect apps to use a per cluster dataroot to support sites that have seperate file systems for each cluster.

Surprisingly, all the tests still pass. Mostly because we have stubs for `dataroot` in all the tests.

This feature should have:
- [x] tests
- [ ] similar job composer support
- [x] feature flag
- [ ] find a suitible location for `context.json` files because they're cluster independent and should only exist on the web node.