### PR TITLE
add a rake task to release archives to zenodo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ require "#{TASK_DIR}/lint"
 require "#{TASK_DIR}/docker"
 require "#{TASK_DIR}/development"
 require "#{TASK_DIR}/install"
+require "#{TASK_DIR}/release"
 
 include RakeHelper
 

--- a/lib/tasks/release.rb
+++ b/lib/tasks/release.rb
@@ -51,7 +51,7 @@ namespace :release do
       request['Content-type'] = 'application/json'
       request.body = { "metadata" => 
             {
-              "version" => "#{version}-1", "publication_date" => Date.today,
+              "version" => "#{version}", "publication_date" => Date.today,
               "upload_type" => "software", 
               "description" => "This is the source code for Open OnDemand. You can find all releases on github at https://github.com/OSC/ondemand/releases.",
               "title" => "Open OnDemand Source Code",

--- a/lib/tasks/release.rb
+++ b/lib/tasks/release.rb
@@ -47,7 +47,6 @@ namespace :release do
       # edit the metadata to reflect new publish date and new version
       version = /ondemand-(.+).zip/.match(p.basename.to_s)[1]
       uri = URI("https://zenodo.org/api/deposit/depositions/#{id}?access_token=#{token}")
-      # uri = URI("https://zenodo.org/api/deposit/depositions/#{id}/actions/edit?access_token=#{token}")
       request = Net::HTTP::Put.new(uri)
       request['Content-type'] = 'application/json'
       request.body = { "metadata" => 

--- a/lib/tasks/release.rb
+++ b/lib/tasks/release.rb
@@ -1,0 +1,42 @@
+
+namespace :release do
+  task :zenodo do
+    require 'net/http'
+    require 'json'
+
+    if ENV['ZENODO_TOKEN'].to_s == '' || ENV['RELEASE_ARCHIVE'].to_s == ''
+      raise StandardError.new('environment variables ZENODO_TOKEN and RELEASE_ARCHIVE have to be set')
+    end
+    token = ENV['ZENODO_TOKEN'].to_s
+
+    uri = URI("https://zenodo.org/api/deposit/depositions?access_token=#{token}")
+
+    data = Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      request = Net::HTTP::Get.new(uri)
+      request['Accept'] = 'application/json'
+      
+      response = http.request(request)
+
+      raise StandardError.new("cannot contact the zenodo server. It responded with #{response.code}") unless response.code.to_i == 200
+      
+      JSON.parse(response.body)[0]
+    end 
+
+    id = data['id']
+    uri = URI("https://zenodo.org/api/deposit/depositions/#{id}/files?access_token=#{token}")
+
+    upload_response = Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      request = Net::HTTP::Post.new(uri)
+      request['Accept'] = 'application/json'
+      p = Pathname.new(ENV['RELEASE_ARCHIVE'].to_s)
+      request.set_form([['file', File.open(p.to_s)], ['name', p.basename.to_s]], 'multipart/form-data')
+      
+      response = http.request(request)
+
+      raise StandardError.new("Cannot upload archive. Zenodo Server responded with #{response.code}") unless response.code.to_i == 201
+      response
+    end
+
+    puts "successfully uploaded #{ENV['RELEASE_ARCHIVE']} to Zenodo's #{id}"
+  end
+end

--- a/lib/tasks/release.rb
+++ b/lib/tasks/release.rb
@@ -8,11 +8,11 @@ namespace :release do
       raise StandardError.new('environment variables ZENODO_TOKEN and RELEASE_ARCHIVE have to be set')
     end
     token = ENV['ZENODO_TOKEN'].to_s
+    host = 'zenodo.org'
+    port = '443'
 
-    uri = URI("https://zenodo.org/api/deposit/depositions?access_token=#{token}")
-
-    data = Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
-      request = Net::HTTP::Get.new(uri)
+    data = Net::HTTP.start(host, port, :use_ssl => true) do |http|
+      request = Net::HTTP::Get.new(URI("https://zenodo.org/api/deposit/depositions?access_token=#{token}"))
       request['Accept'] = 'application/json'
       
       response = http.request(request)
@@ -23,20 +23,41 @@ namespace :release do
     end 
 
     id = data['id']
-    uri = URI("https://zenodo.org/api/deposit/depositions/#{id}/files?access_token=#{token}")
 
-    upload_response = Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
-      request = Net::HTTP::Post.new(uri)
+    Net::HTTP.start(host, port, :use_ssl => true) do |http|
+      # upload the new archive
+      request = Net::HTTP::Post.new(URI("https://zenodo.org/api/deposit/depositions/#{id}/files?access_token=#{token}"))
       request['Accept'] = 'application/json'
       p = Pathname.new(ENV['RELEASE_ARCHIVE'].to_s)
-      request.set_form([['file', File.open(p.to_s)], ['name', p.basename.to_s]], 'multipart/form-data')
+      request.set_form([['file', File.open(p.to_s)]], 'multipart/form-data')
+      response = http.request(request)
+      raise StandardError.new("Cannot upload archive. Zenodo Server responded with #{response.code}:#{response.body}") unless response.code.to_i == 201
+
+
+      # TODO remove the existing file
+
+      # edit the metadata to reflect new publish date and new version
+      version = /ondemand-(.+).zip/.match(p.basename.to_s)[1]
+      uri = URI("https://zenodo.org/api/deposit/depositions/#{id}?access_token=#{token}")
+      # uri = URI("https://zenodo.org/api/deposit/depositions/#{id}/actions/edit?access_token=#{token}")
+      request = Net::HTTP::Put.new(uri)
+      request.set_form_data("metadata" => {"version" => "#{version}-1", "publication_date" => Date.today})
+      response = http.request(request)
+      puts response.body
+      raise StandardError.new("Cannot edit new version. Zenodo Server responded with #{response.code}:#{response.body}") unless response.code.to_i == 201
+    end
+
+    uri = URI("#{data['links']['publish']}?access_token=#{token}")
+    
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      request = Net::HTTP::Post.new(uri)
+      request['Accept'] = 'application/json'
       
       response = http.request(request)
 
-      raise StandardError.new("Cannot upload archive. Zenodo Server responded with #{response.code}") unless response.code.to_i == 201
-      response
+      raise StandardError.new("Cannot publish archive. Zenodo Server responded with #{response.code}:#{response.body}") unless response.code.to_i == 202
     end
 
-    puts "successfully uploaded #{ENV['RELEASE_ARCHIVE']} to Zenodo's #{id}"
+    puts "sucessfully published #{ENV['RELEASE_ARCHIVE']} to zendo at #{data['doi_url']}"
   end
 end


### PR DESCRIPTION
This adds a rake task to upload archives to Zenodo.  I'll add the CITATION info and an action after I get this sorted out.

Here's our zenodo record 
https://zenodo.org/record/6325946

and the DOI (that hasn't been synced yet maybe?)

https://doi.org/10.5281/zenodo.6325946



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201917271462044) by [Unito](https://www.unito.io)
