### PR TITLE
add the ability for sub apps to have their own caption

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -104,6 +104,10 @@ module BatchConnect
       ood_app.manifest.description
     end
 
+    def caption
+      form_config.fetch(:caption, ood_app.caption)
+    end
+
     def link
       OodAppLink.new(
         # FIXME: better to use default_title and "" description
@@ -111,7 +115,7 @@ module BatchConnect
         description: description,
         url: url,
         icon_uri: ood_app.icon_uri,
-        caption: ood_app.caption,
+        caption: caption,
         new_tab: false,
         data: preset? ? { 'method': 'post' } : {}
       )

--- a/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/owens.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/owens.yml
@@ -1,4 +1,5 @@
 ---
+caption: 'gnome desktop on the owens cluster'
 title: "Owens Desktop"
 cluster: "owens"
 attributes:

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -292,4 +292,22 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       assert_equal Hash.new, app.build_session_context.attributes
     end
   end
+
+  test 'subapps use caption from form' do
+    r = PathRouter.new('test/fixtures/usr/shared/bc_with_subapps/')
+    app = BatchConnect::App.new(router: r)
+    sub_apps = app.sub_app_list
+
+    assert_equal 2, sub_apps.size
+    assert_equal 'Oakley Desktop', sub_apps[0].title
+    assert_equal 'Owens Desktop', sub_apps[1].title
+
+    # path router's default caption is nil. But owens overrides
+    assert_nil sub_apps[0].caption
+    assert_equal 'gnome desktop on the owens cluster', app.sub_app_list[1].caption
+
+    # links hold the right caption too
+    assert_nil sub_apps[0].link.caption
+    assert_equal 'gnome desktop on the owens cluster', sub_apps[1].link.caption
+  end
 end


### PR DESCRIPTION
Fixes #1899 

The result is something like this


* Rstudio Server: Choice --- default
* Rstudio Server: Preset --- uses this feature
* Jupyter (no subapp) - uses caption from the app's manifest.
![image](https://user-images.githubusercontent.com/4874123/164265495-8b07c906-b0a3-4e07-afdb-1940cd30ec68.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202158895428972) by [Unito](https://www.unito.io)
