### PR TITLE
Fix passenger_options using wrong method

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -74,7 +74,7 @@ module NginxStage
 
     def passenger_options
       # Ensure that all options begin with passenger_
-      @passenger_options.select { |key, value| key.to_s.starts_with?('passenger_') }
+      @passenger_options.select { |key, value| key.to_s.start_with?('passenger_') }
     end
 
     #


### PR DESCRIPTION
This PR fixes a bug we found while trying to enable `passenger_options` in `nginx_stage.yml`.


    Error -- undefined method `starts_with?' for "passenger_friendly_error_pages":String
    Did you mean?  start_with?
    Run 'nginx_stage --help' to see a full list of available command line options.

`starts_with?` is available in Rails only, and is deprecated anyway from what I understand.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201625178070145/1201727777708717) by [Unito](https://www.unito.io)
