### PR TITLE
Refactor Transfer class to separate handling of different transfers

### DIFF
--- a/apps/dashboard/app/models/local_transfer.rb
+++ b/apps/dashboard/app/models/local_transfer.rb
@@ -1,0 +1,131 @@
+class LocalTransfer < Transfer
+
+  validates_each :files do |record, attr, files|
+    if record.action == 'mv' || record.action == 'cp'
+      conflicts = files.values.select { |f| File.exist?(f) }
+      record.errors.add :files, "these files already exist: #{conflicts.join(', ')}" if conflicts.present?
+    end
+
+    files.each do |k, v|
+      record.errors.add :files, "#{k} is not included under ALLOWLIST_PATH" unless AllowlistPolicy.default.permitted?(k.to_s)
+      # rm commands are [{ k => nil}] - nil values
+      record.errors.add :files, "#{v} is not included under ALLOWLIST_PATH" if !v.nil? && !AllowlistPolicy.default.permitted?(v.to_s)
+    end
+  end
+
+  class << self
+    def transfers
+      # all transfers stored in the Transfer class
+      Transfer.transfers
+    end
+  end
+
+  # number of files to copy, move or delete
+  def steps
+    return @steps if @steps
+
+    names = files.keys.map {|f| File.basename(f)}
+
+    # a move to a different device does a cp then mv
+    if action == 'mv' && mv_to_same_device?
+      @steps = files.count
+    else
+      @steps = PosixFile.num_files(from, names)
+      @steps *= 2 if action == 'mv'
+    end
+
+    @steps
+  end
+
+  # array of arguments that will be executed
+  def command
+    # command is executed in the directory containing the "from" files
+
+    if action == 'mv'
+      args = [action.to_s, '-v']
+
+      if files.count == 1
+        # for renaming a single file
+        # { file_src => file_dest} changes to [file_src, file_dest] and absolute paths are fine here
+        args += files.to_a.flatten
+      else
+        args += files.keys.map { |f| File.basename(f) }
+        args << to
+      end
+    elsif action == 'cp'
+      args = [action.to_s, '-v']
+      args << '-r'
+      args += files.keys.map { |f| File.basename(f) }
+      args << to
+    elsif action == 'rm'
+      args = [action.to_s, '-v']
+      args << '-r'
+
+      args += files.keys
+    else
+      raise "Unknown action: #{action.inspect}"
+    end
+
+    args
+  end
+
+  def perform
+    self.status = OodCore::Job::Status.new(state: :running)
+    self.started_at = Time.now.to_i
+
+    # calculate number of steps prior to starting the removal of files
+    steps
+
+    Open3.popen3(*command, chdir: from) do |i, o, e, t|
+      self.pid = t.pid
+
+      err_reader = Thread.new { e.read  }
+
+      o.each_line.with_index do |l, index|
+        #FIXME: slice(?).last so that we only update progress a few times per...
+        update_percent(index+1)
+      end
+      o.close
+
+      self.exit_status = t.value
+      self.completed_at = Time.now.to_i
+
+      # FIXME: figure out what we are going to do here, since we save the stderr output twice
+      self.stderr = err_reader.value.to_s.strip
+      if self.stderr.present? || ! self.exit_status.success?
+        errors.add :base, "#{self.command} exited with status #{self.exit_status.exitstatus}\n\n#{self.stderr}"
+      end
+
+      self
+    end
+  rescue => e
+    errors.add :base, e.message
+  ensure
+    self.status = OodCore::Job::Status.new(state: :completed)
+  end
+
+  def from
+    File.dirname(files.keys.first) if files.keys.first
+  end
+
+  def to
+    File.dirname(files.values.first) if files.values.first
+  end
+
+  def target_dir
+    # directory where files are being moved/copied to OR removed from
+    if action == "rm"
+      Pathname.new(from).cleanpath if from
+    else
+      Pathname.new(to).cleanpath if to
+    end
+  end
+
+  def synchronous?
+    mv_to_same_device?
+  end
+
+  def mv_to_same_device?
+    action == "mv" && from && to && PosixFile.stat(from)[:dev] == PosixFile.stat(File.dirname(to))[:dev]
+  end
+end

--- a/apps/dashboard/app/models/transfer.rb
+++ b/apps/dashboard/app/models/transfer.rb
@@ -7,19 +7,6 @@ class Transfer
   attr_accessor :id, :status, :created_at, :started_at, :completed_at
   attr_writer :percent
 
-  validates_each :files do |record, attr, files|
-    if record.action == 'mv' || record.action == 'cp'
-      conflicts = files.values.select { |f| File.exist?(f) }
-      record.errors.add :files, "these files already exist: #{conflicts.join(', ')}" if conflicts.present?
-    end
-
-    files.each do |k, v|
-      record.errors.add :files, "#{k} is not included under ALLOWLIST_PATH" unless AllowlistPolicy.default.permitted?(k.to_s)
-      # rm commands are [{ k => nil}] - nil values
-      record.errors.add :files, "#{v} is not included under ALLOWLIST_PATH" if !v.nil? && !AllowlistPolicy.default.permitted?(v.to_s)
-    end
-  end
-
   def percent
     (status && status.completed?) ? 100 : (@percent || 0)
   end
@@ -49,7 +36,7 @@ class Transfer
         files = Hash[files.map { |f| [f, nil] }]
       end
 
-      Transfer.new(action: action, files: files)
+      LocalTransfer.new(action: action, files: files)
     end
   end
 
@@ -119,57 +106,12 @@ class Transfer
     end
   end
 
+  def steps
+    0
+  end
+
   def persisted?
     ! id.nil?
-  end
-
-  # number of files to copy, move or delete
-  def steps
-    return @steps if @steps
-
-    names = files.keys.map {|f| File.basename(f)}
-
-    # a move to a different device does a cp then mv
-    if action == 'mv' && mv_to_same_device?
-      @steps = files.count
-    else
-      @steps = PosixFile.num_files(from, names)
-      @steps *= 2 if action == 'mv'
-    end
-
-    @steps
-  end
-
-  # array of arguments that will be executed
-  def command
-    # command is executed in the directory containing the "from" files
-
-    if action == 'mv'
-      args = [action.to_s, '-v']
-
-      if files.count == 1
-        # for renaming a single file
-        # { file_src => file_dest} changes to [file_src, file_dest] and absolute paths are fine here
-        args += files.to_a.flatten
-      else
-        args += files.keys.map { |f| File.basename(f) }
-        args << to
-      end
-    elsif action == 'cp'
-      args = [action.to_s, '-v']
-      args << '-r'
-      args += files.keys.map { |f| File.basename(f) }
-      args << to
-    elsif action == 'rm'
-      args = [action.to_s, '-v']
-      args << '-r'
-
-      args += files.keys
-    else
-      raise "Unknown action: #{action.inspect}"
-    end
-
-    args
   end
 
   def command_str
@@ -180,68 +122,8 @@ class Transfer
     self.percent = steps == 0 ? 100 : (100.0*((step).to_f/steps)).to_i
   end
 
-  def perform
-    self.status = OodCore::Job::Status.new(state: :running)
-    self.started_at = Time.now.to_i
-
-    # calculate number of steps prior to starting the removal of files
-    steps
-
-    Open3.popen3(*command, chdir: from) do |i, o, e, t|
-      self.pid = t.pid
-
-      err_reader = Thread.new { e.read  }
-
-      o.each_line.with_index do |l, index|
-        #FIXME: slice(?).last so that we only update progress a few times per...
-        update_percent(index+1)
-      end
-      o.close
-
-      self.exit_status = t.value
-      self.completed_at = Time.now.to_i
-
-      # FIXME: figure out what we are going to do here, since we save the stderr output twice
-      self.stderr = err_reader.value.to_s.strip
-      if self.stderr.present? || ! self.exit_status.success?
-        errors.add :base, "#{self.command} exited with status #{self.exit_status.exitstatus}\n\n#{self.stderr}"
-      end
-
-      self
-    end
-  rescue => e
-    errors.add :base, e.message
-  ensure
-    self.status = OodCore::Job::Status.new(state: :completed)
-  end
-
   def perform_later
     save
     TransferLocalJob.perform_later(self)
-  end
-
-  def from
-    File.dirname(files.keys.first) if files.keys.first
-  end
-
-  def to
-    File.dirname(files.values.first) if files.values.first
-  end
-
-  def target_dir
-    # directory where files are being moved/copied to OR removed from
-    if action == "rm"
-      Pathname.new(from).cleanpath if from
-    else
-      Pathname.new(to).cleanpath if to
-    end
-  end
-
-  def synchronous?
-    mv_to_same_device?
-  end
-
-  def mv_to_same_device?
-    action == "mv" && from && to && PosixFile.stat(from)[:dev] == PosixFile.stat(File.dirname(to))[:dev]
   end
 end

--- a/apps/dashboard/test/jobs/transfer_local_job_test.rb
+++ b/apps/dashboard/test/jobs/transfer_local_job_test.rb
@@ -16,7 +16,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
       # or we do "to" but "with_prefix" added if from and to are the same
       # directory
       # end
-      transfer = Transfer.new(action: 'cp', files: {testfile => destfile})
+      transfer = Transfer.build(action: 'cp', files: {testfile => destfile})
       transfer.perform
 
       assert_equal 0, transfer.exit_status, "job exited with error #{transfer.stderr}"
@@ -58,7 +58,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
         testfile = File.join(dir, 'foo')
         destfile = File.join(dir, 'dest/foo')
 
-        transfer = Transfer.new(action: 'cp', files: {testfile => destfile})
+        transfer = Transfer.build(action: 'cp', files: {testfile => destfile})
         transfer.perform
 
         assert transfer.stderr.present?, 'copy should have preserved stderr of job'
@@ -93,7 +93,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
       File.write(testfile, 'this is a test file')
       FileUtils.mkpath File.dirname(destfile)
 
-      transfer = Transfer.new(action: 'cp', files: {testfile => destfile})
+      transfer = Transfer.build(action: 'cp', files: {testfile => destfile})
       transfer.save
       job = TransferLocalJob.perform_later(transfer)
       assert job.job_id != nil
@@ -119,7 +119,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
       # this tests the number of calls to update_progress
       # note: progress.percent is not called because this mocks the method
       num_files = PosixFile.num_files(dir, ['app'])
-      transfer = Transfer.new(action: 'cp', files: {testdir => File.join(destdir, 'app')})
+      transfer = Transfer.build(action: 'cp', files: {testdir => File.join(destdir, 'app')})
       transfer.expects(:percent=).times(num_files)
 
       transfer.perform

--- a/apps/dashboard/test/models/transfer_test.rb
+++ b/apps/dashboard/test/models/transfer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TransferTest < ActiveSupport::TestCase
   test 'copy command' do
-    transfer = Transfer.new action: 'cp', files: {
+    transfer = Transfer.build action: 'cp', files: {
       '/Users/efranz/dev/ondemand/apps/dashboard/app' => '/var/folders/w7/fn8w83s10510pkc5j2wq8cpnhxtn3j/T/d20210201-68201-u3azoj/app',
       '/Users/efranz/dev/ondemand/apps/dashboard/config' => '/var/folders/w7/fn8w83s10510pkc5j2wq8cpnhxtn3j/T/d20210201-68201-u3azoj/config',
       '/Users/efranz/dev/ondemand/apps/dashboard/manifest.yml' => '/var/folders/w7/fn8w83s10510pkc5j2wq8cpnhxtn3j/T/d20210201-68201-u3azoj/manifest.yml'
@@ -38,7 +38,7 @@ class TransferTest < ActiveSupport::TestCase
   end
 
   test 'steps for cp bin' do
-    assert_equal Dir['bin/*'].count + 1, Transfer.new(action: 'cp', files: { 'bin' => 'bin.2' }).steps
+    assert_equal Dir['bin/*'].count + 1, Transfer.build(action: 'cp', files: { 'bin' => 'bin.2' }).steps
   end
 
   # This tests https://github.com/OSC/ondemand/issues/1337 and fails if it's not patched


### PR DESCRIPTION
This is a small PR I've been thinking about submitting for a while now, it should be useful for any approach we use for the cloud storage (Active Storage, Rclone, other?) as the way these classes are set up seems to handle tracking transfer progress quite well.

This adds a `LocalTransfer` class that handles the transfers(move, copy, delete) on the local filesystem.
The idea is that `Transfer.build` creates an instance of a suitable subclass depending what kind of transfer it is, e.g. `RemoteTransfer` or `S3Transfer` could be future classes.
Would this be better as `PosixTransfer` to match `PosixFile`?



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202100406538885) by [Unito](https://www.unito.io)
