### PR TITLE
Fix files upload system tests randomly failing

### DIFF
--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -160,6 +160,7 @@ class FilesTest < ApplicationSystemTestCase
       src_file = 'test/fixtures/files/upload/osc-logo.png'
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
       assert File.exist?(File.join(dir, File.basename(src_file)))
 
       find('tbody a', exact_text: 'foo').click


### PR DESCRIPTION
This PR fixes the systems tests for file uploading added in #2195 failing sometimes due to the test checking too quickly if the file exists.
This waits until the file is visible in the file browser before checking if it exists.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202734899114873) by [Unito](https://www.unito.io)
