### PR TITLE
Prepare for 2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         dist: ["el7", "el8", "ubuntu-20.04"]
-        version: ["2.0"]
+        version: ["2.1"]
     runs-on: "ubuntu-latest"
     name: E2E test ${{ matrix.dist }} (ondemand-${{ matrix.version }})
 

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -3,7 +3,7 @@ Section: unknown
 Priority: optional
 Maintainer: Ohio Super Computer Center
 Build-Depends: debhelper (>=11~), curl, build-essential,
-  ruby, ruby-dev, nodejs, npm, sqlite, libsqlite3-dev
+  ruby, ruby-dev, nodejs, npm, sqlite, libsqlite3-dev, python
 Standards-Version: 4.1.4
 Homepage: https://openondemand.org
 

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -56,17 +56,15 @@ BuildRequires:   ondemand-runtime >= %{runtime_version}, ondemand-runtime < %{ne
 BuildRequires:   ondemand-scldevel >= %{runtime_version}, ondemand-scldevel < %{next_major_version}, ondemand-scldevel < %{next_minor_version}
 BuildRequires:   ondemand-build >= %{runtime_version}, ondemand-build < %{next_major_version}, ondemand-build < %{next_minor_version}
 BuildRequires:   ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_major_version}, ondemand-ruby < %{next_minor_version}
-BuildRequires:   ondemand-python >= %{runtime_version}, ondemand-python < %{next_major_version}, ondemand-python < %{next_minor_version}
 BuildRequires:   ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}
 BuildRequires:   rsync
 BuildRequires:   git
 Requires:        git
 Requires:        sudo, lsof, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib, lua-posix
 Requires:        ondemand-apache >= %{runtime_version}, ondemand-apache < %{next_major_version}, ondemand-apache < %{next_minor_version}
-Requires:        ondemand-nginx = 1.18.0
-Requires:        ondemand-passenger = 6.0.7
+Requires:        ondemand-nginx = 1.20.1
+Requires:        ondemand-passenger = 6.0.11
 Requires:        ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_major_version}, ondemand-ruby < %{next_minor_version}
-Requires:        ondemand-python >= %{runtime_version}, ondemand-python < %{next_major_version}, ondemand-python < %{next_minor_version}
 Requires:        ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}
 Requires:        ondemand-runtime >= %{runtime_version}, ondemand-runtime < %{next_major_version}, ondemand-runtime < %{next_minor_version}
 Requires:        %{gems_name}

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -40,12 +40,14 @@ Source2:   ondemand-selinux.fc
 %define apache_service httpd
 %define apache_daemon /usr/sbin/httpd
 %define htcacheclean_service htcacheclean
+%define python_dep python2
 %else
 %bcond_without scl_apache
 %define apache_confd /opt/rh/httpd24/root/etc/httpd/conf.d
 %define apache_service httpd24-httpd
 %define apache_daemon /opt/rh/httpd24/root/usr/sbin/httpd-scl-wrapper
 %define htcacheclean_service httpd24-htcacheclean
+%define python_dep python
 %endif
 
 # Disable automatic dependencies as it causes issues with bundled gems and
@@ -59,8 +61,11 @@ BuildRequires:   ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_maj
 BuildRequires:   ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}
 BuildRequires:   rsync
 BuildRequires:   git
+BuildRequires:   %{python_dep}
+
 Requires:        git
 Requires:        sudo, lsof, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib, lua-posix
+Requires:        %{python_dep}
 Requires:        ondemand-apache >= %{runtime_version}, ondemand-apache < %{next_major_version}, ondemand-apache < %{next_minor_version}
 Requires:        ondemand-nginx = 1.20.1
 Requires:        ondemand-passenger = 6.0.11

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -126,7 +126,7 @@ def bootstrap_repos
       repos << 'centos-release-scl yum-plugin-priorities'
     else
       on hosts, 'dnf -y module enable ruby:2.7'
-      on hosts, 'dnf -y module enable nodejs:12'
+      on hosts, 'dnf -y module enable nodejs:14'
     end
   elsif host_inventory['platform'] == 'ubuntu'
     on hosts, 'apt-get update'


### PR DESCRIPTION
The runtime updates to nodejs 14, fixes #1382
Require NGINX 1.20.1, fixes #1440
Remove dependency on ondemand-python
Bump E2E test version

@johrstrom I am hoping this will resolve issues you saw in #1548