### PR TITLE
use strict same site cookies

### DIFF
--- a/apps/dashboard/config/initializers/session_store.rb
+++ b/apps/dashboard/config/initializers/session_store.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 if Rails.application.config.session_store.nil?
-  Rails.application.config.session_store :cookie_store, key: '_dashboard_session', secure: Rails.env.production?
+  Rails.application.config.session_store :cookie_store, key: '_dashboard_session', secure: Rails.env.production?, same_site: :strict
 end

--- a/apps/myjobs/config/initializers/session_store.rb
+++ b/apps/myjobs/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_job_constructor_session', secure: Rails.env.production?
+Rails.application.config.session_store :cookie_store, key: '_job_constructor_session', secure: Rails.env.production?, same_site: :strict


### PR DESCRIPTION
use strict same site cookies because there's no real advantage to lax. I mean the session store cookies serve no purpose on another site.

Also just to get rid of these warnings:
![image](https://user-images.githubusercontent.com/4874123/135123491-e2fa5462-ffb3-4e04-a4ff-d8281fe63d8a.png)
