### PR TITLE
add an aria-label for these progress bars

### DIFF
--- a/apps/dashboard/app/views/widgets/_xdmod_widget_job_efficiency.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_job_efficiency.html.erb
@@ -17,15 +17,15 @@
       {{#if nodata}}
         <p class="card-text">{{msg}}</p>
       {{else}}
-      <p class="d-flex justify-content-between card-text font-weight-bold"><span class="text-success">{{good_percent}}% efficient</span> <span class="text-danger">{{bad_percent}}% inefficent</span></p>
+      <p class="d-flex justify-content-between card-text font-weight-bold"><span class="text-success">{{good_percent}}% efficient</span> <span class="text-danger">{{bad_percent}}% inefficient</span></p>
       <div class="progress progress-custom">
-        <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{good_percent}}" aria-valuemin="0" aria-valuemax="100" style="width: {{good_percent}}%">
+        <div class="progress-bar bg-success" role="progressbar" aria-label="percent efficient" aria-valuenow="{{good_percent}}" aria-valuemin="0" aria-valuemax="100" style="width: {{good_percent}}%">
         </div>
-        <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{bad_percent}}" aria-valuemin="0" aria-valuemax="100" style="width: {{bad_percent}}%">
+        <div class="progress-bar bg-danger" role="progressbar" aria-label="percent inefficient" aria-valuenow="{{bad_percent}}" aria-valuemin="0" aria-valuemax="100" style="width: {{bad_percent}}%">
         </div>
       </div>
       <p class="card-text text-center mt-2">
-        <span class="text-danger">{{count_bad}} inefficent {{unit}} </span> &frasl; {{count}} total {{unit}}
+        <span class="text-danger">{{count_bad}} inefficient {{unit}} </span> &frasl; {{count}} total {{unit}}
       </p>
       {{/if}}
     {{/if}}


### PR DESCRIPTION
add an aria-label for these progress bars so they read '% efficient' then give a number (give some context to the progress bars).

This also fixes the misspelling of inefficient.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202402701047226) by [Unito](https://www.unito.io)
