### PR TITLE
Add overflow-auto to batch_connect/sessions card-header

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -3,7 +3,7 @@ module BatchConnect::SessionsHelper
     content_tag(:div, id: "id_#{session.id}", class: "card session-panel mb-4", data: { id: session.id, hash: session.to_hash }) do
       concat(
         content_tag(:div, class: "card-heading") do
-          content_tag(:h5, class: "card-header alert-#{status_context(session)}") do
+          content_tag(:h5, class: "card-header overflow-auto alert-#{status_context(session)}") do
             concat link_to(content_tag(:span, session.title, class: "card-text alert-#{status_context(session)}"), new_batch_connect_session_context_path(token: session.token))
             concat tag.span(" (#{session.job_id})", class: 'card-text')
             concat(


### PR DESCRIPTION
Fixes error caused by batch_connect session status group floating below the containing box of the header



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202429992257460) by [Unito](https://www.unito.io)
