### PR TITLE
normalize keys in table to account for options with hyphens

### DIFF
--- a/apps/dashboard/app/javascript/packs/batchConnect.js
+++ b/apps/dashboard/app/javascript/packs/batchConnect.js
@@ -276,10 +276,13 @@ function setValue(event, changeId) {
  * allows for, say, gpu to have the same min & max across clusters.
  */
 class Table {
-  // FIXME: probably need to make Vector class? Wouldn't want to add a flag to the constructor.
   constructor(x, y) {
+    // FIXME: probably need to make Vector class? Wouldn't want to add a flag to the constructor.
+    // we don't use x or y internally, though x is used externally.
+    this.x = x;
     this.xIdxLookup = {};
 
+    this.y = y;
     this.yIdxLookup = {};
     this.table = y === undefined ? [] : [[]];
   }

--- a/apps/dashboard/app/javascript/packs/batchConnect.js
+++ b/apps/dashboard/app/javascript/packs/batchConnect.js
@@ -74,12 +74,12 @@ function snakeCaseWords(str) {
   let first = true;
 
   str.split('').forEach((c) => {
-    if (first){
+    if (first) {
       first = false;
       snakeCase += c.toLowerCase();
-    } else if(c === '-') {
+    } else if(c === '-' || c === '_') {
       snakeCase += '_';
-    } else if(c == c.toUpperCase()) {
+    } else if(c == c.toUpperCase() && !(c >= '0' && c <= '9')) {
       snakeCase += `_${c.toLowerCase()}`;
     } else {
       snakeCase += c;
@@ -276,17 +276,18 @@ function setValue(event, changeId) {
  * allows for, say, gpu to have the same min & max across clusters.
  */
 class Table {
+  // FIXME: probably need to make Vector class? Wouldn't want to add a flag to the constructor.
   constructor(x, y) {
-    this.x = x;
     this.xIdxLookup = {};
 
-    this.y = y;
     this.yIdxLookup = {};
     this.table = y === undefined ? [] : [[]];
   }
 
   put(x, y, value) {
     if(!x) return;
+    x = snakeCaseWords(x);
+    y = snakeCaseWords(y);
 
     if(this.xIdxLookup[x] === undefined) this.xIdxLookup[x] = Object.keys(this.xIdxLookup).length;
     if(y && this.yIdxLookup[y] === undefined) this.yIdxLookup[y] = Object.keys(this.yIdxLookup).length;
@@ -319,8 +320,8 @@ class Table {
   }
 
   get(x, y) {
-    const xIdx = this.xIdxLookup[x];
-    const yIdx = this.yIdxLookup[y];
+    const xIdx = this.xIdxLookup[snakeCaseWords(x)];
+    const yIdx = this.yIdxLookup[snakeCaseWords(y)];
 
     if(this.table[xIdx] === undefined){
       return undefined;

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -54,6 +54,11 @@ attributes:
           data-min-bc-num-slots: 100,
           data-max-bc-num-slots: 200
         ]
+      - [
+          "other-40ish-option",
+          data-min-bc-num-slots-for-cluster-owens: 40,
+          data-min-bc-num-slots-for-cluster-oakley: 48,
+        ]
   python_version:
     # let's set the account used by the python version for some reason
     widget: select

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -56,8 +56,8 @@ attributes:
         ]
       - [
           "other-40ish-option",
-          data-min-bc-num-slots-for-cluster-owens: 40,
-          data-min-bc-num-slots-for-cluster-oakley: 48,
+          data-max-bc-num-slots-for-cluster-owens: 40,
+          data-max-bc-num-slots-for-cluster-oakley: 48,
         ]
   python_version:
     # let's set the account used by the python version for some reason

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -276,4 +276,20 @@ class BatchConnectTest < ApplicationSystemTestCase
     select('same', from: bc_ele_id('node_type'))
     assert !find("##{bc_ele_id('cuda_version')}", visible: false).visible?
   end
+
+  test 'options with hyphens' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # defaults
+    assert_equal 'owens', find_value('cluster')
+    assert_equal 'any', find_value('node_type')
+    assert_equal 20, find_max('bc_num_slots')
+
+    select('other-40ish-option', from: bc_ele_id('node_type'))
+    assert_equal 40, find_max('bc_num_slots')
+
+    # now change the cluster and the max changes
+    select('oakley', from: bc_ele_id('cluster'))
+    assert_equal 48, find_max('bc_num_slots')
+  end
 end


### PR DESCRIPTION
Fixes #1607.

Here the `Table` class is going to normalize keys internally as a pose to the upper layers having to keep track of things.
This means `any-40core` turns into `any_40core` internally.

This also fixes bugs with snake casing words with hyphens in them.