### PR TITLE
Use correct path for service.d unit overrides.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DESTDIR            = $(CURDIR)/debian/ondemand
 export GEM_HOME           = $(CURDIR)/gems
 export GEM_PATH           = $(GEM_HOME):$(shell printenv GEM_PATH)
 export APACHE_DIR         = "$(DESTDIR)/var/www/ood"
-export APACHE_SYSTEMD_DIR = "$(DESTDIR)/lib/systemd/system/apache2.service.d"
+export APACHE_SYSTEMD_DIR = "$(DESTDIR)/etc/systemd/system/apache2.service.d"
 export CONFIG_DIR         = "$(DESTDIR)/etc/ood/config"
 
 


### PR DESCRIPTION
Fixes #1478

See #1478 for rational of why this is needed.  The way systemd is configured is rather uniform across different operating systems so even if don't do best practice, this makes the location the same for RPM and deb packages.