### PR TITLE
Force SVGs to be downloaded (2.0 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.17] - 2021-10-05
+
+### Security
+
+- .svg files in the file browser are now being forced to be downloaded as they could
+  contain malicous javascript that would execute in the browser within a site's context.
+
 ## [2.0.16] - 2021-08-25
 
 ### Fixed

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -206,7 +206,9 @@ class FilesController < ApplicationController
   def show_file
     type = Files.mime_type_by_extension(@path).presence || Files.mime_type(@path)
 
-    if params[:download]
+    # svgs aren't safe to view until we update our CSP
+    if params[:download] || type.symbol == :svg
+      type = 'text/plain; charset=utf-8' if type.symbol == :svg
       send_file @path, type: type
     else
       send_file @path, disposition: 'inline', type: Files.mime_type_for_preview(type)


### PR DESCRIPTION
Same as #1435 but for the 2.0 release branch. Force SVGs to be downloaded (2.0 backport).