### PR TITLE
Shell: display specific connection error (detect on connection)

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -151,7 +151,7 @@ wss.on('connection', function connection (ws, req) {
 
   // Verify authentication
   token = req.url.match(/csrf=([^&]*)/)[1];
-  authError = detect_auth_error(token, req.origin, custom_server_origin(), host);
+  authError = detect_auth_error(token, req.origin, custom_server_origin(default_server_origin(req)), host);
   if (authError) {
     // 3146 has no meaning, any number between 3000-3999 is fair to use
     ws.close(3146, authError);

--- a/apps/shell/public/javascripts/ood_shell.2.js
+++ b/apps/shell/public/javascripts/ood_shell.2.js
@@ -65,6 +65,12 @@ OodShell.prototype.closeTerminal = function (ev) {
     errorDiv.className = 'error';
     errorDiv.innerHTML = 'Failed to establish a websocket connection. Be sure you are using a browser that supports websocket connections.';
     this.element.appendChild(errorDiv);
+  } else if (ev.code === 3146) {
+    document.querySelector('iframe').remove();
+    errorDiv = document.createElement('div');
+    errorDiv.className = 'error';
+    errorDiv.innerHTML = ev.reason;
+    this.element.appendChild(errorDiv);
   } else {
     this.term.io.print('\r\nYour connection to the remote server has been terminated.');
   }


### PR DESCRIPTION
New pr alternative to #1961. Closes #681.
Move credential check from `server.on('upgrade')` to `wss.on('connection')`