### PR TITLE
Backport js fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.21] - 2021-12-20
+
+### Fixed
+
+- Dynamic javascript now correctly clamps values correcting [1649](https://github.com/OSC/ondemand/issues/1649).
+- Dynamic javascript can hide multiple elements correcting [1666](https://github.com/OSC/ondemand/issues/1666).
+- Dynamic javascript now correctly handles options with numbers, hyphens and underscores
+  back-porting [1656](https://github.com/OSC/ondemand/pull/1656).
+
 ## [2.0.20] - 2021-12-01
 
 ### Security
@@ -935,7 +944,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - From 1.3.7 - 1.4.2 updated app versions
 
 
-[Unreleased]: https://github.com/OSC/ondemand/compare/v2.0.20...release_2.0
+[Unreleased]: https://github.com/OSC/ondemand/compare/v2.0.21...release_2.0
+[2.0.21]: https://github.com/OSC/ondemand/compare/v2.0.20...v2.0.21
 [2.0.20]: https://github.com/OSC/ondemand/compare/v2.0.19...v2.0.20
 [2.0.19]: https://github.com/OSC/ondemand/compare/v2.0.18...v2.0.19
 [2.0.18]: https://github.com/OSC/ondemand/compare/v2.0.17...v2.0.18

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -26,6 +26,7 @@ attributes:
       - [
           "any",
           data-hide-cuda-version: true,
+          data-hide-advanced-options: true,
           data-minnn-bc-not-found-for-cluster-mistype: 30,
           data-max-bc-not-found-for-cluster-mistype: 30,
           data-maximum-bc-not-found-for-cluster-mistype: 30
@@ -44,6 +45,7 @@ attributes:
           "hugemem",
           data-option-for-cluster-oakley: false,
           data-hide-cuda-version: true,
+          data-hide-advanced-options: true,
           data-max-bc-num-slots-for-cluster-owens: 42,
           data-min-bc-num-slots-for-cluster-owens: 42,
         ]
@@ -58,11 +60,13 @@ attributes:
       - [
           "same",
           data-hide-cuda-version: true,
+          data-hide-advanced-options: true,
           data-min-bc-num-slots: 100,
           data-max-bc-num-slots: 200
         ]
       - [
           "other-40ish-option",
+          data-hide-advanced-options: true,
           data-max-bc-num-slots-for-cluster-owens: 40,
           data-max-bc-num-slots-for-cluster-oakley: 48,
         ]
@@ -103,6 +107,23 @@ attributes:
       - "4"
       - "7"
       - "38"
+  classroom:
+    widget: select
+    options:
+      - [ 'Physics 1234', 'physics_1234' ]
+      - [ 'Astronomy 5678', 'astronomy_5678' ]
+  classroom_size:
+    widget: select
+    options:
+      - [ 'small', 'small' ]
+      - [
+          'medium', 'medium',
+          data-option-for-classroom-astronomy-5678: false,
+        ]
+      - [
+          'large', 'large',
+          data-option-for-classroom-astronomy-5678: false,
+        ]
 form:
   - bc_num_hours
   - bc_num_slots
@@ -113,3 +134,6 @@ form:
   - python_version
   - cuda_version
   - hidden_change_thing
+  - classroom
+  - classroom_size
+  - advanced_options


### PR DESCRIPTION
Backport these 3 dynamic javascript bugfixes to 2.0.


- Dynamic javascript now correctly clamps values correcting [1649](https://github.com/OSC/ondemand/issues/1649).
- Dynamic javascript can hide multiple elements correcting [1666](https://github.com/OSC/ondemand/issues/1666).
- Dynamic javascript now correctly handles options with numbers, hyphens and underscores
  back-porting [1656](https://github.com/OSC/ondemand/pull/1656).