### PR TITLE
More Slurm job info in ActiveJobs

### DIFF
--- a/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
+++ b/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
@@ -116,7 +116,12 @@ module ActiveJobs
       attributes.push Attribute.new "Total CPUs", info.native[:cpus]
       attributes.push Attribute.new "Time Limit", info.native[:time_limit]
       attributes.push Attribute.new "Time Used", info.native[:time_used]
+      attributes.push Attribute.new "Start Time",
+        DateTime.parse(info.native[:start_time]).strftime("%Y-%m-%d %H:%M:%S") unless info.native[:start_time] == "N/A"
+      attributes.push Attribute.new "End Time",
+        DateTime.parse(info.native[:end_time]).strftime("%Y-%m-%d %H:%M:%S") unless info.native[:end_time] == "N/A"
       attributes.push Attribute.new "Memory", info.native[:min_memory]
+      attributes.push Attribute.new "GRES", info.native[:gres].gsub(/gres:/, "") unless info.native[:gres] == "N/A"
       self.native_attribs = attributes
 
       self.submit_args = nil


### PR DESCRIPTION
This PR adds some information about [GRES](https://slurm.schedmd.com/gres.html), start times and end times of Slurm jobs to the Active Jobs app. The fields are hidden if they are not defined (N/A).

Example output:
![image](https://user-images.githubusercontent.com/61623634/168268226-1d1f526f-5f63-4ebd-85b0-22d5700dc065.png)
