### PR TITLE
Selinux updates

### DIFF
--- a/packaging/rpm/ondemand-selinux.te
+++ b/packaging/rpm/ondemand-selinux.te
@@ -146,26 +146,6 @@ optional_policy(`
 
 ## <desc>
 ## <p>
-## Allow OnDemand to use Shell app
-## DEPRECATED, use ondemand_use_ssh instead
-## </p>
-## </desc>
-gen_tunable(ondemand_use_shell_app, false)
-
-tunable_policy(`ondemand_use_shell_app',`
-  allow ood_pun_t ptmx_t:chr_file { ioctl open read write };
-  ssh_exec(ood_pun_t)
-  corenet_tcp_connect_ssh_port(ood_pun_t)
-  allow ood_pun_t self:key { read view write };
-')
-
-tunable_policy(`ondemand_use_shell_app && ondemand_manage_user_home_dir',`
-  manage_dirs_pattern(ood_pun_t, ssh_home_t, ssh_home_t)
-  manage_files_pattern(ood_pun_t, ssh_home_t, ssh_home_t)
-')
-
-## <desc>
-## <p>
 ## Allow OnDemand to use SSH
 ## </p>
 ## </desc>


### PR DESCRIPTION
I will open a different pull request for 2.0 once I've had more chances to test this.

Marking WIP for now as still need to further test.  So far what I've tested is that on a Permissive system, adding these policy changes and enabling the SELinux booleans and then running `audit2allow` shows all are now allowed under current policy:

```
setsebool ondemand_use_slurm=on ondemand_use_kubernetes=on
```

The only denial we get now would be allowed with this:

```
allow ood_pun_t var_lib_t:file { ioctl open read };
```

This is from the initializer we deploy at our site to read `/var/lib/node_exporter/textfile_collector/autofs-file-test.prom`.  I don't think it's necessarily appropriate to account for that in this repo.

FOR DOCS:

New booleans
* ondemand_use_ssh
* ondemand_use_kubernetes

Removed booleans

* ondemand_use_shell_app