### PR TITLE
Fix file uploads and directory changes

### DIFF
--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -359,6 +359,8 @@ class DataTable {
                     history.pushState({
                         currentDirectory: data.path,
                         currentDirectoryUrl: data.url,
+                        currentFilesPath: data.files_path,
+                        currentFilesUploadPath: data.files_upload_path,
                         currentFilenames: Array.from(data.files, x => x.name)
                     }, data.name, data.url);
                 }      

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -146,4 +146,51 @@ class FilesTest < ApplicationSystemTestCase
       refute File.exist?(src)
     end
   end
+
+  test "uploading files" do
+    Dir.mktmpdir do |dir|
+
+      FileUtils.mkpath File.join(dir, 'foo')
+
+      visit files_url(dir)
+      find('#upload-btn').click
+
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+
+      src_file = 'test/fixtures/files/upload/osc-logo.png'
+      attach_file 'files[]', src_file, visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert File.exist?(File.join(dir, File.basename(src_file)))
+
+      find('tbody a', exact_text: 'foo').click
+      # Need to wait until we're in the new directory before clicking upload
+      assert_no_selector 'tbody a', exact_text: 'foo', wait: MAX_WAIT
+
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+
+      src_file = 'test/fixtures/files/upload/hello-world.c'
+      attach_file 'files[]', src_file, visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      find('tbody a', exact_text: 'hello-world.c', wait: MAX_WAIT)
+    end
+  end
+
+  test "changing directory" do
+    visit files_url(Rails.root.to_s)
+    find('tbody a', exact_text: 'app')
+    find('tbody a', exact_text: 'config')
+
+    find('#goto-btn').click
+    find('#swal2-input').set(Rails.root.join("app"))
+    find('.swal2-confirm').click
+    find('tbody a', exact_text: 'helpers')
+    find('tbody a', exact_text: 'controllers')
+
+    find('#goto-btn').click
+    find('#swal2-input').set(Rails.root.to_s)
+    find('.swal2-confirm').click
+    find('tbody a', exact_text: 'app')
+    find('tbody a', exact_text: 'config')
+  end
 end


### PR DESCRIPTION
#2094 seems to have a removed two lines of code, causing file uploads and changing directory to only work after a fresh page load, not after navigating into a different directory. This PR fixes that bug and also adds system tests for this for both local filesystem and cloud storage.

To reproduce:


* Open file browser
* Click on a directory
* Upload file as usual

![image](https://user-images.githubusercontent.com/61623634/182328184-669f72d1-6cd6-4551-9704-461cb320e116.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202710899810484) by [Unito](https://www.unito.io)
