### PR TITLE
enable reporting on CSP and refactor configs a little

### DIFF
--- a/apps/dashboard/config/initializers/content_security_policy.rb
+++ b/apps/dashboard/config/initializers/content_security_policy.rb
@@ -4,19 +4,19 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end if Configuration.csp_enabled?
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
@@ -27,4 +27,6 @@
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+if Configuration.csp_enabled?
+  Rails.application.config.content_security_policy_report_only = Configuration.csp_report_only
+end

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -1,0 +1,4 @@
+csp_enabled: true
+csp_report_only: true
+bc_dynamic_js: true
+per_cluster_dataroot: true


### PR DESCRIPTION
I wanted to enable CSP behind a couple feature flags, so I took the opportunity to refactor the ConfigurationSingleton a little bit so that we don't need to go through a whole thing, new APIs and so on, for every option we enable.

So this adds the `boolean_configs` that we can loop through with their defaults and create some methods dynamically from that.