### PR TITLE
add an action to release archives to zenodo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,10 @@ jobs:
           asset_name: ondemand-${{ steps.version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
       - name: Upload to Zenodo
-        uses: rseng/zenodo-release@main
+        uses: rseng/zenodo-release@0.0.17
         with:
-          token: ${{ secrets.ZENODO_TOKEN }}
+          token: ${{ secrets.OSC_ROBOT_ZENODO_TOKEN }}
           version: ${{ steps.version.outputs.version }}
           zenodo_json: .zenodo.json
           archive: packaging/rpm/ondemand-${{ steps.version.outputs.version }}.tar.gz
+          doi: '10.5281/zenodo.6323791'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,10 @@ jobs:
           asset_path: packaging/rpm/ondemand-${{ steps.version.outputs.version }}.tar.gz
           asset_name: ondemand-${{ steps.version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
+      - name: Upload to Zenodo
+        uses: rseng/zenodo-release@main
+        with:
+          token: ${{ secrets.ZENODO_TOKEN }}
+          version: ${{ steps.version.outputs.version }}
+          zenodo_json: .zenodo.json
+          archive: packaging/rpm/ondemand-${{ steps.version.outputs.version }}.tar.gz

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,29 @@
+{
+  "upload_type": "software", 
+  "description": "This is the source code for Open OnDemand. You can find all releases on github at https://github.com/OSC/ondemand/releases.",
+  "title": "Open OnDemand Source Code",
+  "creators": [
+    {
+      "affiliation": "Ohio SuperComputer Center",
+      "name": "Jeff Ohrstrom"
+    },
+    {
+      "affiliation": "Ohio SuperComputer Center",
+      "name": "Travis Ravert"
+    },
+    {
+      "affiliation": "Ohio SuperComputer Center",
+      "name": "Gerald Byrket"
+    },
+    {
+      "affiliation": "Ohio SuperComputer Center",
+      "name": "Trey Dockendorf"
+    },
+    {
+      "affiliation": "Ohio SuperComputer Center",
+      "name": "Alan Chalker"
+    }
+  ],
+  "keywords": ["gateway", "hpc", "ruby", "rails"],
+  "license": "MIT"
+}


### PR DESCRIPTION
A replacement for #1885 to use a GH action instead of our own rake task.

This is our zenodo artifact https://zenodo.org/record/6325946#.Yid-QerMJPY with doi for all versions being https://doi.org/10.5281/zenodo.6323791



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201922183782012) by [Unito](https://www.unito.io)
