### PR TITLE
Added full navigation definition in UserConfiguration

### DIFF
--- a/apps/dashboard/app/apps/featured_app.rb
+++ b/apps/dashboard/app/apps/featured_app.rb
@@ -1,21 +1,19 @@
-# A simple subclass of OodApp that overrides category
-# and subcategory to allow for groupings other than what's
+# A simple subclass of OodApp that provides 2 new properties feature
+# and sub_feature to allow for groupings other than what's
 # provided in the app's manifest & definition.
 class FeaturedApp < OodApp
-  alias_method :original_category, :category
-  alias_method :original_subcategory, :subcategory
 
-  attr_reader :category, :subcategory, :token
+  attr_reader :feature, :sub_feature, :token
 
-  def self.from_ood_app(app, token: nil)
-    FeaturedApp.new(app.router, token: token)
+  def self.from_app(app, token: nil, feature: nil, sub_feature: nil)
+    FeaturedApp.new(app.router, token: token, feature: feature, sub_feature: sub_feature)
   end
 
-  def initialize(router, category: I18n.t("dashboard.pinned_apps_category"), subcategory: I18n.t('dashboard.pinned_apps_title'), token: nil)
+  def initialize(router, token: nil, feature: nil, sub_feature: nil)
     super(router)
 
-    @category = category.to_s
-    @subcategory = subcategory.to_s
+    @feature = feature.to_s
+    @sub_feature = sub_feature.to_s
     @token = token || router.token
   end
 

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -1,0 +1,115 @@
+class NavBar
+
+  attr_reader :nav_items
+
+  def self.from_config(nav_bar)
+    nav_items = nav_bar.map do |nav_item|
+      NavBar.parse_nav_item(nav_item)
+    end
+
+    NavBar.new(nav_items: nav_items)
+  end
+
+  def initialize(nav_items: [])
+    @nav_items = nav_items
+  end
+
+  def empty?
+    nav_items.size == 0
+  end
+
+  def to_s
+    "nav_items: #{nav_items}"
+  end
+
+  private
+
+  def self.parse_nav_item(nav_item)
+    type = nav_item.fetch(:type, nil) || NavBar.infer_type(nav_item)
+    NavItem.new(type.to_sym, nav_item)
+  end
+
+  def self.infer_type(nav_item)
+    links = nav_item.fetch(:links, nil)
+    return :nav_menu if links
+
+    url = nav_item.fetch(:url, nil)
+    return :nav_link if url
+
+    profile = nav_item.fetch(:profile, nil)
+    return :nav_link if profile
+
+    app = nav_item.fetch(:app, nil)
+    return :nav_app if app
+
+    tokens = nav_item.fetch(:tokens, nil)
+    return :nav_app if tokens
+
+    template = nav_item.fetch(:template, nil)
+    return :nav_template if template
+
+    #default type is :nav_divider
+    return :nav_divider
+  end
+
+  class NavItem
+    attr_reader :type, :items, :links, :title, :url, :icon, :new_tab, :template, :data
+
+    def initialize(type, config)
+      config = config.to_h.compact.symbolize_keys
+
+      @type      = type
+      @items     = config.fetch(:links, []).map{|link_item| NavBar.parse_nav_item(link_item)}
+
+      @title     = config.fetch(:title, nil)
+      @url       = config.fetch(:url, nil)
+      @icon      = URI(config.fetch(:icon, "fas://cog").to_s)
+      @new_tab   = !!config.fetch(:new_tab, true)
+
+      @app       = config.fetch(:app, nil)
+      @tokens    = config.fetch(:tokens, nil)
+      @template  =  File.join("layouts/nav", config.fetch(:template, default_template))
+
+      @profile   = config.fetch(:profile, nil)
+      set_profile_attributes if @profile
+
+      set_app_links if @app
+      set_matched_token_links if @tokens
+    end
+
+    def items?
+      items.size > 0
+    end
+
+    private
+
+    def default_template
+      File.join("custom", type.to_s)
+    end
+
+    def set_app_links
+      @links = []
+      app_router = Router.router_from_token(@app)
+      return if app_router.nil?
+
+      ood_app = OodApp.new(app_router)
+      @links = ood_app.manifest.valid? ? ood_app.links : []
+    end
+
+    def set_matched_token_links
+      matched_apps = Router.feature_apps(@tokens, SysRouter.apps)
+      @links = matched_apps.each_with_object([]) do |app, links|
+        links.concat(app.respond_to?(:links) ? app.links : [app.link])
+      end
+    end
+
+    def set_profile_attributes
+      @title = @profile unless @title
+      @url = Rails.application.routes.url_helpers.settings_path("settings[profile]" => @profile)
+      @data = { method: "post" }
+      @new_tab = false
+    end
+
+  end
+
+end

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_user, :set_user_configuration, :set_pinned_apps, :set_nav_groups, :set_announcements
   before_action :set_my_balances, only: [:index, :new, :featured]
-  before_action :set_featured_group
+  before_action :set_featured_group, :set_custom_navigation
 
   def set_user
     @user = CurrentUser
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
 
   def set_user_configuration
     @user_configuration ||= UserConfiguration.new(request_hostname: request.hostname)
+  end
+
+  def set_custom_navigation
+    @nav_bar = NavBar.from_config(@user_configuration.nav_bar)
   end
 
   def set_nav_groups
@@ -57,7 +61,7 @@ class ApplicationController < ActionController::Base
   end
 
   def pinned_app_group
-    OodAppGroup.groups_for(apps: @pinned_apps, nav_limit: @user_configuration.pinned_apps_menu_length)
+    OodAppGroup.groups_for(apps: @pinned_apps, group_by: :feature, nav_limit: @user_configuration.pinned_apps_menu_length)
   end
 
   def set_pinned_apps

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -36,6 +36,10 @@ class UserConfiguration
     ConfigurationProperty.property(name: :pinned_apps, default_value: []),
     # The length of the "Pinned Apps" navbar menu
     ConfigurationProperty.property(name: :pinned_apps_menu_length, default_value: 6),
+    # What to group pinned apps by
+    # @return [String, ""] Defaults to ""
+    ConfigurationProperty.property(name: :pinned_apps_group_by, read_from_env: true, default_value: ""),
+
 
     # Links to change profile under the Help navigation menu
     # example:
@@ -60,6 +64,8 @@ class UserConfiguration
 
     # Navigation properties
     ConfigurationProperty.with_boolean_mapper(name: :show_all_apps_link, default_value: false, read_from_env: true, env_names: ['SHOW_ALL_APPS_LINK']),
+    # New navigation definition property
+    ConfigurationProperty.property(name: :nav_bar, default_value: []),
   ].freeze
 
   def initialize(request_hostname: nil)
@@ -80,22 +86,6 @@ class UserConfiguration
       'light'
     else
       'dark'
-    end
-  end
-
-  # What to group pinned apps by
-  # @return [String, ""] Defaults to ""
-  def pinned_apps_group_by
-    group_by = ENV['OOD_PINNED_APPS_GROUP_BY'] || fetch(:pinned_apps_group_by, '')
-
-    # FIXME: the user_configuration shouldn't really know the API of
-    # OodApp or subclasses. This is a hack because subclasses of OodApp overload
-    # the category and subcategory to something new while saving the original.
-    # The fix would be to move this knowledge to somewhere more appropriate than here.
-    if group_by == 'category' || group_by == 'subcategory'
-      "original_#{group_by}"
-    else
-      group_by
     end
   end
 

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -37,10 +37,14 @@
 
       <div class="collapse navbar-collapse" id="navbar">
         <ul class="navbar-nav mr-auto">
-          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
-          <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
-          <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
-          <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
+          <% if @nav_bar.empty? %>
+            <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
+            <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
+            <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
+            <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
+          <% else %>
+            <%= render partial: 'layouts/nav/custom/nav_bar' if !@nav_bar.empty?%>
+          <% end %>
         </ul>
 
         <ul class="navbar-nav">

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -2,7 +2,7 @@
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 
   <ul class="dropdown-menu">
-    <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, nav_limit: group.nav_limit).each_with_index do |g, index| %>
+    <% OodAppGroup.groups_for(apps: group.apps, group_by: :sub_feature, nav_limit: group.nav_limit).each_with_index do |g, index| %>
       <%= content_tag "li", "", class: "dropdown-divider", role: "separator" if index > 0 %>
       <%= content_tag "li", g.title_with_nav_limit_caption, class: "dropdown-header" unless g.title_with_nav_limit_caption.empty? %>
       <% g.apps.take(g.nav_limit).map { |app| app.links.first }.compact.each do |link| %>

--- a/apps/dashboard/app/views/layouts/nav/custom/_nav_app.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/custom/_nav_app.html.erb
@@ -1,0 +1,22 @@
+
+<% links = nav_item.respond_to?(:links) ? nav_item.links : [nav_item.link] %>
+<% links.each do |link| %>
+<% title = nav_item.title ? nav_item.title : link.title %>
+  <li>
+    <%=
+      link_to(
+        link.url.to_s,
+        title: title,
+        class: parent.nil? ? "nav-link" : "dropdown-item",
+        target: link.new_tab? ? "_blank" : nil,
+        aria: ({ current: ('page' if (current_page?(link.url))) }),
+        data: link.data
+      ) do
+    %>
+    <%= icon_tag(link.icon_uri) %> <%= title %>
+    <% if link.subtitle.present? %>
+      <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
+    <% end %>
+  <% end %>
+  </li>
+<% end %>

--- a/apps/dashboard/app/views/layouts/nav/custom/_nav_bar.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/custom/_nav_bar.html.erb
@@ -1,0 +1,3 @@
+<% @nav_bar.nav_items.each do |nav_item| %>
+  <%= render partial: nav_item.template, locals: { nav_item: nav_item, parent: nil } %>
+<% end %>

--- a/apps/dashboard/app/views/layouts/nav/custom/_nav_divider.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/custom/_nav_divider.html.erb
@@ -1,0 +1,5 @@
+<% if nav_item.title %>
+  <%= content_tag(:li, nav_item.title, class: ["dropdown-header"]) %>
+<% else %>
+  <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") %>
+<% end %>

--- a/apps/dashboard/app/views/layouts/nav/custom/_nav_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/custom/_nav_featured_apps.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>

--- a/apps/dashboard/app/views/layouts/nav/custom/_nav_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/custom/_nav_link.html.erb
@@ -1,0 +1,14 @@
+<li>
+  <%=
+    link_to(
+      nav_item.url.to_s,
+      title: nav_item.title,
+      class: parent.nil? ? "nav-link" : "dropdown-item",
+      target: nav_item.new_tab ? "_blank" : nil,
+      aria: ({ current: ('page' if (current_page?(nav_item.url))) }),
+      data: nav_item.data
+    ) do
+  %>
+    <%= icon_tag(nav_item.icon) %> <%= nav_item.title %>
+  <% end %>
+</li>

--- a/apps/dashboard/app/views/layouts/nav/custom/_nav_menu.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/custom/_nav_menu.html.erb
@@ -1,0 +1,11 @@
+<li class="nav-item dropdown" title="<%= nav_item.title %>">
+  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= nav_item.title %><span class="caret"></span></a>
+
+  <% if nav_item.items? %>
+    <ul class="dropdown-menu">
+      <% nav_item.items.each do |item| %>
+        <%= render partial: item.template, locals: { nav_item: item, parent: nav_item } %>
+      <% end %>
+    </ul>
+  <% end %>
+</li>

--- a/apps/dashboard/test/apps/featured_app_test.rb
+++ b/apps/dashboard/test/apps/featured_app_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class FeaturedAppTest < ActiveSupport::TestCase
+
+  def setup
+    # Mock the sys installed applications
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+  end
+
+  test "FeaturedApp.from_app should initialize object correctly" do
+    app = OodApp.new(Router.router_from_token("sys/token"))
+
+    target = FeaturedApp.from_app(app, token: "other/token", feature: "From App Feature", sub_feature: "From App Sub Feature")
+    assert_equal "From App Feature", target.feature
+    assert_equal "From App Sub Feature", target.sub_feature
+    assert_equal "other/token", target.token
+    assert_equal "sys/token", target.router.token
+  end
+
+  test "FeaturedApp.feature can be set on creation" do
+    target = FeaturedApp.new(Router.router_from_token("sys/token"), feature: "Test Feature")
+    assert_equal "Test Feature", target.feature
+  end
+
+  test "FeaturedApp.sub_feature can be set on creation" do
+    target = FeaturedApp.new(Router.router_from_token("sys/token"), sub_feature: "Test Sub Feature")
+    assert_equal "Test Sub Feature", target.sub_feature
+  end
+
+  test "FeaturedApp.sub_app_list should return a single BatchConnect::App for sub apps" do
+    # Given a token for a sub app
+    token = "sys/bc_desktop/oakley"
+    # And a application with 2 sub apps "sys/bc_desktop"
+    ood_app = OodApp.new(Router.router_from_token(token))
+    assert_equal 2, ood_app.send(:sub_app_list).size
+
+    # When a FeatureApp is created
+    target = FeaturedApp.new(Router.router_from_token(token), token: token)
+    # Then sub_app_list only contains the sub app driven by the token"
+    assert_equal [BatchConnect::App.from_token(token)], target.send(:sub_app_list)
+    assert_equal "oakley", target.send(:sub_app_name)
+  end
+
+  test "FeaturedApp.sub_app_list should return a single BatchConnect::App for apps" do
+    # Given a token for a sub app
+    token = "sys/bc_jupyter"
+    # And a application with no sub apps "sys/bc_jupyter"
+    ood_app = OodApp.new(Router.router_from_token(token))
+    assert_equal 1, ood_app.send(:sub_app_list).size
+
+    # When a FeatureApp is created
+    target = FeaturedApp.new(Router.router_from_token(token), token: token)
+    # Then sub_app_list only contains the sub app driven by the token"
+    assert_equal [BatchConnect::App.from_token(token)], target.send(:sub_app_list)
+    assert_equal "bc_jupyter", target.send(:sub_app_name)
+  end
+
+end

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class NavBarTest < ActiveSupport::TestCase
+
+  test "NavBar.infer_type should infer :nav_menu when nav_item has links property" do
+    nav_item = {
+      title: "test",
+      links: []
+    }
+
+    assert_equal :nav_menu,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_link when nav_item has url property" do
+    nav_item = {
+      title: "test",
+      url: "/test"
+    }
+
+    assert_equal :nav_link,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_link when nav_item has profile property" do
+    nav_item = {
+      title: "test",
+      profile: "profile1"
+    }
+
+    assert_equal :nav_link,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_app when nav_item has app property" do
+    nav_item = {
+      title: "test",
+      app: "sys/rstudio"
+    }
+
+    assert_equal :nav_app,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_app when nav_item has tokens property" do
+    nav_item = {
+      title: "test",
+      tokens: ["sys/rstudio"]
+    }
+
+    assert_equal :nav_app,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_template when nav_item has template property" do
+    nav_item = {
+      title: "test",
+      template: "all_apps"
+    }
+
+    assert_equal :nav_template,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_divider when nav_item has no recognizable properties" do
+    nav_item = {
+      new_property: "test",
+      other: "all_apps"
+    }
+    assert_equal :nav_divider,  NavBar.send(:infer_type, nav_item)
+  end
+
+  test "NavBar.infer_type should infer :nav_divider when nav_item has no properties" do
+    assert_equal :nav_divider,  NavBar.send(:infer_type, { })
+  end
+
+  test "NavBar.from_config should delegate to NavBar.infer_type and create a NavBar::NavItem for each nav_item in the array" do
+    menu_item = {
+      title: "test",
+      links: []
+    }
+    app_item = {
+      title: "test",
+      app: "sys/rstudio"
+    }
+
+    NavBar.expects(:infer_type).with(menu_item).returns(:nav_menu)
+    NavBar::NavItem.expects(:new).with(:nav_menu, menu_item)
+    NavBar.expects(:infer_type).with(app_item).returns(:nav_app)
+    NavBar::NavItem.expects(:new).with(:nav_app, app_item)
+    NavBar.from_config([menu_item, app_item])
+  end
+
+  test "NavBar.from_config should use type property when provided in configuration" do
+    menu_item = {
+      type: "nav_link",
+      title: "test",
+    }
+    app_item = {
+      title: "test",
+      app: "sys/rstudio"
+    }
+
+    NavBar::NavItem.expects(:new).with(:nav_link, menu_item)
+    NavBar.expects(:infer_type).with(menu_item).never
+    NavBar.expects(:infer_type).with(app_item).returns(:nav_app)
+    NavBar::NavItem.expects(:new).with(:nav_app, app_item)
+
+    NavBar.from_config([menu_item, app_item])
+  end
+
+  test "NavBar should keep navigation order from configuration" do
+    titles = (1..10).to_a.map{ |_| SecureRandom.uuid }
+    config = titles.map{ |x| {title: x} }
+
+    result = NavBar.from_config(config)
+    assert_equal 10,  result.nav_items.size
+    titles.each_with_index do |title, index|
+      assert_equal title,  result.nav_items[index].title
+    end
+  end
+
+  test "empty? should be false when NavBar has items" do
+    assert_equal false,  NavBar.new(nav_items: [stub()]).empty?
+  end
+
+  test "empty? should be true when NavBar is empty" do
+    assert_equal true,  NavBar.new(nav_items: []).empty?
+  end
+
+end

--- a/apps/dashboard/test/apps/nav_item_test.rb
+++ b/apps/dashboard/test/apps/nav_item_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+
+class NavItemTest < ActiveSupport::TestCase
+
+  test "type should return the provided type" do
+    assert_equal :nav_menu,  NavBar::NavItem.new(:nav_menu, {}).type
+  end
+
+  test "title should default to nil when not provided" do
+    assert_nil NavBar::NavItem.new(:type_name, {}).title
+  end
+
+  test "title should return provided property value" do
+    nav_item_config = {title: "Nav Item Title"}
+    assert_equal "Nav Item Title", NavBar::NavItem.new(:type_name, nav_item_config).title
+  end
+
+  test "url should default to nil when not provided" do
+    assert_nil NavBar::NavItem.new(:type_name, {}).url
+  end
+
+  test "url should return provided property value" do
+    nav_item_config = {url: "/nav/url"}
+    assert_equal "/nav/url", NavBar::NavItem.new(:type_name, nav_item_config).url
+  end
+
+  test "icon should default to cog when not provided" do
+    assert_equal URI("fas://cog"),  NavBar::NavItem.new(:type_name, {}).icon
+  end
+
+  test "icon should return provided property value" do
+    nav_item_config = {icon: "fa://test_icon"}
+    assert_equal URI("fa://test_icon"), NavBar::NavItem.new(:type_name, nav_item_config).icon
+  end
+
+  test "new_tab should default to true when not provided" do
+    assert_equal true,  NavBar::NavItem.new(:type_name, {}).new_tab
+  end
+
+  test "new_tab should return provided property value" do
+    nav_item_config = {new_tab: false}
+    assert_equal false, NavBar::NavItem.new(:type_name, nav_item_config).new_tab
+  end
+
+  test "new_tab should convert string properties values to true" do
+    nav_item_config = {new_tab: "true"}
+    assert_equal true, NavBar::NavItem.new(:type_name, nav_item_config).new_tab
+
+    nav_item_config = {new_tab: "false"}
+    assert_equal true, NavBar::NavItem.new(:type_name, nav_item_config).new_tab
+
+    nav_item_config = {new_tab: "error"}
+    assert_equal true, NavBar::NavItem.new(:type_name, nav_item_config).new_tab
+  end
+
+  test "profile attributes should be set when profile property is provided" do
+    nav_item_config = {title: "profile title", profile: "profile1"}
+
+    target = NavBar::NavItem.new(:type_name, nav_item_config)
+    expected_data_property = {method: "post"}
+    assert_equal "profile title", target.title
+    assert_equal false, target.new_tab
+    assert_equal expected_data_property, target.data
+    assert_equal  Rails.application.routes.url_helpers.settings_path("settings[profile]" => "profile1"), target.url
+  end
+
+  test "title should default to profile when no title provided and profile property is set" do
+    nav_item_config = {profile: "profile1"}
+
+    target = NavBar::NavItem.new(:type_name, nav_item_config)
+    assert_equal "profile1", target.title
+  end
+
+  test "links should default to nil when no app or tokens property provided" do
+    assert_nil NavBar::NavItem.new(:type_name, {}).links
+  end
+
+  test "links should return OodApp.links when app property is provided" do
+    expected_link_list = [OodAppLink.new]
+    ood_app_mock = stub({manifest: stub({:valid? => true}), links: expected_link_list})
+    OodApp.stubs(:new).returns(ood_app_mock)
+
+    nav_item_config = {app: "sys/mock"}
+    assert_equal expected_link_list, NavBar::NavItem.new(:type_name, nav_item_config).links
+  end
+
+  test "links should return SysRouter apps that match the tokens provided with the tokens property" do
+    expected_link_list = [OodAppLink.new]
+    featured_app_mock = stub({links: expected_link_list})
+    app_list = [featured_app_mock]
+    Router.stubs(:feature_apps).with(["sys/mock"], SysRouter.apps).returns(app_list)
+
+    nav_item_config = {tokens: ["sys/mock"]}
+    assert_equal expected_link_list, NavBar::NavItem.new(:type_name, nav_item_config).links
+  end
+
+  test "links should return empty array when invalid router provided in app configuration" do
+    nav_item_config = {app: "invalid_router/app"}
+    assert_equal [], NavBar::NavItem.new(:type_name, nav_item_config).links
+  end
+
+  test "links should return empty array when invalid sys app provided" do
+    nav_item_config = {app: "sys/invalid"}
+    assert_equal [], NavBar::NavItem.new(:type_name, nav_item_config).links
+  end
+
+  test "template should be based on the type name when no template property provided" do
+    assert_equal "layouts/nav/custom/type_name",  NavBar::NavItem.new(:type_name, {}).template
+  end
+
+  test "template should be based on the template property when provided" do
+    nav_item_config = {template: "path/to/template"}
+    assert_equal "layouts/nav/path/to/template",  NavBar::NavItem.new(:type_name, nav_item_config).template
+
+    nav_item_config = {template: "/path/to/template"}
+    assert_equal "layouts/nav/path/to/template",  NavBar::NavItem.new(:type_name, nav_item_config).template
+  end
+
+end

--- a/apps/dashboard/test/integration/custom_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_navigation_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class CustomNavigationTest < ActionDispatch::IntegrationTest
+ test "should render a custom navigation menu when nav_bar is defined in UserConfiguration" do
+   # Mock the sys installed applications
+   SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+   # Test a navigation item of each type
+   stub_user_configuration({nav_bar: [
+     {title: "Custom Menu",
+      links: [
+        {title: "Custom Menu Dropdown Header"},
+        {title: "Menu Link",
+         url: "/menu/link"}
+      ]},
+     {title: "Custom Apps",
+      links: [
+        {title: "Custom Apps Dropdown Header"},
+        {title: "App Link",
+         app: "sys/systemstatus"}
+      ]},
+     {title: "Custom Tokens",
+      links: [
+        {title: "Custom Tokens Dropdown Header"},
+        {tokens: ["sys/systemstatus"]}
+      ]},
+     {title: "Custom Link",
+      url: "/custom/link"},
+     {template: "all_apps"},
+   ]})
+
+   get root_path
+   assert_response :success
+   # Check nav menus
+   assert_select "#navbar li.dropdown[title]", 4 # +1 here is 'Help'
+   # Check nav links
+   assert_select "#navbar li a.nav-link[title]", 1
+
+   assert_select nav_menu(1), text: "Custom Menu"
+   assert_select nav_menu_header("Custom Menu"), text: "Custom Menu Dropdown Header"
+   assert_select nav_menu_link("Custom Menu", 1), text: "Menu Link"
+   assert_select nav_menu_link("Custom Menu", 1) do |link|
+     assert_equal "/menu/link", link.first['href']
+   end
+
+   assert_select nav_menu(2), text: "Custom Apps"
+   assert_select nav_menu_header("Custom Apps"), text: "Custom Apps Dropdown Header"
+   assert_select nav_menu_link("Custom Apps", 1), text: "App Link"
+   assert_select nav_menu_link("Custom Apps", 1) do |link|
+     assert_equal "/apps/show/systemstatus", link.first['href']
+   end
+
+   assert_select nav_menu(3), text: "Custom Tokens"
+   assert_select nav_menu_header("Custom Tokens"), text: "Custom Tokens Dropdown Header"
+   assert_select nav_menu_link("Custom Tokens", 1), text: "System Status"
+   assert_select nav_menu_link("Custom Tokens", 1) do |link|
+     assert_equal "/apps/show/systemstatus", link.first['href']
+   end
+
+   assert_select nav_link("Custom Link"), text: "Custom Link"
+   assert_select nav_link("Custom Link") do |link|
+     assert_equal "/custom/link", link.first['href']
+   end
+
+   # Check all_apps template.
+   assert_select "#navbar .navbar-nav li.nav-item[title='All Apps']", text: "All Apps"
+ end
+
+ def nav_menu(order)
+   "#navbar .navbar-nav li.dropdown:nth-of-type(#{order}) a"
+ end
+
+ def nav_menu_link(title, order)
+   "#navbar .navbar-nav li.dropdown[title='#{title}'] ul.dropdown-menu a:nth-of-type(#{order})"
+ end
+
+ def nav_menu_header(title)
+   "#navbar .navbar-nav li.dropdown[title='#{title}'] ul.dropdown-menu li.dropdown-header"
+ end
+
+ def nav_link(title)
+   "#navbar .navbar-nav li a.nav-link[title='#{title}']"
+ end
+end

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -297,7 +297,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
         'sys/bc_paraview',
         'sys/pseudofun',
       ],
-      pinned_apps_group_by: "original_category"
+      pinned_apps_group_by: "category"
     })
 
     env = {}
@@ -319,7 +319,7 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
         'sys/bc_paraview',
         'sys/pseudofun',
       ],
-      pinned_apps_group_by: "original_subcategory"
+      pinned_apps_group_by: "subcategory"
     })
 
     env = {}

--- a/apps/dashboard/test/models/router_test.rb
+++ b/apps/dashboard/test/models/router_test.rb
@@ -41,6 +41,7 @@ class RouterTest < ActiveSupport::TestCase
   end
 
   test "pinned apps with specific dev apps" do
+    SysRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
     DevRouter.stubs(:base_path).returns(Pathname.new("test/fixtures/sys_with_gateway_apps"))
     real_tokens = [
       'dev/bc_jupyter',

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -60,6 +60,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       show_all_apps_link: false,
       filter_nav_categories?: false,
       nav_categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
+      nav_bar: [],
     }
 
     # ensure all properties are tested
@@ -102,16 +103,6 @@ class UserConfigurationTest < ActiveSupport::TestCase
     with_modified_env(OOD_NAVBAR_TYPE: 'light') do
       assert_equal 'light', UserConfiguration.new.navbar_type
     end
-  end
-
-  test "pinned_apps_group_by returns original category when configured with category" do
-    Configuration.stubs(:config).returns({pinned_apps_group_by: "category"})
-    assert_equal "original_category", UserConfiguration.new.pinned_apps_group_by
-  end
-
-  test "pinned_apps_group_by returns original subcategory when configured with subcategory" do
-    Configuration.stubs(:config).returns({pinned_apps_group_by: "subcategory"})
-    assert_equal "original_subcategory", UserConfiguration.new.pinned_apps_group_by
   end
 
   test "reads pinned apps from config" do


### PR DESCRIPTION
Created PR to share discuss implementation ideas.

Fixes: https://github.com/OSC/ondemand/issues/2154

Sample configuration:

```yaml
    nav_bar:
      - title: "Help"
        links:
          - title: "Doc Links"
          - title: "how to docs"
            icon: fa://desktop
            url: "/docs"
            new_tab: false
          - title: "submit a help ticket"
            icon: fa://question-circle
            url: "/tickets"
            new_tab: false
          - app: "sys/sas"
      - title: "Documentation"
        url: "/sid2"
        new_tab: true
      - title: "Apps Menu"
        links:
          - title: "Main App"
          - app: "sys/shell"
          - title: "Sas Main"
            app: "sys/sas"
          - title: "SubApp"
            tokens: [ "sys/Rstudio/gpu" ]
          - title: "Core Apps"
          - tokens: [ "sys/Rstudio/*" ]
          - title: "Profiles"
          - title: "Team 1"
            icon: fa://question-circle
            profile: "team1"
      - title: "SAS Menu"
        app: "sys/sas"
      - title: "Wiki"
        icon: fa://desktop
        url: "/sid2"
        new_tab: true
      - title: "About"
        url: "https://www.iq.harvard.edu/research-computing#AboutSidNG"
        new_tab: false
      - template: "sessions"
      - template: "custom/nav_featured_apps"
```
Renders:

<img width="1225" alt="Screenshot 2022-09-01 at 12 10 25" src="https://user-images.githubusercontent.com/17336210/187900506-0902af0a-cdb1-4ff4-8626-eff4739e19f6.png">

<img width="639" alt="Screenshot 2022-09-01 at 12 10 33" src="https://user-images.githubusercontent.com/17336210/187900539-bdc099e4-3f9f-4299-a469-84f58324035e.png">

<img width="831" alt="Screenshot 2022-09-01 at 12 13 21" src="https://user-images.githubusercontent.com/17336210/187900881-aedfee62-8ed4-42d9-817e-c25d964ca044.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202851741436551) by [Unito](https://www.unito.io)
