### PR TITLE
prep 2.0.28 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Support for Ubuntu 20.04 packages was added in [2141](https://github.com/OSC/ondemand/pull/2141).
+- Support for Ubuntu 18.04 packages was added in [2160](https://github.com/OSC/ondemand/pull/2160).
 - Support for `fujitsu_tcs` scheduler also through the `ood_core` update.
 - Dex can now be proxied behind Apache in [2183](https://github.com/OSC/ondemand/pull/2183).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Support for Ubuntu 20.04 packages was added in [2141](https://github.com/OSC/ondemand/pull/2141).
 - Support for `fujitsu_tcs` scheduler also through the `ood_core` update.
-- Dex can now proxied to from apache in [2183](https://github.com/OSC/ondemand/pull/2183).
+- Dex can now be proxied behind Apache in [2183](https://github.com/OSC/ondemand/pull/2183).
 
 ## [2.0.27] - 06-23-2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.28] - 08-01-2022
+
 ### Fixed
 
 - `passenger_options` are now safe to use in [2016](https://github.com/OSC/ondemand/pull/2016).
 - Interactive jobs now have compatability with turbovnc 3.0+ in [2153](https://github.com/OSC/ondemand/pull/2153).
   Through the `ood_core` update.
+- PUNs now start with only the environment variables required in [2156](https://github.com/OSC/ondemand/pull/2156).
 
 ### Added
 
 - Support for Ubuntu 20.04 packages was added in [2141](https://github.com/OSC/ondemand/pull/2141).
+- Support for `fujitsu_tcs` scheduler also through the `ood_core` update.
+- Dex can now proxied to from apache in [2183](https://github.com/OSC/ondemand/pull/2183).
 
 ## [2.0.27] - 06-23-2022
 
@@ -1016,7 +1021,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - From 1.3.7 - 1.4.2 updated app versions
 
 
-[Unreleased]: https://github.com/OSC/ondemand/compare/v2.0.27...release_2.0
+[Unreleased]: https://github.com/OSC/ondemand/compare/v2.0.28...release_2.0
+[2.0.28]: https://github.com/OSC/ondemand/compare/v2.0.27...v2.0.28
 [2.0.27]: https://github.com/OSC/ondemand/compare/v2.0.26...v2.0.27
 [2.0.26]: https://github.com/OSC/ondemand/compare/v2.0.25...v2.0.26
 [2.0.25]: https://github.com/OSC/ondemand/compare/v2.0.24...v2.0.25

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       ood_core (~> 0.1)
       rails (> 4.0.7, < 6.0)
       redcarpet (~> 3.2)
-    ood_core (0.20.2)
+    ood_core (0.21.0)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       ood_core (~> 0.1)
       rails (> 4.0.7, < 6.0)
       redcarpet (~> 3.2)
-    ood_core (0.20.2)
+    ood_core (0.21.0)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)


### PR DESCRIPTION
prep 2.0.28 release. Updates `ood_core` to pick up the Fujitsu adapter and update the changelog. This will be the last change for `2.0.28`.