### PR TITLE
rm Cache-Control header so we can cache images

### DIFF
--- a/ood-portal-generator/checksum.rb
+++ b/ood-portal-generator/checksum.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+# use this file when you need to generate a new checksum for testing against.
+# ./checksum.rb spec/fixture/the-file-i-changed
+
+require "digest"
+
+def read_file_omitting_comments(input)
+  File.readlines(input).reject { |line| line =~ /^\s*#/ }.join('')
+end
+
+def checksum(input)
+  Digest::SHA256.hexdigest(read_file_omitting_comments(input))
+end
+
+puts checksum(ARGV[0])

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -75,7 +75,6 @@ Listen 8080
   RewriteCond %{REMOTE_ADDR} !^192\.168\.1\..*
   RewriteRule ^.*$ /assets/maintenance/index.html [R=503,L]
   ErrorDocument 503 /assets/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors https://test.server.name;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.default
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.default
@@ -55,7 +55,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -55,7 +55,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -67,7 +67,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors https://example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -67,7 +67,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors https://example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -57,7 +57,6 @@
   RewriteCond %{REMOTE_ADDR} !^10\.0\.0\..*
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -59,7 +59,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors http://ondemand.example.com;"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -67,7 +67,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors https://ondemand.example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -67,7 +67,6 @@
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   Header always set Content-Security-Policy "frame-ancestors https://example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"

--- a/ood-portal-generator/spec/fixtures/sum.default
+++ b/ood-portal-generator/spec/fixtures/sum.default
@@ -1,1 +1,1 @@
-051c639f68c21bf54d6dfe1ee3df3da0726dae906322a03137b51d34a5064a79 /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf
+cd5604171979c12b019086af5a5f40b655c8ee5cea98e2efef18a0a59ef6d250 /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -92,7 +92,6 @@ Listen <%= addr_port %>
   <%- end -%>
   RewriteRule ^.*$ <%= @public_uri %>/maintenance/index.html [R=503,L]
   ErrorDocument 503 <%= @public_uri %>/maintenance/index.html
-  Header Set Cache-Control "max-age=0, no-store"
 
   <%- end -%>
   <%- if @security_csp_frame_ancestors -%>


### PR DESCRIPTION
Fixes #1271 so we can start to cache images (again? seems we missed it when the change was made).

I tracked the change down to #370. @treydock do you recall off hand why we needed a Cache-Control header for maintenance mode?
https://github.com/OSC/ondemand/blob/7222ff58cc4edea65e6e3b3abc38ca8dd2047e8d/ood-portal-generator/templates/ood-portal.conf.erb#L95

This PR also adds a `checksum.rb` as a helper when we need to update these templates and need a new checksum to test against. Also, you'll note that I only changed 1 of the sum file fixtures. `sum.dex` and `sum.not-default` are being loaded in tests, though I'm not quite sure why they're not being evaluated or respected.
