### PR TITLE
Support creating directories on all remote filesystems

### DIFF
--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -188,6 +188,9 @@ en:
     files_directory_size_calculation_timeout: "Timeout while trying to determine directory size."
     files_directory_size_unknown: "Error with status %{exit_code} when trying to determine directory size: %{error}"
 
+    files_remote_empty_dir_unsupported: "Remote does not support empty directories"
+    files_remote_dir_not_created: "Did not create directory %{path}"
+
     jobs_project_created: "Project successfully created!"
     jobs_project_deleted: "Project successfully deleted!"
     jobs_project_delete_project_confirmation: "Delete all contents of project directory?"


### PR DESCRIPTION
Fixes #2247. This PR makes it possible to create directories on remotes that don't support empty directories. This is achieved by using `rclone touch` to touch a file in that directory.

Adding tests for this is a bit problematic as we can't easily set up a remote that doesn't have support for empty directories.
I attempted stubbing `RcloneUtil.rclone` to return the Rclone warning to trigger the workaround also for the local remotes used in the tests, but didn't seem like stubbing like that is possible without ugly workarounds.
I.e. I would like to do something like this:

```
RcloneUtil.stubs(:rclone).with('mkdir', 'alias_remote:/dir').returns('', "Warning: running mkdir on a remote which can't have empty directories does nothing", nil)
RcloneUtil.stubs(:rclone).with(any_parameters) # this should return the normal return value from RcloneUtil.rclone
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202866239151572) by [Unito](https://www.unito.io)
