### PR TITLE
Disable shallow clone depth for Gitlab pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ stages:
 
 variables:
   GIT_STRATEGY: clone
+  GIT_DEPTH: 0
 
 rpm-build-nightly-el7:
   stage: build


### PR DESCRIPTION
This is needed to fix nightly builds.  The default depth is 50 and I think we are not 50 commits from last tag so when Git fetches the code, there are no tags. At least that's my guess.  The behavior I'm seeing with failed nightly build is the code is unable to detect latest git tag to build tar.gz and RPM.