### PR TITLE
using . in the file names here is deprecated.

### DIFF
--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -20,7 +20,7 @@ json.files @files do |f|
   json.mode f[:mode]
 end
 
-json.breadcrumbs_html render partial: 'breadcrumb.html.erb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path }
-json.shell_dropdown_html render partial: 'shell_dropdown.html.erb'
+json.breadcrumbs_html render partial: 'breadcrumb', formats: [:html, :erb], collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path }
+json.shell_dropdown_html render partial: 'shell_dropdown', formats: [:html, :erb]
 json.time Time.now.to_i
 json.error_message alert if alert


### PR DESCRIPTION
Using . in partial file names here is deprecated. Instead specify the formats.

This fixes this warning:

```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: files/_breadcrumb.html.erb (called from _app_views_files_index_json_jbuilder___283522221466645663_19980 at /home/jeff/ondemand/src/apps/dashboard/app/views/files/index.json.jbuilder:23)
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: files/_shell_dropdown.html.erb (called from _app_views_files_index_json_jbuilder___283522221466645663_19980 at /home/jeff/ondemand/src/apps/dashboard/app/views/files/index.json.jbuilder:24)
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202111656403898) by [Unito](https://www.unito.io)
