### PR TITLE
Add support for multiple Homepage layouts and widgets configurations (#2117)

### DIFF
--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -25,7 +25,11 @@ class Router
   #
   # @return [FeaturedApp]
   def self.pinned_apps(tokens, all_apps)
-    @pinned_apps ||= tokens.to_a.each_with_object([]) do |token, pinned_apps|
+    @pinned_apps ||= {}
+    tokens_key = ActiveSupport::Cache.expand_cache_key(tokens)
+    return @pinned_apps[tokens_key] if @pinned_apps.key?(tokens_key)
+
+    @pinned_apps[tokens_key] = tokens.to_a.each_with_object([]) do |token, pinned_apps|
       pinned_apps.concat pinned_apps_from_token(token, all_apps)
     end.uniq do |app|
       app.token.to_s

--- a/apps/dashboard/app/apps/user_configuration.rb
+++ b/apps/dashboard/app/apps/user_configuration.rb
@@ -1,0 +1,56 @@
+class UserConfiguration
+
+  def initialize
+    @config = ::Configuration.config
+  end
+
+  # The dashboard's landing page layout. Defaults to nil.
+  def dashboard_layout
+    fetch(:dashboard_layout, nil)
+  end
+
+  # The configured pinned apps
+  def pinned_apps
+    fetch(:pinned_apps, [])
+  end
+
+  # The length of the "Pinned Apps" navbar menu
+  def pinned_apps_menu_length
+    fetch(:pinned_apps_menu_length, 6)
+  end
+
+  # What to group pinned apps by
+  # @return [String, ""] Defaults to ""
+  def pinned_apps_group_by
+    group_by = fetch(:pinned_apps_group_by, "")
+
+    # FIXME: the user_configuration shouldn't really know the API of
+    # OodApp or subclasses. This is a hack because subclasses of OodApp overload
+    # the category and subcategory to something new while saving the original.
+    # The fix would be to move this knowledge to somewhere more appropriate than here.
+    if group_by == 'category' || group_by == 'subcategory'
+      "original_#{group_by}"
+    else
+      group_by
+    end
+  end
+
+  def profile_links
+    fetch(:profile_links, [])
+  end
+
+  def profile
+    CurrentUser.user_settings[:profile].to_sym if CurrentUser.user_settings[:profile]
+  end
+
+  private
+
+  def fetch(key_value, default_value = nil)
+    key = key_value ? key_value.to_sym : nil
+    profile_config = @config.dig(:profiles, profile) || {}
+
+    # Returns the value if they key is present in the profile, even if the value is nil
+    # This is to mimic the Hash.fetch behaviour that only uses the default_value when key is not present
+    profile_config.key?(key) ? profile_config[key] : @config.fetch(key, default_value)
+  end
+end

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -3,12 +3,16 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :set_user, :set_pinned_apps, :set_nav_groups, :set_announcements
+  before_action :set_user, :set_user_configuration, :set_pinned_apps, :set_nav_groups, :set_announcements
   before_action :set_my_balances, only: [:index, :new, :featured]
   before_action :set_featured_group
 
   def set_user
     @user = CurrentUser
+  end
+
+  def set_user_configuration
+    @user_configuration ||= UserConfiguration.new
   end
 
   def set_nav_groups
@@ -53,11 +57,11 @@ class ApplicationController < ActionController::Base
   end
 
   def pinned_app_group
-    OodAppGroup.groups_for(apps: @pinned_apps, nav_limit: ::Configuration.pinned_apps_menu_length)
+    OodAppGroup.groups_for(apps: @pinned_apps, nav_limit: @user_configuration.pinned_apps_menu_length)
   end
 
   def set_pinned_apps
-    @pinned_apps ||= Router.pinned_apps(::Configuration.pinned_apps, nav_all_apps)
+    @pinned_apps ||= Router.pinned_apps(@user_configuration.pinned_apps, nav_all_apps)
   end
 
   def set_announcements

--- a/apps/dashboard/app/controllers/settings_controller.rb
+++ b/apps/dashboard/app/controllers/settings_controller.rb
@@ -1,0 +1,28 @@
+class SettingsController < ApplicationController
+
+  ALLOWED_SETTINGS = [:profile].freeze
+
+  def update
+    new_settings = read_settings(settings_param)
+    CurrentUser.update_user_settings(new_settings) unless new_settings.empty?
+
+    logger.info "settings: updated user settings to: #{new_settings}"
+    respond_to do |format|
+      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_updated') }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def settings_param
+    params.require(:settings).permit(ALLOWED_SETTINGS) if params[:settings].present?
+  end
+
+  def read_settings(params)
+    {}.tap do |settings|
+      params.each { |key, value| settings[key] = value } if params
+    end
+  end
+
+end

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -20,11 +20,12 @@ module ApplicationHelper
   # @param icon [String] favicon icon name (i.e. "refresh" "for "fa "fa-refresh")
   # @param url [#to_s, nil] url to access
   # @param role [String] app role i.e. "vdi", "shell", etc.
+  # @param method [String] change the method used in this link.
   # @return nil if url not set or the HTML string for the bootstrap nav link
-  def nav_link(title, icon, url, target: '', role: nil)
+  def nav_link(title, icon, url, target: '', role: nil, method: nil)
     if url
       render partial: 'layouts/nav/link',
-             locals:  { title: title, faicon: icon, url: url.to_s, target: target, role: role }
+             locals:  { title: title, faicon: icon, url: url.to_s, target: target, role: role, method: method }
     end
   end
 
@@ -71,5 +72,14 @@ module ApplicationHelper
     else
       image_tag icon_uri.to_s, class: 'app-icon', title: icon_uri.to_s, "aria-hidden": true
     end
+  end
+
+  def profile_links
+    @user_configuration.profile_links
+  end
+
+  def profile_link(profile_info)
+    profile_id = profile_info[:id]
+    nav_link(profile_info.fetch(:name, profile_id), profile_info.fetch(:icon, "user"), settings_path("settings[profile]" => profile_id), method: "post") if profile_id
   end
 end

--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -34,7 +34,7 @@ module DashboardHelper
 
   def dashboard_layout
     #FIXME: should sanitize the landing_page_layout or cast somethings to Array in the upper layers
-    Configuration.dashboard_layout || default_dashboard_layout
+    @user_configuration.dashboard_layout || default_dashboard_layout
   end
 
   def render_widget(widget)

--- a/apps/dashboard/app/models/current_user.rb
+++ b/apps/dashboard/app/models/current_user.rb
@@ -11,7 +11,7 @@ class CurrentUser
 
   class << self
     delegate :name, :uid, :gid, :gecos, :dir, :shell, to: :instance
-    delegate :primary_group, :home, to: :instance
+    delegate :primary_group, :home, :user_settings, :update_user_settings, to: :instance
   end
 
   attr_reader :pwuid
@@ -20,9 +20,44 @@ class CurrentUser
 
   def initialize
     @pwuid = Etc.getpwuid
+    @user_settings = read_user_settings
   end
 
   def primary_group
     @primary_group ||= Etc.getgrgid(gid).name
+  end
+
+  def user_settings
+    @user_settings.clone
+  end
+
+  def update_user_settings(new_user_settings)
+    @user_settings.deep_merge!(new_user_settings.deep_symbolize_keys)
+    save_user_settings
+  end
+
+  private
+  def read_user_settings
+    user_settings = {}
+    return user_settings unless user_settings_path.exist?
+
+    begin
+      yml = YAML.safe_load(user_settings_path.read) || {}
+      user_settings = yml.deep_symbolize_keys
+    rescue => e
+      Rails.logger.error("Can't read or parse settings file: #{user_settings_path} because of error #{e}")
+    end
+
+    user_settings
+  end
+
+  def save_user_settings
+    # Ensure there is a directory to write the user settings file
+    user_settings_path.dirname.tap { |p| p.mkpath unless p.exist? }
+    File.open(user_settings_path.to_s, "w") { |file| file.write(@user_settings.deep_stringify_keys.to_yaml) }
+  end
+
+  def user_settings_path
+    Pathname.new(::Configuration.dataroot).join(::Configuration.user_settings_file)
   end
 end

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -12,5 +12,13 @@
       <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, target: "_blank" ) %>
     <% end %>
     <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
+    <% unless profile_links.empty? %>
+      <li class="dropdown-divider" role="separator"></li>
+      <li class="dropdown-header"><%= t('dashboard.profile_links_title') %></li>
+      <% profile_links.each do | profile_info | %>
+        <%= profile_link(profile_info) %>
+      <% end %>
+    <% end %>
+
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_link.html.erb
@@ -5,8 +5,9 @@ url - required - link url string
 faicon - optional, default "cog" - font awesome icon to use
 target - optional, default "_self" - link target
 role - optional, default ""
+method - optional, data-method for the link
 %>
-<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:target, '_self'), class: "dropdown-item m-auto #{local_assigns.fetch(:role, nil)}" do %>
+<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:target, '_self'), class: "dropdown-item m-auto #{local_assigns.fetch(:role, nil)}",  'data-method': local_assigns.fetch(:method, nil) do %>
   <%= tag.i class: "fas fa-fw fa-#{local_assigns.fetch(:faicon, 'cog')}" %>
   <%= tag.span do %>
     <%= local_assigns.fetch(:title, 'No title') %>

--- a/apps/dashboard/app/views/widgets/_pinned_apps.html.erb
+++ b/apps/dashboard/app/views/widgets/_pinned_apps.html.erb
@@ -3,8 +3,8 @@
 
 <h3><%= t('dashboard.pinned_apps_title') %> <small><%= t('dashboard.pinned_apps_caption_html', all_apps_url: apps_index_path) %></small></h3>
 
-<%- if Configuration.pinned_apps_group_by.present? -%>
-  <%= render(partial: "/widgets/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: Configuration.pinned_apps_group_by.to_sym))  %>
+<%- if @user_configuration.pinned_apps_group_by.present? -%>
+  <%= render(partial: "/widgets/pinned_apps/group", collection: OodAppGroup.groups_for(apps: @pinned_apps, group_by: @user_configuration.pinned_apps_group_by.to_sym))  %>
 <%- else -%>
   <div class="row">
     <%= render partial: "/widgets/pinned_apps/app", collection: @pinned_apps %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -53,6 +53,7 @@ class ConfigurationSingleton
   def string_configs
     {
       :module_file_dir      => nil,
+      :user_settings_file   => '.ood',
     }.freeze
   end
 
@@ -315,16 +316,6 @@ class ConfigurationSingleton
     Pathname.new(ENV['OOD_CONFIG_D_DIRECTORY'] || "/etc/ood/config/ondemand.d")
   end
 
-  # The configured pinned apps
-  def pinned_apps
-    config.fetch(:pinned_apps, [])
-  end
-
-  # The length of the "Pinned Apps" navbar menu
-  def pinned_apps_menu_length
-    config.fetch(:pinned_apps_menu_length, 6)
-  end
-
   # Setting terminal functionality in files app
   def files_enable_shell_button
     to_bool(config.fetch(:files_enable_shell_button, true))
@@ -333,27 +324,6 @@ class ConfigurationSingleton
   # Report performance of activejobs table rendering
   def console_log_performance_report?
     dataroot.join("debug").file? || rails_env != 'production'
-  end
-
-  # What to group pinned apps by
-  # @return [String, ""] Defaults to ""
-  def pinned_apps_group_by
-    group_by = config.fetch(:pinned_apps_group_by, "")
-
-    # FIXME: the configuration_singleton shouldn't really know the API of
-    # OodApp or subclasses. This is a hack because subclasses of OodApp overload
-    # the category and subcategory to something new while saving the original.
-    # The fix would be to move this knowledge to somewhere more appropriate than here.
-    if group_by == 'category' || group_by == 'subcategory'
-      "original_#{group_by}"
-    else
-      group_by
-    end
-  end
-
-  # The dashboard's landing page layout. Defaults to nil.
-  def dashboard_layout
-    config.fetch(:dashboard_layout, nil)
   end
 
   def can_access_activejobs?
@@ -421,15 +391,15 @@ class ConfigurationSingleton
     (ood_bc_card_time_int < 0) ? 0 : ood_bc_card_time_int
   end
 
+  def config
+    @config ||= read_config
+  end
+
   private
 
   def can_access_core_app?(name)
     app_dir = Rails.root.realpath.parent.join(name)
     app_dir.directory? && app_dir.join('manifest.yml').readable?
-  end
-
-  def config
-    @config ||= read_config
   end
 
   def read_config

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -194,3 +194,7 @@ en:
     jobs_project_manifest_updated: "Project manifest updated!"
     jobs_project_name_validation: "Project name may only contain letters, digits, dashes, and underscores"
     jobs_project_create_new_project_directory: "Create a new project directory"
+
+    settings_updated: "Settings updated"
+
+    profile_links_title: "Profiles"

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -87,6 +87,8 @@ Rails.application.routes.draw do
     delete "/activejobs" => "active_jobs#delete_job",  as: 'delete_job'
   end
 
+  post "settings", :to => "settings#update"
+
   match "/404", :to => "errors#not_found", :via => :all
   match "/500", :to => "errors#internal_server_error", :via => :all
 

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -314,27 +314,9 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     assert_equal ENV["OOD_NATIVE_VNC_LOGIN_HOST"], ConfigurationSingleton.new.native_vnc_login_host
   end
 
-  test "reads pinned apps from config files" do
-    pinned_apps = [
-      "sys/bc_osc_jupyter",
-      "sys/bc_osc_rstudio_server",
-      "sys/iqmol",
-      {
-        type: 'sys',
-        category: 'Interactive Apps',
-        subcategory: 'Servers',
-        field_of_science: 'Biology'
-      }
-    ]
-
-    with_modified_env(config_fixtures) do
-      assert_equal pinned_apps, ConfigurationSingleton.new.pinned_apps
-    end
-  end
-
   test "does not throw error when it can't read config files" do
     with_modified_env(OOD_CONFIG_FILE: "/dev/null", OOD_CONFIG_D_DIRECTORY: "/dev/null") do
-      assert_equal ConfigurationSingleton.new.pinned_apps, []
+      assert_equal ConfigurationSingleton.new.files_enable_shell_button, true
       assert_equal ConfigurationSingleton.new.send(:config), {}
     end
   end
@@ -378,24 +360,6 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       Rails.logger.expects(:error).with(regexp_matches(bad_yml_rex)).at_least_once
       ConfigurationSingleton.new.send(:config)
     end
-  end
-
-  test "pinned_apps_group_by returns original category when configured with category" do
-    cfg = ConfigurationSingleton.new
-    cfg.stubs(:config).returns({pinned_apps_group_by: "category"})
-    assert_equal "original_category", cfg.pinned_apps_group_by
-  end
-
-  test "pinned_apps_group_by returns original subcategory when configured with subcategory" do
-    cfg = ConfigurationSingleton.new
-    cfg.stubs(:config).returns({pinned_apps_group_by: "subcategory"})
-    assert_equal "original_subcategory", cfg.pinned_apps_group_by
-  end
-
-  test "pinned_apps_group_by returns an empty string by default" do
-    cfg = ConfigurationSingleton.new
-    cfg.stubs(:config).returns({})
-    assert_equal "", cfg.pinned_apps_group_by
   end
 
   test "files_enable_shell_button returns true by default" do
@@ -527,6 +491,9 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       c.boolean_configs.each do |config, default|
         env_var = "OOD_#{config.upcase}"
         assert_equal default, c.send(config), "#{config} should have responded to ENV['#{env_var}']=#{ENV[env_var]}."
+      end
+      c.string_configs.each do |config, _|
+        assert_equal 'string in env variable', c.send(config), "#{config} should have been 'string in env variable'."
       end
     end
 

--- a/apps/dashboard/test/fixtures/config/ondemand.d/profile.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/profile.yml
@@ -1,0 +1,8 @@
+key_1: root_value_1
+key_2: root_value_2
+profiles:
+  profile1:
+    key_1: profile1_value_1
+  profile2:
+    key_1: profile2_value_1
+

--- a/apps/dashboard/test/fixtures/config/ondemand.d/string.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/string.yml
@@ -1,1 +1,2 @@
 module_file_dir: 'string from file'
+user_settings_file: 'string from file'

--- a/apps/dashboard/test/fixtures/config/user_settings/.invalid
+++ b/apps/dashboard/test/fixtures/config/user_settings/.invalid
@@ -1,0 +1,3 @@
+-
+invalid_yaml
+-

--- a/apps/dashboard/test/fixtures/config/user_settings/.valid
+++ b/apps/dashboard/test/fixtures/config/user_settings/.valid
@@ -1,0 +1,2 @@
+---
+profile: file_value

--- a/apps/dashboard/test/helpers/application_helper_test.rb
+++ b/apps/dashboard/test/helpers/application_helper_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+
+  include ApplicationHelper
+
+  def setup
+    @user_configuration = nil
+  end
+
+  test "profile_links should delegate to user_configuration object" do
+    expected_result = ["a", "b", "c"]
+    @user_configuration = stub(:profile_links => expected_result)
+
+    assert_equal expected_result, profile_links
+  end
+
+  test "profile_link should return nil when id is missing" do
+    invalid_profile_link = {
+      name: "test name",
+      icon: "user"
+    }
+
+    assert_nil profile_link(invalid_profile_link)
+  end
+
+  test "profile_link should return a link with data-method set to post containing an icon and text" do
+    profile_link = {
+      id: "test",
+      name: "test name",
+      icon: "user"
+    }
+    result = profile_link(profile_link)
+
+    html_doc = Nokogiri::HTML(result)
+
+    refute_nil html_doc.at_css('a[data-method="post"]')
+    refute_nil html_doc.at_css('a[data-method="post"] i')
+    assert_equal true, html_doc.at_css('a[data-method="post"] i')["class"].include?(profile_link[:icon])
+    assert_equal profile_link[:name], html_doc.at_css('a[data-method="post"]').text.strip
+  end
+end

--- a/apps/dashboard/test/integration/dashboard_layout_test.rb
+++ b/apps/dashboard/test/integration/dashboard_layout_test.rb
@@ -1,9 +1,9 @@
 require 'html_helper'
 require 'test_helper'
 
-# Test the feature for configuring landing pages through ConfigurationSingleton#dashboard_layout.
+# Test the feature for configuring landing pages through UserConfiguration#dashboard_layout.
 
-# Note that the default layout (having no ConfigurationSingleton#dashboard_layout set)
+# Note that the default layout (having no UserConfiguration#dashboard_layout set)
 # and variants (MOTD enabled/disabled, XDMOD & MOTD enabled/disabled and so on) are handled
 # by pinned_apps_test.rb.
 class DashboardLayoutTest < ActionDispatch::IntegrationTest
@@ -27,7 +27,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
 
   test "should show nothing when nothing is given" do
     # XDMOD here isn't really 
-    Configuration.stubs(:dashboard_layout).returns({})
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({})
 
     get '/'
 
@@ -35,7 +35,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
   end
 
   test "nil MOTD and pinned apps render empty elements" do
-    Configuration.stubs(:dashboard_layout).returns({
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -70,7 +70,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
   end
 
   test "shows MOTD a single row, single column" do
-    Configuration.stubs(:dashboard_layout).returns({
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -97,7 +97,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
   end
 
   test "shows widgets with one row and two columns" do
-    Configuration.stubs(:dashboard_layout).returns({
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -141,7 +141,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
 
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -172,13 +172,13 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
   test "shows widgets on a second row" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
       'sys/pseudofun',
     ])
-    Configuration.stubs(:dashboard_layout).returns({
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -230,7 +230,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
   end
 
   test "bad widgets don't throw errors" do
-    Configuration.stubs(:dashboard_layout).returns({
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [
@@ -261,7 +261,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
   end
 
   test "should render brand new widgets with shipped widgets" do
-    Configuration.stubs(:dashboard_layout).returns({
+    UserConfiguration.any_instance.stubs(:dashboard_layout).returns({
       rows: [
         {
           columns: [

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -17,7 +17,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "should create Apps dropdown when pinned apps are available" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -43,7 +43,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "should limit list of Pinned Apps in dropdown" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -51,7 +51,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
       'sys/pseudofun',
       'sys/should_get_filtered'
     ])
-    Configuration.stubs(:pinned_apps_menu_length).returns(2)
+    UserConfiguration.any_instance.stubs(:pinned_apps_menu_length).returns(2)
 
     get '/'
 
@@ -68,7 +68,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "should create Pinned app icons when pinned apps are available" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -93,7 +93,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "does not create pinned apps when no configuration" do
-    Configuration.stubs(:pinned_apps).returns([])
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([])
 
     get '/'
 
@@ -103,7 +103,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "does not create pinned apps when no configuration and app sharing is enabled" do
-    Configuration.stubs(:pinned_apps).returns([])
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([])
     Configuration.stubs(:app_sharing_enabled?).returns(true)
 
     get '/'
@@ -114,7 +114,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "shows pinned apps when MOTD is present" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -147,7 +147,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
   test "shows pinned apps when XDMOD is present" do
 
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -178,7 +178,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "shows pinned apps when both MOTD and XDMOD is present" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/bc_desktop/owens',
@@ -217,7 +217,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "still shows MOTD when no pinned apps" do
-    Configuration.stubs(:pinned_apps).returns([])
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([])
 
     env = {
       MOTD_FORMAT: 'osc',
@@ -236,7 +236,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "still shows XDMOD when no pinned apps" do
-    Configuration.stubs(:pinned_apps).returns([])
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([])
 
     env = {
       #this is going to fail, but that's OK - the widets will still appear
@@ -254,7 +254,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "still shows MOTD and XDMOD when no pinned apps" do
-    Configuration.stubs(:pinned_apps).returns([])
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([])
 
     env = {
       MOTD_FORMAT: 'osc',
@@ -280,12 +280,12 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "groups the apps by categories" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/pseudofun',
     ])
-    Configuration.stubs(:pinned_apps_group_by).returns("original_category")
+    UserConfiguration.any_instance.stubs(:pinned_apps_group_by).returns("original_category")
 
     env = {}
 
@@ -300,12 +300,12 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "groups the apps by sub-categories" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/pseudofun',
     ])
-    Configuration.stubs(:pinned_apps_group_by).returns("original_subcategory")
+    UserConfiguration.any_instance.stubs(:pinned_apps_group_by).returns("original_subcategory")
 
     env = {}
 
@@ -320,12 +320,12 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "still shows ungroupable apps" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/pseudofun',
     ])
-    Configuration.stubs(:pinned_apps_group_by).returns("some_unknown_field")
+    UserConfiguration.any_instance.stubs(:pinned_apps_group_by).returns("some_unknown_field")
 
     env = {}
 
@@ -339,12 +339,12 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
   end
 
   test "group by metadata fields works" do
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'sys/bc_jupyter',
       'sys/bc_paraview',
       'sys/pseudofun',
     ])
-    Configuration.stubs(:pinned_apps_group_by).returns("languages")
+    UserConfiguration.any_instance.stubs(:pinned_apps_group_by).returns("languages")
 
     env = {}
 
@@ -361,7 +361,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
   test "shows only the shared apps that have been configured" do
     Configuration.stubs(:app_sharing_enabled?).returns(true)
-    Configuration.stubs(:pinned_apps).returns([{
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([{
       type: 'usr',
       category: 'Me'
     }])
@@ -385,7 +385,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
 
   test "shows all shared and sys apps" do
     Configuration.stubs(:app_sharing_enabled?).returns(true)
-    Configuration.stubs(:pinned_apps).returns([
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns([
       'usr/*',
       'sys/bc_jupyter',
       'sys/bc_desktop/owens',

--- a/apps/dashboard/test/integration/settings_controller_test.rb
+++ b/apps/dashboard/test/integration/settings_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class SettingsControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    # lot's of setup here to get a valid csrf-token
+    get root_path
+    assert :success
+
+    doc = Nokogiri::XML(@response.body)
+    @token = doc.xpath("/html/head/meta[@name='csrf-token']/@content").to_s
+    @headers = { 'X-CSRF-Token' => @token }
+  end
+
+  test "should call Configuration.update_user_settings when posting settings data" do
+    data = {
+      settings: {
+        profile: "test_profile"
+      }
+    }
+    Dir.mktmpdir {|temp_data_dir|
+      Configuration.stubs(:dataroot).returns(temp_data_dir)
+      CurrentUser.expects(:update_user_settings).with({ "profile" => "test_profile" }).once
+
+      post settings_path, params: data, headers: @headers
+      assert_response :redirect
+    }
+  end
+
+  test "should not call Configuration.update_user_settings when no data" do
+    data = { settings: { } }
+    CurrentUser.expects(:update_user_settings).never
+
+    post settings_path, params: data, headers: @headers
+    assert_response :redirect
+  end
+
+  test "parameters outside the settings namespace should be ignored" do
+    data = { profile: "root_value" }
+    CurrentUser.expects(:update_user_settings).never
+
+    post settings_path, params: data, headers: @headers
+    assert_response :redirect
+  end
+
+end

--- a/apps/dashboard/test/models/current_user_test.rb
+++ b/apps/dashboard/test/models/current_user_test.rb
@@ -18,4 +18,55 @@ class CurrentUserTest < ActiveSupport::TestCase
     assert_equal gid, CurrentUser.gid
     assert_equal Etc.getgrgid(gid).name, CurrentUser.primary_group
   end
+
+  test "user_settings cannot be modified" do
+    current_settings = CurrentUser.user_settings
+    current_settings[:profile] = "new value"
+
+    refute_equal current_settings, CurrentUser.user_settings
+  end
+
+  test "read_user_settings should read data from user settings file" do
+    with_modified_env(OOD_DATAROOT: "#{Rails.root}/test/fixtures/config/user_settings", OOD_USER_SETTINGS_FILE: ".valid") do
+      expected_user_settings = {:profile=>"file_value"}
+
+      assert_equal expected_user_settings, CurrentUser.instance.send(:read_user_settings)
+    end
+  end
+
+  test "read_user_settings should log errors when reading settings from file" do
+    with_modified_env(OOD_DATAROOT: "#{Rails.root}/test/fixtures/config/user_settings", OOD_USER_SETTINGS_FILE: ".invalid") do
+      Rails.logger.expects(:error).with(regexp_matches(/Can't read or parse settings file/)).at_least_once
+      expected_user_settings = { }
+
+      assert_equal expected_user_settings, CurrentUser.instance.send(:read_user_settings)
+    end
+  end
+
+  test "update_user_settings should create data directory when is not available" do
+    Dir.mktmpdir {|temp_data_dir|
+      data_root = Pathname.new(temp_data_dir).join('update_test')
+      assert_equal false, data_root.exist?
+
+      Configuration.stubs(:dataroot).returns(data_root.to_s)
+
+      CurrentUser.update_user_settings({})
+
+      assert_equal true, data_root.exist?
+    }
+  end
+
+  test "update_user_settings should update internal data and user settings file" do
+    Dir.mktmpdir {|temp_data_dir|
+      Configuration.stubs(:dataroot).returns(temp_data_dir)
+
+      settings = CurrentUser.user_settings
+      settings[:profile] = "profile_value"
+      CurrentUser.update_user_settings(settings)
+
+      assert_equal settings, CurrentUser.user_settings
+      assert_equal settings, YAML.safe_load(File.read(CurrentUser.instance.send(:user_settings_path))).deep_symbolize_keys
+    }
+  end
+
 end

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -1,0 +1,120 @@
+require 'test_helper'
+
+class UserConfigurationTest < ActiveSupport::TestCase
+
+  DEFAULT_CONFIG = {
+    key_1: "default_value_1",
+    key_2: "default_value_2",
+    key_3: "default_value_3",
+    key_4: nil,
+    profiles: {
+      profile_test: {
+        key_1: "test_value_1",
+        key_2: "test_value_2",
+        key_3: nil
+      }
+    }
+  }
+
+  test "pinned_apps_group_by returns original category when configured with category" do
+    Configuration.stubs(:config).returns({pinned_apps_group_by: "category"})
+    assert_equal "original_category", UserConfiguration.new.pinned_apps_group_by
+  end
+
+  test "pinned_apps_group_by returns original subcategory when configured with subcategory" do
+    Configuration.stubs(:config).returns({pinned_apps_group_by: "subcategory"})
+    assert_equal "original_subcategory", UserConfiguration.new.pinned_apps_group_by
+  end
+
+  test "pinned_apps_group_by returns an empty string by default" do
+    Configuration.stubs(:config).returns({})
+    assert_equal "", UserConfiguration.new.pinned_apps_group_by
+  end
+
+  test "reads pinned apps from config" do
+    pinned_apps = [
+      "sys/bc_osc_jupyter",
+      "sys/bc_osc_rstudio_server",
+      "sys/iqmol",
+      {
+        type: 'sys',
+        category: 'Interactive Apps',
+        subcategory: 'Servers',
+        field_of_science: 'Biology'
+      }
+    ]
+
+    Configuration.stubs(:config).returns({ pinned_apps: pinned_apps })
+    CurrentUser.stubs(:user_settings).returns({})
+
+    assert_equal pinned_apps, UserConfiguration.new.pinned_apps
+  end
+
+  test "profile should delegate to CurrentUser settings" do
+    target = UserConfiguration.new
+    CurrentUser.stubs(:user_settings).returns({profile: "user_settings_profile_value"})
+
+    assert_equal :user_settings_profile_value, target.profile
+  end
+
+  test "fetch should use key as symbol" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({profile: "profile_test"})
+    target = UserConfiguration.new
+
+    assert_equal "test_value_1", target.send(:fetch, "key_1")
+    assert_equal "test_value_2", target.send(:fetch, "key_2")
+  end
+
+  test "fetch should use the profile value when profile defines a value" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({profile: "profile_test"})
+    target = UserConfiguration.new
+
+    assert_equal "test_value_1", target.send(:fetch, :key_1)
+    assert_equal "test_value_2", target.send(:fetch, :key_2)
+  end
+
+  test "fetch should use the root configuration value when profile do not define a value" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({})
+    target = UserConfiguration.new
+
+    assert_nil target.profile
+    assert_equal "default_value_3", target.send(:fetch, :key_3)
+  end
+
+  test "fetch should use the default value when the profile and root configurations do not define a value" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({profile: "profile_test"})
+    target = UserConfiguration.new
+
+    assert_equal "default_value_argument", target.send(:fetch, :missing_key, "default_value_argument")
+  end
+
+  test "fetch should use the profile value when is define but null" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({profile: "profile_test"})
+    target = UserConfiguration.new
+
+    assert_nil target.send(:fetch, :key_3, "default")
+  end
+
+  test "fetch should use the root value when is define but null and not defined in profile" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({profile: "profile_test"})
+    target = UserConfiguration.new
+
+    assert_nil target.send(:fetch, :key_4, "default")
+  end
+
+  test "fetch should handle nil keys" do
+    Configuration.stubs(:config).returns(DEFAULT_CONFIG)
+    CurrentUser.stubs(:user_settings).returns({})
+    target = UserConfiguration.new
+
+    assert_nil target.send(:fetch, nil)
+    assert_equal "default_value_argument", target.send(:fetch, nil, "default_value_argument")
+  end
+
+end

--- a/apps/dashboard/test/system/preset_apps_pinned_test.rb
+++ b/apps/dashboard/test/system/preset_apps_pinned_test.rb
@@ -10,7 +10,7 @@ class PresetAppsPinnedTest < ApplicationSystemTestCase
   def setup
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
     SysRouter.stubs(:base_path).returns(Rails.root.join('test/fixtures/apps'))
-    Configuration.stubs(:pinned_apps).returns(['sys/preset_app/*'])
+    UserConfiguration.any_instance.stubs(:pinned_apps).returns(['sys/preset_app/*'])
     BatchConnect::Session.any_instance.stubs(:stage).raises(StandardError.new(err_msg))
     Router.instance_variable_set('@pinned_apps', nil)
   end


### PR DESCRIPTION
Enhance the current configuration object to support profiles. These new profiles will work as overrides to the default root configuration. For every configuration item, first, there will be a lookup into the current profile configuration, then into the root configuration.

Implementation for issue #2117

**Sample Configuration for testing**
Adding a new homepage layout for a `test` profile:
Add the following configuration to an existing or to a new configuration file under the `Configuration.config_directory`.
This is usually: `/etc/ood/config/ondemand.d`
```
pinned_apps:
  - type: sys

profile_links:
  - id: default
    name: "default"
    icon: "cog"
  - id: test
    name: "Test"
    icon: "user"

dashboard_layout:
  rows:
    - columns:
        - width: 12
          widgets:
            - "pinned_apps"

profiles:
  test:
    dashboard_layout:
      rows:
        - columns:
            - width: 6
              widgets:
                - "pinned_apps"
```
This is a simple configuration to have a different layout for the homepage of the `test` profile.

the `profile_links` configuration item is to show links under the `help` menu to change the current profile.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202562633426597) by [Unito](https://www.unito.io)
