### PR TITLE
Upgrade EL builds to use Ruby 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf -y install https://yum.osc.edu/ondemand/latest/ondemand-release-web-late
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled powertools && \
-    dnf -y module enable nodejs:14 ruby:2.7 && \
+    dnf -y module enable nodejs:14 ruby:3.0 && \
     dnf install -y \
         file \
         lsof \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN cp /etc/yum.repos.d/ondemand-web.repo /etc/yum.repos.d/ondemand-nightly-web.
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled powertools && \
-    dnf -y module enable nodejs:14 ruby:2.7 && \
+    dnf -y module enable nodejs:14 ruby:3.0 && \
     dnf install -y ondemand ondemand-dex && \
     dnf clean all && rm -rf /var/cache/dnf/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rake'
 gem 'dotenv', '~> 2.1'
 
 group :package do
-  gem 'ood_packaging', '~> 0.1.4'
+  gem 'ood_packaging', '~> 0.2.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     oga (3.3)
       ast
       ruby-ll (~> 2.1)
-    ood_packaging (0.1.4)
+    ood_packaging (0.2.0)
       rake (~> 13.0.1)
     open_uri_redirections (0.2.1)
     parallel (1.21.0)
@@ -186,7 +186,7 @@ DEPENDENCIES
   beaker-docker (~> 1.0.1)
   beaker-rspec
   dotenv (~> 2.1)
-  ood_packaging (~> 0.1.4)
+  ood_packaging (~> 0.2.0)
   rake
   rspec
   rubocop

--- a/ood-portal-generator/lib/ood_portal_generator.rb
+++ b/ood-portal-generator/lib/ood_portal_generator.rb
@@ -39,7 +39,7 @@ module OodPortalGenerator
     end
 
     def fqdn
-      Socket.gethostbyname(Socket.gethostname).first
+      Addrinfo.getaddrinfo(Socket.gethostname, nil, :INET, :STREAM, nil, Socket::AI_CANONNAME).first.canonname
     end
 
     # Determine dex username

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -7,7 +7,7 @@
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
 %define runtime_version %{major_version}.%{minor_version}.1
 %define runtime_release 1
-%define runtime_version_full %{runtime_version}-%{runtime_release}
+%define runtime_version_full %{runtime_version}-%{runtime_release}%{?dist}
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 %global selinux_module_version %{package_version}.%{package_release}
 %global gem_home %{scl_ondemand_core_gem_home}/%{version}

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -5,9 +5,9 @@
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
 %define major_version %(echo %{git_tag_minus_v} | cut -d. -f1)
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
-%define runtime_version %{major_version}.%{minor_version}-1
-%define next_major_version %(echo $((%{major_version}+1))).0
-%define next_minor_version %{major_version}.%(echo $((%{minor_version}+1)))
+%define runtime_version %{major_version}.%{minor_version}.1
+%define runtime_release 1
+%define runtime_version_full %{runtime_version}-%{runtime_release}
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 %global selinux_module_version %{package_version}.%{package_release}
 %global gem_home %{scl_ondemand_core_gem_home}/%{version}
@@ -47,11 +47,11 @@ Source2:   ondemand-selinux.fc
 # node.js packages used in the apps
 AutoReqProv:     no
 
-BuildRequires:   ondemand-runtime >= %{runtime_version}, ondemand-runtime < %{next_major_version}, ondemand-runtime < %{next_minor_version}
-BuildRequires:   ondemand-scldevel >= %{runtime_version}, ondemand-scldevel < %{next_major_version}, ondemand-scldevel < %{next_minor_version}
-BuildRequires:   ondemand-build >= %{runtime_version}, ondemand-build < %{next_major_version}, ondemand-build < %{next_minor_version}
-BuildRequires:   ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_major_version}, ondemand-ruby < %{next_minor_version}
-BuildRequires:   ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}
+BuildRequires:   ondemand-runtime = %{runtime_version_full}
+BuildRequires:   ondemand-scldevel = %{runtime_version_full}
+BuildRequires:   ondemand-build = %{runtime_version_full}
+BuildRequires:   ondemand-ruby = %{runtime_version_full}
+BuildRequires:   ondemand-nodejs = %{runtime_version_full}
 BuildRequires:   rsync
 BuildRequires:   git
 BuildRequires:   python3
@@ -59,12 +59,12 @@ BuildRequires:   python3
 Requires:        git
 Requires:        sudo, lsof, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib, lua-posix, diffutils
 Requires:        python3
-Requires:        ondemand-apache >= %{runtime_version}, ondemand-apache < %{next_major_version}, ondemand-apache < %{next_minor_version}
-Requires:        ondemand-nginx = 1.20.2-1.p6.0.14.ood%{major_version}.%{minor_version}%{?dist}
-Requires:        ondemand-passenger = 6.0.14-1.ood%{major_version}.%{minor_version}%{?dist}
-Requires:        ondemand-ruby >= %{runtime_version}, ondemand-ruby < %{next_major_version}, ondemand-ruby < %{next_minor_version}
-Requires:        ondemand-nodejs >= %{runtime_version}, ondemand-nodejs < %{next_major_version}, ondemand-nodejs < %{next_minor_version}
-Requires:        ondemand-runtime >= %{runtime_version}, ondemand-runtime < %{next_major_version}, ondemand-runtime < %{next_minor_version}
+Requires:        ondemand-apache = %{runtime_version_full}
+Requires:        ondemand-nginx = 1.20.2-1.p6.0.14.ood%{runtime_version}%{?dist}
+Requires:        ondemand-passenger = 6.0.14-1.ood%{runtime_version}%{?dist}
+Requires:        ondemand-ruby = %{runtime_version_full}
+Requires:        ondemand-nodejs = %{runtime_version_full}
+Requires:        ondemand-runtime = %{runtime_version_full}
 Requires:        %{gems_name}
 
 BuildRequires: systemd

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -131,7 +131,7 @@ def bootstrap_repos
     if host_inventory['platform_version'] =~ /^7/
       repos << 'centos-release-scl yum-plugin-priorities'
     else
-      on hosts, 'dnf -y module enable ruby:2.7'
+      on hosts, 'dnf -y module enable ruby:3.0'
       on hosts, 'dnf -y module enable nodejs:14'
     end
   elsif host_inventory['platform'] == 'ubuntu'


### PR DESCRIPTION
Simplify the dependencies of ondemand RPM
Also address one Ruby 3.0 deprecation warning



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202344085269182) by [Unito](https://www.unito.io)
