### PR TITLE
options with hyphens still dont work right

### DIFF
--- a/apps/dashboard/app/javascript/packs/batchConnect.js
+++ b/apps/dashboard/app/javascript/packs/batchConnect.js
@@ -26,7 +26,7 @@ const setValueLookup = {};
 const hideLookup = {};
 
 // the regular expression for mountain casing
-const mcRex = /[[-_]([a-z])|([_-][0-9])/g;
+const mcRex = /[-_]([a-z])|([_-][0-9])/g;
 
 function bcElement(name) {
   return `${bcPrefix}_${name.toLowerCase()}`;

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -77,16 +77,19 @@ attributes:
       - [
           "2.7",
           data-option-for-node-type-advanced: false,
+          data-option-for-node-type-other-40ish-option: false,
           data-set-bc-account: 'python27'
         ]
       - [
           "3.1",
           data-option-for-node-type-advanced: false,
+          data-option-for-node-type-other-40ish-option: false,
           data-set-bc-account: 'python31'
         ]
       - [
           "3.2",
           data-option-for-node-type-advanced: false,
+          data-option-for-node-type-other-40ish-option: false,
           data-set-bc-account: 'python32'
         ]
       - [

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -302,7 +302,7 @@ class BatchConnectTest < ApplicationSystemTestCase
     assert find("##{bc_ele_id('advanced_options')}").visible?
   end
 
-  test 'options with hyphens' do
+  test 'options with hyphens set min & max' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 
     # defaults
@@ -316,6 +316,23 @@ class BatchConnectTest < ApplicationSystemTestCase
     # now change the cluster and the max changes
     select('oakley', from: bc_ele_id('cluster'))
     assert_equal 48, find_max('bc_num_slots')
+  end
+
+  test 'options with hyphens get hidden' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # defaults
+    assert_equal 'owens', find_value('cluster')
+    assert_equal 'any', find_value('node_type')
+    assert_equal '2.7', find_value('python_version')
+
+    # now switch node type and find that 2.7, and more, are hidden and 3.6 is the choice now
+    # even when the options has hyphens in it
+    select('other-40ish-option', from: bc_ele_id('node_type'))
+    assert_equal 'display: none;', find_option_style('python_version', '2.7')
+    assert_equal 'display: none;', find_option_style('python_version', '3.1')
+    assert_equal 'display: none;', find_option_style('python_version', '3.2')
+    assert_equal '3.6', find("##{bc_ele_id('python_version')}").value
   end
 
   test 'options with numbers' do


### PR DESCRIPTION
While #1656 may have fixed options with numbers, it broke options with hyhens (like clusters that are named `kubernetes-test`). It seems to be a very simple mistake with an extra `[` in the regex and sadly, there was no test case for the same.