### PR TITLE
Removed Index from Public RootOptions as to not allow Directory Index

### DIFF
--- a/ood-portal-generator/checksum.rb
+++ b/ood-portal-generator/checksum.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+# use this file when you need to generate a new checksum for testing against.
+# ./checksum.rb spec/fixture/the-file-i-changed
+
+require "digest"
+
+def read_file_omitting_comments(input)
+  File.readlines(input).reject { |line| line =~ /^\s*#/ }.join('')
+end
+
+def checksum(input)
+  Digest::SHA256.hexdigest(read_file_omitting_comments(input))
+end
+
+puts checksum(ARGV[0])

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -119,7 +119,7 @@ Listen 8080
   #
   Alias "/assets" "/var/www/configured/public"
   <Directory "/var/www/configured/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>
@@ -240,7 +240,7 @@ Listen 8080
   #
   Alias "/discover" "/var/www/ood/discover"
   <Directory "/var/www/ood/discover">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>
@@ -254,7 +254,7 @@ Listen 8080
   #
   Alias "/register" "/var/www/ood/register"
   <Directory "/var/www/ood/register">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
 
     AuthType openid-connect

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.default
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.default
@@ -87,7 +87,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -101,7 +101,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -119,7 +119,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -119,7 +119,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -89,7 +89,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -78,7 +78,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -109,7 +109,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -123,7 +123,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -119,7 +119,7 @@
   #
   Alias "/public" "/var/www/ood/public"
   <Directory "/var/www/ood/public">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/ood-portal-generator/spec/fixtures/sum.default
+++ b/ood-portal-generator/spec/fixtures/sum.default
@@ -1,1 +1,1 @@
-4fe33e88acaf968dd2f601215d9a5206fac16004a0d47c9d95be91cf2f7b8edf /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf
+e5891fae1abde47d878ecbda0edbed7a132afa7ea166ecdaecb2214547fe102d /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -180,7 +180,7 @@ Listen <%= addr_port %>
   #
   Alias "<%= @public_uri %>" "<%= @public_root %>"
   <Directory "<%= @public_root %>">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>
@@ -322,7 +322,7 @@ Listen <%= addr_port %>
   #
   Alias "<%= @oidc_discover_uri %>" "<%= @oidc_discover_root %>"
   <Directory "<%= @oidc_discover_root %>">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>
@@ -337,7 +337,7 @@ Listen <%= addr_port %>
   #
   Alias "<%= @register_uri %>" "<%= @register_root %>"
   <Directory "<%= @register_root %>">
-    Options Indexes FollowSymLinks
+    Options FollowSymLinks
     AllowOverride None
 
     <%- @auth.each do |line| -%>


### PR DESCRIPTION
A release 2.0 of #1618

* Removed Index from Public RootOptions as to not allow Directory Indexing - Issues #1617

* Cleaned up ood-portal.conf.erb and updated fixtures to not contain Indexes

* Updated CheckSum for ood-portal.conf.default