### PR TITLE
Fix for Fujitsu TCS resource manager

### DIFF
--- a/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
+++ b/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
@@ -49,6 +49,8 @@ module ActiveJobs
           extended_data_pbspro(info)
         elsif cluster.job_config[:adapter] == "sge"
           extended_data_sge(info)
+        elsif cluster.job_config[:adapter] == "fujitsu_tcs"
+          extended_data_fujitsu_tcs(info)
         else
           extended_data_default(info)
         end
@@ -262,6 +264,25 @@ module ActiveJobs
         self.file_explorer_url = build_file_explorer_url(output_pathname)
         self.shell_url = build_shell_url(output_pathname, self.cluster)
       end
+
+      self
+    end
+
+    # Store additional data about the job. (Fujitsu TCS specific)
+    #
+    # @return [Jobstatusdata] self
+    def extended_data_fujitsu_tcs(info)
+      return unless info.native
+      attributes = []
+      attributes.push Attribute.new "Nodes", info.native[:NODES]
+      attributes.push Attribute.new "Time Limit", pretty_time(info.wallclock_limit)
+      attributes.push Attribute.new "Submittion Time", info.native[:ACCEPT]
+      attributes.push Attribute.new "Start Time", info.native[:START_DATE]
+      self.native_attribs = attributes
+
+      output_pathname = Pathname.new(info.native[:STD]).dirname
+      self.file_explorer_url = build_file_explorer_url(output_pathname)
+      self.shell_url = build_shell_url(output_pathname, self.cluster)
 
       self
     end

--- a/apps/dashboard/lib/smart_attributes/attributes/bc_num_slots.rb
+++ b/apps/dashboard/lib/smart_attributes/attributes/bc_num_slots.rb
@@ -63,6 +63,8 @@ module SmartAttributes
           native = ["-l", "select=1:ncpus=#{slots}"]
         when "lsf"
           native = ["-n", slots]
+        when "fujitsu_tcs"
+          native = ["-L", "node=#{slots}"]
         else
           native = nil
         end


### PR DESCRIPTION
Fujitsu TCS resource manager as a new adapter has been added (https://github.com/OSC/ood_core/pull/766).
Along with that, I would like to display the details of the job information in Active Jobs.
I would also like to support a Fujitsu TCS for bc_num_slots.

Thanks,