### PR TITLE
account for options with numbers after hyphens & underscores

### DIFF
--- a/apps/dashboard/app/javascript/packs/batchConnect.js
+++ b/apps/dashboard/app/javascript/packs/batchConnect.js
@@ -24,6 +24,9 @@ const minMaxLookup = {};
 const setValueLookup = {};
 const hideLookup = {};
 
+// the regular expression for mountain casing
+const mcRex = /[[-_]([a-z])|([_-][0-9])/g;
+
 function bcElement(name) {
   return `${bcPrefix}_${name.toLowerCase()}`;
 };
@@ -42,29 +45,26 @@ function shortId(elementId) {
 
 /**
  * Mountain case the words from a string, by tokenizing on [-_].  In the
- * simplest case it simple capitalizes.
+ * simplest case it just capitalizes.
  *
- * @param      {string}  str     The word string to capitalize
+ * There is a special case where seperators are followed numbers. In this case
+ * The seperator is kept as a hyphen because that's how jQuery expects it.
+ *
+ * @param      {string}  str     The word string to mountain case
  *
  * @example  given 'foo' this returns 'Foo'
  * @example  given 'foo-bar' this returns 'FooBar'
+ * @example  given 'physics_1234' this returns 'Physics-1234'
  */
- function mountainCaseWords(str) {
-  let camelCase = "";
-  let capitalize = true;
-
-  str.split('').forEach((c) => {
-    if (capitalize) {
-      camelCase += c.toUpperCase();
-      capitalize = false;
-    } else if(c == '-' || c == '_') {
-      capitalize = true;
-    } else {
-      camelCase += c;
-    }
+// Convert dashed to camelCase
+function mountainCaseWords(str) {
+  const lower = str.toLowerCase();
+  const first = lower.charAt(0).toUpperCase();
+  const rest = lower.slice(1).replace(mcRex, function(_all, letter, prefixedNumber) {
+    return letter ? letter.toUpperCase() : prefixedNumber.replace('_','-');
   });
 
-  return camelCase;
+  return  `${first}${rest}`;
 }
 
 function snakeCaseWords(str) {

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -103,6 +103,23 @@ attributes:
       - "4"
       - "7"
       - "38"
+  classroom:
+    widget: select
+    options:
+      - [ 'Physics 1234', 'physics_1234' ]
+      - [ 'Astronomy 5678', 'astronomy_5678' ]
+  classroom_size:
+    widget: select
+    options:
+      - [ 'small', 'small' ]
+      - [
+          'medium', 'medium',
+          data-option-for-classroom-astronomy-5678: false,
+        ]
+      - [
+          'large', 'large',
+          data-option-for-classroom-astronomy-5678: false,
+        ]
 form:
   - bc_num_hours
   - bc_num_slots
@@ -113,3 +130,5 @@ form:
   - python_version
   - cuda_version
   - hidden_change_thing
+  - classroom
+  - classroom_size

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -292,4 +292,19 @@ class BatchConnectTest < ApplicationSystemTestCase
     select('oakley', from: bc_ele_id('cluster'))
     assert_equal 48, find_max('bc_num_slots')
   end
+
+  test 'options with numbers' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # defaults
+    assert_equal 'physics_1234', find_value('classroom')
+    assert_equal 'small', find_value('classroom_size')
+    assert_equal '', find_option_style('classroom_size', 'medium')
+    assert_equal '', find_option_style('classroom_size', 'large')
+
+    # now change the classroom and see the other sizes disappear
+    select('Astronomy 5678', from: bc_ele_id('classroom'))
+    assert_equal 'display: none;', find_option_style('classroom_size', 'medium')
+    assert_equal 'display: none;', find_option_style('classroom_size', 'large')
+  end
 end


### PR DESCRIPTION
account for options with numbers after hyphens & underscores.

Options like this do not work. The key we're looking for is `Physics-1234` which preserves the hyphen. 

```yaml
data-option-for-classroom-physics-1234: false
```

You can see with a configuration like that above is translated to this in HTML:
![image](https://user-images.githubusercontent.com/4874123/145878126-9a00fd40-3e73-427a-a968-46012f0c35b4.png)

But in jQuery you can see the that the hyphen is preserved.
![image](https://user-images.githubusercontent.com/4874123/145877949-fa2bf4f3-bce1-4456-98ed-1d7b2ba3d7ae.png)

