### PR TITLE
Added full navigation definition in UserConfiguration (Group/Link)

### DIFF
--- a/apps/dashboard/app/apps/app_recategorizer.rb
+++ b/apps/dashboard/app/apps/app_recategorizer.rb
@@ -1,0 +1,22 @@
+# Wrapper around OodApp to override category and subcategory
+# This is to create artificial groups and subgroups for a custom navigation
+class AppRecategorizer < SimpleDelegator
+
+  def initialize(ood_app, category: nil, subcategory: nil)
+    super(ood_app)
+    @inner_category = category
+    @inner_subcategory = subcategory
+  end
+
+  def category
+    inner_category
+  end
+
+  def subcategory
+    inner_subcategory
+  end
+
+  private
+
+  attr_reader :inner_category, :inner_subcategory
+end

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -86,7 +86,7 @@ class NavBar
     if matched_apps.size == 1
       extend_link(matched_apps.first.links.first)
     elsif matched_apps.size > 1
-      extend_group(OodAppGroup.groups_for(apps: matched_apps))
+      extend_group(OodAppGroup.groups_for(apps: matched_apps).first)
     else
       group = OodAppGroup.groups_for(apps: SysRouter.apps).select { |g| g.title.downcase == token.downcase }.first
       group.nil? ? nil : extend_group(group)

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -1,0 +1,134 @@
+class NavBar
+
+  def self.items(nav_config)
+    nav_config.map do |nav_item|
+      if nav_item.is_a?(String)
+        item_from_token(nav_item)
+      elsif nav_item.is_a?(Hash)
+        if nav_item.fetch(:links, nil)
+          extend_item(nav_menu(nav_item), 'layouts/nav/group')
+        elsif nav_item.fetch(:url, nil)
+          extend_item(nav_link(nav_item, nil, nil), 'layouts/nav/link')
+        elsif nav_item.fetch(:apps, nil)
+          matched_apps = nav_apps(nav_item, nil, nil)
+          extend_item(matched_apps.first.links.first, 'layouts/nav/link') if matched_apps.first && matched_apps.first.links.first
+        elsif nav_item.fetch(:template, nil)
+          nav_template(nav_item)
+        end
+      end
+    end.flatten.compact
+  end
+
+  private
+
+  def self.nav_menu(hash_item)
+    menu_title = hash_item.fetch(:title, '')
+    menu_items = hash_item.fetch(:links, [])
+
+    group_title = ''
+    apps = menu_items.map do |item|
+      group_title = item.fetch(:group, group_title)
+      if item.fetch(:url, nil)
+        nav_link(item, menu_title, group_title)
+      elsif item.fetch(:apps, nil)
+        nav_apps(item, menu_title, group_title)
+      elsif item.fetch(:profile, nil)
+        nav_profile(item, menu_title, group_title)
+      end
+    end.flatten.compact
+
+    OodAppGroup.new(apps: apps, title: menu_title, sort: false)
+  end
+
+  def self.nav_link(item, category, subcategory)
+    LinkDecorator.new(OodAppLink.new(item), category: category, subcategory: subcategory)
+  end
+
+  def self.nav_template(item)
+    template = File.join("layouts/nav", item.fetch(:template))
+    extend_item(item, template)
+  end
+
+  def self.nav_apps(item, category, subcategory)
+    app_configs = Array.wrap(item.fetch(:apps, []))
+    app_configs.map do |config_string|
+      matched_apps = Router.pinned_apps_from_token(config_string, SysRouter.apps)
+      matched_apps.map do |reg_app|
+        AppDecorator.new(reg_app, category: category, subcategory: subcategory)
+      end
+    end.flatten
+  end
+
+  def self.nav_profile(item, category, subcategory)
+    profile = item.fetch(:profile)
+    profile_data = item.clone
+    profile_data[:title] = profile unless item.fetch(:title, nil)
+    profile_data[:url] = Rails.application.routes.url_helpers.settings_path('settings[profile]' => profile)
+    profile_data[:data] = { method: 'post' }
+    profile_data[:new_tab] = false
+    LinkDecorator.new(OodAppLink.new(profile_data), category: category, subcategory: subcategory)
+  end
+
+  def self.item_from_token(token)
+    matched_apps = Router.pinned_apps_from_token(token, SysRouter.apps)
+    if matched_apps.size == 1
+      extend_item(matched_apps.first.links.first, 'layouts/nav/link')
+    elsif matched_apps.size > 1
+      extend_item(OodAppGroup.groups_for(apps: matched_apps), 'layouts/nav/group')
+    else
+      group = OodAppGroup.groups_for(apps: SysRouter.apps, sort: false).select { |g| g.title.downcase == token.downcase }.first
+      group.nil? ? nil : extend_item(group, 'layouts/nav/group')
+    end
+  end
+
+  def self.extend_item(item, partial_path)
+    extended = NavItemDecorator.new(item)
+    extended.partial_path = partial_path
+    extended
+  end
+
+  class NavItemDecorator < SimpleDelegator
+    attr_accessor :partial_path
+  end
+
+  # redefine an OodApp's category & subcategory
+  class AppDecorator < SimpleDelegator
+    def initialize(link, category: nil, subcategory: nil)
+      super(link)
+      @inner_category = category
+      @inner_subcategory = subcategory
+    end
+
+    def category
+      inner_category
+    end
+
+    def subcategory
+      inner_subcategory
+    end
+
+    private
+
+    attr_reader :inner_category, :inner_subcategory
+  end
+
+  # make an OodAppLink look like an OodApp
+  class LinkDecorator < SimpleDelegator
+    attr_reader :category, :subcategory
+
+    def initialize(link, category: nil, subcategory: nil)
+      super(link)
+      @category = category
+      @subcategory = subcategory
+    end
+
+    def links
+      [self]
+    end
+
+    def metadata
+      {}
+    end
+  end
+
+end

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -53,7 +53,7 @@ class NavBar
   end
 
   def self.nav_link(item, category, subcategory)
-    OodAppLink::AppDecorator.new(OodAppLink.new(item), category: category, subcategory: subcategory)
+    OodAppLink.new(item).categorize(category: category, subcategory: subcategory)
   end
 
   def self.nav_apps(item, category, subcategory)
@@ -73,7 +73,7 @@ class NavBar
     profile_data[:url] = Rails.application.routes.url_helpers.settings_path('settings[profile]' => profile)
     profile_data[:data] = { method: 'post' }
     profile_data[:new_tab] = false
-    OodAppLink::AppDecorator.new(OodAppLink.new(profile_data), category: category, subcategory: subcategory)
+    OodAppLink.new(profile_data).categorize(category: category, subcategory: subcategory)
   end
 
   def self.item_from_token(token)

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -1,4 +1,12 @@
+# Creates navigation items based on user configuration.
+#
 class NavBar
+
+  STATIC_LINKS = {
+    all_apps: "layouts/nav/all_apps",
+    featured_apps: "layouts/nav/featured_apps",
+    sessions: "layouts/nav/sessions",
+  }
 
   def self.items(nav_config)
     nav_config.map do |nav_item|
@@ -6,14 +14,14 @@ class NavBar
         item_from_token(nav_item)
       elsif nav_item.is_a?(Hash)
         if nav_item.fetch(:links, nil)
-          extend_item(nav_menu(nav_item), 'layouts/nav/group')
+          extend_group(nav_menu(nav_item))
         elsif nav_item.fetch(:url, nil)
-          extend_item(nav_link(nav_item, nil, nil), 'layouts/nav/link')
+          extend_link(nav_link(nav_item, nil, nil))
         elsif nav_item.fetch(:apps, nil)
           matched_apps = nav_apps(nav_item, nil, nil)
-          extend_item(matched_apps.first.links.first, 'layouts/nav/link') if matched_apps.first && matched_apps.first.links.first
-        elsif nav_item.fetch(:template, nil)
-          nav_template(nav_item)
+          extend_link(matched_apps.first.links.first) if matched_apps.first && matched_apps.first.links.first
+        elsif nav_item.fetch(:profile, nil)
+          extend_link(nav_profile(nav_item, nil, nil))
         end
       end
     end.flatten.compact
@@ -27,6 +35,10 @@ class NavBar
 
     group_title = ''
     apps = menu_items.map do |item|
+      if item.is_a?(String)
+        item = { apps: item }
+      end
+
       group_title = item.fetch(:group, group_title)
       if item.fetch(:url, nil)
         nav_link(item, menu_title, group_title)
@@ -41,12 +53,7 @@ class NavBar
   end
 
   def self.nav_link(item, category, subcategory)
-    LinkDecorator.new(OodAppLink.new(item), category: category, subcategory: subcategory)
-  end
-
-  def self.nav_template(item)
-    template = File.join("layouts/nav", item.fetch(:template))
-    extend_item(item, template)
+    OodAppLink::AppDecorator.new(OodAppLink.new(item), category: category, subcategory: subcategory)
   end
 
   def self.nav_apps(item, category, subcategory)
@@ -54,7 +61,7 @@ class NavBar
     app_configs.map do |config_string|
       matched_apps = Router.pinned_apps_from_token(config_string, SysRouter.apps)
       matched_apps.map do |reg_app|
-        AppDecorator.new(reg_app, category: category, subcategory: subcategory)
+        AppRecategorizer.new(reg_app, category: category, subcategory: subcategory)
       end
     end.flatten
   end
@@ -66,69 +73,40 @@ class NavBar
     profile_data[:url] = Rails.application.routes.url_helpers.settings_path('settings[profile]' => profile)
     profile_data[:data] = { method: 'post' }
     profile_data[:new_tab] = false
-    LinkDecorator.new(OodAppLink.new(profile_data), category: category, subcategory: subcategory)
+    OodAppLink::AppDecorator.new(OodAppLink.new(profile_data), category: category, subcategory: subcategory)
   end
 
   def self.item_from_token(token)
+    static_link_template = STATIC_LINKS.fetch(token.to_sym, nil)
+    if static_link_template
+      return NavItemDecorator.new({}, static_link_template)
+    end
+
     matched_apps = Router.pinned_apps_from_token(token, SysRouter.apps)
     if matched_apps.size == 1
-      extend_item(matched_apps.first.links.first, 'layouts/nav/link')
+      extend_link(matched_apps.first.links.first)
     elsif matched_apps.size > 1
-      extend_item(OodAppGroup.groups_for(apps: matched_apps), 'layouts/nav/group')
+      extend_group(OodAppGroup.groups_for(apps: matched_apps))
     else
-      group = OodAppGroup.groups_for(apps: SysRouter.apps, sort: false).select { |g| g.title.downcase == token.downcase }.first
-      group.nil? ? nil : extend_item(group, 'layouts/nav/group')
+      group = OodAppGroup.groups_for(apps: SysRouter.apps).select { |g| g.title.downcase == token.downcase }.first
+      group.nil? ? nil : extend_group(group)
     end
   end
 
-  def self.extend_item(item, partial_path)
-    extended = NavItemDecorator.new(item)
-    extended.partial_path = partial_path
-    extended
+  def self.extend_group(item)
+    NavItemDecorator.new(item, 'layouts/nav/group')
+  end
+
+  def self.extend_link(item)
+    NavItemDecorator.new(item, 'layouts/nav/link')
   end
 
   class NavItemDecorator < SimpleDelegator
-    attr_accessor :partial_path
-  end
+    attr_reader :partial_path
 
-  # redefine an OodApp's category & subcategory
-  class AppDecorator < SimpleDelegator
-    def initialize(link, category: nil, subcategory: nil)
-      super(link)
-      @inner_category = category
-      @inner_subcategory = subcategory
-    end
-
-    def category
-      inner_category
-    end
-
-    def subcategory
-      inner_subcategory
-    end
-
-    private
-
-    attr_reader :inner_category, :inner_subcategory
-  end
-
-  # make an OodAppLink look like an OodApp
-  class LinkDecorator < SimpleDelegator
-    attr_reader :category, :subcategory
-
-    def initialize(link, category: nil, subcategory: nil)
-      super(link)
-      @category = category
-      @subcategory = subcategory
-    end
-
-    def links
-      [self]
-    end
-
-    def metadata
-      {}
+    def initialize(nav_item, partial_path)
+      super(nav_item)
+      @partial_path = partial_path
     end
   end
-
 end

--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -1,10 +1,11 @@
 class OodAppGroup
-  attr_accessor :apps, :title
+  attr_accessor :apps, :title, :sort
 
-  def initialize(title: "", apps: [], nav_limit: nil)
+  def initialize(title: "", apps: [], nav_limit: nil, sort: true)
     @apps = apps
     @title = title
     @nav_limit = nav_limit
+    @sort = sort
   end
 
   def has_apps?
@@ -38,14 +39,25 @@ class OodAppGroup
     @nav_limit || apps.size
   end
 
+  def to_h
+    {
+      :group => self,
+      :apps => apps,
+      :title => title,
+      :nav_limit => nav_limit,
+      :sort => sort
+    }
+  end
+
   # given an array of apps, group those apps by app category (or the attribute)
   # specified by 'group_by', sorting both groups and apps arrays by title
-  def self.groups_for(apps: [], group_by: :category, nav_limit: nil)
-    apps.group_by { |app|
+  def self.groups_for(apps: [], group_by: :category, nav_limit: nil, sort: true)
+    groups = apps.group_by { |app|
       app.respond_to?(group_by) ? app.send(group_by) : app.metadata[group_by]
     }.map { |k,v|
-      OodAppGroup.new(title: k, apps: v.sort_by { |a| a.title }, nav_limit: nav_limit)
-    }.sort_by { |g| [ g.title.nil? ? 1 : 0, g.title ] } # make sure that the ungroupable app is always last
+      OodAppGroup.new(title: k, apps: sort ? v.sort_by { |a| a.title } : v, nav_limit: nav_limit)
+    }
+    sort ? groups.sort_by { |g| [ g.title.nil? ? 1 : 0, g.title ] } : groups # make sure that the ungroupable app is always last
   end
 
   # select a subset of groups by the specified array of titles

--- a/apps/dashboard/app/apps/ood_app_link.rb
+++ b/apps/dashboard/app/apps/ood_app_link.rb
@@ -29,5 +29,24 @@ class OodAppLink
       hash[var.to_s.gsub('@', '').to_sym] = instance_variable_get(var)
     end
   end
+
+  # make an OodAppLink look like an OodApp
+  class AppDecorator < SimpleDelegator
+    attr_reader :category, :subcategory
+
+    def initialize(link, category: nil, subcategory: nil)
+      super(link)
+      @category = category
+      @subcategory = subcategory
+    end
+
+    def links
+      [self]
+    end
+
+    def metadata
+      {}
+    end
+  end
 end
 

--- a/apps/dashboard/app/apps/ood_app_link.rb
+++ b/apps/dashboard/app/apps/ood_app_link.rb
@@ -23,5 +23,11 @@ class OodAppLink
   def new_tab?
     @new_tab
   end
+
+  def to_h
+    instance_variables.each_with_object({}) do |var, hash|
+      hash[var.to_s.gsub('@', '').to_sym] = instance_variable_get(var)
+    end
+  end
 end
 

--- a/apps/dashboard/app/apps/ood_app_link.rb
+++ b/apps/dashboard/app/apps/ood_app_link.rb
@@ -30,8 +30,14 @@ class OodAppLink
     end
   end
 
+  def categorize(category: nil, subcategory: nil)
+    LinkCategorizer.new(self, category: category, subcategory: subcategory)
+  end
+
+  private
+
   # make an OodAppLink look like an OodApp
-  class AppDecorator < SimpleDelegator
+  class LinkCategorizer < SimpleDelegator
     attr_reader :category, :subcategory
 
     def initialize(link, category: nil, subcategory: nil)

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_user, :set_user_configuration, :set_pinned_apps, :set_nav_groups, :set_announcements
   before_action :set_my_balances, only: [:index, :new, :featured]
-  before_action :set_featured_group
+  before_action :set_featured_group, :set_custom_navigation
 
   def set_user
     @user = CurrentUser
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
 
   def set_user_configuration
     @user_configuration ||= UserConfiguration.new(request_hostname: request.hostname)
+  end
+
+  def set_custom_navigation
+    @nav_bar = NavBar.items(@user_configuration.nav_bar)
   end
 
   def set_nav_groups

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -20,13 +20,13 @@ module ApplicationHelper
   # @param icon [String] favicon icon name (i.e. "refresh" "for "fa "fa-refresh")
   # @param url [#to_s, nil] url to access
   # @param role [String] app role i.e. "vdi", "shell", etc.
-  # @param method [String] change the method used in this link.
+  # @param data [Hash] data parameter for the link_to helper.
   # @return nil if url not set or the HTML string for the bootstrap nav link
-  def nav_link(title, icon, url, new_tab: false, role: nil, method: nil)
+  def nav_link(title, icon, url, new_tab: false, role: nil, data: nil)
     if url
       icon_uri = URI("fa://#{icon}")
       render partial: 'layouts/nav/link',
-             locals:  { title: title, class: 'dropdown-item', icon_uri: icon_uri, url: url.to_s, new_tab: new_tab, role: role, method: method }
+             locals:  { title: title, class: 'dropdown-item', icon_uri: icon_uri, url: url.to_s, new_tab: new_tab, role: role, data: data }
     end
   end
 
@@ -81,7 +81,7 @@ module ApplicationHelper
 
   def profile_link(profile_info)
     profile_id = profile_info[:id]
-    nav_link(profile_info.fetch(:name, profile_id), profile_info.fetch(:icon, "user"), settings_path("settings[profile]" => profile_id), method: "post") if profile_id
+    nav_link(profile_info.fetch(:name, profile_id), profile_info.fetch(:icon, "user"), settings_path("settings[profile]" => profile_id), data: {method: "post"}) if profile_id
   end
 
   def custom_css_paths

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -22,10 +22,11 @@ module ApplicationHelper
   # @param role [String] app role i.e. "vdi", "shell", etc.
   # @param method [String] change the method used in this link.
   # @return nil if url not set or the HTML string for the bootstrap nav link
-  def nav_link(title, icon, url, target: '', role: nil, method: nil)
+  def nav_link(title, icon, url, new_tab: false, role: nil, method: nil)
     if url
+      icon_uri = URI("fa://#{icon}")
       render partial: 'layouts/nav/link',
-             locals:  { title: title, faicon: icon, url: url.to_s, target: target, role: role, method: method }
+             locals:  { title: title, class: 'dropdown-item', icon_uri: icon_uri, url: url.to_s, new_tab: new_tab, role: role, method: method }
     end
   end
 

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -60,6 +60,8 @@ class UserConfiguration
 
     # Navigation properties
     ConfigurationProperty.with_boolean_mapper(name: :show_all_apps_link, default_value: false, read_from_env: true, env_names: ['SHOW_ALL_APPS_LINK']),
+    # New navigation definition property
+    ConfigurationProperty.property(name: :nav_bar, default_value: []),
   ].freeze
 
   def initialize(request_hostname: nil)

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -38,19 +38,13 @@
       <div class="collapse navbar-collapse" id="navbar">
         <ul class="navbar-nav mr-auto">
           <% if @nav_bar.empty? %>
-            <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
+            <%= render partial: 'layouts/nav/featured_apps' if @featured_group.present? %>
             <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
             <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
             <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
           <% else %>
             <% @nav_bar.each do |nav_item| %>
-              <%= begin
-                    render partial: nav_item.partial_path, locals: nav_item.to_h
-                  rescue NoMethodError => e
-                    raise StandardError, nav_item.inspect
-                    # raise e
-                  end
-              %>
+              <%= render partial: nav_item.partial_path, locals: nav_item.to_h %>
             <% end %>
           <% end %>
         </ul>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -37,10 +37,22 @@
 
       <div class="collapse navbar-collapse" id="navbar">
         <ul class="navbar-nav mr-auto">
-          <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
-          <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
-          <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
-          <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
+          <% if @nav_bar.empty? %>
+            <%= render partial: 'layouts/nav/featured_apps', locals: { group: @featured_group } if @featured_group.present? %>
+            <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
+            <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
+            <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
+          <% else %>
+            <% @nav_bar.each do |nav_item| %>
+              <%= begin
+                    render partial: nav_item.partial_path, locals: nav_item.to_h
+                  rescue NoMethodError => e
+                    raise StandardError, nav_item.inspect
+                    # raise e
+                  end
+              %>
+            <% end %>
+          <% end %>
         </ul>
 
         <ul class="navbar-nav">

--- a/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -5,7 +5,7 @@
 
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
     <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
-    <%= nav_link(t('dashboard.nav_develop_docs'), "book", Configuration.developer_docs_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_develop_docs'), "book", Configuration.developer_docs_url, new_tab: true) %>
     <%= nav_link(products_title(:dev), "cog", products_path(type: "dev")) %>
     <% if Configuration.app_sharing_enabled? %>
       <%= nav_link(products_title(:usr), "share-alt", products_path(type: "usr")) %>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -1,3 +1,4 @@
+<% group = @featured_group %>
 <li class="nav-item dropdown" title="<%= group.title %>" >
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -2,7 +2,7 @@
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 
   <ul class="dropdown-menu">
-    <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory).each_with_index do |g, index| %>
+    <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, sort: group.sort).each_with_index do |g, index| %>
       <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
       <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
       <% g.apps.each do |app| %>

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -4,12 +4,12 @@
   </a>
 
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
-    <%= nav_link(t('dashboard.nav_help_support'), "question-circle", support_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_help_support'), "question-circle", support_url, new_tab: true) %>
+    <%= nav_link(t('dashboard.nav_help_docs'), "info-circle", docs_url, new_tab: true) %>
+    <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, new_tab: true) %>
+    <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, new_tab: true) %>
     <% if help_custom_url %>
-      <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, target: "_blank" ) %>
+      <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, new_tab: true) %>
     <% end %>
     <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
     <% unless profile_links.empty? %>

--- a/apps/dashboard/app/views/layouts/nav/_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_link.html.erb
@@ -2,13 +2,14 @@
 locals:
 title - required - text for the link
 url - required - link url string
+class - optional, main type of link.
 faicon - optional, default "cog" - font awesome icon to use
 target - optional, default "_self" - link target
 role - optional, default ""
 method - optional, data-method for the link
 %>
-<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:target, '_self'), class: "dropdown-item m-auto #{local_assigns.fetch(:role, nil)}",  'data-method': local_assigns.fetch(:method, nil) do %>
-  <%= tag.i class: "fas fa-fw fa-#{local_assigns.fetch(:faicon, 'cog')}" %>
+<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:new_tab, false) ? "_blank" : nil, class: "#{local_assigns.fetch(:class, 'nav-link')} m-auto #{local_assigns.fetch(:role, nil)}",  'data-method': local_assigns.fetch(:method, nil) do %>
+  <%= icon_tag(local_assigns.fetch(:icon_uri, URI("fas://cog"))) %>
   <%= tag.span do %>
     <%= local_assigns.fetch(:title, 'No title') %>
   <% end %>

--- a/apps/dashboard/app/views/layouts/nav/_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_link.html.erb
@@ -2,15 +2,28 @@
 locals:
 title - required - text for the link
 url - required - link url string
-class - optional, main type of link.
-faicon - optional, default "cog" - font awesome icon to use
-target - optional, default "_self" - link target
+class - optional, default "nav-link" - main css class for the link.
+icon_uri - optional, default "fas://cog" - font awesome icon to use
+new_tab - optional, default false - link target
 role - optional, default ""
-method - optional, data-method for the link
+data - optional, data parameter for the link_to helper
 %>
-<%= tag.a href: local_assigns.fetch(:url), target: local_assigns.fetch(:new_tab, false) ? "_blank" : nil, class: "#{local_assigns.fetch(:class, 'nav-link')} m-auto #{local_assigns.fetch(:role, nil)}",  'data-method': local_assigns.fetch(:method, nil) do %>
+<%
+  title = local_assigns.fetch(:title, 'No title')
+  url = local_assigns.fetch(:url)
+%>
+<%=
+  link_to(
+    url,
+    title: title,
+    class: "#{local_assigns.fetch(:class, 'nav-link')} m-auto #{local_assigns.fetch(:role, nil)}",
+    target: local_assigns.fetch(:new_tab, false) ? "_blank" : nil,
+    aria: ({ current: ('page' if (current_page?(url))) }),
+    data: local_assigns.fetch(:data, nil)
+  ) do
+%>
   <%= icon_tag(local_assigns.fetch(:icon_uri, URI("fas://cog"))) %>
   <%= tag.span do %>
-    <%= local_assigns.fetch(:title, 'No title') %>
+    <%= title %>
   <% end %>
 <% end %>

--- a/apps/dashboard/test/apps/app_recategorizer_test.rb
+++ b/apps/dashboard/test/apps/app_recategorizer_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class AppRecategorizerTest < ActiveSupport::TestCase
+
+  test "should create an OodApp with category and subcategory" do
+    result = AppRecategorizer.new(stub(), category: "test_category", subcategory: "test_subcategory")
+    assert_equal "test_category",  result.category
+    assert_equal "test_subcategory",  result.subcategory
+  end
+
+end

--- a/apps/dashboard/test/apps/featured_app_test.rb
+++ b/apps/dashboard/test/apps/featured_app_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class FeaturedAppTest < ActiveSupport::TestCase
+
+  def setup
+    # Mock the sys installed applications
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+  end
+
+  test "FeaturedApp.from_ood_app should initialize object correctly" do
+    app = OodApp.new(Router.router_from_token("sys/token"))
+
+    target = FeaturedApp.from_ood_app(app, token: "other/token")
+    assert_equal "Apps", target.category
+    assert_equal "Pinned Apps", target.subcategory
+    assert_equal "other/token", target.token
+    assert_equal "sys/token", target.router.token
+  end
+
+  test "FeaturedApp.category can be set on creation" do
+    target = FeaturedApp.new(Router.router_from_token("sys/token"), category: "Test Feature")
+    assert_equal "Test Feature", target.category
+  end
+
+  test "FeaturedApp.subcategory can be set on creation" do
+    target = FeaturedApp.new(Router.router_from_token("sys/token"), subcategory: "Test Sub Feature")
+    assert_equal "Test Sub Feature", target.subcategory
+  end
+
+  test "FeaturedApp.sub_app_list should return a single BatchConnect::App for sub apps" do
+    # Given a token for a sub app
+    token = "sys/bc_desktop/oakley"
+    # And a application with 2 sub apps "sys/bc_desktop"
+    ood_app = OodApp.new(Router.router_from_token(token))
+    assert_equal 2, ood_app.send(:sub_app_list).size
+
+    # When a FeatureApp is created
+    target = FeaturedApp.new(Router.router_from_token(token), token: token)
+    # Then sub_app_list only contains the sub app driven by the token"
+    assert_equal [BatchConnect::App.from_token(token)], target.send(:sub_app_list)
+    assert_equal "oakley", target.send(:sub_app_name)
+  end
+
+  test "FeaturedApp.sub_app_list should return a single BatchConnect::App for apps" do
+    # Given a token for a sub app
+    token = "sys/bc_jupyter"
+    # And a application with no sub apps "sys/bc_jupyter"
+    ood_app = OodApp.new(Router.router_from_token(token))
+    assert_equal 1, ood_app.send(:sub_app_list).size
+
+    # When a FeatureApp is created
+    target = FeaturedApp.new(Router.router_from_token(token), token: token)
+    # Then sub_app_list only contains the sub app driven by the token"
+    assert_equal [BatchConnect::App.from_token(token)], target.send(:sub_app_list)
+    assert_equal "bc_jupyter", target.send(:sub_app_name)
+  end
+
+end

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -21,6 +21,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/link",  result[0].partial_path
     assert_equal "Jupyter Notebook",  result[0].title
     assert_equal "/batch_connect/sys/bc_jupyter/session_contexts/new",  result[0].url
   end
@@ -30,6 +31,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/group",  result[0].partial_path
     assert_equal "Apps",  result[0].title
     assert_equal 4,  result[0].apps.size
   end
@@ -39,6 +41,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/group",  result[0].partial_path
     assert_equal "Interactive Apps",  result[0].title
     assert_equal 4,  result[0].apps.size
   end
@@ -51,6 +54,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/group",  result[0].partial_path
     assert_equal "menu title",  result[0].title
   end
 
@@ -62,6 +66,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/link",  result[0].partial_path
     assert_equal "link title",  result[0].title
     assert_equal "/path/test",  result[0].url
   end
@@ -74,6 +79,7 @@ class NavBarTest < ActiveSupport::TestCase
     expected_data_property = { method: 'post' }
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/link",  result[0].partial_path
     assert_equal "profile title",  result[0].title
     assert_equal "/settings?settings%5Bprofile%5D=profile1",  result[0].url
     assert_equal expected_data_property,  result[0].data
@@ -87,6 +93,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/link",  result[0].partial_path
     assert_equal "Jupyter Notebook",  result[0].title
   end
 
@@ -97,6 +104,7 @@ class NavBarTest < ActiveSupport::TestCase
 
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
+    assert_equal "layouts/nav/link",  result[0].partial_path
     assert_equal "Jupyter Notebook",  result[0].title
   end
 
@@ -123,6 +131,12 @@ class NavBarTest < ActiveSupport::TestCase
     result = NavBar.items([stub(), valid_item, stub()])
     assert_equal 1,  result.size
     assert_equal "Jupyter Notebook",  result[0].title
+  end
+
+  test "Check supported static links" do
+    NavBar::STATIC_LINKS.each do |name, template|
+      assert_equal true,  [:all_apps, :featured_apps, :sessions].include?(name)
+    end
   end
 
 end

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -1,0 +1,128 @@
+require 'test_helper'
+
+class NavBarTest < ActiveSupport::TestCase
+
+  def setup
+    # Mock the sys installed applications
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+  end
+
+  test "NavBar.items should return navigation template when nav_item is a string matching a static link" do
+    nav_item = "all_apps"
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "layouts/nav/all_apps",  result[0].partial_path
+  end
+
+  test "NavBar.items should return navigation link when nav_item is a string matching one app token" do
+    nav_item = "sys/bc_jupyter"
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "Jupyter Notebook",  result[0].title
+    assert_equal "/batch_connect/sys/bc_jupyter/session_contexts/new",  result[0].url
+  end
+
+  test "NavBar.items should return navigation group when nav_item is a string matching multiple app tokens" do
+    nav_item = "sys/bc_*"
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "Apps",  result[0].title
+    assert_equal 4,  result[0].apps.size
+  end
+
+  test "NavBar.items should return navigation group when nav_item is a string matching an sys application category" do
+    nav_item = "Interactive Apps"
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "Interactive Apps",  result[0].title
+    assert_equal 4,  result[0].apps.size
+  end
+
+  test "NavBar.items should return navigation group when nav_item has links property" do
+    nav_item = {
+      title: "menu title",
+      links: []
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "menu title",  result[0].title
+  end
+
+  test "NavBar.items should return navigation link when nav_item has url property" do
+    nav_item = {
+      title: "link title",
+      url: "/path/test"
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "link title",  result[0].title
+    assert_equal "/path/test",  result[0].url
+  end
+
+  test "NavBar.items should return navigation profile when nav_item has profile property" do
+    nav_item = {
+      title: "profile title",
+      profile: "profile1"
+    }
+    expected_data_property = { method: 'post' }
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "profile title",  result[0].title
+    assert_equal "/settings?settings%5Bprofile%5D=profile1",  result[0].url
+    assert_equal expected_data_property,  result[0].data
+    assert_equal false,  result[0].new_tab?
+  end
+
+  test "NavBar.items should return navigation link when nav_item has app property" do
+    nav_item = {
+      apps: "sys/bc_jupyter"
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "Jupyter Notebook",  result[0].title
+  end
+
+  test "NavBar.items should return navigation link when nav_item has tokens property" do
+    nav_item = {
+      apps: ["sys/bc_jupyter"]
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal 1,  result.size
+    assert_equal "Jupyter Notebook",  result[0].title
+  end
+
+  test "NavBar should keep navigation order from configuration" do
+    titles = (1..10).to_a.map{ |_| SecureRandom.uuid }
+    config = titles.map{ |x| {title: x, links: []} }
+
+    result = NavBar.items(config)
+    assert_equal 10,  result.size
+    titles.each_with_index do |title, index|
+      assert_equal title,  result[index].title
+    end
+  end
+
+  test "NavBar.items should return empty list when empty configuration provided" do
+    assert_equal true,  NavBar.items([]).empty?
+  end
+
+  test "NavBar.items should discard invalid configuration items" do
+    valid_item = {
+      apps: "sys/bc_jupyter"
+    }
+
+    result = NavBar.items([stub(), valid_item, stub()])
+    assert_equal 1,  result.size
+    assert_equal "Jupyter Notebook",  result[0].title
+  end
+
+end

--- a/apps/dashboard/test/apps/ood_app_link_test.rb
+++ b/apps/dashboard/test/apps/ood_app_link_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class OodAppLinkTest < ActiveSupport::TestCase
+
+  def setup
+    @default_link_data = {
+      title: "title",
+      subtitle: "subtitle",
+      description: "description",
+      url: "url",
+      icon_uri: "fas://test",
+      caption: "caption",
+      new_tab: false,
+      data: { method: "post" },
+    }
+  end
+
+  test "OodAppLink should update all properties based on hash input" do
+    result = OodAppLink.new(@default_link_data)
+    check_default_link_data(result)
+  end
+
+  test "OodAppLink expected defaults" do
+    link_data = {}
+
+    result = OodAppLink.new(link_data)
+    assert_equal "",  result.title
+    assert_equal "",  result.subtitle
+    assert_equal "",  result.description
+    assert_equal "",  result.url
+    assert_equal URI("fas://cog"),  result.icon_uri
+    assert_nil result.caption
+    assert_equal true,  result.new_tab?
+    assert_equal({},  result.data)
+  end
+
+  test "OodAppLink.to_h should create a hash with all link attributes" do
+    result = OodAppLink.new(@default_link_data).to_h
+    assert_equal "title",  result[:title]
+    assert_equal "subtitle",  result[:subtitle]
+    assert_equal "description",  result[:description]
+    assert_equal "url",  result[:url]
+    assert_equal URI("fas://test"),  result[:icon_uri]
+    assert_equal "caption",  result[:caption]
+    assert_equal false,  result[:new_tab]
+    assert_equal({ method: "post" },  result[:data])
+  end
+
+  test "OodAppLink.categorize should create an OodAppLink with category and subcategory" do
+    result = OodAppLink.new(@default_link_data).categorize(category: "test_category", subcategory: "test_subcategory")
+    check_default_link_data(result)
+    assert_equal "test_category",  result.category
+    assert_equal "test_subcategory",  result.subcategory
+  end
+
+  def check_default_link_data(link)
+    assert_equal "title",  link.title
+    assert_equal "subtitle",  link.subtitle
+    assert_equal "description",  link.description
+    assert_equal "url",  link.url
+    assert_equal URI("fas://test"),  link.icon_uri
+    assert_equal "caption",  link.caption
+    assert_equal false,  link.new_tab?
+    assert_equal({ method: "post" },  link.data)
+  end
+
+end

--- a/apps/dashboard/test/integration/custom_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_navigation_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class CustomNavigationTest < ActionDispatch::IntegrationTest
+ test "should render a custom navigation menu when nav_bar is defined in UserConfiguration" do
+   # Mock the sys installed applications
+   SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+   # Test a navigation item of each type
+   stub_user_configuration({nav_bar: [
+     {title: "Custom Menu",
+      links: [
+        {group: "Custom Menu Dropdown Header"},
+        {title: "Menu Link",
+         url: "/menu/link"}
+      ]},
+     {title: "Custom Apps",
+      links: [
+        {group: "Custom Apps Dropdown Header"},
+        {apps: "sys/systemstatus"}
+      ]},
+     {title: "Custom Link",
+      url: "/custom/link"},
+     "all_apps",
+   ]})
+
+   get root_path
+   assert_response :success
+   # Check nav menus
+   assert_select "#navbar li.dropdown[title]", 3 # +1 here is 'Help'
+   # Check nav links
+   assert_select "#navbar > ul > a.nav-link[title]", 1
+
+   assert_select nav_menu(1), text: "Custom Menu"
+   assert_select nav_menu_header("Custom Menu"), text: "Custom Menu Dropdown Header"
+   assert_select nav_menu_link("Custom Menu", 1), text: "Menu Link"
+   assert_select nav_menu_link("Custom Menu", 1) do |link|
+     assert_equal "/menu/link", link.first['href']
+   end
+
+   assert_select nav_menu(2), text: "Custom Apps"
+   assert_select nav_menu_header("Custom Apps"), text: "Custom Apps Dropdown Header"
+   assert_select nav_menu_link("Custom Apps", 1), text: "System Status"
+   assert_select nav_menu_link("Custom Apps", 1) do |link|
+     assert_equal "/apps/show/systemstatus", link.first['href']
+   end
+
+   assert_select nav_link("Custom Link"), text: "Custom Link"
+   assert_select nav_link("Custom Link") do |link|
+     assert_equal "/custom/link", link.first['href']
+   end
+
+   # Check all_apps static link.
+   assert_select "#navbar .navbar-nav li.nav-item[title='All Apps']", text: "All Apps"
+ end
+
+ def nav_menu(order)
+   "#navbar .navbar-nav li.dropdown:nth-of-type(#{order}) a"
+ end
+
+ def nav_menu_link(title, order)
+   "#navbar .navbar-nav li.dropdown[title='#{title}'] ul.dropdown-menu a:nth-of-type(#{order})"
+ end
+
+ def nav_menu_header(title)
+   "#navbar .navbar-nav li.dropdown[title='#{title}'] ul.dropdown-menu li.dropdown-header"
+ end
+
+ def nav_link(title)
+   "#navbar .navbar-nav a.nav-link[title='#{title}']"
+ end
+end

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -60,6 +60,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       show_all_apps_link: false,
       filter_nav_categories?: false,
       nav_categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
+      nav_bar: [],
     }
 
     # ensure all properties are tested


### PR DESCRIPTION
Full navigation implementation based on Groups and Links.

Sample configuration and result:

```yaml
    nav_bar:
      - title: "Help"
        links:
          - group: "Doc Links"
          - apps: "sys/sas"
          - group: "Other Links"
          - apps: "sys/sas"
          - title: "how to docs"
            icon_uri: fa://desktop
            url: "/docs"
            new_tab: false
          - title: "Submit a help ticket"
            icon_uri: fa://question-circle
            url: "/tickets"
            new_tab: false
          - apps: "sys/sas"
      - title: "Documentation"
        url: "/sid2"
        new_tab: true
      - title: "Apps Menu"
        links:
          - "sys/Rstudio/*"
          - apps: [ "sys/sas" ]
          - group: "SubApp"
            apps: [ "sys/bc_desktop" ]
          - group: "Core Apps"
          - apps: [ "sys/bc_desktop" ]
          - title: "RStudio"
          - apps: [ "sys/Rstudio/*" ]
          - group: "Profiles"
          - title: "Team 1"
            profile: "team1"
          - title: "Team 2"
            profile: "team2"
      - apps: "sys/sas"
      - title: "Wiki"
        icon_uri: fa://desktop
        url: "/sid2"
        new_tab: true
      - title: "About"
         url: "https://www.iq.harvard.edu/research-computing#AboutSidNG"
         new_tab: false
      - all_apps
      - sessions
      - featured_apps
      - title: "Team 1"
         profile: "team1"
```

<img width="986" alt="Screenshot 2022-09-06 at 10 32 49" src="https://user-images.githubusercontent.com/17336210/188601072-fc11aed7-97cd-4178-af58-2e867d6903f8.png">


<img width="704" alt="Screenshot 2022-09-06 at 10 33 22" src="https://user-images.githubusercontent.com/17336210/188601306-80893643-0bb7-4340-9925-e3e83fc86e2c.png">



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202926714550802) by [Unito](https://www.unito.io)
