### PR TITLE
Bump ondemand-runtime dependency

### DIFF
--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -5,7 +5,7 @@
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
 %define major_version %(echo %{git_tag_minus_v} | cut -d. -f1)
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
-%define runtime_version %{major_version}.%{minor_version}-1
+%define runtime_version %{major_version}.%{minor_version}-2
 %define next_major_version %(echo $((%{major_version}+1))).0
 %define next_minor_version %{major_version}.%(echo $((%{minor_version}+1)))
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)

--- a/spec/e2e/nodesets/el8.yml
+++ b/spec/e2e/nodesets/el8.yml
@@ -4,7 +4,7 @@ HOSTS:
       - agent
     platform: el-8-x86_64
     hypervisor: docker
-    image: centos:8
+    image: rockylinux/rockylinux:8
     docker_preserve_image: true
     docker_cmd:
       - '/usr/sbin/init'


### PR DESCRIPTION
Pulls in https://github.com/OSC/ondemand-packaging/pull/187 so that when someone does `yum update ondemand` or fresh install, the dependency is fixed. This mostly affects fresh installs.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201754840610064) by [Unito](https://www.unito.io)
