### PR TITLE
Enable passenger_preload_bundler for PUN

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -32,6 +32,7 @@ http {
 
   <%- if disable_bundle_user_config? -%>
   passenger_env_var BUNDLE_USER_CONFIG /dev/null;
+  passenger_preload_bundler on;
 
   <%- end -%>
 


### PR DESCRIPTION
Fixes #2167

Can be disabled with 

```yaml
disable_bundle_user_config: false
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202699283182846) by [Unito](https://www.unito.io)
