### PR TITLE
ensure bc clusters preserve the order

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["2.7"]
+        ruby: ["2.7.1"]
         bundler: ["2.1.4"]
     runs-on: ${{ matrix.os }}
     name: Unit tests
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "2.7.1"
           bundler: "2.1.4"
           bundler-cache: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.1"
+          ruby-version: "2.7"
           bundler: "2.1.4"
           bundler-cache: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["2.7.1"]
+        ruby: ["2.7"]
         bundler: ["2.1.4"]
     runs-on: ${{ matrix.os }}
     name: Unit tests

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -124,16 +124,6 @@ module BatchConnect
         .map { |c| c.to_s.strip }
         .compact
     end
-
-    # Wheter the cluster is allowed or not based on the configured
-    # clusters and if the cluster allows jobs (job_allow?)
-    #
-    # @return [Boolean] whether the cluster is allowed or not
-    def cluster_allowed(cluster)
-      cluster.job_allow? && configured_clusters.any? do |pattern|
-        File.fnmatch(pattern, cluster.id.to_s, File::FNM_EXTGLOB)
-      end
-    end
     
     # Read in context from cache file if cache is disabled and context.json exist
     def update_session_with_cache(session_context, cache_file)
@@ -152,13 +142,17 @@ module BatchConnect
         (self.clusters.size == 1 && self.clusters[0] != cached_cluster)
     end
 
-
     # The clusters that the batch connect app can use. It's a combination
     # of what the app is configured to use and what the user is allowed
-    # to use.
-    # @return [OodCore::Clusters] clusters available to the app user
+    # to use. If the app has clusters configured, it preserves the order
+    # when it can. glob configurations' order may be platform dependent.
+    #
+    # @return [Array<OodCore::Cluster>] clusters available to the app user
     def clusters
-      OodAppkit.clusters.select { |cluster| cluster_allowed(cluster) }
+      @clusters ||=
+        configured_clusters.map do |config|
+          cfg_to_clusters(config)
+        end.flatten.compact.select(&:job_allow?)
     end
 
     # Whether this is a valid app the user can use
@@ -279,6 +273,17 @@ module BatchConnect
     end
 
     private
+
+      def cfg_to_clusters(config)
+        c = OodAppkit.clusters[config.to_sym] || nil
+        return [c] unless c.nil?
+
+        # cluster may be a glob at this point
+        OodAppkit.clusters.select do |cluster|
+          File.fnmatch(config, cluster.id.to_s, File::FNM_EXTGLOB)
+        end
+      end
+
       def build_sub_app_list
         return [self] unless sub_app_root.directory? && sub_app_root.readable? && sub_app_root.executable?
         list = sub_app_root.children.select(&:file?).map do |f|
@@ -366,21 +371,13 @@ module BatchConnect
           attributes[:cluster] = {
             widget: "select",
             label: "Cluster",
-            options: sorted_clusters
+            options: clusters.map(&:id)
           }
         else
           attributes[:cluster] = {
             value: clusters.first.id.to_s,
             widget: "hidden_field"
           }
-        end
-      end
-
-      def sorted_clusters
-        OodAppkit.clusters.select do |cluster|
-          cluster_allowed(cluster)
-        end.sort_by do |cluster|
-          configured_clusters.index(cluster.id) || cluster.id
         end
       end
   end

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -366,6 +366,7 @@ module BatchConnect
           attributes[:cluster] = {
             widget: "select",
             label: "Cluster",
+            # clusters.map doesn't seem to preserve the order of the clusters across platforms
             options: clusters.each_with_object([]) { |c, clusters| clusters.concat [c.id.to_s] }
           }
         else

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -366,7 +366,7 @@ module BatchConnect
           attributes[:cluster] = {
             widget: "select",
             label: "Cluster",
-            options: clusters.map { |cluster| cluster.id.to_s }
+            options: clusters.each_with_object([]) { |c, clusters| clusters.concat [c.id.to_s] }
           }
         else
           attributes[:cluster] = {

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -366,13 +366,21 @@ module BatchConnect
           attributes[:cluster] = {
             widget: "select",
             label: "Cluster",
-            options: clusters.map { |cluster| cluster.id.to_s }
+            options: sorted_clusters
           }
         else
           attributes[:cluster] = {
             value: clusters.first.id.to_s,
             widget: "hidden_field"
           }
+        end
+      end
+
+      def sorted_clusters
+        OodAppkit.clusters.select do |cluster|
+          cluster_allowed(cluster)
+        end.sort_by do |cluster|
+          configured_clusters.index(cluster.id) || cluster.id
         end
       end
   end

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -366,8 +366,7 @@ module BatchConnect
           attributes[:cluster] = {
             widget: "select",
             label: "Cluster",
-            # clusters.map doesn't seem to preserve the order of the clusters across platforms
-            options: clusters.each_with_object([]) { |c, clusters| clusters.concat [c.id.to_s] }
+            options: clusters.map { |cluster| cluster.id.to_s }
           }
         else
           attributes[:cluster] = {

--- a/apps/dashboard/test/fixtures/config/clusters.d/ruby.yml
+++ b/apps/dashboard/test/fixtures/config/clusters.d/ruby.yml
@@ -1,0 +1,8 @@
+v2:
+  job:
+    foo: bar
+  acls:
+    - adapter: 'group'
+      groups: 
+        - 'hopefully-doesnt-exist'
+      type: 'whitelist'

--- a/apps/dashboard/test/integration/apps_test.rb
+++ b/apps/dashboard/test/integration/apps_test.rb
@@ -19,7 +19,7 @@ class AppsTest < ActionDispatch::IntegrationTest
   end
 
   test "default table is correct" do
-    OodAppkit.stubs(:clusters).returns([]) # this gets rid of interactive apps
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.new([])) # this gets rid of interactive apps
     get "/apps/index"
 
     headers = css_select('tr[id="all-apps-table-header"] th')

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -7,6 +7,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
   end
 
   def expected_clusters(*args)
+    # want the return value to have the same order as *args so OodAppkit.clusters.select won't work
     args.each_with_object([]) do |arg, clusters|
       clusters.append(OodAppkit.clusters[arg.to_s])
     end.compact
@@ -91,7 +92,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       r.path.join("form.yml").write("cluster:\n  - ruby")
 
       app = BatchConnect::App.new(router: r)
-      assert ! app.valid?
+      assert !app.valid?
       assert_equal [], app.clusters
     }
   end
@@ -104,7 +105,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
 
       app = BatchConnect::App.new(router: r)
       assert app.valid?
-      assert_equal [ OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}}) ], app.clusters
+      assert_equal [OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' } })], app.clusters
     }
   end
 
@@ -152,7 +153,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       app = BatchConnect::App.new(router: r)
       # it's valid but there are no clusters. they're user defined and not validated by us
       assert app.valid?
-      assert_equal [], app.clusters
+      assert_equal expected_clusters, app.clusters
     }
   end
 

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -1,6 +1,17 @@
 require 'test_helper'
 
 class BatchConnect::AppTest < ActiveSupport::TestCase
+
+  def setup
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
+  end
+
+  def expected_clusters(*args)
+    args.each_with_object([]) do |arg, clusters|
+      clusters.append(OodAppkit.clusters[arg.to_s])
+    end.compact
+  end
+
   test "app with malformed form.yml" do
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
@@ -63,40 +74,18 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     end
   end
 
-  def good_clusters
-    [
-      OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}}),
-      OodCore::Cluster.new({id: 'pitzer', job: {foo: 'bar'}})
-    ]
-  end
-
-  def bad_clusters
-    [
-      # ruby not allowed bc the acl
-      OodCore::Cluster.new({
-        id: 'ruby',
-        job: { foo: 'bar'},
-        acls: [{ adapter: 'group', groups: ['hopefully-doesnt-exist'], type: 'whitelist' }]
-      })
-    ]
-  end
-
   test "app with multiple clusters" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
       r.path.join("form.yml").write("cluster:\n  - owens\n  - pitzer\n  - ruby")
 
       app = BatchConnect::App.new(router: r)
       assert app.valid?
-      assert_equal good_clusters, app.clusters # make sure you only allow good clusters
+      assert_equal expected_clusters(:owens, :pitzer), app.clusters # make sure you only allow good clusters
     }
   end
 
   test "app with a single invalid cluster" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
       r.path.join("form.yml").write("cluster:\n  - ruby")
@@ -108,8 +97,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
   end
 
   test "app with a single valid cluster" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
       # note the format here, it's a string not array for backward compatability
@@ -122,8 +109,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
   end
 
   test "app with special case of all clusters (*)" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
       # note the format here, it's a string not array for backward compatability
@@ -132,34 +117,30 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
 
       app = BatchConnect::App.new(router: r)
       assert app.valid?
-      assert_equal good_clusters, app.clusters # make sure you only allow good clusters
+      assert_equal expected_clusters(:owens, :oakley, :pitzer, :quick), app.clusters # make sure you only allow good clusters
     }
   end
 
   test "app with single glob to get owens" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
-      r.path.join("form.yml").write("cluster: o*")
+      r.path.join("form.yml").write("cluster: ow*")
 
       app = BatchConnect::App.new(router: r)
       assert app.valid?
-      assert_equal [ OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}}) ], app.clusters
+      assert_equal expected_clusters(:owens), app.clusters
     }
   end
 
-  test "app with multiple globs to get owens and pitzer, but not ruby" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
+  test "app with multiple globs to get owens and oakley, but not ruby" do
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
-      # try to pick up owens pitzer by globs
-      r.path.join("form.yml").write("cluster:\n  - o*\n  - p*\n  - r*")
+      # try to pick up all of them by globs
+      r.path.join("form.yml").write("cluster:\n  - ow*\n  - oak*\n  - r*")
 
       app = BatchConnect::App.new(router: r)
       assert app.valid?
-      assert_equal good_clusters, app.clusters # make sure you only allow good clusters
+      assert_equal expected_clusters(:owens, :oakley), app.clusters # make sure you only allow good clusters
     }
   end
 
@@ -190,8 +171,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
   end
 
   test "app disregards empty cluster strings" do
-    OodAppkit.stubs(:clusters).returns(good_clusters + bad_clusters)
-
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
       # note the empty string and the string with whitespace
@@ -202,13 +181,14 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       assert app.valid?
       # only owens gets through
       assert_equal [ 'owens' ], app.configured_clusters
-      assert_equal [ OodCore::Cluster.new({id: 'owens', job: {foo: 'bar'}}) ], app.clusters
+      assert_equal expected_clusters(:owens), app.clusters
     }
   end
 
   test "app does not include quick_pitzer when given pitzer" do
-    clusters = good_clusters +
+    clusters = OodAppkit.clusters.to_a +
       [
+        OodCore::Cluster.new({ id: 'pitzer', job: { foo: 'bar' } }),
         OodCore::Cluster.new({ id: 'quick_pitzer', job: { foo: 'bar' } }),
         OodCore::Cluster.new({ id: 'owens_login', job: { foo: 'bar' } }),
         OodCore::Cluster.new({ id: '_owens_', job: { foo: 'bar' } }),
@@ -217,16 +197,15 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
         OodCore::Cluster.new({ id: 'owen', job: { foo: 'bar' } })
       ]
 
-    OodAppkit.stubs(:clusters).returns(clusters + bad_clusters)
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.new(clusters))
 
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
       r.path.join("form.yml").write("cluster:\n  - \"owens\"\n  - \"pitzer\"")
 
       app = BatchConnect::App.new(router: r)
-
       assert app.valid?
-      assert_equal good_clusters, app.clusters
+      assert_equal expected_clusters(:owens, :pitzer), app.clusters
     }
   end
 
@@ -241,7 +220,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
   end
 
   test "select widgets with no options values throws error" do
-    OodAppkit.stubs(:clusters).returns(good_clusters)
     r = PathRouter.new("test/fixtures/sys_with_interactive_apps/broken_app")
     app = BatchConnect::App.new(router: r)
 

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -118,7 +118,8 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
 
       app = BatchConnect::App.new(router: r)
       assert app.valid?
-      assert_equal expected_clusters(:owens, :oakley, :pitzer, :quick), app.clusters # make sure you only allow good clusters
+      # have to cast to set here because globs ordering is not gaurenteed.
+      assert_equal expected_clusters(:owens, :oakley, :pitzer, :quick).to_set, app.clusters.to_set
     }
   end
 

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -411,7 +411,7 @@ class BatchConnect::SessionTest < ActiveSupport::TestCase
     Dir.mktmpdir('staged_root') do |dir|
       OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
       BatchConnect::Session.any_instance.stubs(:id).returns('test-id')
-      OodAppkit.stubs(:clusters).returns([OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' } })])
+      OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
       session = BatchConnect::Session.new
 
       assert !Dir.exist?(session.staged_root)

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -244,9 +244,11 @@ class BatchConnectTest < ApplicationSystemTestCase
     Dir.mktmpdir('bc_cache_test') do |tmpdir|
       OodAppkit.stubs(:dataroot).returns(Pathname.new(tmpdir.to_s))
 
-      # puts "cache root is #{BatchConnect::Session.cache_root}"
+      a = BatchConnect::App.from_token('sys/bc_jupyter')
+      puts "#{a.send(:configured_clusters)} & #{a.send(:clusters).map(&:id).map(&:to_s)}"
 
       visit new_batch_connect_session_context_url('sys/bc_jupyter')
+      puts  find("##{bc_ele_id('cluster')}")['innerHTML']
       assert_equal 'owens', find_value('cluster')
       assert_equal 'any', find_value('node_type')
       assert_equal '2.7', find_value('python_version')

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -244,8 +244,6 @@ class BatchConnectTest < ApplicationSystemTestCase
     Dir.mktmpdir('bc_cache_test') do |tmpdir|
       OodAppkit.stubs(:dataroot).returns(Pathname.new(tmpdir.to_s))
 
-      a = BatchConnect::App.from_token('sys/bc_jupyter')
-      puts "#{a.send(:configured_clusters)} & #{a.send(:clusters).map(&:id).map(&:to_s)}"
 
       visit new_batch_connect_session_context_url('sys/bc_jupyter')
       puts  find("##{bc_ele_id('cluster')}")['innerHTML']

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -246,7 +246,6 @@ class BatchConnectTest < ApplicationSystemTestCase
 
 
       visit new_batch_connect_session_context_url('sys/bc_jupyter')
-      puts  find("##{bc_ele_id('cluster')}")['innerHTML']
       assert_equal 'owens', find_value('cluster')
       assert_equal 'any', find_value('node_type')
       assert_equal '2.7', find_value('python_version')

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -15,7 +15,7 @@ require 'timecop'
 class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 
-  UserDouble = Struct.new(:name)
+  UserDouble = Struct.new(:name, :groups)
 
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
@@ -30,8 +30,8 @@ class ActiveSupport::TestCase
   end
 
   def stub_usr_router
-    OodSupport::Process.stubs(:user).returns(UserDouble.new('me'))
-    OodSupport::User.stubs(:new).returns(UserDouble.new('me'))
+    OodSupport::Process.stubs(:user).returns(UserDouble.new('me', ['me']))
+    OodSupport::User.stubs(:new).returns(UserDouble.new('me', ['me']))
 
     UsrRouter.stubs(:base_path).with(:owner => "me").returns(Pathname.new("test/fixtures/usr/me"))
     UsrRouter.stubs(:base_path).with(:owner => 'shared').returns(Pathname.new("test/fixtures/usr/shared"))


### PR DESCRIPTION
I believe this is ready now. I believe `OodCore::Clusters`'s order is determined by the order the files are read which may be platform dependent.  This is currently breaking tests because our CI seems to be different than our laptops.

The main fix here is for `BatchConnect::App#cluster` to try to preserve the order of how things are defined in the `form.*` file, not the order they were read off disk which is how `OodCore::Clusters`' (and subsequently ood appkit) seem to behave.

Globs configurations like `o*` or just `*` for all clusters do not guarantee any order.

Test files have been updated because they had stubs at the wrong layer. Tests now read fixture files directly instead of stubbing at some other layer.

