### PR TITLE
fix /nginx/stop redirections

### DIFF
--- a/mod_ood_proxy/lib/nginx.lua
+++ b/mod_ood_proxy/lib/nginx.lua
@@ -54,7 +54,7 @@ function nginx_handler(r)
     if redir then
       local pun_app_request = redir:match("^" .. pun_uri .. "(/.+)$")
       if not pun_app_request then return http.http404(r, "bad `redir` request (" .. redir .. ")") end
-      return http.http302(r, pun_app_request)  -- ignore errors
+      return http.http302(r, redir)  -- ignore errors
     else
       return err and http.http404(r, err) or http.http200(r)
     end

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -108,11 +108,10 @@ describe 'Node and Rnode proxies' do
   end 
 
   it '/nginx/init correctly redirects to /pun/sys/dashboard' do
-    url = "#{ctr_base_url}/nginx/init?redir=/pun/sys/dashboard"
-    browser.goto url
+    browser.goto "#{ctr_base_url}/nginx/init?redir=/pun/sys/dashboard"
     # TODO somehow ensure it's a 302 response on redirect
     # no status response codes available so urls or page elements need used somehow
-    expect(browser.url).to eq(url)
+    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard")
   end
 
   it '/nginx/init will not redirect to another host' do
@@ -142,10 +141,10 @@ describe 'Node and Rnode proxies' do
   # end
 
   # TODO: examine "stop" else logic as it is skipping to "or http.http200(r)" choice each run
-  it '/nginx/stop needs a redirect' do
+  it '/nginx/stop does not needs a redirect' do
     url = "#{ctr_base_url}/nginx/stop"
     browser.goto url
-    expect(browser.text).to eq('Error -- bad `redir` request ()')
+    expect(browser.text).to eq('Success')
     expect(browser.url).to eq(url)
   end
 

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -100,36 +100,40 @@ describe 'Node and Rnode proxies' do
     expect(browser.div(id: 'test-div').present?).to be true
   end
 
-  it 'node correctly returns redir error when no redirect is given on init' do
-    browser.goto "#{ctr_base_url}/nginx/init"
+  it '/nginx/init needs a redirect' do
+    url = "#{ctr_base_url}/nginx/init"
+    browser.goto url
     expect(browser.text).to eq('Error -- requires a `redir` query parameter')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
+    expect(browser.url).to eq(url)
   end 
 
-  it 'redirects to /pun/sys/dashboard when redirect is given on init' do
-    browser.goto "#{ctr_base_url}/nginx/init?redir=/pun/sys/dashboard"
+  it '/nginx/init correctly redirects to /pun/sys/dashboard' do
+    url = "#{ctr_base_url}/nginx/init?redir=/pun/sys/dashboard"
+    browser.goto url
     # TODO somehow ensure it's a 302 response on redirect
     # no status response codes available so urls or page elements need used somehow
-    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard")
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
+    expect(browser.url).to eq(url)
   end
 
-  it 'node correctly returns "bad redir error" when redirect to "github.com" given on init' do
+  it '/nginx/init will not redirect to another host' do
+    url = "#{ctr_base_url}/nginx/init?redir=github.com"
     browser.goto "#{ctr_base_url}/nginx/init?redir=github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (github.com)')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
+    expect(browser.url).to eq(url)
   end
 
-  it 'node correctly returns "bad redir error" when redirect to "https://github.com" given on init' do
-    browser.goto "#{ctr_base_url}/nginx/init?redir=https://github.com"
+  it '/nginx/init will not redirect to another url with a scheme' do
+    url = "#{ctr_base_url}/nginx/init?redir=https://github.com"
+    browser.goto url
     expect(browser.text).to eq('Error -- bad `redir` request (https://github.com)')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
+    expect(browser.url).to eq(url)
   end
 
-  it 'node correctly returns "bad redir error" when redirect to "/node/localhost/5001" is given on init' do
-    browser.goto "#{ctr_base_url}/nginx/init?redir=/node/localhost/5001"
+  it '/nginx/init will not redirect to /node' do
+    url = "#{ctr_base_url}/nginx/init?redir=/node/localhost/5001"
+    browser.goto url
     expect(browser.text).to eq('Error -- bad `redir` request (/node/localhost/5001)')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
+    expect(browser.url).to eq(url)
   end
 
   # TODO: returns error message when it can't correctly boot the PUN
@@ -139,27 +143,31 @@ describe 'Node and Rnode proxies' do
 
   # TODO: examine "stop" else logic as it is skipping to "or http.http200(r)" choice each run
   it '/nginx/stop needs a redirect' do
-    browser.goto "#{ctr_base_url}/nginx/stop"
-    expect(browser.selector(name: 'pre')).to eq('Error -- bad `redir` request ()')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
+    url = "#{ctr_base_url}/nginx/stop"
+    browser.goto url
+    expect(browser.text).to eq('Error -- bad `redir` request ()')
+    expect(browser.url).to eq(url)
   end
 
   it '/nginx/stop wont redirect to another host' do
-    browser.goto "#{ctr_base_url}/nginx/stop?redir=github.com"
+    url = "#{ctr_base_url}/nginx/stop?redir=github.com"
+    browser.goto url
     expect(browser.text).to eq('Error -- bad `redir` request (github.com)')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
+    expect(browser.url).to eq(url)
   end
 
   it '/nginx/stop wont redirect to a url with a scheme' do
-    browser.goto "#{ctr_base_url}/nginx/stop?redir=https://github.com"
+    url = "#{ctr_base_url}/nginx/stop?redir=https://github.com"
+    browser.goto url
     expect(browser.text).to eq('Error -- bad `redir` request (https://github.com)')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
+    expect(browser.url).to eq(url)
   end
 
   it '/nginx/stop wont redirect to /node' do
-    browser.goto "#{ctr_base_url}/nginx/stop?redir=/node/localhost/5001"
+    url = "#{ctr_base_url}/nginx/stop?redir=/node/localhost/5001"
+    browser.goto url
     expect(browser.text).to eq('Error -- bad `redir` request (/node/localhost/5001)')
-    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
+    expect(browser.url).to eq(url)
   end
 
   it '/nginx/stop will redirect to /pun/*' do
@@ -173,8 +181,10 @@ describe 'Node and Rnode proxies' do
   # end
 
   it 'node correctly returns "Success" in browser when no redirect is given on noop' do
+    url = "#{ctr_base_url}/nginx/noop"
     browser.goto "#{ctr_base_url}/nginx/noop"
     expect(browser.text).to eq('Success')
+    expect(browser.url).to eq(url)
   end 
 
   # TODO expand "noop" logic in nginx.lua to handle redir for remaining noop tests

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -133,24 +133,29 @@ describe 'Node and Rnode proxies' do
   # end
 
   # TODO: examine "stop" else logic as it is skipping to "or http.http200(r)" choice each run
-  # it 'node correctly returns "bad redir error" when no redirect is given on stop' do
-  #   browser.goto "#{ctr_base_url}/nginx/stop"
-  #   expect(browser.selector(name: 'pre')).to eq('Error -- bad `redir` request ()')
-  # end
+  it '/nginx/stop needs a redirect' do
+    browser.goto "#{ctr_base_url}/nginx/stop"
+    expect(browser.selector(name: 'pre')).to eq('Error -- bad `redir` request ()')
+  end
 
-  it 'node correctly returns "bad redir error" when redirect to "github.com" given on stop' do
+  it '/nginx/stop wont redirect to another host' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (github.com)')
   end
 
-  it 'node correctly returns "bad redir error" when redirect to "https://github.com" given on stop' do
+  it '/nginx/stop wont redirect to a url with a scheme' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=https://github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (https://github.com)')
   end
 
-  it 'node correctly returns "bad redir error" when redirect to "/node/localhost/5001" is given on stop' do
+  it '/nginx/stop wont redirect to /node' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=/node/localhost/5001"
     expect(browser.text).to eq('Error -- bad `redir` request (/node/localhost/5001)')
+  end
+
+  it '/nginx/stop will redirect to /pun/*' do
+    browser.goto "#{ctr_base_url}/nginx/stop?redir=/pun/sys/dashboard"
+    expect(browser.url).to eq('/pun/sys/dashboard')
   end
 
   # TODO: stub PUN that does not boot

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -103,6 +103,7 @@ describe 'Node and Rnode proxies' do
   it 'node correctly returns redir error when no redirect is given on init' do
     browser.goto "#{ctr_base_url}/nginx/init"
     expect(browser.text).to eq('Error -- requires a `redir` query parameter')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
   end 
 
   it 'redirects to /pun/sys/dashboard when redirect is given on init' do
@@ -110,21 +111,25 @@ describe 'Node and Rnode proxies' do
     # TODO somehow ensure it's a 302 response on redirect
     # no status response codes available so urls or page elements need used somehow
     expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard")
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
   end
 
   it 'node correctly returns "bad redir error" when redirect to "github.com" given on init' do
     browser.goto "#{ctr_base_url}/nginx/init?redir=github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (github.com)')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
   end
 
   it 'node correctly returns "bad redir error" when redirect to "https://github.com" given on init' do
     browser.goto "#{ctr_base_url}/nginx/init?redir=https://github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (https://github.com)')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
   end
 
   it 'node correctly returns "bad redir error" when redirect to "/node/localhost/5001" is given on init' do
     browser.goto "#{ctr_base_url}/nginx/init?redir=/node/localhost/5001"
     expect(browser.text).to eq('Error -- bad `redir` request (/node/localhost/5001)')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/init")
   end
 
   # TODO: returns error message when it can't correctly boot the PUN
@@ -136,26 +141,30 @@ describe 'Node and Rnode proxies' do
   it '/nginx/stop needs a redirect' do
     browser.goto "#{ctr_base_url}/nginx/stop"
     expect(browser.selector(name: 'pre')).to eq('Error -- bad `redir` request ()')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
   end
 
   it '/nginx/stop wont redirect to another host' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (github.com)')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
   end
 
   it '/nginx/stop wont redirect to a url with a scheme' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=https://github.com"
     expect(browser.text).to eq('Error -- bad `redir` request (https://github.com)')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
   end
 
   it '/nginx/stop wont redirect to /node' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=/node/localhost/5001"
     expect(browser.text).to eq('Error -- bad `redir` request (/node/localhost/5001)')
+    expect(browser.url).to eq("#{ctr_base_url}/nginx/stop")
   end
 
   it '/nginx/stop will redirect to /pun/*' do
     browser.goto "#{ctr_base_url}/nginx/stop?redir=/pun/sys/dashboard"
-    expect(browser.url).to eq('/pun/sys/dashboard')
+    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard")
   end
 
   # TODO: stub PUN that does not boot


### PR DESCRIPTION
Fixes #1800 to correctly redirect from `/nginx/stop`.

How to test - 
* get a container
* mount this addition into the container by setting `OOD_MNT_PROXY`
* login
* restart the PUN and you should be correctly redirected to `/pun/sys/dashboard`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201847407045909) by [Unito](https://www.unito.io)
