### PR TITLE
cant get rid of sass-rails just yet

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '6.0.4.1'
+# TODO: remove me once we migrate all js & css to webpack
+gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -99,11 +99,9 @@ GEM
     erubi (1.10.0)
     execjs (2.8.1)
     ffi (1.15.4)
-    font-awesome-sass (5.12.0)
-      sassc (>= 1.11)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -212,8 +210,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     sdoc (2.2.0)
       rdoc (>= 5.0)
     selenium-webdriver (4.0.3)
@@ -280,7 +276,6 @@ DEPENDENCIES
   dotenv-rails (~> 2.1)
   dotiw
   erubi
-  font-awesome-sass (= 5.12.0)
   jbuilder (~> 2.0)
   jquery-datatables-rails (~> 3.4)
   jquery-rails


### PR DESCRIPTION
cant get rid of sass-rails just yet. This should fix the update CI and other build errors we're seeing.