### PR TITLE
Moved navigation settings to profile based configuration (#2251)

### DIFF
--- a/apps/dashboard/app/apps/nav_config.rb
+++ b/apps/dashboard/app/apps/nav_config.rb
@@ -1,3 +1,6 @@
+#
+# Deprecated.
+# This is now configurable through configuration. See UserConfiguration class
 class NavConfig
     class << self
       attr_accessor :categories, :categories_whitelist

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -90,10 +90,10 @@ class ApplicationController < ActionController::Base
   private
 
   def filter_groups(groups)
-    if NavConfig.categories_whitelist?
-      OodAppGroup.select(titles: NavConfig.categories, groups: groups)
+    if @user_configuration.filter_nav_categories?
+      OodAppGroup.select(titles: @user_configuration.categories, groups: groups)
     else
-      OodAppGroup.order(titles: NavConfig.categories, groups: groups)
+      OodAppGroup.order(titles: @user_configuration.categories, groups: groups)
     end
   end
 end

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
           <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
           <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
           <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
-          <%= render partial: 'layouts/nav/all_apps' if Configuration.show_all_apps_link? %>
+          <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
         </ul>
 
         <ul class="navbar-nav">

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -234,10 +234,6 @@ class ConfigurationSingleton
     to_bool(ENV["OOD_BATCH_CONNECT_CACHE_ATTR_VALUES"] || true )
   end
 
-  def show_all_apps_link?
-    to_bool(ENV['SHOW_ALL_APPS_LINK'])
-  end
-
   def developer_docs_url
     ENV['OOD_DASHBOARD_DEV_DOCS_URL'] || "https://go.osu.edu/ood-app-dev"
   end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -226,15 +226,6 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     assert_equal "https://www.example.com", ConfigurationSingleton.new.developer_docs_url
   end
 
-  test "should hide the all apps link by default" do
-    refute ConfigurationSingleton.new.show_all_apps_link?
-  end
-
-  test "can enable the all apps link" do
-    ENV["SHOW_ALL_APPS_LINK"] = "true"
-    assert ConfigurationSingleton.new.show_all_apps_link?
-  end
-
   test "should have default dataroot under app if not production" do
     assert_equal Rails.root.join("data"), ConfigurationSingleton.new.dataroot
   end

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -67,10 +67,9 @@ class ActiveSupport::TestCase
   end
 
   def stub_user_configuration(user_configuration_overrides)
+    ::Configuration.stubs(:config).returns(user_configuration_overrides)
     user_configuration = UserConfiguration.new
-    user_configuration_overrides.each do |method, new_value|
-      user_configuration.stubs(method).returns(new_value)
-    end
+    ::Configuration.unstub(:config)
 
     UserConfiguration.stubs(:new).returns(user_configuration)
 


### PR DESCRIPTION
PR to move the navigation settings to the new profile based configuration (UserConfiguration)
The navigation settings this PR are:

* `NavConfig.categories`
* `NavConfig.categories_whitelist`
* `Configuration.show_all_apps_link?`

Fixes #2251



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202822721888116) by [Unito](https://www.unito.io)
