### PR TITLE
Shell: Display specific failed connection error 

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -88,7 +88,9 @@ function default_server_origin(headers){
 }
 
 function detect_auth_error(requestToken, client_origin, server_origin, host) {
-  if (client_origin &&
+  if (host_allowlist.length == 0) {
+    return "No clusters defined.";
+  } else if (client_origin &&
     client_origin.startsWith('http') &&
     server_origin && client_origin !== server_origin) {
     return "Invalid Origin.";

--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -121,6 +121,17 @@ router.get('/ssh*', function (req, res) {
     });
 });
 
+router.get('/authCheck/:host/:requestToken', function (req, res) {
+  // Verify that user is authorized to connect to the server. If not, return error stating why
+  // Not intended to prevent user from connecting, just to tell the user why they can't
+
+  const client_origin = req.headers['origin'],
+        server_origin = custom_server_origin(default_server_origin(req.headers));
+
+  var authError = detect_auth_error(req.params.requestToken, client_origin, server_origin, req.params.host);
+  res.send(authError);
+})
+
 router.use(express.static(path.join(__dirname, 'public')));
 
 // Setup app

--- a/apps/shell/public/javascripts/ood_shell.2.js
+++ b/apps/shell/public/javascripts/ood_shell.2.js
@@ -87,8 +87,10 @@ OodShell.prototype.closeTerminal = function (ev) {
   window.onbeforeunload = null;
 
   // Inform user that they cannot connect to websocket. Do not add another error message if one already exists
-  if ( this.term === null && !document.getElementById('errorMessageBox')) {
-    displayErrorMessage('Failed to establish a websocket connection. Be sure you are using a browser that supports websocket connections.');
+  if ( this.term === null ) {
+    if (!document.getElementById('errorMessageBox')) {
+      displayErrorMessage('Failed to establish a websocket connection. Be sure you are using a browser that supports websocket connections.');
+    }
   } else {
     this.term.io.print('\r\nYour connection to the remote server has been terminated.');
   }


### PR DESCRIPTION
Approach:
Created a new http route for user to send the user's credentials before they attempt a websocket connection and show a specific error if they can't connect.

Closes #681


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202150585711031) by [Unito](https://www.unito.io)
