### PR TITLE
allow for job composer to copy environment

### DIFF
--- a/apps/myjobs/app/models/resource_mgr_adapter.rb
+++ b/apps/myjobs/app/models/resource_mgr_adapter.rb
@@ -31,7 +31,8 @@ class ResourceMgrAdapter
     script = OodCore::Job::Script.new(
       content: script_path.read,
       accounting_id: account_string,
-      job_array_request: workflow.job_array_request.presence
+      job_array_request: workflow.job_array_request.presence,
+      copy_environment: workflow.copy_environment.eql?("1") ? true: false
     )
     adapter(cluster).submit( script, **depends_on)
 

--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -8,7 +8,7 @@ class Workflow < ApplicationRecord
   # add accessors: [ :attr1, :attr2 ] etc. when you want to add getters and
   # setters to add new attributes stored in the JSON store
   # don't remove attributes from this list going forward! only deprecate
-  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request]
+  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request, :copy_environment]
 
   attr_accessor :staging_template_dir
 

--- a/apps/myjobs/app/views/workflows/_edit_form_job_attrs.html.erb
+++ b/apps/myjobs/app/views/workflows/_edit_form_job_attrs.html.erb
@@ -20,3 +20,5 @@ API at: https://github.com/bootstrap-ruby/rails-bootstrap-forms %>
         placeholder: '1-10'
 %>
 <% end %>
+
+<%= f.check_box :copy_environment, label: t('jobcomposer.options_copy_environment'), default: 0 %>

--- a/apps/myjobs/config/locales/en.yml
+++ b/apps/myjobs/config/locales/en.yml
@@ -36,5 +36,6 @@ en:
     options_script_title: "Specify job script"
     options_script_help: "Files larger than 65KB are omitted for the job script field"
     options_title: "Job Options"
+    options_copy_environment: "Copy environment"
     xdmod_url_warning_message: "This job may not appear in Open XDMoD until 24 hours after the completion of the job."
     xdmod_url_warning_message_seconds_after_job_completion: 86400


### PR DESCRIPTION
allow for job composer to copy environment so things like `srun` in Slurm work of out the box.

To test, I just copied the default job and began to edit it
* allocate more cores through `#SBATCH --ntasks=5` comment
* add a `srun hostname` to the file so it uses srun
* run with copy environment checked (this will work)
* run without copy environment checked (this will complain about srun)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201863073369921) by [Unito](https://www.unito.io)
