### PR TITLE
Use versioned build repo for E2E tests (Release 2.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,3 +104,4 @@ jobs:
         run: bundle exec rake test:e2e
         env:
           BEAKER_set: ${{ matrix.dist }}
+          OOD_BUILD_REPO: ${{ matrix.version }}

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -116,6 +116,7 @@ def install_ondemand
   if host_inventory['platform'] == 'redhat'
     release_rpm = 'https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm'
     on hosts, "[ -f /etc/yum.repos.d/ondemand-web.repo ] || #{packager} install -y #{release_rpm}"
+    on hosts, "sed -i 's|/latest/|/build/2.0/|g' /etc/yum.repos.d/ondemand-web.repo"
     config_manager = if host_inventory['platform_version'] =~ /^7/
                        'yum-config-manager'
                      else

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -112,11 +112,15 @@ def ondemand_repo
   end
 end
 
+def build_repo_version
+  ENV['OOD_BUILD_REPO'] || '2.0'
+end
+
 def install_ondemand
   if host_inventory['platform'] == 'redhat'
     release_rpm = 'https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm'
     on hosts, "[ -f /etc/yum.repos.d/ondemand-web.repo ] || #{packager} install -y #{release_rpm}"
-    on hosts, "sed -i 's|/latest/|/build/2.0/|g' /etc/yum.repos.d/ondemand-web.repo"
+    on hosts, "sed -i 's|/latest/|/build/#{build_repo_version}/|g' /etc/yum.repos.d/ondemand-web.repo"
     config_manager = if host_inventory['platform_version'] =~ /^7/
                        'yum-config-manager'
                      else


### PR DESCRIPTION
Release 2.0 for #1556

Needed so any pull requests targeting 2.0 will have E2E tests work.