### PR TITLE
some bundler fixups

### DIFF
--- a/lib/tasks/build.rb
+++ b/lib/tasks/build.rb
@@ -15,7 +15,7 @@ namespace :build do
       next unless a.ruby_app?
 
       chdir a.path do
-        sh  "#{bundle_env} bin/bundle install #{bundle_args.join(' ')}"
+        sh "#{bundle_env} bin/bundle install #{bundle_args.join(' ')}"
       end
     end
 

--- a/lib/tasks/build.rb
+++ b/lib/tasks/build.rb
@@ -5,23 +5,23 @@ require_relative 'rake_helper'
 namespace :build do
   include RakeHelper
 
-  desc "Build gems"
+  desc 'Build gems'
   task :gems do
-    bundle_args = ["--jobs 4", "--retry 2"]
-    if VENDOR_BUNDLE
-      bundle_args << "--path vendor/bundle"
-    end
-    if PASSENGER_APP_ENV == "production"
-      bundle_args << "--without doc"
-    end
+    bundle_args = ['--jobs 4', '--retry 2']
+    bundle_args << '--path vendor/bundle' if VENDOR_BUNDLE
+    bundle_env = "BUNDLE_WITHOUT='doc'" if PASSENGER_APP_ENV == 'production'
+
     apps.each do |a|
       next unless a.ruby_app?
+
       chdir a.path do
-        sh "bin/bundle install #{bundle_args.join(' ')}"
+        sh  "#{bundle_env} bin/bundle install #{bundle_args.join(' ')}"
       end
     end
+
     infrastructure.each do |a|
       next unless a.gemfile?
+
       chdir a.path do
         sh "bundle install #{bundle_args.join(' ')}"
       end

--- a/ood_auth_map/ood_auth_map.gemspec
+++ b/ood_auth_map/ood_auth_map.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.1.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0.1"
 end


### PR DESCRIPTION
This removes the bundler version dependency in ood_auth_map (because of bundler security updates).  It also fixes the now deprecated `--without` flag in installing gems just because I happen to see it's still there while I was investigating what bundler versions are available.

Lastly some changes are just linting fixes.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203009101239487) by [Unito](https://www.unito.io)
