### PR TITLE
Ensure ood-portal-generator doesn't treat EL9 as SCL

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator.rb
+++ b/ood-portal-generator/lib/ood_portal_generator.rb
@@ -25,10 +25,10 @@ module OodPortalGenerator
 
     def scl_apache?
       return true if os_release_file.nil?
-      env = Dotenv.parse(os_release_file)
-      return false if ("#{env['ID']} #{env['ID_LIKE']}" =~ /(rhel|fedora)/ && env['VERSION_ID'] =~ /^8/)
       return false if debian?
-      true
+      env = Dotenv.parse(os_release_file)
+      return true if ("#{env['ID']} #{env['ID_LIKE']}" =~ /(rhel|fedora)/ && env['VERSION_ID'] =~ /^7/)
+      false
     end
 
     def debian?

--- a/ood-portal-generator/spec/ood_portal_generator_spec.rb
+++ b/ood-portal-generator/spec/ood_portal_generator_spec.rb
@@ -73,6 +73,17 @@ describe OodPortalGenerator do
       expect(described_class.scl_apache?).to eq(false)
     end
 
+    it 'returns false if RHEL9' do
+      os_release = <<~EOS
+        ID="rhel"
+        ID_LIKE="fedora"
+        VERSION_ID="9.0"
+      EOS
+      File.write(os_release_file.path, os_release)
+      allow(described_class).to receive(:os_release_file).and_return(os_release_file.path)
+      expect(described_class.scl_apache?).to eq(false)
+    end
+
     it 'returns false for Ubuntu 20.04' do
       os_release = <<~EOS
         ID=ubuntu


### PR DESCRIPTION
Ran into this issue when testing EL9 builds in ondemand-packaging repo.  The EL9 builds were thinking they used Apache from SCL.  Reworked logic a bit since only one supported OS uses SCL, there are now more not using than using it.