### PR TITLE
extend the timeout for uppy uploads

### DIFF
--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -558,7 +558,8 @@ function getFilesAndDirectoriesFromDirectory (directoryReader, oldEntries, logDr
     withCredentials: true,
     fieldName: 'file',
     limit: 1,
-    headers: { 'X-CSRF-Token': csrf_token }
+    headers: { 'X-CSRF-Token': csrf_token },
+    timeout: 128 * 1000,
   });
 
   uppy.on('file-added', (file) => {


### PR DESCRIPTION
Relates to #1378.  (I don't want to automatically close this yet).

I can't quite get 1378 to trigger, but I believe this resolves it. A google search and a spot check show that Linux default TCP TTL is 64 and Windows is 128. So, I set this to the larger, even if we don't support Windows - though I can reset to 64 if we think that better.

