### PR TITLE
icon provided by font-awesome-sass no longer provided

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   def clusters
     OodCore::Clusters.new(OodAppkit.clusters.select(&:allow?).reject { |c| c.metadata.hidden })
@@ -19,8 +21,11 @@ module ApplicationHelper
   # @param url [#to_s, nil] url to access
   # @param role [String] app role i.e. "vdi", "shell", etc.
   # @return nil if url not set or the HTML string for the bootstrap nav link
-  def nav_link(title, icon, url, target: "", role: nil)
-    render partial: "layouts/nav/link", locals: { title: title, faicon: icon, url: url.to_s, target: target, role: role  } if url
+  def nav_link(title, icon, url, target: '', role: nil)
+    if url
+      render partial: 'layouts/nav/link',
+             locals:  { title: title, faicon: icon, url: url.to_s, target: target, role: role }
+    end
   end
 
   def support_url
@@ -43,29 +48,28 @@ module ApplicationHelper
     ENV['OOD_DASHBOARD_HELP_CUSTOM_URL']
   end
 
-  def fa_icon(icon, fa_style: "fas", id: "")
-    content_tag(:i, "", id: id, class: [fa_style, "fa-#{icon}", "fa-fw", "app-icon"] , title: "FontAwesome icon specified: #{icon}", "aria-hidden": true)
+  def fa_icon(icon, fa_style: 'fas', id: '', classes: 'app-icon')
+    content_tag(:i, '', id: id, class: [fa_style, "fa-#{icon}", 'fa-fw'].concat(Array(classes)),
+                title: "FontAwesome icon specified: #{icon}", "aria-hidden": true)
   end
 
   def app_icon_tag(app)
     if app.image_icon?
       image_tag app.icon_uri, class: 'app-icon', title: app.icon_path
-    else # default to font awesome icon 
-      if app.manifest.icon =~ /^(fa[bsrl]?):\/\/(.*)/
-        icon = $2
-        style = $1
-        fa_icon(icon, fa_style: style)
-      else
-        fa_icon("cog")
-      end
+    elsif app.manifest.icon =~ %r{^(fa[bsrl]?)://(.*)} # default to font awesome icon
+      icon = Regexp.last_match(2)
+      style = Regexp.last_match(1)
+      fa_icon(icon, fa_style: style)
+    else
+      fa_icon('cog')
     end
   end
 
   def icon_tag(icon_uri)
-    if %w(fa fas far fab fal).include?(icon_uri.scheme)
+    if ['fa', 'fas', 'far', 'fab', 'fal'].include?(icon_uri.scheme)
       fa_icon(icon_uri.host, fa_style: icon_uri.scheme)
-    else 
-      image_tag icon_uri.to_s, class: "app-icon", title: icon_uri.to_s, "aria-hidden": true
+    else
+      image_tag icon_uri.to_s, class: 'app-icon', title: icon_uri.to_s, "aria-hidden": true
     end
   end
 end

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -167,7 +167,7 @@ module BatchConnect::SessionsHelper
 
   def delete(session)
     link_to(
-      icon("fas", "trash-alt", t('dashboard.batch_connect_sessions_delete_title'), class: "fa-fw"),
+      fa_icon('trash-alt', classes: nil) << ' ' << t('dashboard.batch_connect_sessions_delete_title'),
       session,
       method: :delete,
       class: "btn btn-danger float-right btn-delete",


### PR DESCRIPTION
Fixes #1565.

`icon` provided by font-awesome-sass isn't available anymore. Luckily we already have `fa_icon` api. All I had to do was fix it up so that `app-icon` as a class can be overridden.