### PR TITLE
Add method for listing Rclone remotes to RcloneUtil

### DIFF
--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -190,6 +190,7 @@ en:
 
     files_remote_empty_dir_unsupported: "Remote does not support empty directories"
     files_remote_dir_not_created: "Did not create directory %{path}"
+    files_remote_error_listing_remotes: "Error listing Rclone remotes: %{error}"
 
     jobs_project_created: "Project successfully created!"
     jobs_project_deleted: "Project successfully deleted!"

--- a/apps/dashboard/lib/rclone_util.rb
+++ b/apps/dashboard/lib/rclone_util.rb
@@ -226,6 +226,17 @@ class RcloneUtil
       end
     end
 
+    # Lists remotes configured in default rclone.conf or environment variables
+    # @return [Array<String>] Rclone remotes
+    def list_remotes
+      o, e, s = rclone("listremotes")
+      if s.success?
+        o.lines.map { |l| l.strip.delete_suffix(":") }
+      else
+        raise RcloneError.new(s.exitstatus), I18n.t("dashboard.files_remote_error_listing_remotes", error: e)
+      end
+    end
+
     def rclone_cmd
       # TODO: Make this configurable
       "rclone"

--- a/apps/dashboard/test/fixtures/config/rclone/rclone.conf
+++ b/apps/dashboard/test/fixtures/config/rclone/rclone.conf
@@ -1,0 +1,7 @@
+[s3]
+type = s3
+provider = Other
+env_auth = false
+access_key_id = 
+secret_access_key = 
+acl = private

--- a/apps/dashboard/test/rclone_helper.rb
+++ b/apps/dashboard/test/rclone_helper.rb
@@ -9,7 +9,8 @@ class ActiveSupport::TestCase
       OOD_FILES_APP_REMOTE_FILES:        'true',
       RCLONE_CONFIG_LOCAL_REMOTE_TYPE:   'local',
       RCLONE_CONFIG_ALIAS_REMOTE_TYPE:   'alias',
-      RCLONE_CONFIG_ALIAS_REMOTE_REMOTE: "local_remote:#{root_dir}"
+      RCLONE_CONFIG_ALIAS_REMOTE_REMOTE: "local_remote:#{root_dir}",
+      RCLONE_CONFIG: Rails.root.join('test/fixtures/config/rclone/rclone.conf').to_s
     }
   end
 

--- a/apps/dashboard/test/unit/rclone_util_test.rb
+++ b/apps/dashboard/test/unit/rclone_util_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+require 'rclone_helper'
+require 'rclone_util'
+
+class RcloneUtilTest < ActiveSupport::TestCase
+  test "list_remotes handles rclone.conf and env" do
+    with_rclone_conf("/") do
+        assert_equal ["alias_remote", "local_remote", "s3"], RcloneUtil.list_remotes
+    end
+  end
+
+  test "list_remotes handles missing rclone conf" do
+    with_modified_env(RCLONE_CONFIG: "/dev/null") do
+        assert_equal [], RcloneUtil.list_remotes
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2232. This adds a `list_remotes` method that can be used for listing Rclone remotes available.

Example `ood.rb` initializer:

```
require "rclone_util"

Rails.application.config.after_initialize do |_|
  remotes = RcloneUtil.list_remotes.map { |r| FavoritePath.new("", title: r, filesystem: r) }

  OodFilesApp.candidate_favorite_paths.tap do |paths|
    paths.concat(remotes)
  end
rescue => e
  Rails.logger.error(e.message)
end
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202917863766653) by [Unito](https://www.unito.io)
