### PR TITLE
Fix incorrect permissions on uploaded file

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -139,10 +139,9 @@ class FilesController < ApplicationController
     FileUtils.mv params[:file].tempfile, path.to_s
 
     # umasks apply on top of 666 (-rw-rw-rw-) permissions. So a u mask of 022 would result
-    # in 666 - 022 = 644. Umasks are base 8 octal so we have to cast back and forth between
-    # decimal (ruby integers) and octal (what all this stuff expects).
-    mode = 666 - File.umask.to_s(8).to_i
-    File.chmod(mode.to_s.to_i(8), path.to_s)
+    # in 666 - 022 = 644. Umasks are base 8 octal (what all this stuff expects).
+    mode = 0666 & (0777 ^ File.umask)
+    File.chmod(mode, path.to_s)
 
     render json: {}
   rescue AllowlistPolicy::Forbidden => e


### PR DESCRIPTION
This PR fixes a bug we found where uploaded files had incorrect permissions when the umask was 0007.
umask 0007 gave the permissions:
`----rw-r-x. 1 robinkar robinkar 0 Feb 21 16:31 test.txt`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201860781440061) by [Unito](https://www.unito.io)
