### PR TITLE
use osc robot instead of osc wiag

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -36,9 +36,9 @@ jobs:
           commit-message: update changelog
           committer: OSC ROBOT <osc.robot@gmail.com>
           author: osc-bot <osc.robot@gmail.com>
-          branch: osc-bot/changelog-update
           delete-branch: true
           title: 'Update Changelog'
+          push-to-fork: osc-bot/ondemand
           body: |
             Changelog updates from the last 7 days
 

--- a/.github/workflows/document-merge.yml
+++ b/.github/workflows/document-merge.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - 'feature/**'
+      - 'release/**'
     types: [closed]
 
 jobs:
@@ -26,7 +27,7 @@ jobs:
 
           curl --silent --output /dev/null --request POST \
           --url https://api.github.com/repos/OSC/ood-documentation/issues \
-          --header 'Authorization: token ${{ secrets.OSCWIAG_ISSUE_TOKEN }}' \
+          --header 'Authorization: token ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}' \
           --header 'content-type: application/json' \
           --data "$BODY"
 
@@ -42,7 +43,7 @@ jobs:
 
           curl --silent --output /dev/null --request POST \
           --url https://api.github.com/repos/OSC/puppet-module-openondemand/issues \
-          --header 'Authorization: token ${{ secrets.OSCWIAG_ISSUE_TOKEN }}' \
+          --header 'Authorization: token ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}' \
           --header 'content-type: application/json' \
           --data "$BODY"
 
@@ -58,6 +59,6 @@ jobs:
 
           curl --silent --output /dev/null --request POST \
           --url https://api.github.com/repos/OSC/ood-ansible/issues \
-          --header 'Authorization: token ${{ secrets.OSCWIAG_ISSUE_TOKEN }}' \
+          --header 'Authorization: token ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}' \
           --header 'content-type: application/json' \
           --data "$BODY"

--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -10,15 +10,15 @@ jobs:
   assign-milestone:
     runs-on: ubuntu-latest
     steps:
-      - name: Assign the created issue to the "Needs Triaged" milestone if no milestone is defined.
+      - name: Put in the backlog milestone if no milestone is defined.
         if: github.event.issue.milestone == null
         # Set environment
         env:
-          MILESTONE_ID: 8
+          MILESTONE_ID: 5
         run: |
           curl --silent --output /dev/null --request PATCH \
           --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }} \
-          --header 'authorization: token ${{ secrets.OSCWIAG_ISSUE_TOKEN }}' \
+          --header 'authorization: token ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{
               "milestone": "'$MILESTONE_ID'"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
     - uses: actions/labeler@main
       with:
-        repo-token: ${{ secrets.OSCWIAG_ISSUE_TOKEN }}
+        repo-token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
         configuration-path: .github/labeler.yml
         sync-labels: true # Revert the labels applied to the PR when changes are reverted.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.OSCWIAG_ISSUE_TOKEN }}
-          commit-message: update dependencies
-          committer: OSC WIAG <oscwiag@gmail.com>
-          author: oscwiag <oscwiag@gmail.com>
-          branch: oscwiag/dependency-updates
+          token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
+          commit-message: update changelog
+          committer: OSC ROBOT <osc.robot@gmail.com>
+          author: osc-bot <osc.robot@gmail.com>
           delete-branch: true
           title: 'Update Dependencies'
+          push-to-fork: osc-bot/ondemand
           body: |
             Update dependencies generated from `rake update`


### PR DESCRIPTION
This does a little bit more that that. But that's the big one. Also fixes #1502.  I think we can get rid of the triaged milestone and just move everything into the backlog.

Also - the osc robot is submitting PRs from it's own fork now. This is to reduce some privileges it has (namely write).