### PR TITLE
Internationalize Apps menu title

### DIFF
--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -11,7 +11,7 @@ class FeaturedApp < OodApp
     FeaturedApp.new(app.router, token: token)
   end
 
-  def initialize(router, category: I18n.t("dashboard.featured_apps_title"), subcategory: I18n.t('dashboard.pinned_apps_title'), token: nil)
+  def initialize(router, category: I18n.t("dashboard.pinned_apps_category"), subcategory: I18n.t('dashboard.pinned_apps_title'), token: nil)
     super(router)
 
     @category = category.to_s

--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -11,7 +11,7 @@ class FeaturedApp < OodApp
     FeaturedApp.new(app.router, token: token)
   end
 
-  def initialize(router, category: "Apps", subcategory: I18n.t('dashboard.pinned_apps_title'), token: nil)
+  def initialize(router, category: I18n.t("dashboard.featured_apps_title"), subcategory: I18n.t('dashboard.pinned_apps_title'), token: nil)
     super(router)
 
     @category = category.to_s

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -173,6 +173,7 @@ en:
     not_grouped: "Other Apps"
 
     nav_limit_caption: 'showing %{subset_count} of %{total_count}'
+    featured_apps_title: "Apps"
     pinned_apps_title: 'Pinned Apps'
     pinned_apps_caption_html: 'A featured subset of <a href="%{all_apps_url}">all available apps</a>'
     development_apps_caption: "Sandbox App"

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -173,7 +173,7 @@ en:
     not_grouped: "Other Apps"
 
     nav_limit_caption: 'showing %{subset_count} of %{total_count}'
-    featured_apps_title: "Apps"
+    pinned_apps_category: "Apps"
     pinned_apps_title: 'Pinned Apps'
     pinned_apps_caption_html: 'A featured subset of <a href="%{all_apps_url}">all available apps</a>'
     development_apps_caption: "Sandbox App"

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -28,7 +28,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
     get '/'
 
-    dd = dropdown_list(I18n.t('dashboard.featured_apps_title'))
+    dd = dropdown_list(I18n.t('dashboard.pinned_apps_category'))
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [
@@ -55,7 +55,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
     get '/'
 
-    dd = dropdown_list(I18n.t('dashboard.featured_apps_title'))
+    dd = dropdown_list(I18n.t('dashboard.pinned_apps_category'))
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -28,7 +28,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
     get '/'
 
-    dd = dropdown_list('Apps')
+    dd = dropdown_list(I18n.t('dashboard.featured_apps_title'))
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [
@@ -55,7 +55,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
     get '/'
 
-    dd = dropdown_list('Apps')
+    dd = dropdown_list(I18n.t('dashboard.featured_apps_title'))
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [


### PR DESCRIPTION
Alternative solution to #1664.
Internationalizes the title for the featured apps in the navbar.