### PR TITLE
bugfix to define the default ssh host if it is not specified

### DIFF
--- a/apps/shell/test/helpers.test.js
+++ b/apps/shell/test/helpers.test.js
@@ -76,5 +76,16 @@ describe('Helper function definedHosts()', () => {
 
     expect(defaultHost).toEqual('the.new.default.host');
   });
+
+  test('when no default is defined', () => {
+    // no default is defined in these cluster files or through an environment variable.
+    // so, the default cluster is just the first one we found.
+    process.env['OOD_CLUSTERS'] = 'test/no.defaults.clusters.d';
+
+    let defaultHost = helpers.definedHosts()['default'];
+
+    expect(defaultHost).toEqual('pitzer.osc.edu');
+    expect(helpers.definedHosts()['hosts']).toEqual(['pitzer.osc.edu', 'ruby.osc.edu']);
+  })
 });
 

--- a/apps/shell/test/no.defaults.clusters.d/pitzer.yml
+++ b/apps/shell/test/no.defaults.clusters.d/pitzer.yml
@@ -1,0 +1,14 @@
+---
+v2:
+  metadata:
+    title: "Pitzer"
+    url: "https://www.osc.edu/supercomputing/computing/pitzer"
+    hidden: false
+  login:
+    host: "pitzer.osc.edu"
+  job:
+    adapter: "torque"
+    host: "pitzer-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"

--- a/apps/shell/test/no.defaults.clusters.d/ruby.yml
+++ b/apps/shell/test/no.defaults.clusters.d/ruby.yml
@@ -1,0 +1,15 @@
+---
+v2:
+  metadata:
+    title: "Ruby"
+    url: "https://www.osc.edu/supercomputing/computing/ruby"
+    hidden: false
+  login:
+    host: "ruby.osc.edu"
+    # no default!
+  job:
+    adapter: "torque"
+    host: "ruby-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"

--- a/apps/shell/utils/helpers.js
+++ b/apps/shell/utils/helpers.js
@@ -31,6 +31,11 @@ function definedHosts() {
       }
     });
 
+  // couldn't find a defined default, so let's just make one now if we can
+  if(hosts['default'] === null && hosts['hosts'].length > 0) {
+    hosts['default'] = hosts['hosts'][0];
+  }
+
   return hosts;
 }
 


### PR DESCRIPTION
#1427 missed this one feature where if there's no default ssh host defined, we just use the first one available. This fixes that bug.