### PR TITLE
disable apache's insecure trace

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -76,6 +76,8 @@ Listen 8080
   RewriteRule ^.*$ /assets/maintenance/index.html [R=503,L]
   ErrorDocument 503 /assets/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors https://test.proxy.name;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -56,6 +56,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 
   # OIDC configuration

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -68,6 +68,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors https://example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -68,6 +68,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors https://example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -58,6 +58,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 
   # Lua configuration

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -48,6 +48,8 @@
   CustomLog "logs/example.com_access.log" combined
 
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 
   # Lua configuration

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -60,6 +60,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors http://ondemand.example.com;"
 
   # OIDC configuration

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -68,6 +68,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors https://ondemand.example.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -68,6 +68,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors https://example-proxy.com;"
   Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 

--- a/ood-portal-generator/spec/fixtures/output/auth.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth.conf
@@ -56,6 +56,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 
   # Lua configuration

--- a/ood-portal-generator/spec/fixtures/output/auth_deb.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth_deb.conf
@@ -56,6 +56,8 @@
   RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
   ErrorDocument 503 /public/maintenance/index.html
 
+  TraceEnable off
+
   Header always set Content-Security-Policy "frame-ancestors http://example.com;"
 
   # Lua configuration

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -94,6 +94,8 @@ Listen <%= addr_port %>
   ErrorDocument 503 <%= @public_uri %>/maintenance/index.html
 
   <%- end -%>
+  TraceEnable off
+
   <%- if @security_csp_frame_ancestors -%>
   Header always set Content-Security-Policy "frame-ancestors <%= @security_csp_frame_ancestors -%>;"
   <%- end -%>


### PR DESCRIPTION
This disables apache's TRACE functionality which we don't need and could possibly be used in XSS attacks.  It's not optional as, again, it's a security whole and we do not respond to TRACE.

https://owasp.org/www-community/attacks/xss/

Apps in the wild may, so someone may ask us to remove it, but I feel like folks' shouldn't use TRACE either way.