### PR TITLE
Also handle doc labels for release branches

### DIFF
--- a/.github/workflows/document-merge.yml
+++ b/.github/workflows/document-merge.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
       - 'feature/**'
-      - 'release/**'
+      - 'release_**'
     types: [closed]
 
 jobs:


### PR DESCRIPTION
The goal (also will be in release_2.0 PR) is to open doc issues and automation when merging into release branches.