### PR TITLE
Ensure ondemand-selinux gets updated if only ondemand release bumped

### DIFF
--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -78,7 +78,7 @@ access, job submission and interactive work on compute nodes.
 %package -n %{name}-selinux
 Summary: SELinux policy for OnDemand
 BuildRequires:      selinux-policy, selinux-policy-devel, checkpolicy, policycoreutils
-Requires:           %{name} = %{version}
+Requires:           %{name} = %{version}-%{release}
 Requires:           selinux-policy >= %{selinux_policy_ver}
 Requires(post):     /usr/sbin/semodule, /sbin/restorecon, /usr/sbin/setsebool, /usr/sbin/selinuxenabled, /usr/sbin/semanage
 Requires(post):     selinux-policy-targeted


### PR DESCRIPTION
Ran into what is likely a rare situation where nightly builds twice in one day did not result in ondemand-selinux update when ondemand was updated due to lacking dependency version that does not include release version.