### PR TITLE
Fix remote FS edge cases alternative

### DIFF
--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -188,6 +188,7 @@ en:
     files_directory_size_calculation_timeout: "Timeout while trying to determine directory size."
     files_directory_size_unknown: "Error with status %{exit_code} when trying to determine directory size: %{error}"
 
+    files_remote_disabled: "Remote file support is not enabled"
     files_remote_empty_dir_unsupported: "Remote does not support empty directories"
     files_remote_dir_not_created: "Did not create directory %{path}"
 

--- a/apps/dashboard/test/integration/files_app_test.rb
+++ b/apps/dashboard/test/integration/files_app_test.rb
@@ -18,4 +18,15 @@ class FilesAppTest < ActionDispatch::IntegrationTest
 
     assert_select "div[id='shell-wrapper']", 0
   end
+
+
+  test "Files app shows error when tring to access remote files when remote files are disabled" do
+    get files_url('s3', '/')
+    assert_equal I18n.t('dashboard.files_remote_disabled'), flash[:alert]
+
+    get files_url('s3', '/'), headers: { 'Accept': 'application/json'}
+    json = JSON.parse(@response.body)
+    assert_equal I18n.t('dashboard.files_remote_disabled'), json['error_message']
+    assert_equal [], json['files']
+  end
 end


### PR DESCRIPTION
Alternative to #2251. Fixes #2231.

This PR makes the FilesController show errors properly when trying to access a remote file system when the remote file system support is disabled.

This uses `rescue_from` to handle the errors that are raised in FilesController instead of the approach in #2251. Though I'm not sure if this is really the right approach to use here since we have different behaviour in the different actions, which makes us need to check `action_name` inside the error handler.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202839439904671) by [Unito](https://www.unito.io)
