### PR TITLE
Support cloud storage file transfers

### DIFF
--- a/apps/dashboard/app/controllers/transfers_controller.rb
+++ b/apps/dashboard/app/controllers/transfers_controller.rb
@@ -17,7 +17,7 @@ class TransfersController < ApplicationController
 
   def create
     body_params = JSON.parse(request.body.read).symbolize_keys
-    @transfer = Transfer.build(action: body_params[:command], files: body_params[:files])
+    @transfer = PosixTransfer.build(action: body_params[:command], files: body_params[:files])
     if ! @transfer.valid?
       # error
       render json: { error_message: @transfer.errors.full_messages.join('. ') }

--- a/apps/dashboard/app/javascript/packs/files/clip_board.js
+++ b/apps/dashboard/app/javascript/packs/files/clip_board.js
@@ -90,6 +90,7 @@ class ClipBoard {
     } else {
       let clipboardData = {
         from: history.state.currentDirectory,
+        from_fs: history.state.currentFilesystem,
         files: selection.toArray().map((f) => {
           return { directory: f.type == 'd', name: f.name };
         })
@@ -116,6 +117,7 @@ class ClipBoard {
       let clipboard = JSON.parse(localStorage.getItem('filesClipboard') || 'null');
       if (clipboard) {
         clipboard.to = history.state.currentDirectory;
+        clipboard.to_fs = history.state.currentFilesystem;
 
         if (clipboard.from == clipboard.to) {
           // No files are changed, so we just have to clear and update the clipboard
@@ -130,7 +132,9 @@ class ClipBoard {
 
           const eventData = {
             'files': files,
-            'token': csrf_token
+            'token': csrf_token,
+            'from_fs': clipboard.from_fs,
+            'to_fs': clipboard.to_fs,
           };
 
           $(CONTENTID).trigger(FILEOPS_EVENTNAME.moveFile, eventData);
@@ -147,9 +151,11 @@ class ClipBoard {
 
       if (clipboard) {
         clipboard.to = history.state.currentDirectory;
-        
+        clipboard.to_fs = history.state.currentFilesystem;
+
         // files is a hashmap with keys of file current path and value as the corresponding files desired path
         let files = {};
+
         if (clipboard.from == clipboard.to) {
           const currentFilenames = history.state.currentFilenames;
           clipboard.files.forEach((f) => {
@@ -187,7 +193,9 @@ class ClipBoard {
 
         const eventData = {
           'files': files,
-          'token': csrf_token
+          'token': csrf_token,
+          'from_fs': clipboard.from_fs,
+          'to_fs': clipboard.to_fs,
         };
 
         $(CONTENTID).trigger(FILEOPS_EVENTNAME.copyFile, eventData);

--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -361,6 +361,7 @@ class DataTable {
                         currentDirectoryUrl: data.url,
                         currentFilesPath: data.files_path,
                         currentFilesUploadPath: data.files_upload_path,
+                        currentFilesystem: data.filesystem,
                         currentFilenames: Array.from(data.files, x => x.name)
                     }, data.name, data.url);
                 }      

--- a/apps/dashboard/app/javascript/packs/files/file_ops.js
+++ b/apps/dashboard/app/javascript/packs/files/file_ops.js
@@ -179,15 +179,15 @@ jQuery(function() {
   });
 
   $(CONTENTID).on(EVENTNAME.deleteFile, function (e, options) {    
-    fileOps.delete(options.files);
+    fileOps.delete(options.files, options.from_fs);
   });
 
   $(CONTENTID).on(EVENTNAME.moveFile, function (e, options) {
-    fileOps.move(options.files, options.token);
+    fileOps.move(options.files, options.token, options.from_fs, options.to_fs);
   });
 
   $(CONTENTID).on(EVENTNAME.copyFile, function (e, options) {
-    fileOps.copy(options.files, options.token);
+    fileOps.copy(options.files, options.token, options.from_fs, options.to_fs);
   });
 
   $(CONTENTID).on(EVENTNAME.changeDirectoryPrompt, function () {
@@ -272,13 +272,13 @@ class FileOps {
 
   
   removeFiles(files) {
-    this.transferFiles(files, "rm", "remove files")
+    this.transferFiles(files, "rm", "remove files", history.state.currentFilesystem)
   } 
 
   renameFile(fileName, newFileName) {
     let files = {};
     files[`${history.state.currentDirectory}/${fileName}`] = `${history.state.currentDirectory}/${newFileName}`;
-    this.transferFiles(files, "mv", "rename file")
+    this.transferFiles(files, "mv", "rename file", history.state.currentFilesystem, history.state.currentFilesystem)
   }
 
   renameFilePrompt(fileName) {
@@ -464,7 +464,7 @@ class FileOps {
     this.removeFiles(files.map(f => [history.state.currentDirectory, f].join('/')), csrf_token);
   }
 
-  transferFiles(files, action, summary){
+  transferFiles(files, action, summary, from_fs, to_fs){
 
     this._failures = 0;
 
@@ -474,7 +474,9 @@ class FileOps {
       method: 'post',
       body: JSON.stringify({
         command: action,
-        files: files
+        files: files,
+        from_fs: from_fs,
+        to_fs: to_fs,
       }),
       headers: { 'X-CSRF-Token': csrf_token }
     })
@@ -566,12 +568,12 @@ class FileOps {
     this.poll(data);
   } 
 
-  move(files, token) {
-    this.transferFiles(files, 'mv', 'move files');
+  move(files, token, from_fs, to_fs) {
+    this.transferFiles(files, 'mv', 'move files', from_fs, to_fs);
   }
 
-  copy(files, token) {
-    this.transferFiles(files, 'cp', 'copy files');
+  copy(files, token, from_fs, to_fs) {
+    this.transferFiles(files, 'cp', 'copy files', from_fs, to_fs);
   }
 
   alertError(title, message) {

--- a/apps/dashboard/app/models/posix_transfer.rb
+++ b/apps/dashboard/app/models/posix_transfer.rb
@@ -1,4 +1,4 @@
-class LocalTransfer < Transfer
+class PosixTransfer < Transfer
 
   validates_each :files do |record, attr, files|
     if record.action == 'mv' || record.action == 'cp'

--- a/apps/dashboard/app/models/posix_transfer.rb
+++ b/apps/dashboard/app/models/posix_transfer.rb
@@ -18,6 +18,18 @@ class PosixTransfer < Transfer
       # all transfers stored in the Transfer class
       Transfer.transfers
     end
+
+    def build(action:, files:)
+      if files.is_a?(Array)
+        # rm action will want to provide an array of files
+        # so if it is an Array we convert it to a hash:
+        #
+        # convert [a1, a2, a3] to {a1 => nil, a2 => nil, a3 => nil}
+        files = Hash[files.map { |f| [f, nil] }].with_indifferent_access
+      end
+
+      self.new(action: action, files: files)
+    end
   end
 
   # number of files to copy, move or delete

--- a/apps/dashboard/app/models/remote_transfer.rb
+++ b/apps/dashboard/app/models/remote_transfer.rb
@@ -1,0 +1,157 @@
+class RemoteTransfer < Transfer
+
+  validates_each :src_remote, :dest_remote do |record, _, remote|
+    remote_type = RcloneUtil.remote_type(remote)
+    if remote_type.nil? && remote != RcloneUtil::LOCAL_FS_NAME
+      record.errors.add :base, "Remote #{remote} does not exist"
+    elsif ::Configuration.allowlist_paths.present? && (remote_type == 'local' || remote_type == 'alias')
+      record.errors.add :base, "Remotes of type #{remote_type} are not allowed due to ALLOWLIST_PATH"
+    end
+  end
+
+  validates_each :files do |record, _, files|
+    files.each do |k, v|
+      # Validate paths in the same was as PosixTransfer for the local filesystem (fs)
+      if record.src_remote == RcloneUtil::LOCAL_FS_NAME
+        record.errors.add :base, "#{k} is not included under ALLOWLIST_PATH" unless AllowlistPolicy.default.permitted?(k.to_s)
+      end
+      if record.dest_remote == RcloneUtil::LOCAL_FS_NAME
+        # rm commands are [{ k => nil}] - nil values
+        record.errors.add :base, "#{v} is not included under ALLOWLIST_PATH" if !v.nil? && !AllowlistPolicy.default.permitted?(v.to_s)
+      end
+    end
+
+    if record.action == 'mv' || record.action == 'cp'
+      # local filesystem
+      if record.dest_remote == RcloneUtil::LOCAL_FS_NAME
+        conflicts = files.values.select { |f| File.exist?(f) }
+        record.errors.add :base, "These files already exist: #{conflicts.join(', ')}" if conflicts.present?
+      else
+        # remote
+        begin
+          existing = RcloneUtil.lsf(record.dest_remote, record.to).map { |file| File.join(record.to, file) }
+          conflicts = files.values.intersection(existing)
+          record.errors.add :base, "These files already exist: #{conflicts.join(', ')}" if conflicts.present?
+        rescue RcloneError => e
+          if e.exitstatus != 3
+            # Rclone will return status 3 if directory doesn't exist (ok), other errors are unexpected
+            record.errors.add :base, "Error checking existing files in destination: #{e}"
+          end
+        end
+      end
+    end
+  end
+
+  attr_accessor :src_remote, :dest_remote, :filesizes, :transferred
+
+  class << self
+    def transfers
+      # all transfers stored in the Transfer class
+      Transfer.transfers
+    end
+
+    def build(action:, files:, src_remote:, dest_remote:)
+      if files.is_a?(Array)
+        # rm action will want to provide an array of files
+        # so if it is an Array we convert it to a hash:
+        #
+        # convert [a1, a2, a3] to {a1 => nil, a2 => nil, a3 => nil}
+        files = Hash[files.map { |f| [f, nil] }].with_indifferent_access
+      end
+
+      self.new(action: action, files: files, src_remote: src_remote, dest_remote: dest_remote)
+    end
+  end
+
+  # total number of bytes
+  def steps
+    return @steps if @steps
+
+    @filesizes = {}.with_indifferent_access
+
+    # Get info from `rclone size` (will not work on Google Drive and Google Photos)
+    total_size = files.keys.map do |file|
+      size = RcloneUtil.size(src_remote, file).fetch('bytes', 0)
+      @filesizes[file] = { :size => size, :transferred => 0 }
+      size
+    end.sum
+
+    @steps = total_size
+  end
+
+  def command_str
+    ''
+  end
+
+  def increment_transferred(amount)
+    @transferred = transferred.to_i + amount
+  end
+
+  # Updates the total progress with progress of one file since last update
+  def update_progress(file, percent_done)
+    file_info = filesizes[file]
+
+    current_bytes = (percent_done * file_info[:size]) / 100
+    since_last = current_bytes - file_info[:transferred]
+    filesizes[file][:transferred] = current_bytes
+
+    increment_transferred(since_last)
+    update_percent(transferred)
+  end
+
+  def perform
+    self.status = OodCore::Job::Status.new(state: :running)
+    self.started_at = Time.now.to_i
+
+    # Store info about sizes of files to transfer for tracking progress
+    steps
+
+    # Transfer each file/directory indiviually
+    files.each do |src, dst|
+      if action == 'mv'
+        RcloneUtil.moveto_with_progress(src_remote, dest_remote, src, dst) do |p|
+          update_progress(src, p)
+        end
+      elsif action == 'cp'
+        RcloneUtil.copyto_with_progress(src_remote, dest_remote, src, dst) do |p|
+          update_progress(src, p)
+        end
+      elsif action == 'rm'
+        RcloneUtil.remove_with_progress(src_remote, src) do |p|
+          update_progress(src, p)
+        end
+      else
+        raise StandardError, "Unknown action: #{action.inspect}"
+      end
+    rescue RcloneError => e
+      # TODO: catch more rclone specific errors here, i.e. if the access keys are invalid it would make
+      # sense to not attempt to transfer the rest of the files
+      errors.add :base, "Error when transferring #{src}: #{e.message}"
+    end
+  rescue => e
+    errors.add :base, e.message
+  ensure
+    self.status = OodCore::Job::Status.new(state: :completed)
+  end
+
+  def from
+    File.dirname(files.keys.first) if files.keys.first
+  end
+
+  def to
+    File.dirname(files.values.first) if files.values.first
+  end
+
+  def target_dir
+    # directory where files are being moved/copied to OR removed from
+    if action == 'rm'
+      Pathname.new(from).cleanpath if from
+    else
+      Pathname.new(to).cleanpath if to
+    end
+  end
+
+  def synchronous?
+    false
+  end
+end

--- a/apps/dashboard/app/models/transfer.rb
+++ b/apps/dashboard/app/models/transfer.rb
@@ -26,18 +26,6 @@ class Transfer
     def find(id)
       transfers.find {|t| t.id == id }
     end
-
-    def build(action:, files:)
-      if files.is_a?(Array)
-        # rm action will want to provide an array of files
-        # so if it is an Array we convert it to a hash:
-        #
-        # convert [a1, a2, a3] to {a1 => nil, a2 => nil, a3 => nil}
-        files = Hash[files.map { |f| [f, nil] }]
-      end
-
-      PosixTransfer.new(action: action, files: files)
-    end
   end
 
   def bootstrap_class

--- a/apps/dashboard/app/models/transfer.rb
+++ b/apps/dashboard/app/models/transfer.rb
@@ -36,7 +36,7 @@ class Transfer
         files = Hash[files.map { |f| [f, nil] }]
       end
 
-      LocalTransfer.new(action: action, files: files)
+      PosixTransfer.new(action: action, files: files)
     end
   end
 

--- a/apps/dashboard/app/views/files/_inline_js.html.erb
+++ b/apps/dashboard/app/views/files/_inline_js.html.erb
@@ -10,6 +10,7 @@ history.replaceState({
   currentDirectoryUpdatedAt: '<%= Time.now.to_i %>',
   currentFilesPath: '<%= files_path(@filesystem, '/') %>',
   currentFilesUploadPath: '<%= url_for(fs: @filesystem, action: 'upload') %>',
+  currentFilesystem: '<%= @filesystem %>'
 }, null);
 
 </script>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -4,6 +4,7 @@ json.url files_path(@filesystem, @path).to_s
 json.shell_url OodAppkit.shell.url(path: @path.to_s).to_s
 json.files_path files_path(@filesystem, '/')
 json.files_upload_path url_for(fs: @filesystem, action: 'upload')
+json.filesystem @filesystem
 
 json.files @files do |f|
   json.id f[:id]

--- a/apps/dashboard/test/jobs/transfer_local_job_test.rb
+++ b/apps/dashboard/test/jobs/transfer_local_job_test.rb
@@ -16,7 +16,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
       # or we do "to" but "with_prefix" added if from and to are the same
       # directory
       # end
-      transfer = Transfer.build(action: 'cp', files: {testfile => destfile})
+      transfer = PosixTransfer.build(action: 'cp', files: {testfile => destfile})
       transfer.perform
 
       assert_equal 0, transfer.exit_status, "job exited with error #{transfer.stderr}"
@@ -38,7 +38,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
   #     testfile = File.join(dir, 'foo')
   #     destfile = File.join(dir, 'dest')
   #
-  #     transfer = Transfer.new(action: 'cp', files: {testfile => destfile})
+  #     transfer = PosixTransfer.build(action: 'cp', files: {testfile => destfile})
   #     transfer.perform
   #
   #     assert transfer.stderr.empty?, "copy should have resulted in no errors but had stderr: #{transfer.stderr}"
@@ -58,7 +58,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
         testfile = File.join(dir, 'foo')
         destfile = File.join(dir, 'dest/foo')
 
-        transfer = Transfer.build(action: 'cp', files: {testfile => destfile})
+        transfer = PosixTransfer.build(action: 'cp', files: {testfile => destfile})
         transfer.perform
 
         assert transfer.stderr.present?, 'copy should have preserved stderr of job'
@@ -93,7 +93,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
       File.write(testfile, 'this is a test file')
       FileUtils.mkpath File.dirname(destfile)
 
-      transfer = Transfer.build(action: 'cp', files: {testfile => destfile})
+      transfer = PosixTransfer.build(action: 'cp', files: {testfile => destfile})
       transfer.save
       job = TransferLocalJob.perform_later(transfer)
       assert job.job_id != nil
@@ -119,7 +119,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
       # this tests the number of calls to update_progress
       # note: progress.percent is not called because this mocks the method
       num_files = PosixFile.num_files(dir, ['app'])
-      transfer = Transfer.build(action: 'cp', files: {testdir => File.join(destdir, 'app')})
+      transfer = PosixTransfer.build(action: 'cp', files: {testdir => File.join(destdir, 'app')})
       transfer.expects(:percent=).times(num_files)
 
       transfer.perform

--- a/apps/dashboard/test/models/transfer_test.rb
+++ b/apps/dashboard/test/models/transfer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TransferTest < ActiveSupport::TestCase
   test 'copy command' do
-    transfer = Transfer.build action: 'cp', files: {
+    transfer = PosixTransfer.build action: 'cp', files: {
       '/Users/efranz/dev/ondemand/apps/dashboard/app' => '/var/folders/w7/fn8w83s10510pkc5j2wq8cpnhxtn3j/T/d20210201-68201-u3azoj/app',
       '/Users/efranz/dev/ondemand/apps/dashboard/config' => '/var/folders/w7/fn8w83s10510pkc5j2wq8cpnhxtn3j/T/d20210201-68201-u3azoj/config',
       '/Users/efranz/dev/ondemand/apps/dashboard/manifest.yml' => '/var/folders/w7/fn8w83s10510pkc5j2wq8cpnhxtn3j/T/d20210201-68201-u3azoj/manifest.yml'
@@ -30,19 +30,19 @@ class TransferTest < ActiveSupport::TestCase
   end
 
   test '1 step for file copy' do
-    assert_equal 1, Transfer.build(action: 'cp', files: { 'config.ru' => '/tmp/config.ru' }).steps
+    assert_equal 1, PosixTransfer.build(action: 'cp', files: { 'config.ru' => '/tmp/config.ru' }).steps
   end
 
   test '1 step for file removal' do
-    assert_equal 1, Transfer.build(action: 'rm', files: ['config.ru']).steps
+    assert_equal 1, PosixTransfer.build(action: 'rm', files: ['config.ru']).steps
   end
 
   test '1 step for file mv' do
-    assert_equal 1, Transfer.build(action: 'mv', files: { 'config.ru' => 'config.ru.2' }).steps
+    assert_equal 1, PosixTransfer.build(action: 'mv', files: { 'config.ru' => 'config.ru.2' }).steps
   end
 
   test 'steps for cp bin' do
-    assert_equal Dir['bin/*'].count + 1, Transfer.build(action: 'cp', files: { 'bin' => 'bin.2' }).steps
+    assert_equal Dir['bin/*'].count + 1, PosixTransfer.build(action: 'cp', files: { 'bin' => 'bin.2' }).steps
   end
 
   # This tests https://github.com/OSC/ondemand/issues/1337 and fails if it's not patched
@@ -54,7 +54,7 @@ class TransferTest < ActiveSupport::TestCase
       FileUtils.touch f
       assert_equal true, File.exist?(f)
 
-      t = Transfer.build(action: 'rm', files: [f])
+      t = PosixTransfer.build(action: 'rm', files: [f])
       assert_equal true, t.valid?, t.errors.full_messages.join('. ')
       assert_equal 1, t.steps
 


### PR DESCRIPTION
This PR adds support for moving, copying, deleting and renaming files and directories on cloud storages using Rclone, fixes #2129.

This adds `from_fs` and `to_fs` optional parameters to the transfers API, which are used to define from and to which Rclone remote files are transferred. The default is `fs`, which is treated as the local (posix) filesystem so that it is fully backwards compatible. The feature is enabled by setting `OOD_FILES_APP_REMOTE_FILES` to true.

Overwriting files is avoided so that it behaves in the same way as normal transfers on the local filesystem. That also simplifies the Rclone commands that are needed significantly. Allowlist paths are also checked for the local filesystem, and remotes of type local and alias are disabled when the allowlist is enabled (same behaviour as in #2119).

Short demo (includes #2140 for easier demonstration):
![remote!UNITO-UNDERSCORE!files!UNITO-UNDERSCORE!transfer](https://user-images.githubusercontent.com/61623634/182144717-8077ed9a-6e92-4a65-b6df-4ac12bb32f98.gif)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699181347389) by [Unito](https://www.unito.io)
