### PR TITLE
Switch format for deb packaging to make Ubuntu 22.04 builds work

### DIFF
--- a/packaging/deb/source/format
+++ b/packaging/deb/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
I could not figure out how to make the necessary tar.gz files during build to have versions work.  Seems using `3.0 (native)` makes our version scheme work with Ubuntu 22.04 builds.  I already had to make this change to other deb builds like Passenger to get them to build with Ubuntu 22.04.