### PR TITLE
upload system test failures in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Run System Dashboard tests
         run: cd apps/dashboard; bin/rake test:system
 
+      - name: Upload system test failures.
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: system-test-failures
+          path: apps/dashboard/tmp/screenshots/*.png
+
   k8s-tests:
     runs-on: ubuntu-latest
     name: Kubernetes tests


### PR DESCRIPTION
This uploads images when system tests do fail so that we can at least see what's going on in the CI.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202194149595595) by [Unito](https://www.unito.io)
