### PR TITLE
fix Manifest superclass issue

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -46,6 +46,10 @@ gem 'autoprefixer-rails', '~> 10.2.5'
 gem 'dotiw'
 gem 'local_time', '~> 1.0.3'
 
+# we don't really need sprockets, but rails depends on it. 4.0+ conflicts
+# with Manifest. See https://github.com/OSC/ondemand/issues/1868
+gem 'sprockets', '~> 3.7.2'
+
 # OOD specific gems
 gem 'ood_support', '~> 0.0.2'
 gem 'ood_appkit', '~> 2.1.0'

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crass (1.0.6)
     dalli (3.2.1)
     dotenv (2.7.6)
@@ -208,7 +208,7 @@ GEM
       rack-protection (= 2.2.0)
       sinatra (= 2.2.0)
       tilt (~> 2.0)
-    sprockets (4.0.3)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -261,6 +261,7 @@ DEPENDENCIES
   selenium-webdriver
   sinatra
   sinatra-contrib
+  sprockets (~> 3.7.2)
   timecop (~> 0.9)
   webpacker (~> 5.4)
   zip_tricks (~> 5.5)

--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -184,35 +184,36 @@ category: OSC
     self.to_h.deep_stringify_keys.compact.to_yaml
   end
 
+end
 
-  class InvalidManifest < Manifest
+class InvalidManifest < Manifest
 
-    def initialize(exception)
-      super({})
+  def initialize(exception)
+    super({})
 
-      @exception = exception
-    end
-
-    def valid?
-      false
-    end
-
-    def save(path)
-      false
-    end
+    @exception = exception
   end
 
-  class MissingManifest < Manifest
-    def valid?
-      false
-    end
+  def valid?
+    false
+  end
 
-    def exist?
-      false
-    end
-
-    def save(path)
-      false
-    end
+  def save(path)
+    false
   end
 end
+
+class MissingManifest < Manifest
+  def valid?
+    false
+  end
+
+  def exist?
+    false
+  end
+
+  def save(path)
+    false
+  end
+end
+

--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -184,36 +184,35 @@ category: OSC
     self.to_h.deep_stringify_keys.compact.to_yaml
   end
 
+
+  class InvalidManifest < Manifest
+
+    def initialize(exception)
+      super({})
+
+      @exception = exception
+    end
+
+    def valid?
+      false
+    end
+
+    def save(path)
+      false
+    end
+  end
+
+  class MissingManifest < Manifest
+    def valid?
+      false
+    end
+
+    def exist?
+      false
+    end
+
+    def save(path)
+      false
+    end
+  end
 end
-
-class InvalidManifest < Manifest
-
-  def initialize(exception)
-    super({})
-
-    @exception = exception
-  end
-
-  def valid?
-    false
-  end
-
-  def save(path)
-    false
-  end
-end
-
-class MissingManifest < Manifest
-  def valid?
-    false
-  end
-
-  def exist?
-    false
-  end
-
-  def save(path)
-    false
-  end
-end
-


### PR DESCRIPTION
Fixes #1868 by moving resetting the sprockets dependency (the other Manifest).  We really don't need sprockets anymore, but rails requires _a_ version of it, so may as well be the latest in 3.7.