### PR TITLE
subclass manifests within the class to avoid superclass mismatches

### DIFF
--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -184,36 +184,34 @@ category: OSC
     self.to_h.deep_stringify_keys.compact.to_yaml
   end
 
+  class InvalidManifest < Manifest
+
+    def initialize(exception)
+      super({})
+
+      @exception = exception
+    end
+
+    def valid?
+      false
+    end
+
+    def save(path)
+      false
+    end
+  end
+
+  class MissingManifest < Manifest
+    def valid?
+      false
+    end
+
+    def exist?
+      false
+    end
+
+    def save(path)
+      false
+    end
+  end
 end
-
-class InvalidManifest < Manifest
-
-  def initialize(exception)
-    super({})
-
-    @exception = exception
-  end
-
-  def valid?
-    false
-  end
-
-  def save(path)
-    false
-  end
-end
-
-class MissingManifest < Manifest
-  def valid?
-    false
-  end
-
-  def exist?
-    false
-  end
-
-  def save(path)
-    false
-  end
-end
-

--- a/apps/dashboard/test/models/manifest_test.rb
+++ b/apps/dashboard/test/models/manifest_test.rb
@@ -50,7 +50,7 @@ class ManifestTest < ActiveSupport::TestCase
       save_result = manifest.save(manifest_file + "empty")
       new_manifest = Manifest.load(manifest_file + "empty")
       assert_equal false, save_result, "Result should not save"
-      assert_instance_of MissingManifest, new_manifest, "Should not exist"
+      assert_instance_of Manifest::MissingManifest, new_manifest, "Should not exist"
     }
   end
 
@@ -61,7 +61,7 @@ class ManifestTest < ActiveSupport::TestCase
       save_result = manifest.save(manifest_file + "empty")
       new_manifest = Manifest.load(manifest_file + "empty")
       assert_equal false, save_result, "Result should not save"
-      assert_instance_of MissingManifest, new_manifest, "Should not exist"
+      assert_instance_of Manifest::MissingManifest, new_manifest, "Should not exist"
     }
   end
 


### PR DESCRIPTION
Fix #1868  by having subclass manifests within the class to avoid superclass mismatches.

I think we're OK given nothing else references the subclasses.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202015484285621) by [Unito](https://www.unito.io)
