### PR TITLE
add benchmarking tests to the dashboard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,22 @@ jobs:
       - name: Run lint tests
         run: bundle exec rake lint || true
 
-      - name: Run System Dashboard tests
+      - name: Run Dashboard System tests
         run: cd apps/dashboard; bin/rake test:system
+
+      - name: Run Dashboard benchmarks
+        if: contains(github.event.pull_request.labels.*.name, 'area/performance')
+        run: |
+          cd apps/dashboard
+          bin/rake test:benchmark 2>/dev/null
+          bin/rake test:profile 2>/dev/null
+
+      - name: upload benchmark files
+        if: contains(github.event.pull_request.labels.*.name, 'area/performance')
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmarks
+          path: apps/dashboard/tmp/performance/*.html
 
   k8s-tests:
     runs-on: ubuntu-latest

--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -28,11 +28,9 @@ end
 group :test do
   gem "capybara"
   gem "selenium-webdriver"
-end
-
-group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  # gem 'web-console', '~> 2.0'
+  # waiting for https://github.com/rails/rails-perftest/pull/44 to be released
+  gem 'rails-perftest', git: 'https://github.com/rails/rails-perftest'
+  gem 'ruby-prof', '0.18.0'
 end
 
 # Extra third-party gems

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/rails/rails-perftest
+  revision: 92ff7d0666306e2b7ff5cd33ad986742ba8e15b9
+  specs:
+    rails-perftest (0.0.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -190,6 +196,7 @@ GEM
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
+    ruby-prof (0.18.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sdoc (2.3.1)
@@ -254,7 +261,9 @@ DEPENDENCIES
   ood_support (~> 0.0.2)
   pbs (~> 2.2.1)
   rails (= 6.1.4.7)
+  rails-perftest!
   redcarpet (~> 3.3)
+  ruby-prof (= 0.18.0)
   sdoc
   selenium-webdriver
   sinatra

--- a/apps/dashboard/test/performance/batch_connect_test.rb
+++ b/apps/dashboard/test/performance/batch_connect_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'performance_test_case'
+
+class BatchConnectPerformanceTest < PerformanceTestCase
+  def setup
+    stub_sys_apps
+    stub_usr_router
+    NavConfig.categories_whitelist = false
+  end
+
+  test 'index' do
+    get '/batch_connect/sessions'
+  end
+end

--- a/apps/dashboard/test/performance_test_case.rb
+++ b/apps/dashboard/test/performance_test_case.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rails/performance_test_help'
+
+class PerformanceTestCase < ActionDispatch::PerformanceTest
+  def self.runs
+    return 25 if ENV['OOD_BENCHMARK_RUNS'].nil?
+
+    ENV['OOD_BENCHMARK_RUNS'].to_i
+  end
+
+  self.profile_options = {
+    runs: runs, metrics: [:wall_time, :process_time, :memory, :objects],
+    output: 'tmp/performance', formats: [:graph_html, :call_tree, :call_stack]
+  }
+end

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] ||= 'test'
-ENV['OOD_LOCALES_ROOT'] = Rails.root.join('config/locales').to_s
+ENV['OOD_LOCALES_ROOT'] = File.expand_path('../config/locales', __dir__)
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
In an effort to take care of speed up the dashboard's responses (#210) we need to first find gather data on how fast it is currently responding - and where all the time is being taken.

This fixes that.

`bin/rake test:benchmark` is OK but I like `bin/rake test:profile` better. (try `bin/rake test:profile 2>/dev/null` to get rid of all the noise).

After you run the file you can inspect a file like `tmp/performance/HomepageTest%23test_index_wall_time_stack.html` (relative to the dashboard) and see stuff like 30% of our time is setting pinned apps.

![image](https://user-images.githubusercontent.com/4874123/165397608-a1127ff2-730f-4728-99fc-98c843f1afab.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699692287576) by [Unito](https://www.unito.io)
