### PR TITLE
enable nonces on js and css assets

### DIFF
--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <%= favicon_link_tag 'favicon.ico', href: OodAppkit.public.url.join('favicon.ico'), skip_pipeline: true %>
 
   <%= javascript_pack_tag 'application', nonce: true %>
-  <%= stylesheet_pack_tag 'application', media: 'all' %>
+  <%= stylesheet_pack_tag 'application', nonce: true, media: 'all' %>
 
   <%= csrf_meta_tags %>
 

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -8,7 +8,7 @@
 
   <%= javascript_pack_tag 'application', nonce: true %>
   <%= javascript_pack_tag 'editor', nonce: true %>
-  <%= stylesheet_pack_tag 'application', media: 'all' %>
+  <%= stylesheet_pack_tag 'application', nonce: true, media: 'all' %>
 
   <%= csrf_meta_tags %>
 

--- a/apps/dashboard/config/initializers/content_security_policy.rb
+++ b/apps/dashboard/config/initializers/content_security_policy.rb
@@ -19,10 +19,10 @@ Rails.application.config.content_security_policy do |policy|
 end if Configuration.csp_enabled?
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+Rails.application.config.content_security_policy_nonce_directives = %w(script-src style-src)
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
This enable nonces on js and css assets.

You'll start to see a header a lot like this
```
[Content-Security-Policy: default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src 'self' https: 'nonce-um92Kvq+YpwJX9z74sfSMA=='; style-src 'self' https: 'nonce-um92Kvq+YpwJX9z74sfSMA=='; connect-src 'self' https: localhost:3035 ws://localhost:3035
```

See the docs for content security policy and specifically the part about nonces.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

