### PR TITLE
Fix backbutton issue on new app page

### DIFF
--- a/apps/dashboard/app/views/products/new_from_git_remote.html.erb
+++ b/apps/dashboard/app/views/products/new_from_git_remote.html.erb
@@ -14,4 +14,4 @@
 
 <hr />
 
-<%= link_to 'Back', products_path(type: @type), class: 'btn btn-default' %>
+<%= link_to 'Back', products_path, class: 'btn btn-default' %>

--- a/apps/dashboard/app/views/products/new_from_git_remote.html.erb
+++ b/apps/dashboard/app/views/products/new_from_git_remote.html.erb
@@ -14,4 +14,4 @@
 
 <hr />
 
-<%= link_to 'Back', new_product_path(type: @type), class: 'btn btn-default' %>
+<%= link_to 'Back', products_path(type: @type), class: 'btn btn-default' %>


### PR DESCRIPTION
To test, do the following:

DEV URL: https://ondemand-dev.osc.edu/pun/dev/dashboard/admin/usr/products/new_from_git_remote

Navigate to ondemand-dev
Click "Develop" and then "My Shared Apps (Production)"
On next page, click "New App" button
On "New App" Page, click the "Back" Button.
It will take you to the Products Index page