### PR TITLE
Do not display Open In Terminal button if SSH to compute is turned off

### DIFF
--- a/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
@@ -39,7 +39,9 @@
     <div class="card-body">
       <% if ENV["USER"] == data.username %>
           <%= link_to "#{icon("fas", "folder-open")} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-outline-black", :target => "_blank", :style => "margin: 10px;" if data.file_explorer_url %>
+        <% if Configuration.ood_bc_ssh_to_compute_node %>
           <%= link_to "#{icon("fas", "terminal")} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-outline-black", :target => "_blank", :style => "margin: 10px;" if data.shell_url %>
+        <% end %>
           <%= link_to "#{icon("fas", "trash-o")} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-outline-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" } %>
       <% end %>
     </div>


### PR DESCRIPTION
Based on issues raised in https://discourse.openondemand.org/t/disable-terminal/2212