### PR TITLE
Added support automatic hostname based profiles

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_user_configuration
-    @user_configuration ||= UserConfiguration.new
+    @user_configuration ||= UserConfiguration.new(request_hostname: request.hostname)
   end
 
   def set_nav_groups

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -44,6 +44,7 @@ class ConfigurationSingleton
       :file_navigator               => false,
       :jobs_app_alpha               => false,
       :files_app_remote_files       => false,
+      :host_based_profiles          => false,
     }.freeze
   end
 

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -5,3 +5,4 @@ per_cluster_dataroot: true
 file_navigator: true
 jobs_app_alpha: true
 files_app_remote_files: true
+host_based_profiles: true

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -143,11 +143,34 @@ class UserConfigurationTest < ActiveSupport::TestCase
     assert_equal Pathname.new("/test/valid/path"), target.public_url
   end
 
-  test "profile should delegate to CurrentUser settings" do
-    target = UserConfiguration.new
+  test "profile should delegate to CurrentUser settings when Configuration.host_based_profiles is false" do
+    Configuration.stubs(:host_based_profiles).returns(false)
+    target = UserConfiguration.new(request_hostname: "request_hostname")
     CurrentUser.stubs(:user_settings).returns({profile: "user_settings_profile_value"})
 
     assert_equal :user_settings_profile_value, target.profile
+  end
+
+  test "profile should return nil when when Configuration.host_based_profiles is false and CurrentUser profile is nil" do
+    Configuration.stubs(:host_based_profiles).returns(false)
+    CurrentUser.stubs(:user_settings).returns({})
+    target = UserConfiguration.new
+
+    assert_nil target.profile
+  end
+
+  test "profile should delegate to request_hostname when Configuration.host_based_profiles is true" do
+    Configuration.stubs(:host_based_profiles).returns(true)
+    target = UserConfiguration.new(request_hostname: "request_hostname")
+
+    assert_equal :request_hostname, target.profile
+  end
+
+  test "profile should return nil when when Configuration.host_based_profiles is true and request_hostname is nil" do
+    Configuration.stubs(:host_based_profiles).returns(true)
+    target = UserConfiguration.new
+
+    assert_nil target.profile
   end
 
   test "fetch should use key as symbol" do


### PR DESCRIPTION
Added a ProfileProvider to allow for different ways of selecting the current profile.
Added 2 profile providers: User Settings and Domain

Implements: #2127



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699184946276) by [Unito](https://www.unito.io)
