### PR TITLE
enable a memory store cache and cache apps

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -21,15 +21,21 @@ class ApplicationController < ActionController::Base
   end
 
   def sys_apps
-    @sys_apps ||= SysRouter.apps
+    Rails.cache.fetch('sys_apps', expires_in: 6.hours) do
+      SysRouter.apps
+    end
   end
 
   def dev_apps
-    @dev_apps ||= ::Configuration.app_development_enabled? ? DevRouter.apps : []
+    Rails.cache.fetch('dev_apps', expires_in: 1.hours) do
+      ::Configuration.app_development_enabled? ? DevRouter.apps : []
+    end
   end
 
   def usr_apps
-    @usr_apps ||= ::Configuration.app_sharing_enabled? ? UsrRouter.all_apps(owners: UsrRouter.owners) : []
+    Rails.cache.fetch('usr_apps', expires_in: 6.hours) do
+      ::Configuration.app_sharing_enabled? ? UsrRouter.all_apps(owners: UsrRouter.owners) : []
+    end
   end
 
   def nav_all_apps

--- a/apps/dashboard/config/environments/development.rb
+++ b/apps/dashboard/config/environments/development.rb
@@ -14,20 +14,19 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.cache_store = :memory_store
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Don't care if the mailer can't send.

--- a/apps/dashboard/config/environments/production.rb
+++ b/apps/dashboard/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/apps/dashboard/config/environments/production.rb
+++ b/apps/dashboard/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Fixes #210 (to my satisfaction) by enabling a memory store cache and caching the apps for the navbar entries. Reading #210 you'll see there's lots of use cases, especially around dynamic titles. I do not believe titles are so dynamic that they regenerated on a per-request basis. 

We should probably make the TTL configurable but I think 6 hours is a good start.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202009815478972) by [Unito](https://www.unito.io)
