### PR TITLE
enumerate over activemodel#errors as an array, not hash

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -23,15 +23,16 @@ locals: {
       <span aria-hidden="true">&times;</span>
     </button>
 
-    <% @session.errors.each do |key, error| %>
-      <% if key == :submit %>
+    <% @session.errors.each do |error| %>
+      <% if error.attribute == :submit %>
         <h4><%= t('dashboard.batch_connect_sessions_errors_submission') %></h4>
-        <pre><%= error %></pre>
-      <% elsif key == :stage %>
+        <pre><%= error.message %></pre>
+      <% elsif error.attribute == :stage %>
         <h4><%= t('dashboard.batch_connect_sessions_errors_staging') %></h4>
-        <pre><%= error %></pre>
+        <pre><%= error.message %></pre>
       <% else %>
-        <h4><%= error %></h4>
+        <h4><%= error.attribute %></h4>
+        <pre><%= error.message %></pre>
       <% end %>
     <% end %>
 

--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -31,9 +31,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     find("##{id}")['class'].to_s
   end
 
-  def verify_bc_alert(token, err_msg)
+  def verify_bc_alert(token, header, message)
     assert_equal batch_connect_session_contexts_path(token), current_path
-    assert_equal err_msg, find('div[role="alert"]').find('h4').text
+    assert_equal header, find('div[role="alert"]').find('h4').text
+    assert_equal message, find('div[role="alert"]').find('pre').text
     find('div[role="alert"]').find('button').click
   end
 end

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -416,4 +416,36 @@ class BatchConnectTest < ApplicationSystemTestCase
     assert_equal 'display: none;', find_option_style('classroom_size', 'medium')
     assert_equal 'display: none;', find_option_style('classroom_size', 'large')
   end
+
+  test 'stage errors are shown' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+    err_msg = 'this is a just a test for staging error messages'
+    Open3.stubs(:capture2e).raises(StandardError.new(err_msg))
+
+    # defaults
+    click_on('Launch')
+    verify_bc_alert('sys/bc_jupyter', I18n.t('dashboard.batch_connect_sessions_errors_staging'), err_msg)
+  end
+
+  test 'submit errors are shown' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+    err_msg = BrokenAdapter::SUBMIT_ERR_MSG
+    Open3.stubs(:capture2e).returns(['', exit_success])
+    BatchConnect::Session.any_instance.stubs(:adapter).returns(BrokenAdapter.new)
+
+    # defaults
+    click_on('Launch')
+    verify_bc_alert('sys/bc_jupyter', I18n.t('dashboard.batch_connect_sessions_errors_submission'), err_msg)
+  end
+
+  test 'save errors are shown' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+    err_msg = 'this is a just a test for staging error messages'
+    # Open3.stubs(:capture2e).returns(['', exit_failure])
+    BatchConnect::Session.any_instance.stubs(:stage).raises(StandardError.new(err_msg))
+
+    # defaults
+    click_on('Launch')
+    verify_bc_alert('sys/bc_jupyter', 'save', err_msg)
+  end
 end

--- a/apps/dashboard/test/system/preset_apps_navbar_test.rb
+++ b/apps/dashboard/test/system/preset_apps_navbar_test.rb
@@ -14,6 +14,10 @@ class PresetAppsNavbarTest < ApplicationSystemTestCase
     'This is just a test'
   end
 
+  def err_header
+    'save'
+  end
+
   # the best we can do in this test is stub out BatchConnect::Session#stage 
   # and verify that the error we threw is on the page. The link at least tries to submit.
   # TODO: get enough stubs to submit the job and get a 'queued' card to show
@@ -22,7 +26,7 @@ class PresetAppsNavbarTest < ApplicationSystemTestCase
     click_on 'Interactive Apps'
     click_on 'Test App: Preset'
 
-    verify_bc_alert('sys/preset_app/preset', err_msg)
+    verify_bc_alert('sys/preset_app/preset', err_header, err_msg)
   end
 
   test 'choice apps in navbar still redirect to the form' do
@@ -34,6 +38,6 @@ class PresetAppsNavbarTest < ApplicationSystemTestCase
     assert_equal new_batch_connect_session_context_path('sys/preset_app/choice'), current_path
     click_on 'Launch'
 
-    verify_bc_alert('sys/preset_app/choice', err_msg)
+    verify_bc_alert('sys/preset_app/choice', err_header, err_msg)
   end
 end

--- a/apps/dashboard/test/system/preset_apps_pinned_test.rb
+++ b/apps/dashboard/test/system/preset_apps_pinned_test.rb
@@ -23,10 +23,14 @@ class PresetAppsPinnedTest < ApplicationSystemTestCase
     'This is just a test'
   end
 
+  def err_header
+    'save'
+  end
+
   test 'preset apps in pinned apps directly launch' do
     visit root_path
     click_on 'Test App: Preset'
-    verify_bc_alert('sys/preset_app/preset', err_msg)
+    verify_bc_alert('sys/preset_app/preset', err_header, err_msg)
   end
 
   test 'choice apps in pinned apps still redirect to the form' do
@@ -37,8 +41,6 @@ class PresetAppsPinnedTest < ApplicationSystemTestCase
     assert_equal new_batch_connect_session_context_path('sys/preset_app/choice'), current_path
     click_on 'Launch'
 
-    verify_bc_alert('sys/preset_app/choice', err_msg)
+    verify_bc_alert('sys/preset_app/choice', err_header, err_msg)
   end
-
-
 end

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
 ENV['OOD_LOCALES_ROOT'] = Rails.root.join('config/locales').to_s
 
@@ -16,6 +18,13 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 
   UserDouble = Struct.new(:name, :groups)
+
+  class BrokenAdapter < OodCore::Job::Adapter
+    SUBMIT_ERR_MSG = 'this adapter cannot submit jobs'
+    def submit(_)
+      raise StandardError, SUBMIT_ERR_MSG
+    end
+  end
 
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)


### PR DESCRIPTION
Fixes #1869 - to enumerate over activemodel#errors as an array, not hash.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202038629870848) by [Unito](https://www.unito.io)
