### PR TITLE
fix #2133 so that test:jobs does not invoke asset building

### DIFF
--- a/apps/dashboard/lib/tasks/test.rake
+++ b/apps/dashboard/lib/tasks/test.rake
@@ -1,4 +1,5 @@
 namespace :test do
+
   namespace :jobs do
     WORKDIR = Pathname.new(ENV["WORKDIR"] || "~/test_jobs").expand_path
 
@@ -59,6 +60,10 @@ namespace :test do
   desc "Test all clusters"
   task :jobs => "jobs:all"
 end
+
+# this is dangerous to run in production (/var/www/ood/apps/sys/dashboard)
+# because test:prepare downloads & compiles javascript & css assets.
+Rake::Task['test:prepare'].clear if ARGV.include?('test:jobs') && Rake::Task.task_defined?('test:prepare')
 
 
 # unit tests need the assets compiled too.


### PR DESCRIPTION
fix #2133 so that test:jobs does not invoke asset building



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202671565324007) by [Unito](https://www.unito.io)
