### PR TITLE
Support defining serveralias in Apache virtual host

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -22,7 +22,7 @@ module OodPortalGenerator
       @protocol         = @ssl ? "https://" : "http://"
       @listen_addr_port = opts.fetch(:listen_addr_port, nil)
       @servername       = opts.fetch(:servername, nil)
-      @serveraliases    = opts.fetch(:serveraliases, nil)
+      @server_aliases   = opts.fetch(:server_aliases, nil)
       @proxy_server     = opts.fetch(:proxy_server, servername)
       @port             = opts.fetch(:port, @ssl ? "443" : "80")
       if OodPortalGenerator.debian?

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -22,6 +22,7 @@ module OodPortalGenerator
       @protocol         = @ssl ? "https://" : "http://"
       @listen_addr_port = opts.fetch(:listen_addr_port, nil)
       @servername       = opts.fetch(:servername, nil)
+      @serveraliases    = opts.fetch(:serveraliases, nil)
       @proxy_server     = opts.fetch(:proxy_server, servername)
       @port             = opts.fetch(:port, @ssl ? "443" : "80")
       if OodPortalGenerator.debian?

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -22,7 +22,7 @@ module OodPortalGenerator
       @protocol         = @ssl ? "https://" : "http://"
       @listen_addr_port = opts.fetch(:listen_addr_port, nil)
       @servername       = opts.fetch(:servername, nil)
-      @server_aliases   = opts.fetch(:server_aliases, nil)
+      @server_aliases   = opts.fetch(:server_aliases, [])
       @proxy_server     = opts.fetch(:proxy_server, servername)
       @port             = opts.fetch(:port, @ssl ? "443" : "80")
       if OodPortalGenerator.debian?

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -15,6 +15,12 @@
 # Default: null (don't use name-based Virtual Host)
 #servername: null
 
+# The server aliases used for the name-based Virtual Host
+# Example:
+#     serveraliases:
+#       - foo.example.com
+#serveraliases: null
+
 # The server name used for rewrites
 # Example:
 #     proxy_server: 'proxy.example.com'

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -19,7 +19,7 @@
 # Example:
 #     server_aliases:
 #       - foo.example.com
-#server_aliases: null
+#server_aliases: []
 
 # The server name used for rewrites
 # Example:

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -17,9 +17,9 @@
 
 # The server aliases used for the name-based Virtual Host
 # Example:
-#     serveraliases:
+#     server_aliases:
 #       - foo.example.com
-#serveraliases: null
+#server_aliases: null
 
 # The server name used for rewrites
 # Example:

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -50,14 +50,18 @@ Listen 8080
 #     #=> https://test.proxy.name:8080
 #
 <VirtualHost *:80>
+  ServerName test.server.name
+  ServerAlias foo.example.com
+
   RewriteEngine On
-  RewriteRule ^(.*) https://test.proxy.name:8080$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:8080$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost
 #
 <VirtualHost *:8080>
   ServerName test.server.name
+  ServerAlias foo.example.com
 
   ErrorLog  "/path/to/my/logs/test.server.name_error_ssl.log"
   CustomLog "/path/to/my/logs/test.server.name_access_ssl.log" combined

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -44,8 +44,10 @@
 #     #=> https://example.com:443
 #
 <VirtualHost *:80>
+  ServerName example.com
+
   RewriteEngine On
-  RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -44,8 +44,10 @@
 #     #=> https://example.com:443
 #
 <VirtualHost *:80>
+  ServerName example.com
+
   RewriteEngine On
-  RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
@@ -44,8 +44,10 @@
 #     #=> https://example.com:443
 #
 <VirtualHost *:80>
+  ServerName example.com
+
   RewriteEngine On
-  RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -44,8 +44,10 @@
 #     #=> https://ondemand.example.com:443
 #
 <VirtualHost *:80>
+  ServerName ondemand.example.com
+
   RewriteEngine On
-  RewriteRule ^(.*) https://ondemand.example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -44,8 +44,10 @@
 #     #=> https://example-proxy.com:443
 #
 <VirtualHost *:80>
+  ServerName example.com
+
   RewriteEngine On
-  RewriteRule ^(.*) https://example-proxy.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
+++ b/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
@@ -17,9 +17,9 @@ servername: test.server.name
 
 # The server aliases used for the name-based Virtual Host
 # Example:
-#     serveraliases:
+#     server_aliases:
 #       - foo.example.com
-serveraliases:
+server_aliases:
   - foo.example.com
 
 # The server name used for rewrites

--- a/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
+++ b/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
@@ -15,6 +15,13 @@ listen_addr_port: 8080
 # Default: null (don't use name-based Virtual Host)
 servername: test.server.name
 
+# The server aliases used for the name-based Virtual Host
+# Example:
+#     serveraliases:
+#       - foo.example.com
+serveraliases:
+  - foo.example.com
+
 # The server name used for rewrites
 # Example:
 #     proxy_server: 'proxy.example.com'

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -58,8 +58,8 @@ Listen <%= addr_port %>
   <%- if @servername -%>
   ServerName <%= @servername %>
   <%- end -%>
-  <%- if @serveraliases -%>
-    <%- @serveraliases.each do |serveralias| -%>
+  <%- if @server_aliases -%>
+    <%- @server_aliases.each do |serveralias| -%>
   ServerAlias <%= serveralias %>
     <%- end -%>
   <%- end -%>
@@ -75,8 +75,8 @@ Listen <%= addr_port %>
   <%- if @servername -%>
   ServerName <%= @servername %>
   <%- end -%>
-  <%- if @serveraliases -%>
-    <%- @serveraliases.each do |serveralias| -%>
+  <%- if @server_aliases -%>
+    <%- @server_aliases.each do |serveralias| -%>
   ServerAlias <%= serveralias %>
     <%- end -%>
   <%- end -%>

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -58,10 +58,8 @@ Listen <%= addr_port %>
   <%- if @servername -%>
   ServerName <%= @servername %>
   <%- end -%>
-  <%- if @server_aliases -%>
-    <%- @server_aliases.each do |serveralias| -%>
+  <%- @server_aliases.each do |serveralias| -%>
   ServerAlias <%= serveralias %>
-    <%- end -%>
   <%- end -%>
 
   RewriteEngine On
@@ -75,10 +73,8 @@ Listen <%= addr_port %>
   <%- if @servername -%>
   ServerName <%= @servername %>
   <%- end -%>
-  <%- if @server_aliases -%>
-    <%- @server_aliases.each do |serveralias| -%>
+  <%- @server_aliases.each do |serveralias| -%>
   ServerAlias <%= serveralias %>
-    <%- end -%>
   <%- end -%>
 
   ErrorLog  "<%= @errorlog %>"

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -55,8 +55,17 @@ Listen <%= addr_port %>
 #     #=> <%= @ssl ? "https" : "http" %>://<%= @proxy_server || "localhost" %>:<%= @port %>
 #
 <VirtualHost *:80>
+  <%- if @servername -%>
+  ServerName <%= @servername %>
+  <%- end -%>
+  <%- if @serveraliases -%>
+    <%- @serveraliases.each do |serveralias| -%>
+  ServerAlias <%= serveralias %>
+    <%- end -%>
+  <%- end -%>
+
   RewriteEngine On
-  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @proxy_server || "%{SERVER_NAME}" %>:<%= @port %>$1 [R=301,NE,L]
+  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://%{HTTP_HOST}:<%= @port %>$1 [R=301,NE,L]
 </VirtualHost>
 <% end -%>
 
@@ -65,6 +74,11 @@ Listen <%= addr_port %>
 <VirtualHost *:<%= @port %>>
   <%- if @servername -%>
   ServerName <%= @servername %>
+  <%- end -%>
+  <%- if @serveraliases -%>
+    <%- @serveraliases.each do |serveralias| -%>
+  ServerAlias <%= serveralias %>
+    <%- end -%>
   <%- end -%>
 
   ErrorLog  "<%= @errorlog %>"


### PR DESCRIPTION
Fixes #1568

For HTTP to HTTPS only use `%{HTTP_HOST}` to ensure that any aliases are kept during redirect.

Also ensure port 80 virtual host is using ServerName to avoid possibly overriding other port 80 configs.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202725200138505) by [Unito](https://www.unito.io)
