### PR TITLE
Write bc session script db files with 600 permission and add 'writes db file correctly' test

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -37,6 +37,10 @@ module BatchConnect
     # @return [String] session title
     attr_accessor :title
 
+    # The view used to display the connection information for this session
+    # @return [String, nil] session view
+    attr_accessor :view
+
     # Batch connect script type
     # @return [String] script type
     attr_accessor :script_type
@@ -62,22 +66,16 @@ module BatchConnect
       nil
     end
 
-    # The view used to display the connection information for this session
-    # @return [String, nil] session view
-    def view
-      app.session_view
-    end
-
     # Return the Batch Connect app from the session token
     # @return [BatchConnect::App]
     def app
-      @app ||= BatchConnect::App.from_token(self.token)
+      BatchConnect::App.from_token(self.token)
     end
 
     # Attributes used for serialization
     # @return [Hash] attributes to be serialized
     def attributes
-      %w(id cluster_id job_id created_at token title script_type cache_completed).map do |attribute|
+      %w(id cluster_id job_id created_at token title view script_type cache_completed).map do |attribute|
         [ attribute, nil ]
       end.to_h
     end
@@ -223,6 +221,7 @@ module BatchConnect
       self.id         = SecureRandom.uuid
       self.token      = app.token
       self.title      = app.title
+      self.view       = app.session_view
       self.created_at = Time.now.to_i
       self.cluster_id = context.try(:cluster).to_s
 

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -536,6 +536,7 @@ batch_connect: { ssh_allow: true } }))
         assert_equal 1, db_dir.children.size
         assert_equal ["#{db_dir}/test_id"], db_dir.children.map(&:to_s)
         assert_equal(expected_file, JSON.parse(File.read("#{db_dir}/test_id")).to_h)
+        assert_equal('100600', File.stat("#{db_dir}/test_id").mode.to_s(8))
       end
     end
   end

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -525,6 +525,7 @@ batch_connect: { ssh_allow: true } }))
         'created_at'      => now.to_i,
         'token'           => 'bc_jupyter',
         'title'           => 'Jupyter Notebook',
+        'view'            => nil,
         'script_type'     => 'basic',
         'cache_completed' => nil
       }


### PR DESCRIPTION
Stop serializing the connection view, and instead read it from the
app directly. This also forces the db files to be 600 for increased
security against umasks.

Lastly, it adds a test to boot.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202538066959106) by [Unito](https://www.unito.io)
