### PR TITLE
preset apps can just launch

### DIFF
--- a/apps/dashboard/app/apps/ood_app_link.rb
+++ b/apps/dashboard/app/apps/ood_app_link.rb
@@ -5,6 +5,7 @@ class OodAppLink
   attr_reader :icon_uri
   attr_reader :caption
   attr_reader :subtitle
+  attr_reader :data
 
   def initialize(config = {})
     config = config.to_h.compact.symbolize_keys
@@ -16,6 +17,7 @@ class OodAppLink
     @icon_uri    = URI(config.fetch(:icon_uri, "fas://cog").to_s)
     @caption     = config.fetch(:caption, nil)
     @new_tab     = !!config.fetch(:new_tab, true)
+    @data        = config.fetch(:data, {}).to_h
   end
 
   def new_tab?

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -74,7 +74,7 @@ class BatchConnect::SessionContextsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def session_contexts_param
-      params.require(:batch_connect_session_context).permit(@session_context.attributes.keys)
+      params.require(:batch_connect_session_context).permit(@session_context.attributes.keys) if params[:batch_connect_session_context].present?
     end
 
     # Store session context into a cache file

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -109,10 +109,11 @@ module BatchConnect
         # FIXME: better to use default_title and "" description
         title: title,
         description: description,
-        url: Rails.application.routes.url_helpers.new_batch_connect_session_context_path(token: token),
+        url: url,
         icon_uri: ood_app.icon_uri,
         caption: ood_app.caption,
-        new_tab: false
+        new_tab: false,
+        data: preset? ? { 'method': 'post' } : {}
       )
     end
 
@@ -153,6 +154,10 @@ module BatchConnect
         configured_clusters.map do |config|
           cfg_to_clusters(config)
         end.flatten.compact.select(&:job_allow?)
+    end
+
+    def preset?
+      valid? && attributes.all?(&:fixed?)
     end
 
     # Whether this is a valid app the user can use
@@ -296,6 +301,16 @@ module BatchConnect
     end
 
     private
+
+      def url
+        helpers = Rails.application.routes.url_helpers
+
+        if preset?
+          helpers.batch_connect_session_contexts_path(token: token)
+        else
+          helpers.new_batch_connect_session_context_path(token: token)
+        end
+      end
 
       def cfg_to_clusters(config)
         c = OodAppkit.clusters[config.to_sym] || nil

--- a/apps/dashboard/app/views/batch_connect/shared/_app_list_item.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_app_list_item.html.erb
@@ -9,8 +9,8 @@
         html: true,
         trigger: "hover",
         title: link.title,
-        container: "body"
-      }
+        container: "body",
+      }.merge(link.data)
     ) do
   %>
     <%= icon_tag(link.icon_uri) %> <%= link.title %>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -12,7 +12,8 @@
                 link.url.to_s,
                 title: link.title,
                 class: "dropdown-item",
-                target: link.new_tab? ? "_blank" : nil
+                target: link.new_tab? ? "_blank" : nil,
+                data: link.data
               ) do
             %>
               <%= icon_tag(link.icon_uri) %> <%=link.title %>

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -14,7 +14,8 @@
                 title: link.title,
                 class: "dropdown-item",
                 target: link.new_tab? ? "_blank" : nil,
-                aria: ({ current: ('page' if (current_page?(link.url))) })
+                aria: ({ current: ('page' if (current_page?(link.url))) }),
+                data: link.data
               ) do
             %>
             <%= icon_tag(link.icon_uri) %> <%= link.title %>

--- a/apps/dashboard/app/views/widgets/pinned_apps/_app.html.erb
+++ b/apps/dashboard/app/views/widgets/pinned_apps/_app.html.erb
@@ -4,7 +4,8 @@
     link_to(
       link.url.to_s,
       class: "app-card",
-      target: link.new_tab? ? "_blank" : nil
+      target: link.new_tab? ? "_blank" : nil,
+      data: link.data
     ) do
   %>
     <div class="center-block text-center">

--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -30,4 +30,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def find_css_class(id)
     find("##{id}")['class'].to_s
   end
+
+  def verify_bc_alert(token, err_msg)
+    assert_equal batch_connect_session_contexts_path(token), current_path
+    assert_equal err_msg, find('div[role="alert"]').find('h4').text
+    find('div[role="alert"]').find('button').click
+  end
 end

--- a/apps/dashboard/test/fixtures/apps/preset_app/form.yml
+++ b/apps/dashboard/test/fixtures/apps/preset_app/form.yml
@@ -1,0 +1,8 @@
+---
+cluster:
+  - "owens"
+  - "oakley"
+form:
+  - version
+  - account
+  - node_type

--- a/apps/dashboard/test/fixtures/apps/preset_app/local/preset.yml
+++ b/apps/dashboard/test/fixtures/apps/preset_app/local/preset.yml
@@ -1,0 +1,5 @@
+cluster: "owens"
+attributes:
+  version: 'the version'
+  account: 'the one with all the $'
+  node_type: 'the biggest one'

--- a/apps/dashboard/test/fixtures/apps/preset_app/manifest.yml
+++ b/apps/dashboard/test/fixtures/apps/preset_app/manifest.yml
@@ -1,0 +1,8 @@
+---
+name: Test App
+category: Interactive Apps
+subcategory: Servers
+role: batch_connect
+description: |
+  This is an app that has some preset sub apps. Preset subapps
+  automatically submit (#create) instead of presenting a form (#new)

--- a/apps/dashboard/test/system/preset_apps_navbar_test.rb
+++ b/apps/dashboard/test/system/preset_apps_navbar_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class PresetAppsNavbarTest < ApplicationSystemTestCase
+
+  def setup
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
+    SysRouter.stubs(:base_path).returns(Rails.root.join('test/fixtures/apps'))
+    BatchConnect::Session.any_instance.stubs(:stage).raises(StandardError.new(err_msg))
+  end
+
+  def err_msg
+    'This is just a test'
+  end
+
+  # the best we can do in this test is stub out BatchConnect::Session#stage 
+  # and verify that the error we threw is on the page. The link at least tries to submit.
+  # TODO: get enough stubs to submit the job and get a 'queued' card to show
+  test 'preset apps in navbars auto launch' do
+    visit root_path
+    click_on 'Interactive Apps'
+    click_on 'Test App: Preset'
+
+    verify_bc_alert('sys/preset_app/preset', err_msg)
+  end
+
+  test 'choice apps in navbar still redirect to the form' do
+    visit root_path
+    click_on 'Interactive Apps'
+    click_on 'Test App: Choice'
+
+    # we can click the launch button and it does the same thing as above.
+    assert_equal new_batch_connect_session_context_path('sys/preset_app/choice'), current_path
+    click_on 'Launch'
+
+    verify_bc_alert('sys/preset_app/choice', err_msg)
+  end
+end

--- a/apps/dashboard/test/system/preset_apps_pinned_test.rb
+++ b/apps/dashboard/test/system/preset_apps_pinned_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+# Very similar to preset_apps_navbar_test.rb only in that there are
+# Pinned apps that _have_ to be stubbed in setup. If these files were combined,
+# you wouldn't be able to tell what's the navbar entry and which is the pinned app
+class PresetAppsPinnedTest < ApplicationSystemTestCase
+
+  def setup
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
+    SysRouter.stubs(:base_path).returns(Rails.root.join('test/fixtures/apps'))
+    Configuration.stubs(:pinned_apps).returns(['sys/preset_app/*'])
+    BatchConnect::Session.any_instance.stubs(:stage).raises(StandardError.new(err_msg))
+    Router.instance_variable_set('@pinned_apps', nil)
+  end
+
+  def teardown
+    Router.instance_variable_set('@pinned_apps', nil)
+  end
+
+  def err_msg
+    'This is just a test'
+  end
+
+  test 'preset apps in pinned apps directly launch' do
+    visit root_path
+    click_on 'Test App: Preset'
+    verify_bc_alert('sys/preset_app/preset', err_msg)
+  end
+
+  test 'choice apps in pinned apps still redirect to the form' do
+    visit root_path
+    click_on 'Test App: Choice'
+
+    # we can click the launch button and it does the same thing as above.
+    assert_equal new_batch_connect_session_context_path('sys/preset_app/choice'), current_path
+    click_on 'Launch'
+
+    verify_bc_alert('sys/preset_app/choice', err_msg)
+  end
+
+
+end


### PR DESCRIPTION
Starts work on #1175.


The premise of this functionality is hard coding all the values in a sub app.

Let's took at this example app that has 3 fields.
```yaml
# form.yml
cluster: 'owens'
form:
  - account
  - node_type
  - version
```

And the sub-app  that's hard coded all the attributes.
```yaml
# local/preset.yml
attributes:
  account: 'abc123'
  node_type: 'any'
  version: 7
```

Now all the links are will be empty POST requests to create the sessions instead of a GET request to the form.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201772179663434) by [Unito](https://www.unito.io)
