### PR TITLE
correctly append css rules to the end of the list

### DIFF
--- a/apps/dashboard/app/javascript/packs/config.js
+++ b/apps/dashboard/app/javascript/packs/config.js
@@ -10,11 +10,11 @@ function setNavbarColor() {
   const cfgData = configData();
   const styles = document.styleSheets[0];
 
-  styles.insertRule(navbar('light', cfgData['bgColor']), styles.lenth);
-  styles.insertRule(navbar('dark', cfgData['bgColor']), styles.lenth);
+  styles.insertRule(navbar('light', cfgData['bgColor']), styles.rules.length);
+  styles.insertRule(navbar('dark', cfgData['bgColor']), styles.rules.length);
   
-  styles.insertRule(navbarHighlight('light', cfgData['linkBgColor']), styles.lenth);
-  styles.insertRule(navbarHighlight('dark', cfgData['linkBgColor']), styles.lenth);
+  styles.insertRule(navbarHighlight('light', cfgData['linkBgColor']), styles.rules.length);
+  styles.insertRule(navbarHighlight('dark', cfgData['linkBgColor']), styles.rules.length);
 }
 
 function navbar(theme, color){


### PR DESCRIPTION
correctly append css rules to the end of the list. `styles.lenth` is not only a mistype that evaluates to `undefined` and puts the rules at the top of the list - it should be `styles.rules.length` to append the rules to the bottom.