### PR TITLE
enable usr sharing in the dev container

### DIFF
--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -6,12 +6,19 @@ set -e
 export USER=$(whoami) # $USER isn't set!?
 
 APP_DEV_DIR="/home/$USER/ondemand/dev"
+APP_USR_DIR="/home/$USER/ondemand/share"
 OOD_DEV_DIR="/var/www/ood/apps/dev/$USER"
+OOD_USR_DIR="/var/www/ood/apps/usr/$USER"
 
 sudo su root <<SETUP
   mkdir -p $OOD_DEV_DIR
   cd $OOD_DEV_DIR
   ln -s $APP_DEV_DIR gateway
+
+
+  mkdir -p $OOD_USR_DIR
+  cd $OOD_USR_DIR
+  ln -s $APP_USR_DIR gateway
 
   /opt/ood/ood-portal-generator/sbin/update_ood_portal --force --insecure
 SETUP


### PR DESCRIPTION
This enables usr sharing apps in the dev container. 

It also fixes up the Permission model but adding some rescue blocks because `nfs4_getfacl` commands don't exist, along with other minor rubocop updates.