### PR TITLE
use dataroot and ensure its safe to use & traverse

### DIFF
--- a/apps/dashboard/app/models/jobs/project.rb
+++ b/apps/dashboard/app/models/jobs/project.rb
@@ -1,16 +1,30 @@
 class Jobs::Project 
   def self.all
-    # return [Array] of all projects in ~/ondemand/data/sys/myjobs/projects
-    Dir.children(base_path)
+    # return [Array] of all projects in ~/ondemand/data/sys/projects
+    return [] unless dataroot.directory? && dataroot.executable? && dataroot.readable?
+    
+    dataroot.children.map do |d|
+      Project.new(d)
+    rescue StandardError => e
+      Rails.logger.warn("Didn't create project. #{e.message}")
+    end.compact
   end
 
-  def self.base_path
-    ENV['HOME'] + '/ondemand/data/sys/myjobs/projects/'
+  def self.dataroot
+    Rails.logger.debug("project path is: #{OodAppkit.dataroot.join('projects')}")
+
+    OodAppkit.dataroot.join('projects').tap do |p|
+      p.mkpath unless p.exist?
+    rescue StandardError => e
+      Pathname.new('')
+    end
   end
 
   attr_reader :dir
 
-  def initialize
+  def initialize(dir: nil)
+    raise StandardError, "#{dir} is not a directory" unless dir File.directory?(directory.to_s)
+
     @dir = dir.to_s
   end
 

--- a/apps/dashboard/test/integration/jobs_controller_test.rb
+++ b/apps/dashboard/test/integration/jobs_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class JobsControllerTest < ActionDispatch::IntegrationTest
 
   def setup
-    Jobs::Project.stubs(:base_path).returns(Rails.root.join('test/fixtures/jobs/projects'))
+    OodAppkit.stubs(:dataroot).returns(Rails.root.join('test/fixtures/jobs'))
     Configuration.stubs(:jobs_app_alpha?).returns(true)
     Rails.application.reload_routes!
   end
@@ -26,5 +26,23 @@ class JobsControllerTest < ActionDispatch::IntegrationTest
   test "should get edit" do
     get edit_jobs_project_path(:id)
     assert_response :success
+  end
+
+  test "safe to get with invalid dataroot" do
+    OodAppkit.stubs(:dataroot).returns(Pathname.new('/dev/null'))
+    get jobs_projects_path
+    assert_response :success
+  end
+
+  test "makes the directory if it doesnt exist" do
+    Dir.mktmpdir do |dir|
+        OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
+        assert  !Dir.exist?("#{dir}/projects")
+
+        get jobs_projects_path
+        assert_response :success
+
+        assert Dir.exist?("#{dir}/projects")
+    end
   end
 end


### PR DESCRIPTION
In looking this feature branch over to pull into the mainline - I made these small additions. Primarily - to use `OodAppKit.dataroot` like other apps and to ensure it's safe to do that.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201625178070145/1201675722026924) by [Unito](https://www.unito.io)
