### PR TITLE
Add initial support for remote files in files app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,9 @@ jobs:
           bundle config path ~/vendor/bundle
           bundle install
 
+      - name: Setup rclone
+        run: sudo apt-get update && sudo apt-get install rclone
+
       - name: Run ShellCheck
         run: bundle exec rake test:shellcheck
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,6 +17,8 @@ RUN dnf -y update && \
     dnf config-manager --set-enabled powertools && \
     dnf -y module enable nodejs:14 ruby:3.0 && \
     dnf install -y ondemand ondemand-dex && \
+    dnf install -y epel-release && \
+    dnf install -y rclone && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
 RUN sed -i 's#^CREATE_MAIL_SPOOL=yes#CREATE_MAIL_SPOOL=no#' /etc/default/useradd; \

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -168,10 +168,13 @@ class FilesController < ApplicationController
 
   def parse_path
     match = params[:filepath].match(/^(?<remote>[0-9A-Za-z_\.\- ]+:(\/)?)?(?<path>.*)$/)
-    return PosixFile.new(normalized_path) if match[:remote].nil?
-    remote = match[:remote].chomp("/").chomp(":")
-    path = Pathname.new("/" + match[:path].chomp("/"))
-    return RemoteFile.new(path, remote)
+    if !::Configuration.files_app_remote_files? || match[:remote].nil?
+      PosixFile.new(normalized_path)
+    else
+      remote = match[:remote].chomp("/").chomp(":")
+      path = Pathname.new("/" + match[:path].chomp("/"))
+      RemoteFile.new(path, remote)
+    end
   end
 
   def validate_path!

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -133,7 +133,7 @@ class FilesController < ApplicationController
   # POST
   def upload
     upload_path = uppy_upload_path
-    @path = PosixFile.new(upload_path)
+    @path = parse_path(upload_path)
 
     validate_path!
 
@@ -162,14 +162,14 @@ class FilesController < ApplicationController
 
   private
 
-  def normalized_path
-    Pathname.new("/" + params[:filepath].chomp("/").delete_prefix("/"))
+  def normalized_path(path = params[:filepath])
+    Pathname.new("/" + path.to_s.chomp("/").delete_prefix("/"))
   end
 
-  def parse_path
-    match = params[:filepath].match(/^(?<remote>[0-9A-Za-z_\.\- ]+:(\/)?)?(?<path>.*)$/)
+  def parse_path(path = params[:filepath])
+    match = path.to_s.match(/^(?<remote>[0-9A-Za-z_\.\- ]+:(\/)?)?(?<path>.*)$/)
     if !::Configuration.files_app_remote_files? || match[:remote].nil?
-      PosixFile.new(normalized_path)
+      PosixFile.new(normalized_path(path))
     else
       remote = match[:remote].chomp("/").chomp(":")
       path = Pathname.new("/" + match[:path].chomp("/"))

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -104,7 +104,7 @@ class FilesController < ApplicationController
 
   # PUT - create or update
   def update
-    @path = PosixFile.new(normalized_path)
+    @path = parse_path
 
     validate_path!
 
@@ -149,7 +149,7 @@ class FilesController < ApplicationController
   end
 
   def edit
-    @path = PosixFile.new(normalized_path)
+    @path = parse_path
     @file_api_url = OodAppkit.files.api(path: @path).to_s
 
     if @path.editable?

--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -8,4 +8,14 @@ module FilesHelper
       segment + " /"
     end
   end
+
+  def editor_url(filesystem, path)
+    base = ENV['OOD_EDITOR_URL']   || '/pun/sys/dashboard/files'
+    OodAppkit::Urls::Editor.new(edit_url: "#{base}/edit/#{filesystem}" ).edit(path: path).to_s
+  end
+
+  def file_api_url(filesystem, path)
+    base = ENV['OOD_FILES_URL']   || '/pun/sys/dashboard/files'
+    OodAppkit::Urls::Files.new(api_url: "#{base}/#{filesystem}" ).api(path: path).to_s
+  end
 end

--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -328,7 +328,6 @@ class DataTable {
     goto(url, pushState = true, show_processing_indicator = true) {
         if(url == history.state.currentDirectoryUrl)
           pushState = false;
-      
         this.reloadTable(url)
           .then((data) => {
             if(data) {
@@ -339,7 +338,9 @@ class DataTable {
             
                     history.pushState({
                         currentDirectory: data.path,
-                        currentDirectoryUrl: data.url
+                        currentDirectoryUrl: data.url,
+                        currentFilesPath: data.files_path,
+                        currentFilesUploadPath: data.files_upload_path,
                     }, data.name, data.url);
                 }      
             }

--- a/apps/dashboard/app/javascript/packs/files/file_ops.js
+++ b/apps/dashboard/app/javascript/packs/files/file_ops.js
@@ -199,7 +199,8 @@ jQuery(function() {
 class FileOps {
   _timeout = 2000;
   _failures = 0;
-  _filesPath = filesPath;
+  // this seems to not be used anywhere?
+  _filesPath = history.state.currentFilesPath;
 
   constructor() {
   }
@@ -218,7 +219,7 @@ class FileOps {
 
   changeDirectory(path) {
     const eventData = {
-      'path': filesPath + path,
+      'path': history.state.currentFilesPath + path,
     };
 
     $(CONTENTID).trigger(DATATABLE_EVENTNAME.goto, eventData);

--- a/apps/dashboard/app/javascript/packs/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/packs/files/uppy_ops.js
@@ -67,7 +67,8 @@ jQuery(function() {
   uppy = new Uppy({
     restrictions: {
       maxFileSize: maxFileSize,
-    }
+    },
+    onBeforeUpload: updateEndpoint,
   });
   
   uppy.use(EmptyDirCreator);
@@ -83,7 +84,6 @@ jQuery(function() {
     note: 'Empty directories will be included in the upload only when a directory upload is initiated via drag and drop. This is because the File and Directory Entries API is available only on a drop event, not during an input change event.'
   });
   uppy.use(XHRUpload, {
-    endpoint: filesUploadPath,
     withCredentials: true,
     fieldName: 'file',
     limit: 1,
@@ -164,6 +164,12 @@ function getEmptyDirs(entry){
         }
       })
     }
+  });
+}
+
+function updateEndpoint() {
+  uppy.getPlugin('XHRUpload').setOptions({
+    endpoint: history.state.currentFilesUploadPath,
   });
 }
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -48,11 +48,27 @@ class RemoteFile
   end
 
   def editable?
+    # Assume file is editable if it exists and isn't a directory even though it
+    # might not actually be (e.g. permissions)
+    !directory?
+  rescue => e
     false
   end
 
   def read(&block)
     RcloneUtil.cat(remote, path, &block)
+  end
+
+  def touch
+    RcloneUtil.touch(remote, path)
+  end
+
+  def mkdir
+    RcloneUtil.mkdir(remote, path)
+  end
+
+  def write(content)
+    RcloneUtil.write(remote, path, content)
   end
 
   def mime_type

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -1,16 +1,15 @@
 require "rclone_util"
 
 class RemoteFile
-  attr_reader :path, :full_path, :remote
+  attr_reader :path, :remote
 
-  delegate :basename, :descend, :parent, :join, :to_s, to: :full_path
+  delegate :basename, :descend, :parent, :join, :to_s, to: :path
 
   def initialize(path, remote)
     # accepts both String and Pathname
     # avoids converting to Pathname in every function
     @path = Pathname.new(path)
     @remote = remote
-    @full_path = Pathname.new("#{@remote}:#{@path}")
   end
 
   def remote_type

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -1,0 +1,71 @@
+require "rclone_util"
+
+class RemoteFile
+  attr_reader :path, :full_path, :remote
+
+  delegate :basename, :descend, :parent, :join, :to_s, to: :full_path
+
+  def initialize(path, remote)
+    # accepts both String and Pathname
+    # avoids converting to Pathname in every function
+    @path = Pathname.new(path)
+    @remote = remote
+    @full_path = Pathname.new("#{@remote}:#{@path}")
+  end
+
+  def remote_type
+    @remote_type ||= RcloneUtil.remote_type(remote)
+  end
+
+  def raise_if_cant_access_directory_contents
+  end
+
+  def directory?
+    RcloneUtil.directory?(remote, path)
+  end
+
+  def ls
+    files = RcloneUtil.ls(remote, path)
+    # Need to return same fields as PosixFile.
+    # owner, mode and dev are not defined for remote files, leaving them empty
+    files.map do |file|
+      {
+        id: file["Path"],
+        name: file["Name"],
+        size: file["IsDir"] ? nil : file["Size"],
+        human_size: file["IsDir"] ? "-" : ::ApplicationController.helpers.number_to_human_size(file["Size"], precision: 3),
+        directory: file["IsDir"],
+        date: DateTime.parse(file["ModTime"]).to_time.to_i,
+        owner: "",
+        mode: "",
+        dev: 0,
+      }
+    end.sort_by { |p| p[:directory] ? 0 : 1 }
+  end
+
+  def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)
+    [false, "Downloading remote files as zip is currently not supported"]
+  end
+
+  def editable?
+    false
+  end
+
+  def read
+    RcloneUtil.cat(remote, path)
+  end
+
+  def mime_type
+    # Rclone does not return same mime types as `file -b --mime-type` used in PosixFile
+    # Results in shell scripts not being viewable as they are application/x-sh and not text/x-shellscript
+    #
+    # TODO: Could something like `rclone cat --head <N> <remote>:<path> | file -b --mime-type -`
+    # be used here to have consistent filetypes with PosixFile
+    RcloneUtil.mime_type(remote, path)
+  end
+
+  # allow implicit conversion to String
+  def to_str
+    to_s
+  end
+end

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -71,6 +71,11 @@ class RemoteFile
     RcloneUtil.write(remote, path, content)
   end
 
+  def handle_upload(tempfile)
+    # FIXME: upload to the remote asynchronously
+    RcloneUtil.moveto(remote, path, tempfile.path)
+  end
+
   def mime_type
     # Rclone does not return same mime types as `file -b --mime-type` used in PosixFile
     # Results in shell scripts not being viewable as they are application/x-sh and not text/x-shellscript

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -51,8 +51,8 @@ class RemoteFile
     false
   end
 
-  def read
-    RcloneUtil.cat(remote, path)
+  def read(&block)
+    RcloneUtil.cat(remote, path, &block)
   end
 
   def mime_type

--- a/apps/dashboard/app/views/files/_breadcrumb.html.erb
+++ b/apps/dashboard/app/views/files/_breadcrumb.html.erb
@@ -1,6 +1,6 @@
 <% if file_counter == 0 %>
   <li class="breadcrumb-item">
-    <a href="<%= files_path(full_path.parent) %>" style="margin-right: 20px;" class="d btn btn-outline-dark btn-sm" title="Go up directory">
+    <a href="<%= files_path(@filesystem, full_path.parent) %>" style="margin-right: 20px;" class="d btn btn-outline-dark btn-sm" title="Go up directory">
       <span class="fa fa-arrow-up"></span></a>
   </li>
 <% end %>
@@ -17,6 +17,6 @@
   </li>
 <% else %>
   <li class="breadcrumb-item">
-    <%= link_to path_segment_with_slash(file.basename.to_s, file_counter, file_count), files_path(file), class: (file_counter == (file_count - 1) ? 'd active' : 'd')  %>
+    <%= link_to path_segment_with_slash(file.basename.to_s, file_counter, file_count), files_path(@filesystem, file), class: (file_counter == (file_count - 1) ? 'd active' : 'd')  %>
   </li>
 <% end %>

--- a/apps/dashboard/app/views/files/_inline_js.html.erb
+++ b/apps/dashboard/app/views/files/_inline_js.html.erb
@@ -1,15 +1,15 @@
 <script>
 const csrf_token = document.querySelector('meta[name="csrf-token"]').content;
 const dashboard_files_directory_download_error_modal_title = '<%= t('dashboard.files_directory_download_error_modal_title') %>';
-const filesPath = '<%= files_path('/') %>';
 const maxFileSize = '<%= Configuration.file_upload_max %>';
-const filesUploadPath = '<%= files_upload_path %>';
 const transfersPath = '<%= transfers_path(format: "json") %>';
 const alert = '<%= alert %>';
 history.replaceState({
   currentDirectory: '<%= @path %>',
-  currentDirectoryUrl: '<%= files_path(@path) %>',
-  currentDirectoryUpdatedAt: '<%= Time.now.to_i %>'
+  currentDirectoryUrl: '<%= files_path(@filesystem, @path) %>',
+  currentDirectoryUpdatedAt: '<%= Time.now.to_i %>',
+  currentFilesPath: '<%= files_path(@filesystem, '/') %>',
+  currentFilesUploadPath: '<%= url_for(fs: @filesystem, action: 'upload') %>',
 }, null);
 
 </script>

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -1,5 +1,5 @@
 
-<pre id="editor" data-path="<%= @path %>" data-api="<%= @file_api_url %>"><%= @content %></pre>
+<pre id="editor" data-path="<%= @path %>" data-api="<%= file_api_url(@filesystem, @path) %>"><%= @content %></pre>
 
 <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ace.js" %>" type="text/javascript" charset="utf-8"></script>
 <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ext-modelist.js" %>" type="text/javascript" charset="utf-8"></script>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -10,7 +10,7 @@ json.files @files do |f|
 
   json.url files_path(@path.join(f[:name]).to_s)
   json.download_url files_path(@path.join(f[:name]).to_s, download: '1') # FIXME: should change for directory
-  json.edit_url OodAppkit.editor.edit(path:@path.join(f[:name])).to_s
+  json.edit_url OodAppkit.editor.edit(path:@path.join(f[:name]).to_s.gsub(/^\/?/, "/")).to_s
 
   json.size f[:size]
   json.human_size f[:human_size]

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -1,16 +1,18 @@
 json.path @path.to_s
-json.url files_path(@path).to_s
+json.url files_path(@filesystem, @path).to_s
 #TODO: support array of shell urls, along with the default shell url which could be above
 json.shell_url OodAppkit.shell.url(path: @path.to_s).to_s
+json.files_path files_path(@filesystem, '/')
+json.files_upload_path url_for(fs: @filesystem, action: 'upload')
 
 json.files @files do |f|
   json.id f[:id]
   json.type f[:directory] ? 'd' : 'f'
   json.name f[:name]
 
-  json.url files_path(@path.join(f[:name]).to_s)
-  json.download_url files_path(@path.join(f[:name]).to_s, download: '1') # FIXME: should change for directory
-  json.edit_url OodAppkit.editor.edit(path:@path.join(f[:name]).to_s.gsub(/^\/?/, "/")).to_s
+  json.url files_path(@filesystem, @path.join(f[:name]).to_s)
+  json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') # FIXME: should change for directory
+  json.edit_url editor_url(@filesystem, @path.join(f[:name]).to_s)
 
   json.size f[:size]
   json.human_size f[:human_size]

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -42,7 +42,8 @@ class ConfigurationSingleton
       :bc_dynamic_js                => false,
       :per_cluster_dataroot         => false,
       :file_navigator               => false,
-      :jobs_app_alpha               => false
+      :jobs_app_alpha               => false,
+      :files_app_remote_files       => false,
     }.freeze
   end
 

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -11,17 +11,17 @@ Rails.application.routes.draw do
 
   # in production, if the user doesn't have access to the files app directory, we hide the routes
   if Configuration.can_access_files?
-    constraints filepath: /.+/ do
-      get "files/fs(/*filepath)" => "files#fs", :defaults => { :format => 'html', :filepath => '/' }, :format => false, as: :files
-      put "files/fs/*filepath" => "files#update", :format => false, :defaults => { :format => 'json' }
+    constraints filepath: /.+/, fs: /(?!edit)[^\/]+/  do
+      get "files/:fs(/*filepath)" => "files#fs", :defaults => { :fs => 'fs', :format => 'html' }, :format => false, as: :files
+      put "files/:fs/*filepath" => "files#update", :format => false, :defaults => { :fs => 'fs', :format => 'json' }
 
       # TODO: deprecate these routes after updating OodAppkit to use the new routes above
       # backwards compatibility with the "api" routes that OodAppkit provides
       # and are used by File Editor and Job Composer
-      get "files/api/v1/fs(/*filepath)" => "files#fs", :defaults => { :format => 'html', :filepath => '/' }, :format => false
-      put "files/api/v1/fs/*filepath" => "files#update", :format => false, :defaults => { :format => 'json' }
+      get "files/api/v1/:fs(/*filepath)" => "files#fs", :defaults => { :fs => 'fs', :format => 'html' }, :format => false
+      put "files/api/v1/:fs/*filepath" => "files#update", :format => false, :defaults => { :fs => 'fs', :format => 'json' }
     end
-    post "files/upload"
+    post "files/upload/:fs" => "files#upload", :defaults => { :fs => 'fs' }
 
     get "files", to: redirect("files/fs#{Dir.home}")
 
@@ -30,8 +30,8 @@ Rails.application.routes.draw do
 
   if  Configuration.can_access_file_editor?
     # App file editor
-    get "files/edit/*filepath" => "files#edit", defaults: { :path => "/" , :format => 'html' }, format: false
-    get "files/edit" => "files#edit", :defaults => { :path => "/", :format => 'html' }, format: false
+    get "files/edit/:fs/*filepath" => "files#edit", defaults: { :fs => 'fs', :path => "/" , :format => 'html' }, format: false
+    get "files/edit/:fs" => "files#edit", :defaults => { :fs => 'fs', :path => "/", :format => 'html' }, format: false
   end
 
   namespace :batch_connect do

--- a/apps/dashboard/lib/rclone_util.rb
+++ b/apps/dashboard/lib/rclone_util.rb
@@ -77,6 +77,34 @@ class RcloneUtil
       end
     end
 
+    def touch(remote, path)
+      full_path = "#{remote}:#{path}"
+      o, e, s = rclone("touch", full_path)
+      if !s.success?
+        raise StandardError, "Error creating file: #{e}"
+      end
+    end
+
+    def mkdir(remote, path)
+      full_path = "#{remote}:#{path}"
+      o, e, s = rclone("mkdir", full_path)
+      if e.include?("Warning: running mkdir on a remote which can't have empty directories does nothing")
+        # TODO: Could most likely do some kind of workaround here, e.g. rclone touch remote:path/.somefile
+        raise StandardError, "Remote does not support empty directories"
+      elsif !s.success?
+        raise StandardError, "Error creating directory: #{e}"
+      end
+    end
+
+    def write(remote, path, content)
+      full_path = "#{remote}:#{path}"
+      # Write to a file on the remote by passing the file contents in stdin
+      o, e, s = rclone("rcat", full_path, stdin_data: content)
+      if !s.success?
+        raise StandardError, "Error writing file: #{e}"
+      end
+    end
+
     def remote_type(remote)
       # Get the rclone remote type (e.g. s3) for a single remote
       o, e, s = rclone("listremotes", "--long")

--- a/apps/dashboard/lib/rclone_util.rb
+++ b/apps/dashboard/lib/rclone_util.rb
@@ -1,0 +1,92 @@
+require "json"
+require "open3"
+require "pathname"
+
+class RcloneUtil
+
+  class << self
+    def ls(remote, path)
+      full_path = "#{remote}:#{path}"
+      # Use lsjson for easy parsing and more info about files
+      # Rclone can hang for >20 minutes if remote isn't available and low-level-retries isn't set
+      o, e, s = rclone("lsjson", "--low-level-retries=1", full_path)
+      if s.success?
+        files = JSON.parse(o)
+        files
+      elsif s.exitstatus == 3 # directory not found
+        raise StandardError, "Remote file or directory '#{path}' does not exist"
+      else
+        raise StandardError, "Error listing files: #{e}"
+      end
+    end
+
+    def directory?(remote, path)
+      # remote:/ will always be a directory
+      if path.root?
+        return true
+      end
+      # List everything in parent and check if requested path ends with a slash and actually exists
+      full_path = "#{remote}:#{path.parent.to_s}"
+      o, e, s = rclone( "lsf", "--low-level-retries=1", full_path)
+      if s.success?
+        match = o.match(/^(?<entry>#{Regexp.escape(path.basename.to_s)}\/?)$/)
+        if match.nil?
+          raise StandardError, "Remote file or directory '#{path}' does not exist"
+        else
+          match[:entry].end_with?("/")
+        end
+      elsif s.exitstatus == 3 # directory not found
+        raise StandardError, "Remote file or directory '#{path}' does not exist"
+      else
+        raise StandardError, "Error checking info for path: #{e}"
+      end
+    end
+
+    def mime_type(remote, path)
+      # Check first is it is a directory, to avoid strange lsjson behaviour
+      # when a directory contains a file with the same name as the directory.
+      # `rclone lsjson remote:/name` and `rlcone lsjson remote:/name/name`
+      # returns only the info for remote:/name/name
+      if directory?(remote, path)
+        "inode/directory"
+      else
+        files = ls(remote, path)
+        files.find { |file| file["Path"] == path.basename.to_s }["MimeType"]
+      end
+    end
+
+    def cat(remote, path)
+      full_path = "#{remote}:#{path}"
+      o, e, s = rclone("cat", full_path)
+      if s.success?
+        o
+      elsif s.exitstatus == 3 # directory not found
+        raise StandardError, "Remote file or directory '#{path}' does not exist"
+      else
+        raise StandardError, "Error reading file #{full_path}: #{e}"
+      end
+    end
+
+    def remote_type(remote)
+      # Get the rclone remote type (e.g. s3) for a single remote
+      o, e, s = rclone("listremotes", "--long")
+      if s.success?
+        remote = o.lines.grep(/^#{Regexp.escape(remote)}:/).first
+        return nil if remote.nil?
+
+        type = remote.split(":")[1].strip
+      else
+        raise StandardError, "Error getting information about remote: #{e}"
+      end
+    end
+
+    def rclone_cmd
+      # TODO: Make this configurable
+      "rclone"
+    end
+
+    def rclone(*args)
+      Open3.capture3(rclone_cmd, *args)
+    end
+  end
+end

--- a/apps/dashboard/lib/rclone_util.rb
+++ b/apps/dashboard/lib/rclone_util.rb
@@ -105,6 +105,15 @@ class RcloneUtil
       end
     end
 
+    def moveto(remote, path, src)
+      full_path = "#{remote}:#{path}"
+      # Move file src on the local filesystem to full_path on the remote
+      o, e, s = rclone("moveto", src, full_path)
+      if !s.success?
+        raise StandardError, "Error moving file: #{e}"
+      end
+    end
+
     def remote_type(remote)
       # Get the rclone remote type (e.g. s3) for a single remote
       o, e, s = rclone("listremotes", "--long")

--- a/apps/dashboard/test/controllers/files_controller_test.rb
+++ b/apps/dashboard/test/controllers/files_controller_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class FilesControllerTest < ActionController::TestCase
+  test "empty path is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "" })
+    path = @controller.send(:parse_path)
+    assert_kind_of PosixFile, path
+    assert_equal "/", path.to_s
+  end
+
+  test "root path is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "/" })
+    path = @controller.send(:parse_path)
+    assert_kind_of PosixFile, path
+    assert_equal "/", path.to_s
+  end
+
+  test "posix path is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "/foo/bar/file.txt" })
+    path = @controller.send(:parse_path)
+    assert_kind_of PosixFile, path
+    assert_equal "/foo/bar/file.txt", path.to_s
+  end
+
+  test "posix path without slash is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "foo/bar" })
+    path = @controller.send(:parse_path)
+    assert_kind_of PosixFile, path
+    assert_equal "/foo/bar", path.to_s
+  end
+
+  test "path beginning with slash is posix path" do
+    @controller.stubs(:params).returns({ :filepath => "/notaremote:/foo/bar" })
+    path = @controller.send(:parse_path)
+    assert_kind_of PosixFile, path
+    assert_equal "/notaremote:/foo/bar", path.to_s
+  end
+
+  test "empty remote path is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "myremote:" })
+    path = @controller.send(:parse_path)
+    assert_kind_of RemoteFile, path
+    assert_equal "/", path.path.to_s
+    assert_equal "myremote", path.remote
+  end
+
+  test "root remote path is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "myremote:/" })
+    path = @controller.send(:parse_path)
+    assert_kind_of RemoteFile, path
+    assert_equal "/", path.path.to_s
+    assert_equal "myremote", path.remote
+  end
+
+  test "remote path is parsed" do
+    @controller.stubs(:params).returns({ :filepath => "myremote:/foo/bar/file.txt" })
+    path = @controller.send(:parse_path)
+    assert_kind_of RemoteFile, path
+    assert_equal "/foo/bar/file.txt", path.path.to_s
+    assert_equal "myremote", path.remote
+  end
+
+  # https://rclone.org/docs/#valid-remote-names
+  test "remote path supports valid rclone remote names" do
+    @controller.stubs(:params).returns({ :filepath => "my_REMOTE 1.2-:/foo/bar" })
+    path = @controller.send(:parse_path)
+    assert_kind_of RemoteFile, path
+    assert_equal "/foo/bar", path.path.to_s
+    assert_equal "my_REMOTE 1.2-", path.remote
+  end
+end

--- a/apps/dashboard/test/controllers/files_controller_test.rb
+++ b/apps/dashboard/test/controllers/files_controller_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class FilesControllerTest < ActionController::TestCase
+
+  def setup
+    Configuration.stubs(:files_app_remote_files?).returns(true)
+  end
+
   test "empty path is parsed" do
     @controller.stubs(:params).returns({ :filepath => "" })
     path = @controller.send(:parse_path)
@@ -67,5 +72,13 @@ class FilesControllerTest < ActionController::TestCase
     assert_kind_of RemoteFile, path
     assert_equal "/foo/bar", path.path.to_s
     assert_equal "my_REMOTE 1.2-", path.remote
+  end
+
+  test "path is posix path if remote files feature is disabled" do
+    Configuration.stubs(:files_app_remote_files?).returns(false)
+    @controller.stubs(:params).returns({ :filepath => "myremote:/foo/bar/file.txt" })
+    path = @controller.send(:parse_path)
+    assert_kind_of PosixFile, path
+    assert_equal "/myremote:/foo/bar/file.txt", path.path.to_s
   end
 end

--- a/apps/dashboard/test/controllers/files_controller_test.rb
+++ b/apps/dashboard/test/controllers/files_controller_test.rb
@@ -7,78 +7,84 @@ class FilesControllerTest < ActionController::TestCase
   end
 
   test "empty path is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "", "fs")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of PosixFile, path
     assert_equal "/", path.to_s
+    assert_equal "fs", @controller.instance_variable_get(:@filesystem)
   end
 
   test "root path is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "/" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "/", "fs")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of PosixFile, path
     assert_equal "/", path.to_s
+    assert_equal "fs", @controller.instance_variable_get(:@filesystem)
   end
 
   test "posix path is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "/foo/bar/file.txt" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "/foo/bar/file.txt", "fs")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of PosixFile, path
     assert_equal "/foo/bar/file.txt", path.to_s
+    assert_equal "fs", @controller.instance_variable_get(:@filesystem)
   end
 
   test "posix path without slash is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "foo/bar" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "foo/bar", "fs")
+    @controller.stubs(:params).returns({ :filepath => "" })
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of PosixFile, path
     assert_equal "/foo/bar", path.to_s
-  end
-
-  test "path beginning with slash is posix path" do
-    @controller.stubs(:params).returns({ :filepath => "/notaremote:/foo/bar" })
-    path = @controller.send(:parse_path)
-    assert_kind_of PosixFile, path
-    assert_equal "/notaremote:/foo/bar", path.to_s
+    assert_equal "fs", @controller.instance_variable_get(:@filesystem)
   end
 
   test "empty remote path is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "myremote:" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "", "myremote")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of RemoteFile, path
     assert_equal "/", path.path.to_s
     assert_equal "myremote", path.remote
+    assert_equal "myremote", @controller.instance_variable_get(:@filesystem)
   end
 
   test "root remote path is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "myremote:/" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "/", "myremote")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of RemoteFile, path
     assert_equal "/", path.path.to_s
     assert_equal "myremote", path.remote
+    assert_equal "myremote", @controller.instance_variable_get(:@filesystem)
   end
 
   test "remote path is parsed" do
-    @controller.stubs(:params).returns({ :filepath => "myremote:/foo/bar/file.txt" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "/foo/bar/file.txt", "myremote")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of RemoteFile, path
     assert_equal "/foo/bar/file.txt", path.path.to_s
     assert_equal "myremote", path.remote
+    assert_equal "myremote", @controller.instance_variable_get(:@filesystem)
   end
 
   # https://rclone.org/docs/#valid-remote-names
   test "remote path supports valid rclone remote names" do
-    @controller.stubs(:params).returns({ :filepath => "my_REMOTE 1.2-:/foo/bar" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "/foo/bar", "my_REMOTE 1.2-")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of RemoteFile, path
     assert_equal "/foo/bar", path.path.to_s
     assert_equal "my_REMOTE 1.2-", path.remote
+    assert_equal "my_REMOTE 1.2-", @controller.instance_variable_get(:@filesystem)
   end
 
+  # FIXME: decide expected behaviour
+  '''
   test "path is posix path if remote files feature is disabled" do
     Configuration.stubs(:files_app_remote_files?).returns(false)
-    @controller.stubs(:params).returns({ :filepath => "myremote:/foo/bar/file.txt" })
-    path = @controller.send(:parse_path)
+    @controller.send(:parse_path, "/foo/bar/file.txt", "myremote")
+    path = @controller.instance_variable_get(:@path)
     assert_kind_of PosixFile, path
-    assert_equal "/myremote:/foo/bar/file.txt", path.path.to_s
+    assert_equal "/foo/bar/file.txt", path.path.to_s
+    assert_equal "myremote", @controller.instance_variable_get(:@filesystem)
   end
+  '''
 end

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -4,3 +4,4 @@ bc_dynamic_js: true
 per_cluster_dataroot: true
 file_navigator: true
 jobs_app_alpha: true
+files_app_remote_files: true

--- a/apps/dashboard/test/integration/remote_files_test.rb
+++ b/apps/dashboard/test/integration/remote_files_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+require 'rclone_helper'
+
+class RemoteFilesIntegrationTest < ActionDispatch::IntegrationTest
+
+  def put_file(path, file, content_type: 'text/plain')
+    # force binary encoding here, but the default utf-8 has the same behaviour
+    data = File.read(file).force_encoding('BINARY')
+    headers = { 'CONTENT_TYPE' => content_type, 'X-CSRF-Token' => @token }
+    put path, params: data, headers: headers
+  end
+
+  def setup
+    # lot's of setup here to get a valid csrf-token
+    get files_path
+    assert :success
+
+    doc = Nokogiri::XML(@response.body)
+    @token = doc.xpath("/html/head/meta[@name='csrf-token']/@content").to_s
+  end
+
+  def upload_and_test(filename, content_type: 'text/plain')
+    Dir.mktmpdir do |tmpdir|
+      # Use tmpdir as root for the rclone alias remote
+      with_rclone_conf(tmpdir) do
+        src_file = "test/fixtures/files/upload/#{filename}"
+        # Upload to subdirectory of tmpdir
+        dest_file = "/files/#{filename}"
+        put_file("#{files_path}/alias_remote:#{dest_file}", src_file, content_type: content_type)
+
+        assert :success
+        assert_equal '{}', @response.body
+        assert_equal '0', `diff #{src_file} #{tmpdir}#{dest_file}; echo $?`.chomp
+      end
+    end
+  end
+
+  test 'can upload file with non-ASCII characters' do
+    upload_and_test('funny_characters.sh')
+  end
+
+  test 'can upload file lots of utf8 characters' do
+    upload_and_test('lots_of_utf8.txt')
+  end
+
+  test 'can upload file image files as text/plain' do
+    upload_and_test('osc-logo.png')
+  end
+
+  test 'can upload file image files as image/png' do
+    upload_and_test('osc-logo.png', content_type: 'image/png')
+  end
+
+  test 'can upload file binary files as text/plain' do
+    upload_and_test('hello-world-c')
+  end
+
+  test 'can upload file binary files as text/plain as application/octet-stream' do
+    upload_and_test('hello-world-c', content_type: 'application/octet-stream')
+  end
+end

--- a/apps/dashboard/test/integration/remote_files_test.rb
+++ b/apps/dashboard/test/integration/remote_files_test.rb
@@ -26,7 +26,7 @@ class RemoteFilesIntegrationTest < ActionDispatch::IntegrationTest
         src_file = "test/fixtures/files/upload/#{filename}"
         # Upload to subdirectory of tmpdir
         dest_file = "/files/#{filename}"
-        put_file("#{files_path}/alias_remote:#{dest_file}", src_file, content_type: content_type)
+        put_file(files_path('alias_remote', dest_file), src_file, content_type: content_type)
 
         assert :success
         assert_equal '{}', @response.body

--- a/apps/dashboard/test/models/remote_file_test.rb
+++ b/apps/dashboard/test/models/remote_file_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+require 'rclone_helper'
+
+class RemoteFileTest < ActiveSupport::TestCase
+  test 'mime_type raises exception for non-file' do
+    assert_raises { RemoteFile.new('/dev/nulll', 'local_remote').mime_type }
+  end
+
+  test 'mime_type handles default types' do
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        f = File.join(dir, 'foo.txt')
+        File.write(f, 'one two three')
+
+        assert_equal 'text/plain; charset=utf-8', RemoteFile.new("/#{File.basename(f)}", 'alias_remote').mime_type
+      end
+    end
+  end
+
+  test 'mime_type handles svg' do
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        f = File.join(dir, 'foo.svg')
+        FileUtils.cp(Rails.root.join('app/assets/images/OpenOnDemand_powered_by_RGB.svg').to_s, f)
+
+        assert_equal 'image/svg+xml', RemoteFile.new("/#{File.basename(f)}", 'alias_remote').mime_type
+      end
+    end
+  end
+
+  test 'mime_type handles empty file' do
+    # "inode/x-empty" is returned by file command on empty file
+    # we want to treat this as an empty file of "text/plain"
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        f = File.join(dir, 'foo.txt')
+        FileUtils.touch f
+
+        assert_equal 'text/plain; charset=utf-8', RemoteFile.new("/#{File.basename(f)}", 'alias_remote').mime_type,
+                     'should treat "inode/x-empty" as "text/plain"'
+      end
+    end
+  end
+
+  test 'directory? handles directories and files' do
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        d = File.join(dir, 'foo')
+        Dir.mkdir(d)
+        # Directories containing files with same name causes problems with some rclone commands, should test
+        f = File.join(d, 'foo')
+        FileUtils.touch(f)
+
+        assert_equal true, RemoteFile.new("/#{File.basename(d)}", 'alias_remote').directory?
+        assert_equal false, RemoteFile.new("/#{File.basename(d)}/#{File.basename(f)}", 'alias_remote').directory?
+      end
+    end
+  end
+
+  test "directory? handles path that doesn't exist" do
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        e = assert_raises(StandardError) do
+          RemoteFile.new('/somepath', 'alias_remote').directory?
+        end
+        assert_equal "Remote file or directory '/somepath' does not exist", e.message
+      end
+    end
+  end
+end

--- a/apps/dashboard/test/rclone_helper.rb
+++ b/apps/dashboard/test/rclone_helper.rb
@@ -1,0 +1,20 @@
+# helper functions for tests that use rclone/remote files in files app
+
+class ActiveSupport::TestCase
+
+  # Avoid using local remote directly to detect cases where the path is valid on both the remote
+  # and posix file system
+  def remote_files_conf(root_dir)
+    {
+      OOD_FILES_APP_REMOTE_FILES:        'true',
+      RCLONE_CONFIG_LOCAL_REMOTE_TYPE:   'local',
+      RCLONE_CONFIG_ALIAS_REMOTE_TYPE:   'alias',
+      RCLONE_CONFIG_ALIAS_REMOTE_REMOTE: "local_remote:#{root_dir}"
+    }
+  end
+
+  def with_rclone_conf(root_dir, &block)
+    conf = remote_files_conf(root_dir)
+    with_modified_env(conf, &block)
+  end
+end

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -1,0 +1,60 @@
+require 'application_system_test_case'
+require 'rclone_helper'
+
+class RemoteFilesTest < ApplicationSystemTestCase
+  MAX_WAIT = 120
+
+  test "visiting files app doesn't raise js errors" do
+    with_rclone_conf(Rails.root.to_s) do
+      visit files_url('alias_remote:/')
+      messages = page.driver.browser.manage.logs.get(:browser)
+      content = messages.join("\n")
+      assert_equal 0, messages.length, "console error messages include:\n\n#{content}\n\n"
+    end
+  end
+
+  test 'visiting files app directory' do
+    with_rclone_conf(Rails.root.to_s) do
+      visit files_url('alias_remote:/')
+      find('tbody a', exact_text: 'app').ancestor('tr').click
+      assert_selector '.selected', count: 1
+      find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
+      assert_selector '.selected', count: 2
+
+      visit files_url("local_remote:#{Rails.root}")
+      find('tbody a', exact_text: 'app').ancestor('tr').click
+      assert_selector '.selected', count: 1
+      find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
+      assert_selector '.selected', count: 2
+    end
+  end
+
+  test 'adding new file' do
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        visit files_url('alias_remote:/')
+        find('#new-file-btn').click
+        find('#swal2-input').set('bar.txt')
+        find('.swal2-confirm').click
+        find('tbody a', exact_text: 'bar.txt', wait: MAX_WAIT)
+        assert File.file? File.join(dir, 'bar.txt')
+      end
+    end
+  end
+
+  test 'adding a new directory' do
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        visit files_url('alias_remote:/')
+        find('#new-dir-btn').click
+        find('#swal2-input').set('bar')
+        find('.swal2-confirm').click
+        find('tbody a.d', exact_text: 'bar', wait: MAX_WAIT)
+        assert File.directory? File.join(dir, 'bar')
+
+        visit files_url("local_remote:#{dir}")
+        find('tbody a.d', exact_text: 'bar', wait: MAX_WAIT)
+      end
+    end
+  end
+end

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -6,7 +6,7 @@ class RemoteFilesTest < ApplicationSystemTestCase
 
   test "visiting files app doesn't raise js errors" do
     with_rclone_conf(Rails.root.to_s) do
-      visit files_url('alias_remote:/')
+      visit files_url('alias_remote', '/')
       messages = page.driver.browser.manage.logs.get(:browser)
       content = messages.join("\n")
       assert_equal 0, messages.length, "console error messages include:\n\n#{content}\n\n"
@@ -15,13 +15,13 @@ class RemoteFilesTest < ApplicationSystemTestCase
 
   test 'visiting files app directory' do
     with_rclone_conf(Rails.root.to_s) do
-      visit files_url('alias_remote:/')
+      visit files_url('alias_remote', '/')
       find('tbody a', exact_text: 'app').ancestor('tr').click
       assert_selector '.selected', count: 1
       find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
       assert_selector '.selected', count: 2
 
-      visit files_url("local_remote:#{Rails.root}")
+      visit files_url('local_remote', Rails.root.to_s)
       find('tbody a', exact_text: 'app').ancestor('tr').click
       assert_selector '.selected', count: 1
       find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
@@ -32,7 +32,7 @@ class RemoteFilesTest < ApplicationSystemTestCase
   test 'adding new file' do
     Dir.mktmpdir do |dir|
       with_rclone_conf(dir) do
-        visit files_url('alias_remote:/')
+        visit files_url('alias_remote', '/')
         find('#new-file-btn').click
         find('#swal2-input').set('bar.txt')
         find('.swal2-confirm').click
@@ -45,14 +45,14 @@ class RemoteFilesTest < ApplicationSystemTestCase
   test 'adding a new directory' do
     Dir.mktmpdir do |dir|
       with_rclone_conf(dir) do
-        visit files_url('alias_remote:/')
+        visit files_url('alias_remote', '/')
         find('#new-dir-btn').click
         find('#swal2-input').set('bar')
         find('.swal2-confirm').click
         find('tbody a.d', exact_text: 'bar', wait: MAX_WAIT)
         assert File.directory? File.join(dir, 'bar')
 
-        visit files_url("local_remote:#{dir}")
+        visit files_url('local_remote', dir)
         find('tbody a.d', exact_text: 'bar', wait: MAX_WAIT)
       end
     end

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -115,7 +115,9 @@ http {
     # redirect all the old apps to the dashboard
     rewrite ^/pun/sys/activejobs(/.*|$)$ /pun/sys/dashboard/activejobs$1 permanent;
     rewrite ^/pun/sys/files(/.*|$)$ /pun/sys/dashboard/files$1 permanent;
-    rewrite ^/pun/sys/file-editor(/.*|$)$ /pun/sys/dashboard/files$1 permanent;
+    rewrite ^/pun/sys/file-editor/?$ /pun/sys/dashboard/files$1 permanent;
+    rewrite ^/pun/sys/file-editor/edit(/.*|$)$ /pun/sys/dashboard/files/edit/fs$1 permanent;
+    rewrite ^/pun/sys/file-editor(/.*|$)$ /pun/sys/dashboard/files/fs$1 permanent;
 
     # Include all app configs user has access to
     <%- app_configs.each do |app_config| -%>

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -42,7 +42,7 @@ describe 'OnDemand browser test' do
 
   it 'redirects /pun/sys/file-editor and preserves the file' do
     browser.goto "#{ctr_base_url}/pun/sys/file-editor/edit/home/ood/.bashrc"
-    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/files/edit/home/ood/.bashrc")
+    expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/files/edit/fs/home/ood/.bashrc")
     expect(browser.title).to eq('File Editor - Open OnDemand - .bashrc')
   end
 


### PR DESCRIPTION
This PR adds support for listing, viewing, downloading, uploading, creating and editing remote files (part of #1789).
The env var `OOD_FILES_APP_REMOTE_FILES` can be set to true to enable support for remote files.
I have saved file transfers for a future PR, so those are currently not supported.

The features supported are currently implemented by using different [rclone](https://rclone.org/) commands (`lsf`, `lsjson`, `cat`, `rcat`, `touch`, `mkdir`, `moveto` and `listremotes`), using the rclone remotes configured in the default `rclone.conf` (see discussion below about that).

This PR modifies only the backend, no frontend changes have been done so far.
There are some frontend changes that would need to be done (mostly regarding paths), but some things need to be decided first.

There are plenty of things that need to be discussed and changed here as there are many ways to implement these features and also many ways how the features could work.
Here are some points which I would consider important to discuss and I would like some opinions on:

* **Request format**: The FilesController currently accepts paths in the same style as Rclone, e.g. `s3remote:/somebucket/somefile.txt` or `/home/user/posixfile.txt`. Full URL in OOD looks like `http://localhost:8080/pun/dev/dashboard/files/fs/s3remote:/somebucket/somefile.txt`

Are there better ways to do this? Currently there is a conflict if the local filesystem (posix) has a directory in root with a colon, e.g. `/somedirectory:/somefile.txt`. In our case this is not a problem at least, but if there are better options it would be good to consider them. Some frontend changes are needed with the current URL format, as e.g. the _Change directory_ dialog does not accept a path in the format `remote:/path` (to test this PR, use `/remote:/path` as in the demo GIF). URLs are received without preceding slash by the FilesController currently, so some changes seem to be needed in the Rails routes too if we want to have a clear distinction between posix and remote URLs.


* **Rclone dependency**: This doesn't currently add Rclone as a dependency anywhere as this should probably be an optional feature. For testing, `rclone` should probably be added to the dev container.

Do we want to require `rclone` to be in path for the feature to be enabled or should the path to the binary be configurable?
Currently `OOD_RCLONE_PATH` can be set, but the current way is mostly to simplify testing and development, so this part should be changed (or atleast moved to ConfigurationSingleton I would assume).


* **Rclone config**: The Rclone config and authentication needs some more thought as there are quite many alternatives here. Currently the [default config file path](https://rclone.org/docs/#config-config-file) is used, but this should probably be configurable at least.

In our (CSC) use case we would most likely want to have a mix of letting users modify their config via the shell, but also automatically generating certain remotes for them where possible. Should there be a simple configuration variable for setting the rclone config path or are there other options that would be better (e.g. OOD generating an `rclone.conf` file under `~/ondemand`)?


* **Testing**: Currently there are some tests for parsing the file path, but surely we would want to have some proper tests for the functionality. What would be the best approach for testing this? Should a `local` rclone remote be configured during testing or are there better approaches?
* **Allowlist**: Using Rclone remotes of types `local` and `alias` could potentially allow bypassing the `OOD_ALLOWLIST_PATH`. Currently these types of remotes are disabled when `OOD_ALLOWLIST_PATH` is enabled. Should we attempt to evaluate the paths in those types of remotes and validate them, or disable them completely (configurable maybe) for now?
* **Error handling**: Currently any errors in the Rclone commands are just propagated up to the FilesController. Should these be parsed in some way to give more descriptive error messages to the user instead of the raw error messages from Rclone with a very short description of what failed? Many of the Rclone error messages seem to vary depending on the type of remote, so there are lots of inconsistencies in error messages too, which might make parsing them difficult.
* **OodAppkit URLs**: Mentioning this here as this affects testing this PR if running the dashboard as a dev app. The URLs from `OodAppkit`, e.g. `OodAppkit.files.api` seem to always point to `/sys/dashboard` even when running as `/dev/dashboard`, so for example the file edit URL in file dropdown and file saving URL in the editor are incorrect. Is there a reason why the Rails URL helpers aren't used for these?

### Testing this PR:
Since rclone is not installed in the dev container currently and only `~/ondemand` is mounted normally, some additional steps are needed for testing.
The easiest way is to place rclone in a path under `~/ondemand` and configure Rclone remotes using environment variables.
Example `$HOME/.config/ondemand/container/config/nginx_stage.yml`:


```
pun_custom_env:
  OOD_RCLONE_PATH: "/home/rkarlsso/ondemand/bin/rclone"
  OOD_FILES_APP_REMOTE_FILES: true

  RCLONE_CONFIG_LOCAL_REMOTE_TYPE: "local"
  # Minio server running on localhost:9000, replace ACCESS_KEY_ID and SECRET_ACCESS_KEY and ENDPOINT
  RCLONE_CONFIG_MINIO_S3_TYPE: "s3"
  RCLONE_CONFIG_MINIO_S3_PROVIDER: "Other"
  RCLONE_CONFIG_MINIO_S3_ENV_AUTH: "false"
  RCLONE_CONFIG_MINIO_S3_ACCESS_KEY_ID: ""
  RCLONE_CONFIG_MINIO_S3_SECRET_ACCESS_KEY: ""
  RCLONE_CONFIG_MINIO_S3_ENDPOINT: "http://localhost:9000"
  RCLONE_CONFIG_MINIO_S3_ACL: "PRIVATE"
```

The above configuration would enable accessing the remotes `local_remote` and `minio_s3` in the file browser by entering `/local_remote:/` or `/minio_s3:/` in the _Change directory_ dialog.

Lastly, here is a short demo showcasing the currently supported features:
![remote!UNITO-UNDERSCORE!files!UNITO-UNDERSCORE!demo](https://user-images.githubusercontent.com/61623634/177794369-e119ee1d-1c1c-4295-a98a-e482c17666d1.gif)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202570815666308) by [Unito](https://www.unito.io)
