### PR TITLE
PUN: Set the passenger_temp_path to be under tmp_root with the other …

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -65,6 +65,7 @@ http {
   fastcgi_temp_path       <%= tmp_root %>/fastcgi_temp;
   uwsgi_temp_path         <%= tmp_root %>/uwsgi_temp;
   scgi_temp_path          <%= tmp_root %>/scgi_temp;
+  passenger_temp_path     <%= tmp_root %>/passenger_temp;
 
   default_type application/octet-stream;
 


### PR DESCRIPTION
This should fix https://github.com/OSC/ondemand/issues/2090 and should probably be backported to the 2.0 line.