### PR TITLE
Build RPMs in CI/CD pipelines using -s flag to disable source download

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           bundler-cache: true
 
       - name: Build package
-        run: bundle exec rake package:rpm[${{ matrix.dist }},'-v']
+        run: bundle exec rake package:rpm[${{ matrix.dist }},'-v -s']
         env:
           VERSION: "${{ matrix.version }}.0"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ rpm-build-nightly-el7:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - bundle exec rake package:rpm:nightly[el7,'-u -v -C']
+    - bundle exec rake package:rpm:nightly[el7,'-u -v -C -s']
   artifacts:
     paths:
       - dist
@@ -31,7 +31,7 @@ rpm-build-nightly-el8:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - bundle exec rake package:rpm:nightly[el8,'-u -v -C']
+    - bundle exec rake package:rpm:nightly[el8,'-u -v -C -s']
   artifacts:
     paths:
       - dist
@@ -42,7 +42,7 @@ rpm-build-el7:
   only:
     - tags
   script:
-    - bundle exec rake package:rpm[el7,'-u -v -C']
+    - bundle exec rake package:rpm[el7,'-u -v -C -s']
   artifacts:
     paths:
       - dist
@@ -53,7 +53,7 @@ rpm-build-el8:
   only:
     - tags
   script:
-    - bundle exec rake package:rpm[el8,'-u -v -C']
+    - bundle exec rake package:rpm[el8,'-u -v -C -s']
   artifacts:
     paths:
       - dist


### PR DESCRIPTION
I think this should fix #1467 for RPM builds.