### PR TITLE
Renamed UserConfiguration.categories to nav_categories

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -91,9 +91,9 @@ class ApplicationController < ActionController::Base
 
   def filter_groups(groups)
     if @user_configuration.filter_nav_categories?
-      OodAppGroup.select(titles: @user_configuration.categories, groups: groups)
+      OodAppGroup.select(titles: @user_configuration.nav_categories, groups: groups)
     else
-      OodAppGroup.order(titles: @user_configuration.categories, groups: groups)
+      OodAppGroup.order(titles: @user_configuration.nav_categories, groups: groups)
     end
   end
 end

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -108,11 +108,11 @@ class UserConfiguration
   # Filtering is controlled with NavConfig.categories_whitelist? unless the configuration property categories is defined.
   # If categories are defined, filter_nav_categories? will always be true.
   def filter_nav_categories?
-    fetch(:categories, nil).nil? ? NavConfig.categories_whitelist? : true
+    fetch(:nav_categories, nil).nil? ? NavConfig.categories_whitelist? : true
   end
 
-  def categories
-    fetch(:categories, NavConfig.categories)
+  def nav_categories
+    fetch(:nav_categories, NavConfig.categories)
   end
 
   # The current user profile. Used to select the configuration properties.

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -177,7 +177,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     NavConfig.stubs(:categories).returns(["Jobs", "Interactive Apps", "Files", "Clusters"])
 
     stub_user_configuration({
-      categories: ["Files", "Interactive Apps", "Clusters"]
+      nav_categories: ["Files", "Interactive Apps", "Clusters"]
     })
 
     get root_path
@@ -195,7 +195,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     NavConfig.stubs(:categories).returns(["Jobs", "Interactive Apps", "Files", "Clusters"])
 
     stub_user_configuration({
-      categories: []
+      nav_categories: []
     })
 
     get root_path

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -59,7 +59,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
 
       show_all_apps_link: false,
       filter_nav_categories?: false,
-      categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
+      nav_categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
     }
 
     # ensure all properties are tested
@@ -151,7 +151,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
   end
 
   test "filter_nav_categories? should return true when categories is set in config" do
-    Configuration.stubs(:config).returns({categories: []})
+    Configuration.stubs(:config).returns({nav_categories: []})
     assert_equal true, UserConfiguration.new.filter_nav_categories?
   end
 


### PR DESCRIPTION
Fixes the outstanding issues for PR: https://github.com/OSC/ondemand/pull/2221

This completes issue: https://github.com/OSC/ondemand/issues/2215



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202839409341736) by [Unito](https://www.unito.io)
