### PR TITLE
Added support for YAML anchors and aliases when reading configuration

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -370,7 +370,7 @@ class ConfigurationSingleton
     files.each_with_object({}) do |f, conf|
       begin
         content = ERB.new(f.read, nil, "-").result(binding)
-        yml = YAML.safe_load(content) || {}
+        yml = YAML.safe_load(content, aliases: true) || {}
         conf.deep_merge!(yml.deep_symbolize_keys)
       rescue => e
         Rails.logger.error("Can't read or parse #{f} because of error #{e}")

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -320,6 +320,18 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     end
   end
 
+  test "supports YAML anchors and aliases" do
+    with_modified_env({ OOD_CONFIG_D_DIRECTORY: "#{Rails.root}/test/fixtures/config/anchors_aliases" }) do
+      cfg = ConfigurationSingleton.new.send(:config)
+      assert_equal 'single_value', cfg[:single_original]
+      assert_equal 'single_value', cfg[:single_with_alias]
+
+      expect_hash = {key_one: "hash_one", key_two: "hash_two"}
+      assert_equal expect_hash, cfg[:hash_original]
+      assert_equal expect_hash, cfg[:hash_with_alias]
+    end
+  end
+
   test "logs read and parse errors" do
     with_modified_env(config_fixtures) do
       bad_erb_rex = /bad_erb.yml.erb because of error undefined local variable or method `wont_find_this_functon/

--- a/apps/dashboard/test/fixtures/config/anchors_aliases/config.yml
+++ b/apps/dashboard/test/fixtures/config/anchors_aliases/config.yml
@@ -1,0 +1,9 @@
+single_original: &single_anchor "single_value"
+single_with_alias: *single_anchor
+
+hash_original: &hash_anchor
+  key_one: "hash_one"
+  key_two: "hash_two"
+
+hash_with_alias: *hash_anchor
+


### PR DESCRIPTION
Updated how YAML config files are loaded to support YAML anchors and aliases
Fixes #2214



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202780995115556) by [Unito](https://www.unito.io)
