### PR TITLE
Use the same 404 error message in app.conf.erb as in pun.conf.erb

### DIFF
--- a/nginx_stage/templates/app.conf.erb
+++ b/nginx_stage/templates/app.conf.erb
@@ -1,4 +1,5 @@
 location ~ ^<%= app_request_uri %>(/.*|$) {
+  error_page 404 @error_404;
   alias <%= app_root %>/public$1;
   passenger_base_uri <%= app_request_uri %>;
   passenger_app_root <%= app_root %>;

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -78,10 +78,14 @@ http {
     listen      unix:<%= socket_path %>;
     server_name localhost;
 
-    <%- if app_init_url -%>
-    location / {
+    location @error_404 {
       default_type text/html;
       return 404 '<%= restart_confirmation %>';
+    }
+
+    <%- if app_init_url -%>
+    location / {
+      error_page 404 @error_404;
     }
     <%- end -%>
 


### PR DESCRIPTION
This allows users to re-initialize dev apps when the app.conf is broken (e.g. due to app_root path change).

# More Details
## Problem
If Open OnDemand is configured to "[Make everyone a developer by default](https://osc.github.io/ood-documentation/latest/app-development/enabling-development-mode.html#make-everyone-a-developer-by-default-optional)," then the app initialization process (`nginx_stage app`) will write the user's home directory path to the app config file (`/var/lib/ondemand-nginx/config/apps/dev/%{owner}/%{name}.conf`). If the path to the user's home directory then later changes, the app will not load, and visiting the app URL will result in a bare nginx 404 page:

![](https://user-images.githubusercontent.com/1382989/155541923-140e0049-d3fb-451e-99c8-516f33781eb2.png)

At this point, the user could restore the app functionality by re-initializing the app, but there is no link for this in the UI. The link to initialize apps is only presented by the PUN when visiting an URL that matches the path prefix `/` and does **not** match the more-specific path defined in the app config.

![](https://user-images.githubusercontent.com/1382989/155543442-38b14931-8e31-4f4b-82e6-a22f1feea8ef.png)

## Solution
To fix this, the same 404 error message used in the PUN for `location /` (in `pun.conf.erb`) can also be used for `location ~ ^<%= app_request_uri %>(/.*|$)` (in `app.conf.erb`). This will permit users to re-initalize development-mode apps with broken configurations.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201879638354584) by [Unito](https://www.unito.io)
