### PR TITLE
Push ondemand tar.gz to release page on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,22 +27,17 @@ jobs:
         run: bundle exec rake package:tar
         env:
           VERSION: ${{ steps.version.outputs.version }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
-          prerelease: true
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Upload Release files
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: packaging/rpm/ondemand-${{ steps.version.outputs.version }}.tar.gz
           asset_name: ondemand-${{ steps.version.outputs.version }}.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release OnDemand
+    steps:
+      - name: Set version
+        id: version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/v}
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.1"
+          bundler: "2.1.4"
+          bundler-cache: true
+      - name: Generate tar.gz
+        run: bundle exec rake package:tar
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload Release files
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: packaging/rpm/ondemand-${{ steps.version.outputs.version }}.tar.gz
+          asset_name: ondemand-${{ steps.version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -39,14 +39,14 @@ namespace :package do
     dist = args[:dist] || 'el8'
     cmd = ['git', 'ls-files', '|', tar, '-c']
     if dist =~ /^el/
+      dir = File.join(proj_root, 'packaging/rpm')
       version = rpm_version
-      tar_file = "packaging/rpm/v#{version}.tar.gz"
     else
       dir = File.join(Dir.pwd, 'build').tap { |p| sh "mkdir -p #{p}" }
       version = deb_version
-      tar_file = "#{dir}/#{ood_package_name}-#{version}.tar.gz"
       cmd.concat ["--transform 'flags=r;s,packaging/deb,debian,'"]
     end
+    tar_file = "#{dir}/#{ood_package_name}-#{version}.tar.gz"
     cmd.concat ["--transform 's,^,#{ood_package_name}-#{version}/,'"]
     cmd.concat ['-T', '-', '|', "gzip > #{tar_file}"]
 

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -24,7 +24,7 @@ Summary:   Web server that provides users access to HPC resources
 Group:     System Environment/Daemons
 License:   MIT
 URL:       https://osc.github.io/Open-OnDemand
-Source0:   https://github.com/OSC/%{package_name}/archive/%{git_tag}.tar.gz
+Source0:   https://github.com/OSC/%{package_name}/releases/download/%{git_tag}/%{package_name}-%{git_tag_minus_v}.tar.gz
 Source1:   ondemand-selinux.te
 Source2:   ondemand-selinux.fc
 


### PR DESCRIPTION
Fixes #1546

@johrstrom Because the release action needs the release URL, the release page is also generated using actions. I think that means that to do a new tag, you use git to generate tag, push that tag and then a new release page is created as draft and you can go in and make edits to that draft release.