### PR TITLE
check config before accessing it

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -85,7 +85,7 @@ glob.sync(path.join((process.env.OOD_CLUSTERS || '/etc/ood/config/clusters.d'), 
       return yaml.safeLoad(fs.readFileSync(yml));
     } catch(err) { /** just keep going. dashboard should have an alert about it */}
   })
-  .filter(config => (config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
+  .filter(config => (config && config.v2 && config.v2.login && config.v2.login.host) && ! (config.v2 && config.v2.metadata && config.v2.metadata.hidden))
   .forEach((config) => {
     let host = config.v2.login.host; //Already did checking above
     let isDefault = config.v2.login.default;


### PR DESCRIPTION
#1950 persists in the shell app even after #1988. We missed this one check that was in mainline. 

I tested this by sharing the shell app with my test user and overriding `OOD_CLUSTERS` with some unreadable files.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202348513637156) by [Unito](https://www.unito.io)
