### PR TITLE
Shell: Verify read access to host yml files

### DIFF
--- a/apps/shell/utils/helpers.js
+++ b/apps/shell/utils/helpers.js
@@ -14,12 +14,18 @@ function definedHosts() {
     'default': process.env.OOD_DEFAULT_SSHHOST || process.env.DEFAULT_SSHHOST || null,
     'hosts': []
   };
-
   glob.sync(path.join((process.env.OOD_CLUSTERS || '/etc/ood/config/clusters.d'), '*.y*ml'))
-    .map((yml) => {
+    .filter((yml) => {
+      // Verify read access to yml files
       try {
-        return yaml.safeLoad(fs.readFileSync(yml));
-      } catch(err) { /** just keep going. dashboard should have an alert about it */}
+        fs.accessSync(yml, fs.constants.R_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    })
+    .map((yml) => {
+      return yaml.safeLoad(fs.readFileSync(yml));
     }).filter(config => (config && config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
     .forEach((config) => {
       let host = config.v2.login.host; //Already did checking above


### PR DESCRIPTION
Closes #1950

Remove existing try catch around `yaml.safeload` and added a filter before .map to remove unreadable yml files.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202164797744847) by [Unito](https://www.unito.io)
