### PR TITLE
Enable using enter key for checkboxes in file explorer

### DIFF
--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -34,20 +34,27 @@ jQuery(function () {
         table.goto(options.path)
     });
 
-    $('#show-dotfiles').on('change', () => {
-        let visible = $('#show-dotfiles').is(':checked');
-
-        table.setShowDotFiles(visible);
+    $('#show-dotfiles').on('change', function() {
+        table.setShowDotFiles(this.checked);
         table.updateDotFileVisibility();
     });
-
-    $('#show-owner-mode').on('change', () => {
-        let visible = $('#show-owner-mode').is(':checked');
-
-        table.setShowOwnerMode(visible);
-        table.updateShowOwnerModeVisibility();
+    $('#show-dotfiles').on('keypress', function(event) {
+        if (event.which === 13) {
+          this.checked = !this.checked;
+          this.dispatchEvent(new Event('change'));
+        }
     });
 
+    $('#show-owner-mode').on('change', function() {
+        table.setShowOwnerMode(this.checked);
+        table.updateShowOwnerModeVisibility();
+    });
+    $('#show-owner-mode').on('keypress', function(event) {
+        if (event.which === 13) {
+          this.checked = !this.checked;
+          this.dispatchEvent(new Event('change'));
+        }
+    });
 
     /* END TABLE ACTIONS */
 
@@ -253,7 +260,19 @@ class DataTable {
             $('#open-in-terminal-btn').attr('href', data.shell_url);
             $('#open-in-terminal-btn').removeClass('disabled');
 
-            return await Promise.resolve(data);
+            let result = await Promise.resolve(data);
+            $('td input[type=checkbox]').on('keypress', function(event) {
+                if (event.which === 13) {
+                    this.checked = !this.checked;
+                    this.dispatchEvent(new Event('change'));
+                    if (this.checked) {
+                        table.getTable().row(this.closest('tr')).select();
+                    } else {
+                        table.getTable().row(this.closest('tr')).deselect();
+                    }
+                }
+            })
+            return result;
         } catch (e) {
             const eventData = {
                 'title': `Error occurred when attempting to access ${request_url}`,


### PR DESCRIPTION
Closes #290 
Adds event listeners for show owner mode and show dotfiles checkboxes and each data table row checkbox.
It seems that this should be backported to 2.0 as well.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699239333338) by [Unito](https://www.unito.io)
