### PR TITLE
Enhance file editor navigation bar

### DIFF
--- a/apps/dashboard/app/javascript/stylesheets/application.scss
+++ b/apps/dashboard/app/javascript/stylesheets/application.scss
@@ -122,6 +122,12 @@ pre.motd-monospaced {
 }
 **/
 
+pre:not(#editor) {
+  @extend .bg-light;
+  @extend .p-2;
+  @extend .rounded;
+}
+
 // bootstrap_form creates <small class="form-text" for help text
 // which is too small at 80% so we change it to be close to default
 small.form-text {

--- a/apps/dashboard/app/javascript/stylesheets/application.scss
+++ b/apps/dashboard/app/javascript/stylesheets/application.scss
@@ -122,12 +122,6 @@ pre.motd-monospaced {
 }
 **/
 
-pre {
-  @extend .bg-light;
-  @extend .p-2;
-  @extend .rounded;
-}
-
 // bootstrap_form creates <small class="form-text" for help text
 // which is too small at 80% so we change it to be close to default
 small.form-text {

--- a/apps/dashboard/app/javascript/stylesheets/editor.scss
+++ b/apps/dashboard/app/javascript/stylesheets/editor.scss
@@ -46,6 +46,7 @@
   font-size: 11px;
   height: 20px;
   padding-top: 0px;
+  padding-bottom: 0px;
 }
 
 .editor-navbar .control-label {
@@ -54,6 +55,11 @@
 
 #save-button {
   min-width: 80px;
+  background-color:rgb(2,117,216);
+  padding: 5px;
+  border-radius: 5px;
+  margin-left: 0.5rem;
+  margin-top: 3px;
 }
 
 // Custom Callouts

--- a/apps/dashboard/app/javascript/stylesheets/editor.scss
+++ b/apps/dashboard/app/javascript/stylesheets/editor.scss
@@ -20,13 +20,6 @@
   animation: spin 1000ms infinite linear;
 }
 
-#editor-filename {
-  margin: 0;
-  color: white;
-  margin-left: 1em;
-  flex-grow: 1;
-}
-
 @-webkit-keyframes spin {
   0% {
     -webkit-transform: rotate(0deg);

--- a/apps/dashboard/app/javascript/stylesheets/editor.scss
+++ b/apps/dashboard/app/javascript/stylesheets/editor.scss
@@ -20,6 +20,13 @@
   animation: spin 1000ms infinite linear;
 }
 
+#editor-filename {
+  margin: 0;
+  color: white;
+  margin-left: 1em;
+  flex-grow: 1;
+}
+
 @-webkit-keyframes spin {
   0% {
     -webkit-transform: rotate(0deg);

--- a/apps/dashboard/app/javascript/stylesheets/editor.scss
+++ b/apps/dashboard/app/javascript/stylesheets/editor.scss
@@ -1,11 +1,10 @@
 
 #editor {
   margin: 0;
-  position: absolute;
-  top: 3em;
   bottom: 0;
   left: 0;
   right: 0;
+  height: 100%;
 }
 
 #save-button {

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -5,6 +5,7 @@
 
   <title><%= "File Editor - #{OodAppkit.dashboard.title}" %><%= @path.nil? ? "" : " - #{@path.basename.to_s}" %></title>
   <%= favicon_link_tag 'favicon.ico', href: OodAppkit.public.url.join('favicon.ico'), skip_pipeline: true %>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <%= javascript_include_tag 'application', nonce: true %>
   <%= javascript_include_tag 'editor', nonce: true %>
@@ -18,7 +19,7 @@
     data-link-bg-color="<%= Configuration.brand_link_active_bg_color %>"
   />
 </head>
-<body>
+<body class="d-flex h-100">
 
 <header>
   <!-- navbar  -->
@@ -255,7 +256,7 @@
   </nav>
 </header>
 
-<div class="container" role="main">
+<div class="flex-grow-1 mb-n5" role="main">
 
   <% if alert %>
       <div class="alert alert-danger alert-dismissible" role="alert">

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -37,7 +37,7 @@
           <span>Save</span>
         </div>
 
-        <p id="editor-filename"><%= @path %></p>
+        <p id="editor-filename" class="m-0 navbar-text flex-grow-1 ml-2"><%= @path %></p>
 
         <ul class="navbar-nav">
           <li class="hidden-xs hidden-sm hidden-md px-2 form-group form-inline m-0">

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -37,7 +37,7 @@
           <span>Save</span>
         </div>
 
-        <p id="editor-filename" class="m-0 navbar-text flex-grow-1 ml-2"><%= @path %></p>
+        <p id="editor-filename" class="m-0 navbar-text flex-grow-1 ml-2 overflow-hidden"><%= @path %></p>
 
         <ul class="navbar-nav">
           <li class="hidden-xs hidden-sm hidden-md px-2 form-group form-inline m-0">

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -37,6 +37,8 @@
           <span>Save</span>
         </div>
 
+        <p id="editor-filename"><%= @path %></p>
+
         <ul class="navbar-nav">
           <li class="hidden-xs hidden-sm hidden-md px-2 form-group form-inline m-0">
             <label class="control-label navbar-text px-1" for="keybindings">Key Bindings</label>

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -38,7 +38,7 @@
         </div>
 
         <ul class="navbar-nav">
-          <li class="hidden-xs hidden-sm hidden-md px-2 form-group form-inline">
+          <li class="hidden-xs hidden-sm hidden-md px-2 form-group form-inline m-0">
             <label class="control-label navbar-text px-1" for="keybindings">Key Bindings</label>
             <select class="form-control input-xs" id="keybindings">
               <option value="default">Default</option>
@@ -46,7 +46,7 @@
               <option value="ace/keyboard/emacs">Emacs</option>
             </select>
           </li>
-          <li class="hidden-xs px-2 form-group form-inline">
+          <li class="hidden-xs px-2 form-group form-inline m-0">
             <label class="control-label hidden-sm hidden-md navbar-text px-1" for="fontsize">Font Size</label>
             <select class="form-control input-xs" id="fontsize">
               <option value="8px">8px</option>
@@ -68,7 +68,7 @@
               <option value="72px">72px</option>
             </select>
           </li>
-          <li class="hidden-xs px-2 form-group form-inline">
+          <li class="hidden-xs px-2 form-group form-inline m-0">
             <label class="control-label hidden-sm hidden-md navbar-text px-1" for="mode">Mode</label>
             <select class="form-control input-xs" id="mode">
               <option value="abap">ABAP</option>
@@ -202,7 +202,7 @@
               <option value="django">Django</option>
             </select>
           </li>
-          <li class="hidden-xs px-2 form-group form-inline px-1">
+          <li class="hidden-xs px-2 form-group form-inline px-1 m-0">
             <label class="control-label hidden-sm hidden-md px-1 navbar-text" for="theme">Theme</label>
             <select class="form-control input-xs" id="theme">
               <optgroup label="Bright">
@@ -245,7 +245,7 @@
               </optgroup>
             </select>
           </li>
-          <li class="hidden-xs px-2 form-group form-inline">
+          <li class="hidden-xs px-2 form-group form-inline m-0">
             <label class="control-label hidden-md hidden-lg navbar-text px-1" for="wordwrap">Wrap</label>
             <div class="form-group">
               <input type="checkbox" id="wordwrap" value="">


### PR DESCRIPTION
Closes #255 and #248.

Changes made:
* Editor was previously positioned using `position: absolute` and was causing issues with nav and footer sizing. Fixed this by making body into a flex container that spaces header, editor, and footer to fill the screen nicely without extending.
* Added `:not(#editor)` to pre tag selector in `application.scss`. Setting the background color of the pre tag was preventing setting the background color of the editor with the theme selector.
* Removed padding on select inputs which were causing cutting parts of text to be cut off and causing text to be off-center.
* Added filename text. The filename no longer breaks the config section when it gets too long. Instead, it expands to new lines.
