### PR TITLE
Use python3 for Ubuntu/Debian packages

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -5,7 +5,7 @@ Maintainer: Ohio Supercomputer Center <oschelp@osc.edu>
 Build-Depends: debhelper (>=11~), curl, build-essential,
   ruby, ruby-dev,
   nodejs (>= 14.0), nodejs (<< 15.0),
-  sqlite, libsqlite3-dev, python
+  sqlite, libsqlite3-dev, python3
 Standards-Version: 4.1.4
 Homepage: https://openondemand.org
 

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -38,13 +38,11 @@ Source2:   ondemand-selinux.fc
 %define apache_confd /etc/httpd/conf.d
 %define apache_service httpd
 %define htcacheclean_service htcacheclean
-%define python_dep python2
 %else
 %bcond_without scl_apache
 %define apache_confd /opt/rh/httpd24/root/etc/httpd/conf.d
 %define apache_service httpd24-httpd
 %define htcacheclean_service httpd24-htcacheclean
-%define python_dep python
 %endif
 
 # Disable automatic dependencies as it causes issues with bundled gems and
@@ -58,11 +56,11 @@ BuildRequires:   ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_maj
 BuildRequires:   ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}
 BuildRequires:   rsync
 BuildRequires:   git
-BuildRequires:   %{python_dep}
+BuildRequires:   python3
 
 Requires:        git
 Requires:        sudo, lsof, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib, lua-posix
-Requires:        %{python_dep}
+Requires:        python3
 Requires:        ondemand-apache >= %{runtime_version}, ondemand-apache < %{next_major_version}, ondemand-apache < %{next_minor_version}
 Requires:        ondemand-nginx = 1.20.1
 Requires:        ondemand-passenger = 6.0.11


### PR DESCRIPTION
Ubuntu 22.04 has no `python` package so rather than try some clever logic to make dependencies vary based on OS being built (which is actually quite complicated) , just have everything for deb packages depend on Python 3 which exists in both Ubuntu 20.04 and 22.04.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202262663427249) by [Unito](https://www.unito.io)
