### PR TITLE
remove html_safe where necessary 

### DIFF
--- a/apps/dashboard/app/views/dashboard/_motd_markdown.html.erb
+++ b/apps/dashboard/app/views/dashboard/_motd_markdown.html.erb
@@ -1,3 +1,3 @@
 <h3><%= @motd.title %></h3>
 <hr />
-<div><%= @motd.content.html_safe %></div>
+<div><%= sanitize(@motd.content) %></div>

--- a/apps/dashboard/app/views/dashboard/_motd_rss.html.erb
+++ b/apps/dashboard/app/views/dashboard/_motd_rss.html.erb
@@ -5,7 +5,7 @@
     <div>
       <%= content_tag(:strong, item.pubDate.strftime("%m-%d-%Y")) if item.pubDate %>
       <h4><a href="<%= item.link %>"><%= item.title %></a></h4>
-      <%= content_tag(:p, item.description.html_safe) if item.description %>
+      <%= content_tag(:p, item.description) if item.description %>
       <hr />
     </div>
   <% end %>

--- a/apps/dashboard/app/views/products/_form_git.html.erb
+++ b/apps/dashboard/app/views/products/_form_git.html.erb
@@ -1,6 +1,6 @@
 <div class="field">
   <%= f.text_field :git_remote, help: "Example: <strong>git@github.com:Example/example.git</strong> (<a href='https://help.github.com/articles/generating-an-ssh-key/' rel='noopener' target='_blank'>requires SSH key installed</a>) or <strong>https://github.com/Example/example.git</strong>".html_safe %>
-  <%= content_tag :pre, product.errors[:git_remote_error].first.html_safe, class: "text-danger" if product.errors[:git_remote_error].any? %>
+  <%= content_tag :pre, product.errors[:git_remote_error].first, class: "text-danger" if product.errors[:git_remote_error].any? %>
 </div>
 <div class="alert alert-<%= ssh_key ? "success" : "danger" %> clearfix alert-ssh-key">
   <% if ssh_key %>

--- a/apps/dashboard/app/views/products/_form_reset_git.html.erb
+++ b/apps/dashboard/app/views/products/_form_reset_git.html.erb
@@ -15,5 +15,5 @@
       </span>
     <%- end -%>
   </div>
-  <%= content_tag :pre, product.errors[:reset_git_error].first.html_safe, class: "text-danger" if product.errors[:reset_git_error].any? %>
+  <%= content_tag :pre, product.errors[:reset_git_error].first, class: "text-danger" if product.errors[:reset_git_error].any? %>
 </div>

--- a/apps/dashboard/app/views/products/_product.html.erb
+++ b/apps/dashboard/app/views/products/_product.html.erb
@@ -15,7 +15,7 @@
     <% unless product.valid?(:list_apps) %>
       <% product.errors.full_messages.each do |msg| %>
         <div class="alert alert-danger">
-          <p><%= msg.html_safe %></p>
+          <p><%= msg %></p>
         </div>
       <% end %>
     <% end %>

--- a/apps/dashboard/app/views/products/show.html.erb
+++ b/apps/dashboard/app/views/products/show.html.erb
@@ -150,7 +150,7 @@
   <p>Please fix the errors below:</p>
   <ul class="rails-bootstrap-forms-error-summary">
     <% @product.errors.full_messages.each do |msg| %>
-    <li><%= msg.html_safe %></li>
+    <li><%= msg %></li>
     <% end %>
   </ul>
 </div>


### PR DESCRIPTION
remove `html_safe` where necessary. `html_safe` actually renders html safely. Sometimes this is what we actually want, however in these cases identified we actually want to encode these characters.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699184424295) by [Unito](https://www.unito.io)
