### PR TITLE
allow for additonal capabilites in the dev container

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,6 +79,9 @@ variables you may want and/or need.
 For example if you need additional Linux capabilities you can use `OOD_CTR_CAPABILITIES`
 with a comma separated list of the capabilities you want.
 
+If `privileged` is in this list, no capabilies are used and the container is ran with
+the `--privileged` flag.
+
 ```shell
 OOD_CTR_CAPABILITIES=net_raw,net_admin
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,3 +68,26 @@ you want to rebuild to a newer version use the rebuild task.
 ```text
 rake dev:rebuild
 ```
+
+## Advanced setups
+
+### Additional Capabilities
+
+While starting this container, this library will respond to some environment
+variables you may want and/or need.
+
+For example if you need additional Linux capabilities you can use `OOD_CTR_CAPABILITIES`
+with a comma separated list of the capabilities you want.
+
+```shell
+OOD_CTR_CAPABILITIES=net_raw,net_admin
+```
+
+### Additional Mounts
+
+You can mount the current directory to override what exists in the container
+by setting _anything_ in the `OOD_MNT_` environment variables.
+
+* `OOD_MNT_PORTAL` mounts <project_root>/ood-portal-generator to /opt/ood/ood-portal-generator
+* `OOD_MNT_NGINX` mounts <project_root>/nginx_stage to /opt/ood/nginx_stage
+* `OOD_MNT_PROXY` mounts <project_root>/ood_proxy to /opt/ood/ood_proxy

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -58,9 +58,10 @@ namespace :dev do
   def podman_rt_args
     [
       '--userns', 'keep-id',
-      '--cap-add', 'sys_ptrace',
       '--security-opt', 'label=disable'
-    ].freeze
+    ].tap do |arr|
+      arr.concat [ '--cap-add', 'sys_ptrace'] unless additional_caps.include?('--privileged')
+    end.freeze
   end
 
   def config_directory
@@ -82,7 +83,10 @@ namespace :dev do
   end
 
   def additional_caps
-    ENV['OOD_CTR_CAPABILITIES'].to_s.split(',').map do |cap|
+    caps = ENV['OOD_CTR_CAPABILITIES'].to_s
+    return ['--privileged'] if caps.include?('privileged')
+
+    caps.to_s.split(',').map do |cap|
       [ '--cap-add', cap.downcase ]
     end
   end

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -81,6 +81,15 @@ namespace :dev do
     end
   end
 
+  def additional_caps
+    caps = ENV['OOD_CTR_CAPABILITIES'].to_s
+    return [] if caps.empty?
+
+    caps.split(',').map do |cap|
+      [ '--cap-add', cap.downcase ]
+    end
+  end
+
   desc 'Start development container'
   task :start => ['ensure_dev_files'] do
     Rake::Task['package:dev_container'].invoke unless image_exists?("#{dev_image_name}:latest")
@@ -89,6 +98,7 @@ namespace :dev do
     ctr_args.concat ["--name #{dev_container_name}"]
     ctr_args.concat ['--rm', '--detach']
     ctr_args.concat dev_mounts
+    ctr_args.concat additional_caps
     ctr_args.concat container_rt_args
 
     ctr_args.concat ["#{dev_image_name}:latest"]

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -82,10 +82,7 @@ namespace :dev do
   end
 
   def additional_caps
-    caps = ENV['OOD_CTR_CAPABILITIES'].to_s
-    return [] if caps.empty?
-
-    caps.split(',').map do |cap|
+    ENV['OOD_CTR_CAPABILITIES'].to_s.split(',').map do |cap|
       [ '--cap-add', cap.downcase ]
     end
   end


### PR DESCRIPTION
allow for additonal capabilites in the dev container with some documentation.

I'm having to add `net_admin` and `net_raw` so I can play with iptables in the container.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201546099455280/1201573096078266) by [Unito](https://www.unito.io)
