### PR TITLE
fix permissions on mounted folders for podman

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,6 +22,7 @@ RUN dnf -y update && \
 RUN sed -i 's#^CREATE_MAIL_SPOOL=yes#CREATE_MAIL_SPOOL=no#' /etc/default/useradd; \
     grep $GID /etc/group >/dev/null || groupadd -g $GID $USER; \
     useradd -l -u $UID --create-home --gid $GID $USER && \
+    sudo -u $USER mkdir -p /home/$USER/ondemand && \
     echo "$USER ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/$USER
 
 RUN sed -i 's|--rpm|--rpm -f --insecure|g' /etc/systemd/system/httpd.service.d/ood-portal.conf

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -55,7 +55,9 @@ namespace :dev do
 
   def podman_rt_args
     [
-      '--security-opt', 'label=disable'
+      '--security-opt', 'label=disable',
+      "--uidmap=#{user.uid}:0:1", "--uidmap=0:1:#{user.uid}",
+      "--gidmap=#{user.gid}:0:1", "--gidmap=0:1:#{user.gid}",
     ].tap do |arr|
       arr.concat [ '--cap-add', 'sys_ptrace'] unless additional_caps.include?('--privileged')
     end.freeze


### PR DESCRIPTION
Fix permissions on mounted folders for podman.  Right now, the `ondemand` folder is mounted as `root:root` in podman, but if we fix the UID maps and make the directory in the container (with the right permissions) podman will respect the permissions of the underlay (the fold in the image).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202343392178847) by [Unito](https://www.unito.io)
