### PR TITLE
Fix uploaded file group owner

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -143,6 +143,8 @@ class FilesController < ApplicationController
     mode = 0666 & (0777 ^ File.umask)
     File.chmod(mode, path.to_s)
 
+    path.chown(nil, path.parent.stat.gid) if path.parent.setgid?
+
     render json: {}
   rescue AllowlistPolicy::Forbidden => e
     render json: { error_message: e.message }, status: :forbidden


### PR DESCRIPTION
This PR fixed a bug we also found yesterday.
Uploading files always uses the default group owner and does not respect the setgid bit for the directory. This is important for us as our project directories use the setgid bit.
e.g.


```
mkdir test
chgrp some_group test
chmod g+s test
touch test/file.txt
```

Uploading a file via OOD to the `test` directory would have the wrong group while the correct group would be the one that `file.txt` has.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201872852242021) by [Unito](https://www.unito.io)
