### PR TITLE
Use new ood_appkit files and editor URLs

### DIFF
--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -94,7 +94,7 @@ class OodApp
             title: favorite_path.title || favorite_path.path.to_s,
             subtitle: favorite_path.title ? favorite_path.path.to_s : nil,
             description: manifest.description,
-            url: OodAppkit::Urls::Files.new(base_url: url).url(path: favorite_path.path.to_s),
+            url: OodAppkit::Urls::Files.new(base_url: url).url(path: favorite_path.path.to_s, fs: favorite_path.filesystem),
             icon_uri: "fas://folder",
             caption: caption,
             new_tab: open_in_new_window?

--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -8,14 +8,4 @@ module FilesHelper
       segment + " /"
     end
   end
-
-  def editor_url(filesystem, path)
-    base = ENV['OOD_EDITOR_URL']   || '/pun/sys/dashboard/files'
-    OodAppkit::Urls::Editor.new(edit_url: "#{base}/edit/#{filesystem}" ).edit(path: path).to_s
-  end
-
-  def file_api_url(filesystem, path)
-    base = ENV['OOD_FILES_URL']   || '/pun/sys/dashboard/files'
-    OodAppkit::Urls::Files.new(api_url: "#{base}/#{filesystem}" ).api(path: path).to_s
-  end
 end

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -1,5 +1,5 @@
 
-<pre id="editor" data-path="<%= @path %>" data-api="<%= file_api_url(@filesystem, @path) %>"><%= @content %></pre>
+<pre id="editor" data-path="<%= @path %>" data-api="<%= OodAppkit.files.api(path: @path, fs: @filesystem) %>"><%= @content %></pre>
 
 <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ace.js" %>" type="text/javascript" charset="utf-8"></script>
 <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace/1.2.6/ext-modelist.js" %>" type="text/javascript" charset="utf-8"></script>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -12,7 +12,7 @@ json.files @files do |f|
 
   json.url files_path(@filesystem, @path.join(f[:name]).to_s)
   json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') # FIXME: should change for directory
-  json.edit_url editor_url(@filesystem, @path.join(f[:name]).to_s)
+  json.edit_url OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s
 
   json.size f[:size]
   json.human_size f[:human_size]

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -25,7 +25,16 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     project_path = File.expand_path "test/fixtures/dummy_fs/project"
     project_path2 = Pathname.new("test/fixtures/dummy_fs/project2").expand_path
     missing_path = "/test/fixtures/dummy_fs/missing"
-    OodFilesApp.stubs(:candidate_favorite_paths).returns([FavoritePath.new(scratch_path, title: "Scratch"), project_path, project_path2, missing_path])
+
+    OodFilesApp.stubs(:candidate_favorite_paths).returns(
+      [
+        FavoritePath.new(scratch_path, title: "Scratch"),
+        project_path,
+        project_path2,
+        missing_path,
+        FavoritePath.new("/mybucket", title: "S3", filesystem: "s3")
+      ]
+    )
     
     get root_path
 
@@ -35,7 +44,8 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
       "Home Directory",
       "Scratch #{scratch_path}",
       project_path,
-      project_path2.to_s
+      project_path2.to_s,
+      "S3 /mybucket"
     ], dditems.map { |e| e.gsub(/\s+/, ' ')  }, "Files dropdown item text is incorrect"
 
     dditemurls = dropdown_list_items_urls(dropdown_list('Files'))
@@ -43,7 +53,8 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
       "/pun/sys/files/fs" + Dir.home,
       "/pun/sys/files/fs" + scratch_path,
       "/pun/sys/files/fs" + project_path,
-      "/pun/sys/files/fs" + project_path2.to_s
+      "/pun/sys/files/fs" + project_path2.to_s,
+      "/pun/sys/files/s3/mybucket"
     ], dditemurls, "Files dropdown URLs are incorrect"
   end
 

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -108,4 +108,33 @@ class RemoteFilesTest < ApplicationSystemTestCase
       find('tbody a', exact_text: 'config')
     end
   end
+
+  test "edit file" do
+    OodAppkit.stubs(:files).returns(OodAppkit::Urls::Files.new(title: 'Files', base_url: '/files'))
+    OodAppkit.stubs(:editor).returns(OodAppkit::Urls::Editor.new(title: 'Editor', base_url: '/files'))
+
+    Dir.mktmpdir do |dir|
+      with_rclone_conf(dir) do
+        file = File.join(dir, 'foo.txt')
+        FileUtils.touch file
+
+        visit files_url('alias_remote', '/')
+
+        tr = find('a', exact_text: File.basename(file)).ancestor('tr')
+        tr.find('button.dropdown-toggle').click
+        edit_window = window_opened_by { tr.find('.edit-file').click }
+
+        within_window edit_window do
+          find('#editor').click
+          find('textarea.ace_text-input', visible: false).send_keys 'foobar'
+
+          find('.navbar-toggler').click
+          find('#save-button').click
+        end
+
+        sleep 1 # FIXME: should avoid using sleep here
+        assert_equal 'foobar', File.read(file)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR makes OOD use the `fs` parameter in ood_appkit URLs (introduced in #2201) instead of using workarounds (that are now broken after #2201). This PR fixes favorite path navbar links not working and changes the files browser and editor to use ood_appkit directly instead of using a workaround.

The PR also adds tests cases for remote favorite path navbar links and system tests for editing files.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202822812253549) by [Unito](https://www.unito.io)
