### PR TITLE
Fix nightlies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,8 +87,8 @@ deploy-nightly:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
     - mkdir tmp
-    - echo "Clone ondemand-packaging branch ${OOD_PACKAGE_RELEASE}"
-    - git clone --single-branch --branch $OOD_PACKAGE_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+    - echo "Clone ondemand-packaging branch ${OOD_PACKAGING_RELEASE}"
+    - git clone --single-branch --branch $OOD_PACKAGING_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c nightly ./dist/*
 
 deploy-build:
@@ -97,8 +97,8 @@ deploy-build:
     - tags
   script:
     - mkdir tmp
-    - echo "Clone ondemand-packaging branch ${OOD_PACKAGE_RELEASE}"
-    - git clone --single-branch --branch $OOD_PACKAGE_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+    - echo "Clone ondemand-packaging branch ${OOD_PACKAGING_RELEASE}"
+    - git clone --single-branch --branch $OOD_PACKAGING_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./dist/*
 
 deploy:
@@ -107,6 +107,6 @@ deploy:
     - tags
   script:
     - mkdir tmp
-    - echo "Clone ondemand-packaging branch ${OOD_PACKAGE_RELEASE}"
-    - git clone --single-branch --branch $OOD_PACKAGE_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+    - echo "Clone ondemand-packaging branch ${OOD_PACKAGING_RELEASE}"
+    - git clone --single-branch --branch $OOD_PACKAGING_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 before_script:
   - docker info
-  - '[ -d tmp ] || mkdir tmp'
   - MAJOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f1)
   - MINOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f2)
   - '[ "x$CI_COMMIT_TAG" != "x" ] && OOD_PACKAGING_RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}" || OOD_PACKAGING_RELEASE=main'
@@ -87,8 +86,9 @@ deploy-nightly:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
-    - echo "Clone ondemand-packaging branch ${RELEASE}"
-    - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+    - mkdir tmp
+    - echo "Clone ondemand-packaging branch ${OOD_PACKAGE_RELEASE}"
+    - git clone --single-branch --branch $OOD_PACKAGE_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c nightly ./dist/*
 
 deploy-build:
@@ -96,8 +96,9 @@ deploy-build:
   only:
     - tags
   script:
-    - echo "Clone ondemand-packaging branch ${RELEASE}"
-    - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+    - mkdir tmp
+    - echo "Clone ondemand-packaging branch ${OOD_PACKAGE_RELEASE}"
+    - git clone --single-branch --branch $OOD_PACKAGE_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./dist/*
 
 deploy:
@@ -105,6 +106,7 @@ deploy:
   only:
     - tags
   script:
-    - echo "Clone ondemand-packaging branch ${RELEASE}"
-    - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+    - mkdir tmp
+    - echo "Clone ondemand-packaging branch ${OOD_PACKAGE_RELEASE}"
+    - git clone --single-branch --branch $OOD_PACKAGE_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
 before_script:
   - docker info
   - '[ -d tmp ] || mkdir tmp'
+  - MAJOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f1)
+  - MINOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f2)
+  - '[ "x$CI_COMMIT_TAG" != "x" ] && OOD_PACKAGING_RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}" || OOD_PACKAGING_RELEASE=main'
   - bundle install --path vendor/bundle --without test
 stages:
   - build
@@ -84,6 +87,8 @@ deploy-nightly:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
+    - echo "Clone ondemand-packaging branch ${RELEASE}"
+    - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c nightly ./dist/*
 
 deploy-build:
@@ -91,6 +96,8 @@ deploy-build:
   only:
     - tags
   script:
+    - echo "Clone ondemand-packaging branch ${RELEASE}"
+    - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c build -r $CI_COMMIT_TAG ./dist/*
 
 deploy:
@@ -98,4 +105,6 @@ deploy:
   only:
     - tags
   script:
+    - echo "Clone ondemand-packaging branch ${RELEASE}"
+    - git clone --single-branch --branch $RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
     - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./dist/*


### PR DESCRIPTION
Still need to clone non-gem to push packages to repos as those are still Python scripts.  The actual packaging is gem, the push to repo server is not yet.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201546099455280/1201613089927415) by [Unito](https://www.unito.io)
