### PR TITLE
Fix snakeCaseWords not working as expected

### DIFF
--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -71,7 +71,7 @@ function mountainCaseWords(str) {
 /**
  * Format passed string to snake_case. All characters become lowercase. Existing
  * underscores are unchanged and dashes become underscores. Underscores are added 
- * between locations where a lowercase character is followed by an uppercase character.
+ * before locations where an uppercase character is followed by a lowercase character.
  *
  * @param      {string}  str     The word string to snake case
  *

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -68,6 +68,17 @@ function mountainCaseWords(str) {
   return  `${first}${rest}`;
 }
 
+/**
+ * Format passed string to snake_case. All characters become lowercase. Existing
+ * underscores are unchanged and dashes become underscores. Underscores are added 
+ * between locations where a lowercase character is followed by an uppercase character.
+ *
+ * @param      {string}  str     The word string to snake case
+ *
+ * @example  given 'MountainCase' this returns 'mountain_case'
+ * @example  given 'camelCase' this returns 'camel_case'
+ * @example  given 'OSC_JUPYTER' this returns 'osc_jupyter'
+ */
 function snakeCaseWords(str) {
   if(str === undefined) return undefined;
 

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -72,16 +72,19 @@ function snakeCaseWords(str) {
   if(str === undefined) return undefined;
 
   let snakeCase = "";
-  let first = true;
 
-  str.split('').forEach((c) => {
-    if (first) {
-      first = false;
-      snakeCase += c.toLowerCase();
-    } else if(c === '-' || c === '_') {
+  str.split('').forEach((c, index) => {
+    if(c === '-' || c === '_') {
       snakeCase += '_';
-    } else if(c == c.toUpperCase() && !(c >= '0' && c <= '9')) {
-      snakeCase += `_${c.toLowerCase()}`;
+    } else if (index == 0) {
+      snakeCase += c.toLowerCase();
+    } else if(c == c.toUpperCase() && isNaN(c)) {
+      const nextIsUpper = (index + 1 !== str.length) ? str[index + 1] === str[index + 1].toUpperCase() : true;
+      if (str[index-1] === '_' || nextIsUpper) {
+        snakeCase += c.toLowerCase();
+      } else {
+        snakeCase += `_${c.toLowerCase()}`;
+      }
     } else {
       snakeCase += c;
     }


### PR DESCRIPTION
Fixes #1658

Examples:
"OSC_JUPYTER" -> "osc_jupyter"
"PascalOsc" -> "pascal_osc"
"camelOsc" -> "camel_osc"
"camel_Snake" -> "camel_snake"



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699188025194) by [Unito](https://www.unito.io)
