### PR TITLE
Fix boolean test

### DIFF
--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -459,10 +459,20 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   end
 
   test 'boolean configs respond config files' do
-    with_modified_env(config_fixtures) do
-      c = ConfigurationSingleton.new
-      c.boolean_configs.each do |config, default|
-        assert_equal !default, c.send(config), "#{config} should have been #{!default} through a fixture file."
+    Dir.mktmpdir do |dir|
+      with_modified_env(config_fixtures) do
+        # write !defaults out
+        File.open("#{dir}/config.yml", 'w+') do |file|
+          cfg = ConfigurationSingleton.new.boolean_configs.each_with_object({}) do |(config, default), hsh|
+            hsh[config.to_s] = !default
+          end
+          file.write(cfg.to_yaml)
+        end
+
+        c = ConfigurationSingleton.new
+        c.boolean_configs.each do |config, default|
+          assert_equal !default, c.send(config), "#{config} should have been #{!default} through a fixture file."
+        end
       end
     end
   end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -460,7 +460,7 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
 
   test 'boolean configs respond config files' do
     Dir.mktmpdir do |dir|
-      with_modified_env(config_fixtures) do
+      with_modified_env({ OOD_CONFIG_D_DIRECTORY: dir.to_s }) do
         # write !defaults out
         File.open("#{dir}/config.yml", 'w+') do |file|
           cfg = ConfigurationSingleton.new.boolean_configs.each_with_object({}) do |(config, default), hsh|


### PR DESCRIPTION
#1765 showed that this test case relies on the fixture file. Let's change the test case to remove the reliance of the file and instead write out a temp file to test against.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201625178070145/1201682645298791) by [Unito](https://www.unito.io)
