### PR TITLE
Numerous fixes for deb package

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/application.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/application.rb
@@ -65,7 +65,7 @@ module OodPortalGenerator
 
       def apache
         return ENV['APACHE'] unless ENV['APACHE'].nil?
-        return '/etc/apache2/conf-available/ood-portal.conf' if OodPortalGenerator.debian?
+        return '/etc/apache2/sites-available/ood-portal.conf' if OodPortalGenerator.debian?
         OodPortalGenerator.scl_apache? ? '/opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf' : '/etc/httpd/conf.d/ood-portal.conf'
       end
 

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -378,7 +378,7 @@ describe OodPortalGenerator::Application do
     it 'should work for Debian systems' do
       allow(OodPortalGenerator).to receive(:scl_apache?).and_return(false)
       allow(OodPortalGenerator).to receive(:debian?).and_return(true)
-      expect(described_class.apache).to eq('/etc/apache2/conf-available/ood-portal.conf')
+      expect(described_class.apache).to eq('/etc/apache2/sites-available/ood-portal.conf')
     end
   end
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -6,6 +6,10 @@
 touch /var/lib/ondemand-nginx/config/apps/sys/dashboard.conf
 touch /var/lib/ondemand-nginx/config/apps/sys/shell.conf
 touch /var/lib/ondemand-nginx/config/apps/sys/myjobs.conf
+# ood-portal.conf cannot be in package rules to avoid
+# a prompt when changed during postinst
+touch /etc/apache2/sites-available/ood-portal.conf
+touch /etc/ood/config/ood_portal.sha256sum
 
 /opt/ood/nginx_stage/sbin/update_nginx_stage
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -6,7 +6,6 @@
 touch /var/lib/ondemand-nginx/config/apps/sys/dashboard.conf
 touch /var/lib/ondemand-nginx/config/apps/sys/shell.conf
 touch /var/lib/ondemand-nginx/config/apps/sys/myjobs.conf
-touch /etc/ood/config/ood_portal.sha256sum
 
 /opt/ood/nginx_stage/sbin/update_nginx_stage
 
@@ -15,15 +14,15 @@ touch /var/www/ood/apps/sys/dashboard/tmp/restart.txt
 touch /var/www/ood/apps/sys/shell/tmp/restart.txt
 touch /var/www/ood/apps/sys/myjobs/tmp/restart.txt
 
-cd /etc/apache2/conf-enabled || exit 1
-ln -sf ../conf-available/ood-portal.conf . || true
+cd /etc/apache2/sites-enabled || exit 1
+ln -sf /etc/apache2/sites-available/ood-portal.conf . || true
 
 cd /etc/apache2/mods-enabled || exit 1
-ln -sf ../mods-available/rewrite.load . || true
-ln -sf ../mods-available/lua.load . || true
-ln -sf ../mods-available/headers.load . || true
-ln -sf ../mods-available/proxy.load . || true
-ln -sf ../mods-available/proxy_http.load . || true
+ln -sf /etc/apache2/mods-available/rewrite.load . || true
+ln -sf /etc/apache2/mods-available/lua.load . || true
+ln -sf /etc/apache2/mods-available/headers.load . || true
+ln -sf /etc/apache2/mods-available/proxy.load . || true
+ln -sf /etc/apache2/mods-available/proxy_http.load . || true
 
 # shellcheck disable=SC1091
 [ -e /etc/apache2/envvars ] && . /etc/apache2/envvars

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -4,8 +4,9 @@ if [[ "$1" == "remove" || "$1" == "purge" ]]; then
 	rm -rf /var/tmp/ondemand-nginx &>/dev/null || true
 	rm -rf /var/run/ondemand-ngin &>/dev/null || true
 
-	unlink /etc/apache2/conf-enabled/ood-portal.conf &>/dev/null || true
-	unlink /etc/apache2/conf-available/ood-portal.conf &>/dev/null || true
+	unlink /etc/apache2/sites-enabled/ood-portal.conf &>/dev/null || true
+	unlink /etc/apache2/sites-available/ood-portal.conf &>/dev/null || true
+	unlink /etc/ood/config/ood_portal.sha256sum &>/dev/null || true
 
 	unlink /etc/systemd/system/apache2.service.d/ood.conf &>/dev/null || true
 	unlink /etc/systemd/system/apache2.service.d/ood-portal.conf &>/dev/null || true

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -8,7 +8,6 @@ export GEM_HOME           = $(CURDIR)/gems
 export GEM_PATH           = $(GEM_HOME):$(shell printenv GEM_PATH)
 export APACHE_DIR         = "$(DESTDIR)/var/www/ood"
 export APACHE_SYSTEMD_DIR = "$(DESTDIR)/etc/systemd/system/apache2.service.d"
-export APACHE_CONF_DIR    = "$(DESTDIR)/etc/apache2/sites-available"
 export CONFIG_DIR         = "$(DESTDIR)/etc/ood/config"
 
 
@@ -50,9 +49,6 @@ override_dh_auto_install:
 	rake package:version > $(DESTDIR)/opt/ood/VERSION
 	install -m 644 nginx_stage/share/nginx_stage_example.yml $(CONFIG_DIR)/nginx_stage.yml
 	install -m 640 ood-portal-generator/share/ood_portal_example.yml $(CONFIG_DIR)/ood_portal.yml
-	touch $(CONFIG_DIR)/ood_portal.sha256sum
-	mkdir -p $(APACHE_CONF_DIR)
-	touch $(APACHE_CONF_DIR)/ood-portal.conf
 	install -m 644 ood-portal-generator/share/maintenance.html $(APACHE_DIR)/public/maintenance/index.html
 	install -m 644 hooks/hook.env.example $(CONFIG_DIR)/hook.env
 

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -8,6 +8,7 @@ export GEM_HOME           = $(CURDIR)/gems
 export GEM_PATH           = $(GEM_HOME):$(shell printenv GEM_PATH)
 export APACHE_DIR         = "$(DESTDIR)/var/www/ood"
 export APACHE_SYSTEMD_DIR = "$(DESTDIR)/etc/systemd/system/apache2.service.d"
+export APACHE_CONF_DIR    = "$(DESTDIR)/etc/apache2/sites-available"
 export CONFIG_DIR         = "$(DESTDIR)/etc/ood/config"
 
 
@@ -49,6 +50,9 @@ override_dh_auto_install:
 	rake package:version > $(DESTDIR)/opt/ood/VERSION
 	install -m 644 nginx_stage/share/nginx_stage_example.yml $(CONFIG_DIR)/nginx_stage.yml
 	install -m 640 ood-portal-generator/share/ood_portal_example.yml $(CONFIG_DIR)/ood_portal.yml
+	touch $(CONFIG_DIR)/ood_portal.sha256sum
+	mkdir -p $(APACHE_CONF_DIR)
+	touch $(APACHE_CONF_DIR)/ood-portal.conf
 	install -m 644 ood-portal-generator/share/maintenance.html $(APACHE_DIR)/public/maintenance/index.html
 	install -m 644 hooks/hook.env.example $(CONFIG_DIR)/hook.env
 


### PR DESCRIPTION
Use absolute paths for Apache symlinks, works with Puppet
Ensure that both ood-portal.conf and checksum exist inside package to do what RPM does to make things behave the same with automation
Also use the sites-available which is where vhost configs go.
