### PR TITLE
Move FilesController posix file methods out from update and upload routes

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -131,19 +131,12 @@ class FilesController < ApplicationController
 
   # POST
   def upload
-    path = uppy_upload_path
-    AllowlistPolicy.default.validate!(path)
+    upload_path = uppy_upload_path
+    @path = PosixFile.new(upload_path)
 
-    path.parent.mkpath unless path.parent.directory?
+    AllowlistPolicy.default.validate!(@path)
 
-    FileUtils.mv params[:file].tempfile, path.to_s
-
-    # umasks apply on top of 666 (-rw-rw-rw-) permissions. So a u mask of 022 would result
-    # in 666 - 022 = 644. Umasks are base 8 octal (what all this stuff expects).
-    mode = 0666 & (0777 ^ File.umask)
-    File.chmod(mode, path.to_s)
-
-    path.chown(nil, path.parent.stat.gid) if path.parent.setgid?
+    @path.handle_upload(params[:file].tempfile)
 
     render json: {}
   rescue AllowlistPolicy::Forbidden => e

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -104,15 +104,15 @@ class FilesController < ApplicationController
 
   # PUT - create or update
   def update
-    path = normalized_path
-    AllowlistPolicy.default.validate!(path)
+    @path = PosixFile.new(normalized_path)
+    AllowlistPolicy.default.validate!(@path)
 
     if params.include?(:dir)
-      Dir.mkdir path
+      @path.mkdir
     elsif params.include?(:file)
-      FileUtils.mv params[:file].tempfile, path
+      @path.mv_from(params[:file].tempfile)
     elsif params.include?(:touch)
-      FileUtils.touch path
+      @path.touch
     else
       content = request.body.read
 
@@ -121,7 +121,7 @@ class FilesController < ApplicationController
       # see test cases for plain text, utf-8 text, images and binary files
       content.force_encoding('UTF-8')
 
-      File.write(path, content)
+      @path.write(content)
     end
 
     render json: {}

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -99,6 +99,18 @@ class PosixFile
     FileUtils.mv(src, path)
   end
 
+  def handle_upload(tempfile)
+    path.parent.mkpath unless path.parent.directory?
+
+    FileUtils.mv tempfile, path.to_s
+
+    # Apply the user's umask on top of 0666 (-rw-rw-rw-), since the file doesn't need to be executable.
+    mode = 0666 & (0777 ^ File.umask)
+    File.chmod(mode, path.to_s)
+
+    path.chown(nil, path.parent.stat.gid) if path.parent.setgid?
+  end
+
   def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)
     can_download = false
     error = nil

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -2,7 +2,7 @@ class PosixFile
 
   attr_reader :path
 
-  delegate :basename, :descend, :parent, :join, :to_s, :read, to: :path
+  delegate :basename, :descend, :parent, :join, :to_s, :read, :write, :mkdir, to: :path
 
   class << self
     def stat(path)
@@ -89,6 +89,14 @@ class PosixFile
 
   def editable?
     path.file? && path.readable? && path.writable?
+  end
+
+  def touch
+    FileUtils.touch(path)
+  end
+
+  def mv_from(src)
+    FileUtils.mv(src, path)
   end
 
   def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)


### PR DESCRIPTION
This PR moves parts of the update and upload route code to PosixFile.

Implementing upload and update for remote files using Rclone is quite easy after these changes.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202556882410121) by [Unito](https://www.unito.io)
