### PR TITLE
Shell: Create test for unreadable yml file

### DIFF
--- a/apps/shell/test/helpers.test.js
+++ b/apps/shell/test/helpers.test.js
@@ -100,10 +100,10 @@ describe('Helper function definedHosts()', () => {
       // owens.yml has default in it
       expect(defaultHost).toEqual('owens.osc.edu');
       expect(allHosts).toEqual(['owens.osc.edu', 'ruby.osc.edu']);
-      fs.chmodSync(unreadableYmlPath, 420);
+      fs.chmodSync(unreadableYmlPath, 0o644);
     } catch (err) {
       // wait to send error until file permissions are restored 
-      fs.chmodSync(unreadableYmlPath, 420);
+      fs.chmodSync(unreadableYmlPath, 0o644);
       throw err;
     }
   })

--- a/apps/shell/test/helpers.test.js
+++ b/apps/shell/test/helpers.test.js
@@ -1,4 +1,6 @@
 'use strict';
+const path = require('path');
+const fs = require('fs');
 
 /**
  * Allowlist helper function tests
@@ -86,6 +88,24 @@ describe('Helper function definedHosts()', () => {
 
     expect(defaultHost).toEqual('pitzer.osc.edu');
     expect(helpers.definedHosts()['hosts']).toEqual(['pitzer.osc.edu', 'ruby.osc.edu']);
+  })
+
+  test('when an unreadable yml file is present', () => {
+    const unreadableYmlPath = path.join(process.env.OOD_CLUSTERS, 'pitzer.yml');
+    fs.chmodSync(unreadableYmlPath, 0);
+    try {
+      let hosts = helpers.definedHosts();
+      let defaultHost = hosts['default'];
+      let allHosts = hosts['hosts'];
+      // owens.yml has default in it
+      expect(defaultHost).toEqual('owens.osc.edu');
+      expect(allHosts).toEqual(['owens.osc.edu', 'ruby.osc.edu']);
+      fs.chmodSync(unreadableYmlPath, 420);
+    } catch (err) {
+      // wait to send error until file permissions are restored 
+      fs.chmodSync(unreadableYmlPath, 420);
+      throw err;
+    }
   })
 });
 


### PR DESCRIPTION
As requested in #1967. Add test case to ensure functionality if a yml does not have read permissions.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202234867920347) by [Unito](https://www.unito.io)
