### PR TITLE
rm js source maps and minify for production builds

### DIFF
--- a/apps/dashboard/esbuild.config.js
+++ b/apps/dashboard/esbuild.config.js
@@ -27,6 +27,7 @@ function filesFromDir(dir) {
 esbuild.build({
   entryPoints: entryPoints,
   bundle: true,
+  sourcemap: true,
   format: 'esm',
   outdir: 'app/assets/builds',
   external: ['fs'],

--- a/apps/dashboard/esbuild.config.js
+++ b/apps/dashboard/esbuild.config.js
@@ -27,9 +27,9 @@ function filesFromDir(dir) {
 esbuild.build({
   entryPoints: entryPoints,
   bundle: true,
-  sourcemap: true,
   format: 'esm',
   outdir: 'app/assets/builds',
   external: ['fs'],
+  minify: process.env.RAILS_ENV == 'production' ? true : false,
 }).catch((e) => console.error(e.message));
 


### PR DESCRIPTION
Remove js source maps (because we don't use them) and minify for production javascript builds.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1202989852390153) by [Unito](https://www.unito.io)
