### PR TITLE
Make favorite paths support remote filesystems

### DIFF
--- a/apps/dashboard/app/apps/favorite_path.rb
+++ b/apps/dashboard/app/apps/favorite_path.rb
@@ -1,10 +1,15 @@
 class FavoritePath
-  def initialize(path, title:nil)
+  def initialize(path, title:nil, filesystem:nil)
     @title = title || path.try(:title)
     @path = Pathname.new(path.to_s)
+    @filesystem = filesystem || path.try(:filesystem) || "fs"
   end
 
-  attr_accessor :path, :title
+  attr_accessor :path, :title, :filesystem
+
+  def remote?
+    filesystem != "fs"
+  end
 
   def to_s
     path.to_s

--- a/apps/dashboard/app/apps/ood_files_app.rb
+++ b/apps/dashboard/app/apps/ood_files_app.rb
@@ -18,7 +18,7 @@ class OodFilesApp
   # a link to the user's home directory
   # returns an array of other paths provided as shortcuts to the user
   def favorite_paths
-    @favorite_paths ||= candidate_favorite_paths.select {|p| p.path.directory? && p.path.readable? && p.path.executable? }
+    @favorite_paths ||= candidate_favorite_paths.select {|p| p.remote? || p.path.directory? && p.path.readable? && p.path.executable? }
   end
 
 end

--- a/apps/dashboard/app/views/files/_favorites.html.erb
+++ b/apps/dashboard/app/views/files/_favorites.html.erb
@@ -5,7 +5,7 @@
     <ul id="favorites" class="nav nav-pills flex-column">
       <li role="presentation" class="nav-item"><%= link_to 'Home Directory', files_path(Dir.home), class: "nav-link d bg-light" %></li>
       <% OodFilesApp.new.favorite_paths.each do |p| %>
-        <li class="nav-item"><%= link_to p.title || p.path.to_s, files_path(p.path.to_s), class: "nav-link d bg-light" %>
+        <li class="nav-item"><%= link_to p.title || p.path.to_s, files_path(p.filesystem, p.path.to_s), class: "nav-link d bg-light" %>
       <% end %>
     </ul>
   </nav>


### PR DESCRIPTION
This PR makes it possible to create favorite paths for remote filesystems (#1789). It defaults to `fs`, so it is fully backwards compatible.

Currently there is no validation that the remotes exists and their paths are valid, so that needs to be done in the `ood.rb` initializer if wanted.

Example `ood.rb` that adds all remotes from rclone

```
require "ood_files_app"
require "open3"

def remotes
  o, e, s = Open3.capture3("rclone", "listremotes")
  if s.success?
    o.lines.map { |l| l.gsub(/:$/, "").strip }
  else
    raise "Error listing remotes: #{e}"
  end
end

OodFilesApp.candidate_favorite_paths.tap do |paths|
  paths.concat remotes.map { |r| FavoritePath.new("/", title: r, filesystem: r) }
end
```

![image](https://user-images.githubusercontent.com/61623634/179780270-bb56c9d5-cff3-412a-971e-8a6386d7c943.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699190561199) by [Unito](https://www.unito.io)
