### PR TITLE
remove https from default CSP

### DIFF
--- a/apps/dashboard/config/initializers/content_security_policy.rb
+++ b/apps/dashboard/config/initializers/content_security_policy.rb
@@ -5,14 +5,14 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
-  policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data
+  policy.default_src :self,
+  policy.font_src    :self, :data
+  policy.img_src     :self, :data
   policy.object_src  :none
-  policy.script_src  :self, :https
-  policy.style_src   :self, :https
+  policy.script_src  :self
+  policy.style_src   :self
   # If you are using webpack-dev-server then specify webpack-dev-server host
-  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+  policy.connect_src :self, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"

--- a/apps/dashboard/config/initializers/content_security_policy.rb
+++ b/apps/dashboard/config/initializers/content_security_policy.rb
@@ -5,7 +5,7 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self,
+  policy.default_src :self
   policy.font_src    :self, :data
   policy.img_src     :self, :data
   policy.object_src  :none


### PR DESCRIPTION
The current CSP has `https:` for all sources. Here's `script-src` just for example:

`script-src 'self' https: 'nonce-RiZwOmto88rJdw/AqpzbSQ==';`

The problem is that `https:` says 'you can load scripts from any resource that is secure (over https)'. Which is not what we want. We actually need to serve everything from `self` - and eventually everything through nonces and remove self too.