### PR TITLE
Added help navigation definition in UserConfiguration

### DIFF
--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -6,6 +6,8 @@ class NavBar
     all_apps: "layouts/nav/all_apps",
     featured_apps: "layouts/nav/featured_apps",
     sessions: "layouts/nav/sessions",
+    log_out: "layouts/nav/log_out",
+    user: "layouts/nav/user",
   }
 
   def self.items(nav_config)

--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
 
   def set_custom_navigation
     @nav_bar = NavBar.items(@user_configuration.nav_bar)
+    @help_bar = NavBar.items(@user_configuration.help_bar)
   end
 
   def set_nav_groups

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -60,8 +60,9 @@ class UserConfiguration
 
     # Navigation properties
     ConfigurationProperty.with_boolean_mapper(name: :show_all_apps_link, default_value: false, read_from_env: true, env_names: ['SHOW_ALL_APPS_LINK']),
-    # New navigation definition property
+    # New navigation definition properties
     ConfigurationProperty.property(name: :nav_bar, default_value: []),
+    ConfigurationProperty.property(name: :help_bar, default_value: []),
   ].freeze
 
   def initialize(request_hostname: nil)

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -43,25 +43,19 @@
             <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
             <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
           <% else %>
-            <% @nav_bar.each do |nav_item| %>
-              <%= render partial: nav_item.partial_path, locals: nav_item.to_h %>
-            <% end %>
+            <%= render partial: "layouts/nav/custom_navigation", locals: { navigation: @nav_bar }%>
           <% end %>
         </ul>
 
         <ul class="navbar-nav">
-          <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
-          <%= render partial: "layouts/nav/help_dropdown" %>
-
-          <li class="nav-item" data-container="body" data-toggle="popover" data-content="<%= t('dashboard.nav_user', username: @user.name) %>" data-placement="bottom">
-            <a class="nav-link disabled">
-              <i class="fas fa-user" aria-hidden="true" title="<%= t('dashboard.nav_user', username: @user.name) %>" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_user', username: @user.name) %></span>
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a class="nav-link" href="/logout"><i class="fas fa-sign-out-alt" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_logout') %></span></a>
-          </li>
+          <% if @help_bar.empty? %>
+            <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
+            <%= render partial: "layouts/nav/help_dropdown" %>
+            <%= render partial: "layouts/nav/user" %>
+            <%= render partial: "layouts/nav/log_out" %>
+          <% else %>
+            <%= render partial: "layouts/nav/custom_navigation", locals: { navigation: @help_bar }%>
+          <% end %>
         </ul>
       </div>
     </nav>

--- a/apps/dashboard/app/views/layouts/nav/_custom_navigation.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_custom_navigation.html.erb
@@ -1,0 +1,3 @@
+<% navigation.each do |nav_item| %>
+  <%= render partial: nav_item.partial_path, locals: nav_item.to_h %>
+<% end %>

--- a/apps/dashboard/app/views/layouts/nav/_log_out.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_log_out.html.erb
@@ -1,0 +1,3 @@
+<li class="nav-item">
+  <a class="nav-link" href="/logout"><i class="fas fa-sign-out-alt" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_logout') %></span></a>
+</li>

--- a/apps/dashboard/app/views/layouts/nav/_user.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_user.html.erb
@@ -1,0 +1,5 @@
+<li class="nav-item" data-container="body" data-toggle="popover" data-content="<%= t('dashboard.nav_user', username: @user.name) %>" data-placement="bottom">
+  <a class="nav-link disabled">
+    <i class="fas fa-user" aria-hidden="true" title="<%= t('dashboard.nav_user', username: @user.name) %>" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_user', username: @user.name) %></span>
+  </a>
+</li>

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -135,7 +135,7 @@ class NavBarTest < ActiveSupport::TestCase
 
   test "Check supported static links" do
     NavBar::STATIC_LINKS.each do |name, template|
-      assert_equal true,  [:all_apps, :featured_apps, :sessions].include?(name)
+      assert_equal true,  [:all_apps, :featured_apps, :sessions, :log_out, :user].include?(name)
     end
   end
 

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -61,6 +61,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       filter_nav_categories?: false,
       nav_categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
       nav_bar: [],
+      help_bar: [],
     }
 
     # ensure all properties are tested


### PR DESCRIPTION
Fixes #2276

Help navigation definition in UserConfiguration.
This is to customize the right hand side navigation in the same way as it is now possible to do for the main navigation



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202956058977851) by [Unito](https://www.unito.io)
