### PR TITLE
Fix remote FS edge cases

### DIFF
--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -188,6 +188,7 @@ en:
     files_directory_size_calculation_timeout: "Timeout while trying to determine directory size."
     files_directory_size_unknown: "Error with status %{exit_code} when trying to determine directory size: %{error}"
 
+    files_remote_disabled: "Remote file support is not enabled"
     files_remote_empty_dir_unsupported: "Remote does not support empty directories"
     files_remote_dir_not_created: "Did not create directory %{path}"
 

--- a/apps/dashboard/test/integration/files_app_test.rb
+++ b/apps/dashboard/test/integration/files_app_test.rb
@@ -18,4 +18,15 @@ class FilesAppTest < ActionDispatch::IntegrationTest
 
     assert_select "div[id='shell-wrapper']", 0
   end
+
+
+  test "Files app shows error when tring to access remote files when remote files are disabled" do
+    get files_url('s3', '/')
+    assert_equal I18n.t('dashboard.files_remote_disabled'), flash[:alert]
+
+    get files_url('s3', '/'), headers: { 'Accept': 'application/json'}
+    json = JSON.parse(@response.body)
+    assert_equal I18n.t('dashboard.files_remote_disabled'), json['error_message']
+    assert_equal [], json['files']
+  end
 end


### PR DESCRIPTION
Fixes #2231.

This PR makes the FilesController show errors properly when trying to access a remote file system when the remote file system support is disabled.

`before_action` caused exceptions to not be handled by the routes, so the standard Rails error page was shown. Using `before_action` with `rescue_from` to handle the exceptions would probably have been possible but seemed overly complicated as we have so different behaviour (HTML, JSON, redirects) in the different routes.

This sets the `@path` to be a PosixFile, but `@filesystem` to be the requested filesystem in the case where remote file systems are disabled and the user tries to access it. This is done to be able to show the files browser index page with the error message while still avoiding accidentally accessing the remote file system.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202829636407043) by [Unito](https://www.unito.io)
