### PR TITLE
Proxy frame ancestors

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -43,7 +43,7 @@ module OodPortalGenerator
       @maintenance_ip_allowlist = Array(opts.fetch(:maintenance_ip_allowlist, nil) || opts.fetch(:maintenance_ip_whitelist, []))
 
       # Security configuration
-      @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@servername ?  @servername : OodPortalGenerator.fqdn}")
+      @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@proxy_server ? @proxy_server : OodPortalGenerator.fqdn}")
       @security_strict_transport = opts.fetch(:security_strict_transport, !@ssl.nil?)
 
       # Portal authentication

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -4,7 +4,7 @@ require "erb"
 module OodPortalGenerator
   # A view class that renders an OOD portal Apache configuration file
   class View
-    attr_reader :ssl, :protocol, :servername, :proxy_server, :port
+    attr_reader :ssl, :protocol, :proxy_server, :port
     attr_accessor :user_map_match, :user_map_cmd, :logout_redirect
     attr_accessor :oidc_uri, :oidc_client_secret, :oidc_remote_user_claim, :oidc_client_id, :oidc_provider_metadata_url, :oidc_redirect_uri
     # @param opts [#to_h] the options describing the context used to render the
@@ -17,7 +17,7 @@ module OodPortalGenerator
       @protocol         = @ssl ? "https://" : "http://"
       @listen_addr_port = opts.fetch(:listen_addr_port, nil)
       @servername       = opts.fetch(:servername, nil)
-      @proxy_server     = opts.fetch(:proxy_server, @servername)
+      @proxy_server     = opts.fetch(:proxy_server, servername)
       @port             = opts.fetch(:port, @ssl ? "443" : "80")
       if OodPortalGenerator.debian?
         @logroot        = opts.fetch(:logroot, "/var/log/apache2")
@@ -43,7 +43,7 @@ module OodPortalGenerator
       @maintenance_ip_allowlist = Array(opts.fetch(:maintenance_ip_allowlist, nil) || opts.fetch(:maintenance_ip_whitelist, []))
 
       # Security configuration
-      @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@proxy_server ? @proxy_server : OodPortalGenerator.fqdn}")
+      @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@proxy_server}")
       @security_strict_transport = opts.fetch(:security_strict_transport, !@ssl.nil?)
 
       # Portal authentication
@@ -92,7 +92,6 @@ module OodPortalGenerator
       @register_uri  = opts.fetch(:register_uri, nil)
       @register_root = opts.fetch(:register_root, nil)
 
-      servername = @servername || OodPortalGenerator.fqdn
       @oidc_provider_metadata_url       = opts.fetch(:oidc_provider_metadata_url, nil)
       @oidc_client_id                   = opts.fetch(:oidc_client_id, nil)
       @oidc_client_secret               = opts.fetch(:oidc_client_secret, nil)
@@ -105,6 +104,10 @@ module OodPortalGenerator
       @oidc_state_max_number_of_cookies = opts.fetch(:oidc_state_max_number_of_cookies, '10 true')
       @oidc_cookie_same_site            = opts.fetch(:oidc_cookie_same_site, @ssl ? 'Off' : 'On')
       @oidc_settings                    = opts.fetch(:oidc_settings, {})
+    end
+
+    def servername
+      @servername || OodPortalGenerator.fqdn
     end
 
     # Helper method to set the filename and path for access and error logs

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -76,7 +76,7 @@ Listen 8080
   RewriteRule ^.*$ /assets/maintenance/index.html [R=503,L]
   ErrorDocument 503 /assets/maintenance/index.html
 
-  Header always set Content-Security-Policy "frame-ancestors https://test.server.name;"
+  Header always set Content-Security-Policy "frame-ancestors https://test.proxy.name;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 
   SSLEngine On

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -68,7 +68,7 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
-  Header always set Content-Security-Policy "frame-ancestors https://example.com;"
+  Header always set Content-Security-Policy "frame-ancestors https://example-proxy.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 
   SSLEngine On


### PR DESCRIPTION
Carrying on the work from #1920 to use `proxy_server` for the content security policy.