### PR TITLE
Use `proxy_server` when creating frame-ancestors header

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -43,7 +43,7 @@ module OodPortalGenerator
       @maintenance_ip_allowlist = Array(opts.fetch(:maintenance_ip_allowlist, nil) || opts.fetch(:maintenance_ip_whitelist, []))
 
       # Security configuration
-      @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@servername ?  @servername : OodPortalGenerator.fqdn}")
+      @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@proxy_server ? @proxy_server : OodPortalGenerator.fqdn}")
       @security_strict_transport = opts.fetch(:security_strict_transport, !@ssl.nil?)
 
       # Portal authentication


### PR DESCRIPTION
`update_ood_portal` generate the following content in `ood-portal.conf`

## Current behavior 
when both `servername` and `proxy_server` are set.


```
Header always set Content-Security-Policy "frame-ancestors <prototcol><servername>"
```

when only `servername` is set.


```
Header always set Content-Security-Policy "frame-ancestors <prototcol><servername>"
```

This is leading to issues when loading embedded pages etc, via a proxy.

## Updated behavior 
when both `servername` and `proxy_server` are set


```
Header always set Content-Security-Policy "frame-ancestors <prototcol><proxy_server>"
```

when only `servername` set


```
Header always set Content-Security-Policy "frame-ancestors <prototcol><servername>"
```

If `proxy_server` is empty it's value is set to `servername` [here](https://github.com/OSC/ondemand/blob/master/ood-portal-generator/lib/ood_portal_generator/view.rb#L20) , so this shouldn't cause any issues



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202016208712196) by [Unito](https://www.unito.io)
