### PR TITLE
Add jobid to Detail Metrics link

### DIFF
--- a/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
@@ -16,7 +16,7 @@
             Node: <%= node %>
             <span class="ml-3">Job: <%= data.pbsid %></span>
             <span class="ml-3">
-              <a href="<%= build_grafana_link(data.cluster, data.starttime, 'node', node) %>" target="_blank">
+              <a href="<%= build_grafana_link(data.cluster, data.starttime, 'node', node, data.pbsid) %>" target="_blank">
                     <span class="fa fa-external-link-square-alt"></span> Detailed Metrics
               </a>
             </span>


### PR DESCRIPTION
The "Detail Metrics" link to Grafana was broken for us as it was missing the jobid. Not sure if this was intentionally left out but this patch works well for us and pains the link correctly.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201625178070145/1201662052788860) by [Unito](https://www.unito.io)
