### PR TITLE
Enable downloading empty sub-directories with zip

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -50,14 +50,14 @@ class FilesController < ApplicationController
             zip_tricks_stream do |zip|
               @path.files_to_zip.each do |file|
                 begin
-                  if File.readable?(file.path)
-                    if File.file?(file.path)
-                      zip.write_deflated_file(file.relative_path.to_s) do |zip_file|
-                        IO.copy_stream(file.path, zip_file)
-                      end
-                    else
-                      zip.add_empty_directory(dirname: file.relative_path.to_s)
+                  next unless File.readable?(file.path)
+
+                  if File.file?(file.path)
+                    zip.write_deflated_file(file.relative_path.to_s) do |zip_file|
+                      IO.copy_stream(file.path, zip_file)
                     end
+                  else
+                    zip.add_empty_directory(dirname: file.relative_path.to_s)
                   end
                 rescue => e
                   logger.warn("error writing file #{file.path} to zip: #{e.message}")

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -50,9 +50,13 @@ class FilesController < ApplicationController
             zip_tricks_stream do |zip|
               @path.files_to_zip.each do |file|
                 begin
-                  if File.file?(file.path) && File.readable?(file.path)
-                    zip.write_deflated_file(file.relative_path.to_s) do |zip_file|
-                      IO.copy_stream(file.path, zip_file)
+                  if File.readable?(file.path)
+                    if File.file?(file.path)
+                      zip.write_deflated_file(file.relative_path.to_s) do |zip_file|
+                        IO.copy_stream(file.path, zip_file)
+                      end
+                    else
+                      zip.add_empty_directory(dirname: file.relative_path.to_s)
                     end
                   end
                 rescue => e


### PR DESCRIPTION
fixes #2121 and solves INC0365594

When downloading a directory previously, the resulting zip would not include sub-directories without files in them. Now, those empty sub-directories are included in the zip download.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202710870115158) by [Unito](https://www.unito.io)
