### PR TITLE
add shell app to unit tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: 'compact'
 Style/WordArray:
   EnforcedStyle: 'brackets'
+Style/SymbolArray:
+  EnforcedStyle: 'brackets'
 
 # layout
 Layout/HashAlignment:

--- a/lib/tasks/test.rb
+++ b/lib/tasks/test.rb
@@ -1,4 +1,6 @@
-desc "Test OnDemand"
+# frozen_string_literal: true
+
+desc 'Test OnDemand'
 task :test => 'test:all'
 
 def yarn_app?(path)
@@ -11,28 +13,31 @@ namespace :test do
 
   testing = {
     'ood-portal-generator': 'spec',
-    'nginx_stage': 'spec',
-    'apps/dashboard': 'test',
-    'apps/myjobs': 'test'
+    'nginx_stage':          'spec',
+    'apps/dashboard':       'test',
+    'apps/myjobs':          'test'
   }
 
-  desc "Setup tests"
+  desc 'Setup tests'
   task :setup do
     testing.each_pair do |app, _task|
       chdir PROJ_DIR.join(app.to_s) do
-
-        if yarn_app?(Dir.pwd)
-          sh 'bin/yarn install'
-        end
+        sh 'bin/yarn install' if yarn_app?(Dir.pwd)
 
         Bundler.with_unbundled_env do
-          sh "bundle install"
+          sh 'bundle install'
         end
       end
     end
+
+    chdir PROJ_DIR.join('apps/shell') do
+      # bin/setup doesn't install dev packages
+      sh 'bin/setup'
+      sh 'tmp/node_modules/yarn/bin/yarn install'
+    end
   end
 
-  desc "Run unit tests"
+  desc 'Run unit tests'
   task :unit => [:setup] do
     testing.each_pair do |app, task|
       chdir PROJ_DIR.join(app.to_s) do
@@ -41,18 +46,22 @@ namespace :test do
         end
       end
     end
+
+    chdir PROJ_DIR.join('apps/shell') do
+      sh 'tmp/node_modules/yarn/bin/yarn test'
+    end
   end
 
-  desc "Run shellcheck"
+  desc 'Run shellcheck'
   task :shellcheck do
-    sh "shellcheck -x ood-portal-generator/sbin/update_ood_portal"
-    sh "shellcheck -x nginx_stage/sbin/nginx_stage"
-    sh "shellcheck nginx_stage/sbin/update_nginx_stage"
-    sh "shellcheck hooks/k8s-bootstrap/*.sh"
+    sh 'shellcheck -x ood-portal-generator/sbin/update_ood_portal'
+    sh 'shellcheck -x nginx_stage/sbin/nginx_stage'
+    sh 'shellcheck nginx_stage/sbin/update_nginx_stage'
+    sh 'shellcheck hooks/k8s-bootstrap/*.sh'
   end
 
   begin
-    require "rspec/core/rake_task"
+    require 'rspec/core/rake_task'
     RSpec::Core::RakeTask.new(:e2e) do |task|
       ENV['BEAKER_setdir'] = PROJ_DIR.join('spec', 'e2e', 'nodesets').to_s
       ENV['PATH'] = PROJ_DIR.join('tests').to_s + ":#{ENV['PATH']}"
@@ -62,8 +71,8 @@ namespace :test do
   rescue LoadError
   end
 
-  desc "Get chromedriver"
-  task :chromedriver, [:version] do |t, args|
+  desc 'Get chromedriver'
+  task :chromedriver, [:version] do |_t, args|
     version = args[:version] || '87.0.4280.88'
     uname = `uname -s`
     case uname.chomp
@@ -74,7 +83,7 @@ namespace :test do
     end
     url = "https://chromedriver.storage.googleapis.com/#{version}/#{file}"
     sh "curl -o tests/#{file} #{url}"
-    chdir PROJ_DIR.join("tests") do
+    chdir PROJ_DIR.join('tests') do
       sh "unzip -o #{file}"
     end
   end


### PR DESCRIPTION
Fixes #1423 although it doesn't cache node_modules. That's sort of a bigger change with the way `bin/setup` works.

The additional rubocop entry is just something I found we needed when I updated this file.