### PR TITLE
init and access browser logs differently for selenium 4.0+

### DIFF
--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -1,13 +1,11 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  # options = Selenium::WebDriver::Chrome::Options.new
-  # options.add_preference "download.default_directory", "/tmp/downloads"
-  # driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: options
-  # driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: {
-  #   prefs: { "download.default_directory" => "/tmp/downloads" }
-  # }
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400] do |options|
+    # only chrome has support for browser logs
+    options.logging_prefs =  { browser: 'ALL' }
+  end
 
   Capybara.server = :webrick
 

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -7,14 +7,9 @@ class FilesTest < ApplicationSystemTestCase
   test "visiting files app doesn't raise js errors" do
     visit files_url(Rails.root.to_s)
 
-    messages = page.driver.browser.manage.logs.get(:browser)
+    messages = page.driver.browser.logs.get(:browser)
     content = messages.join("\n")
     assert_equal 0, messages.length, "console error messages include:\n\n#{content}\n\n"
-
-    # problem with using capybara and the Rails system tests:
-    # https://github.com/rails/rails/issues/39987
-    # though supposedly it still works with headless chrome https://github.com/rails/rails/pull/37792
-    # but watching it visually makes it easier to debug
   end
 
   test "visiting files app directory" do

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -7,7 +7,7 @@ class RemoteFilesTest < ApplicationSystemTestCase
   test "visiting files app doesn't raise js errors" do
     with_rclone_conf(Rails.root.to_s) do
       visit files_url('alias_remote', '/')
-      messages = page.driver.browser.manage.logs.get(:browser)
+      messages = page.driver.browser.logs.get(:browser)
       content = messages.join("\n")
       assert_equal 0, messages.length, "console error messages include:\n\n#{content}\n\n"
     end


### PR DESCRIPTION
This fixes the selenium tests that look through a browsers logs.  Fixing this deprecation warning:

```
2022-08-18 16:48:08 WARN Selenium [DEPRECATION] Manager#logs is deprecated. Use Chrome::Driver#logs instead.
```

means we'll be able to upgrade these dependencies.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202828107774629) by [Unito](https://www.unito.io)
