### PR TITLE
Fix Gitlab package builds

### DIFF
--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -31,8 +31,7 @@ namespace :package do
     cmd.concat ["--branch", branch]
     cmd.concat ["https://github.com/OSC/ondemand-packaging.git", dir]
 
-    sh "rm -rf #{dir}" if Dir.exist?(dir)
-    sh cmd.join(' ')
+    sh cmd.join(' ') unless Dir.exist?(dir)
   end
 
   desc "Tar and zip OnDemand into packaging dir"


### PR DESCRIPTION
The Gitlab builds will clone appropriate version of ondemand-packaging and if we remove it then the bootstrapped GPG keys are deleted and GPG signing is disabled.  The issue with this morning's nightly builds is they lacked GPG signing for this reason.