### PR TITLE
stop inlining style and instead use a bootstrap class

### DIFF
--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -10,9 +10,9 @@ module DashboardHelper
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      tag.img src: uri, alt: "logo", height: Configuration.logo_height, style: "margin-bottom: 10px"
+      tag.img(src: uri, alt: "logo", height: Configuration.logo_height, class: 'py-2')
     else # default logo image
-      image_pack_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85px", style: "margin-bottom: 10px")
+      image_pack_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", class: 'py-2')
     end
   end
 


### PR DESCRIPTION
Stop inlining style and instead use a bootstrap class for the logo image.