### PR TITLE
add support for reading modules and dynamic string configs

### DIFF
--- a/apps/dashboard/app/models/hpc_module.rb
+++ b/apps/dashboard/app/models/hpc_module.rb
@@ -36,6 +36,16 @@ class HpcModule
     @to_s ||= version.nil? ? name : "#{name}/#{version}"
   end
 
+  # Equivlance is based on the a string of the name and version of 
+  # the module, much like in real life.
+  # Two modules are equal if they have the same name and version.
+  #
+  # We want to be sure that uniqeness is by value, not by
+  # identity.
+  #
+  #   new('rstudio', vesrion: 3) == new('rstudio', version: 3) is true.
+  #   and
+  #   new('rstudio', 3) == 'rstudio/3' is also true
   def ==(other)
     to_s == other.to_s
   end

--- a/apps/dashboard/app/models/hpc_module.rb
+++ b/apps/dashboard/app/models/hpc_module.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# HpcModule is a class representing a module you'd see on an HPC system.
+class HpcModule
+  class << self
+    def all(cluster)
+      Rails.cache.fetch("modules_#{cluster}", expires_in: 24.hours) do
+        file = "#{Configuration.module_file_dir}/#{cluster}.json"
+        if File.file?(file) && File.readable?(file)
+          begin
+            JSON.parse(File.read(file)).map do |name, spider_output|
+              spider_output.map do |_, mod|
+                HpcModule.new(name, version: mod['Version'])
+              end
+            end.flatten.uniq(&:to_s)
+          rescue StandardError => e
+            Rails.logger.warn("Did not read #{file} correctly because #{e.class}:#{e.message}")
+            []
+          end
+        else
+          Rails.logger.warn("File #{file} is unreadable.")
+          []
+        end
+      end
+    end
+  end
+
+  attr_reader :name, :version
+
+  def initialize(name, version: nil)
+    @name = name
+    @version = version.to_s if version
+  end
+
+  def to_s
+    @to_s ||= version.nil? ? name : "#{name}/#{version}"
+  end
+
+  def ==(other)
+    to_s == other.to_s
+  end
+  alias eql? ==
+
+  def default?
+    version.nil?
+  end
+end

--- a/apps/dashboard/app/models/hpc_module.rb
+++ b/apps/dashboard/app/models/hpc_module.rb
@@ -12,7 +12,7 @@ class HpcModule
               spider_output.map do |_, mod|
                 HpcModule.new(name, version: mod['Version'])
               end
-            end.flatten.uniq(&:to_s)
+            end.flatten.uniq
           rescue StandardError => e
             Rails.logger.warn("Did not read #{file} correctly because #{e.class}:#{e.message}")
             []
@@ -35,21 +35,6 @@ class HpcModule
   def to_s
     @to_s ||= version.nil? ? name : "#{name}/#{version}"
   end
-
-  # Equivlance is based on the a string of the name and version of 
-  # the module, much like in real life.
-  # Two modules are equal if they have the same name and version.
-  #
-  # We want to be sure that uniqeness is by value, not by
-  # identity.
-  #
-  #   new('rstudio', vesrion: 3) == new('rstudio', version: 3) is true.
-  #   and
-  #   new('rstudio', 3) == 'rstudio/3' is also true
-  def ==(other)
-    to_s == other.to_s
-  end
-  alias eql? ==
 
   def default?
     version.nil?

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -28,12 +28,13 @@ class ConfigurationSingleton
 
   def initialize
     add_boolean_configs
+    add_string_configs
   end
 
   # All the boolean configurations that can be read through
   # environment variables or through the config file.
   #
-  # @return [Hash] key/value pairs of boolean configurations.
+  # @return [Hash] key/value pairs of defaults
   def boolean_configs
     {
       :csp_enabled                  => false,
@@ -42,6 +43,16 @@ class ConfigurationSingleton
       :per_cluster_dataroot         => false,
       :file_navigator               => false,
       :jobs_app_alpha               => false
+    }.freeze
+  end
+
+  # All the boolean configurations that can be read through
+  # environment variables or through the config file.
+  #
+  # @return [Hash] key/value pairs of defaults
+  def string_configs
+    {
+      :module_file_dir      => nil,
     }.freeze
   end
 
@@ -481,6 +492,20 @@ class ConfigurationSingleton
     end.each do |cfg_item, _|
       define_singleton_method("#{cfg_item}?".to_sym) do
         send(cfg_item)
+      end
+    end
+  end
+
+  def add_string_configs
+    string_configs.each do |cfg_item, default|
+      define_singleton_method(cfg_item.to_sym) do
+        e = ENV["OOD_#{cfg_item.to_s.upcase}"]
+
+        e.nil? ? config.fetch(cfg_item, default) : e.to_s
+      end
+    end.each do |cfg_item, _|
+      define_singleton_method("#{cfg_item}?".to_sym) do
+        send(cfg_item).nil?
       end
     end
   end

--- a/apps/dashboard/test/fixtures/config/ondemand.d/string.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/string.yml
@@ -1,0 +1,1 @@
+module_file_dir: 'string from file'

--- a/apps/dashboard/test/fixtures/modules/simple.json
+++ b/apps/dashboard/test/fixtures/modules/simple.json
@@ -1,0 +1,15 @@
+{
+  "jupyter": {
+    "v1_filename": {
+      "Version": "1"
+    },
+    "v2_filename": {
+      "Version": "2"
+    }
+  },
+  
+  "rstudio": {},
+  "rstudio": {
+    "this is a duplicate": {}
+  }
+}

--- a/apps/dashboard/test/models/hpc_module_test.rb
+++ b/apps/dashboard/test/models/hpc_module_test.rb
@@ -43,5 +43,7 @@ class HpcModuleTest < ActiveSupport::TestCase
 
     assert m1 == m2
     assert m1.eql?(m2)
+    assert m1 == "test/9001" && m2 == "test/9001"
+    assert m1.eql?("test/9001") && m2.eql?("test/9001")
   end
 end

--- a/apps/dashboard/test/models/hpc_module_test.rb
+++ b/apps/dashboard/test/models/hpc_module_test.rb
@@ -36,14 +36,4 @@ class HpcModuleTest < ActiveSupport::TestCase
     assert !m.default?
     assert_equal m.version, '9001' # we gave an int, got back a string
   end
-
-  test 'module equivalence' do
-    m1 = HpcModule.new('test', version: 9001)
-    m2 = HpcModule.new('test', version: 9001)
-
-    assert m1 == m2
-    assert m1.eql?(m2)
-    assert m1 == "test/9001" && m2 == "test/9001"
-    assert m1.eql?("test/9001") && m2.eql?("test/9001")
-  end
 end

--- a/apps/dashboard/test/models/hpc_module_test.rb
+++ b/apps/dashboard/test/models/hpc_module_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HpcModuleTest < ActiveSupport::TestCase
+  test 'all safely reads from inaccessabile directories' do
+    with_modified_env({ OOD_MODULE_FILE_DIR: '/dev/null' }) do
+      assert_equal [], HpcModule.all('owens')
+    end
+  end
+
+  test 'all safely reads invalid json' do
+    Dir.mktmpdir do |dir|
+      with_modified_env({ OOD_MODULE_FILE_DIR: dir }) do
+        `echo '{this is bad json}' > #{dir}/owens.json`
+        assert_equal [], HpcModule.all('owens')
+      end
+    end
+  end
+
+  test 'reads a simple file' do
+    with_modified_env({ OOD_MODULE_FILE_DIR: "#{Rails.root}/test/fixtures/modules/" }) do
+      # NOTE: that there are no duplicates and rstudio has no version
+      assert_equal(['jupyter/1', 'jupyter/2', 'rstudio'], HpcModule.all('simple').map(&:to_s))
+    end
+  end
+
+  test 'default version' do
+    m = HpcModule.new('test')
+    assert m.default?
+    assert m.version.nil?
+  end
+
+  test 'module with version version' do
+    m = HpcModule.new('test', version: 9001)
+    assert !m.default?
+    assert_equal m.version, '9001' # we gave an int, got back a string
+  end
+
+  test 'module equivalence' do
+    m1 = HpcModule.new('test', version: 9001)
+    m2 = HpcModule.new('test', version: 9001)
+
+    assert m1 == m2
+    assert m1.eql?(m2)
+  end
+end


### PR DESCRIPTION
Fixes #1922

It also add `string_configs` to the configuration singleton. I didn't _need_ to add the string configs, but I did want to make it easier to add string configurations like we already have. This way, with this addition we cna start to backport some of our existing string (and boolean for that matter) configurations to this new scheme.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202022568160314) by [Unito](https://www.unito.io)
