### PR TITLE
Fix files/api/v1 route not working

### DIFF
--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   # in production, if the user doesn't have access to the files app directory, we hide the routes
   if Configuration.can_access_files?
-    constraints filepath: /.+/, fs: /(?!edit)[^\/]+/  do
+    constraints filepath: /.+/, fs: /(?!(edit|api\/v1))[^\/]+/  do
       get "files/:fs(/*filepath)" => "files#fs", :defaults => { :fs => 'fs', :format => 'html' }, :format => false, as: :files
       put "files/:fs/*filepath" => "files#update", :format => false, :defaults => { :fs => 'fs', :format => 'json' }
 


### PR DESCRIPTION
Fixes #2239 by adding `api/v1` to the constraints of `fs`, so that `files/api/v1/...` URL is handled in the correct place.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202807937528109) by [Unito](https://www.unito.io)
