### PR TITLE
specify cluster in the form so it's got the right order

### DIFF
--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -1,11 +1,13 @@
 ---
 title: "Jupyter Notebook"
-cluster:
-  - "owens"
-  - "oakley"
 description: |
   This is a test jupyter app.
 attributes:
+  cluster:
+    widget: select
+    options:
+      - "owens"
+      - "oakley"
   mode:
     widget: "radio"
     label: "The Mode"
@@ -128,6 +130,7 @@ attributes:
           data-option-for-classroom-astronomy-5678: false,
         ]
 form:
+  - cluster
   - bc_num_hours
   - bc_num_slots
   - mode


### PR DESCRIPTION
As seen in #1988 - `release_2.0` tests are failing for some reason. Specifying the cluster order in the test fixes the issues because the tests all expect `owens` to be the first, default, choice in the cluster dropdown. But it is currently _not_ sorted, it is showing `oakley` and so all the tests fail because they have this assumption built in.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202249800590014) by [Unito](https://www.unito.io)
