### PR TITLE
Added support to select the system applications shown in the UI

### DIFF
--- a/apps/dashboard/app/apps/nav_app.rb
+++ b/apps/dashboard/app/apps/nav_app.rb
@@ -1,0 +1,19 @@
+class NavApp < OodApp
+
+  attr_reader :token
+
+  # Creates a NavApp from an OodApp or BatchConnect::App
+  def self.from_app(app, token: nil)
+    NavApp.new(app.router, token: token)
+  end
+
+  def initialize(router, token: nil)
+    super(router)
+
+    @token = token || router.token
+  end
+
+  def sub_app_list
+    [BatchConnect::App.from_token(token)]
+  end
+end

--- a/apps/dashboard/app/apps/router.rb
+++ b/apps/dashboard/app/apps/router.rb
@@ -40,6 +40,25 @@ class Router
     end
   end
 
+  def self.flat_nav_apps(apps)
+    apps.each_with_object([]) do |app, flat_list|
+      if app.has_sub_apps?
+        flat_list.concat(app.sub_app_list.map{|sub_app| NavApp.from_app(sub_app, token: sub_app.token)})
+      else
+        flat_list.append(NavApp.from_app(app))
+      end
+    end
+  end
+
+  def self.filter_by_tokens(tokens, all_apps)
+    tokens.to_a.each_with_object([]) do |token, matched_apps|
+      matcher = TokenMatcher.new(token)
+      matched_apps.concat(all_apps.select{ |app| matcher.matches_app?(app) })
+    end.uniq do |app|
+      app.token.to_s
+    end
+  end
+
   private
 
   def self.pinned_apps_from_token(token, all_apps)

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -41,7 +41,13 @@ class ApplicationController < ActionController::Base
   end
 
   def nav_sys_apps
-    sys_apps.select(&:should_appear_in_nav?)
+    # Using the new property selected_sys_apps to trigger new behaviour.
+    @user_configuration.selected_sys_apps ? selected_sys_apps : sys_apps.select(&:should_appear_in_nav?)
+  end
+
+  def selected_sys_apps
+    all_nav_sys_apps = Router.flat_nav_apps(sys_apps.select(&:should_appear_in_nav?))
+    @user_configuration.selected_sys_apps ? Router.filter_by_tokens(@user_configuration.selected_sys_apps, all_nav_sys_apps) : all_nav_sys_apps
   end
 
   def nav_dev_apps

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -54,6 +54,10 @@ class UserConfiguration
     ConfigurationProperty.property(name: :custom_css_files, default_value: []),
 
     ConfigurationProperty.property(name: :dashboard_title, default_value: 'Open OnDemand', read_from_env: true),
+
+    # Array of tokens to select the sys applications to show in the UI
+    # Uses the same token matching logic as pinned_apps
+    ConfigurationProperty.property(name: :selected_sys_apps),
   ].freeze
 
   def initialize(request_hostname: nil)

--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -41,6 +41,7 @@ class RouterTest < ActiveSupport::TestCase
   end
 
   test "pinned apps with specific dev apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
     DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
     real_tokens = [
       'dev/bc_jupyter',

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -53,6 +53,8 @@ class UserConfigurationTest < ActiveSupport::TestCase
       brand_link_active_bg_color: nil,
       navbar_type: "dark",
       pinned_apps_group_by: "",
+
+      selected_sys_apps: nil,
     }
 
     # ensure all properties are tested


### PR DESCRIPTION
Proposal to select the system applications shown in the UI based in a new `UserConfiguration` property.

This PR is work in progress. Will add testing once we establish the direction for the implementation.

The proposal is based on how `pinned_apps` are selected.
I wanted to reuse `FeaturedApps`, but in the end, I decided to create a new class to avoid confusion.

Fixes #2223



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202822755172281) by [Unito](https://www.unito.io)
