### PR TITLE
[release_2.0] More specific ondemand-passenger dependency

### DIFF
--- a/packaging/ondemand.spec
+++ b/packaging/ondemand.spec
@@ -65,7 +65,7 @@ Requires:        git
 Requires:        sudo, lsof, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib, lua-posix
 Requires:        ondemand-apache >= %{runtime_version}, ondemand-apache < %{next_major_version}, ondemand-apache < %{next_minor_version}
 Requires:        ondemand-nginx = 1.18.0-2.p6.0.14%{?dist}
-Requires:        ondemand-passenger = 6.0.14
+Requires:        ondemand-passenger = 6.0.14-1%{?dist}
 Requires:        ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_major_version}, ondemand-ruby < %{next_minor_version}
 Requires:        ondemand-python >= %{runtime_version}, ondemand-python < %{next_major_version}, ondemand-python < %{next_minor_version}
 Requires:        ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}


### PR DESCRIPTION
johrstrom I believe it's still the case you could do a tag like v2.0.24-2 to keep 2.0.24 tag but bump package release since this is packaging change.  Or can just bump to v2.0.25 if that's easier.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202314069129887) by [Unito](https://www.unito.io)
