### PR TITLE
Add env var for hiding featured apps menu

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_featured_group
-    @featured_group = filter_groups(pinned_app_group).first # 1 single group called 'Apps'
+    @featured_group = filter_groups(pinned_app_group).first if ::Configuration.show_featured_apps # 1 single group called 'Apps'
   end
 
   def sys_apps

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -334,6 +334,10 @@ class ConfigurationSingleton
     end
   end
 
+  def show_featured_apps
+    to_bool(ENV["OOD_SHOW_FEATURED_APPS"] || true)
+  end
+
   # The dashboard's landing page layout. Defaults to nil.
   def dashboard_layout
     config.fetch(:dashboard_layout, nil)

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -437,6 +437,22 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     assert_equal 'dark', ConfigurationSingleton.new.navbar_type
   end
 
+  test "featured apps are shown by default" do
+    assert ConfigurationSingleton.new.show_featured_apps
+  end
+
+  test "featured apps can be hidden" do
+    with_modified_env(OOD_SHOW_FEATURED_APPS: "false") do
+      refute ConfigurationSingleton.new.show_featured_apps
+    end
+  end
+
+  test "show featured apps enabled shows apps" do
+    with_modified_env(OOD_SHOW_FEATURED_APPS: "true") do
+      assert ConfigurationSingleton.new.show_featured_apps
+    end
+  end
+
   test 'boolean configs have correct default' do
     c = ConfigurationSingleton.new
 


### PR DESCRIPTION
At CSC we want to rename *Interactive Apps* navbar entry to *Apps* and hide the normal *Apps* menu shown by OOD (containing pinned apps and *All Apps* link). This can't be done as trying to filter out *Apps* using `NavConfig.categories_whitelist` filters out our new category too.

This PR adds an environment variable `OOD_SHOW_FEATURED_APPS` that can be changed to be able to disable the *Apps* menu in the navbar. The default is to show the menu entry, so these changes only affect things when the env var is set.