### PR TITLE
Safer form rendering

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -241,10 +241,8 @@ module BatchConnect
         hsh = hsh.deep_merge attribute.submit(fmt: fmt)
       end
 
-      ctx_binding = session_context.get_binding
-      ctx_binding.local_variable_set(:staged_root, staged_root.to_s)
-
-      hsh = hsh.deep_merge submit_config(binding: ctx_binding)
+      struct = session_context.to_openstruct(addons: { staged_root: staged_root })
+      hsh.deep_merge(submit_config(binding: struct.instance_eval { binding }))
 
     # let's write the file out if it's a submit.yml.erb that isn't valid yml
     rescue Psych::SyntaxError => e

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -242,7 +242,8 @@ module BatchConnect
       end
 
       struct = session_context.to_openstruct(addons: { staged_root: staged_root })
-      hsh.deep_merge(submit_config(binding: struct.instance_eval { binding }))
+      ctx_binding = struct.instance_eval { binding }
+      hsh.deep_merge(submit_config(binding: ctx_binding))
 
     # let's write the file out if it's a submit.yml.erb that isn't valid yml
     rescue Psych::SyntaxError => e

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -43,12 +43,6 @@ module BatchConnect
       @attributes.each(&block)
     end
 
-    # Get the binding for this object
-    # @return [Binding] binding of this object
-    def get_binding
-      binding
-    end
-
     # Delegate to attribute object's value getter/setter
     # @param method_name the method name called
     # @param arguments the arguments to the call
@@ -71,6 +65,15 @@ module BatchConnect
    def update_with_cache(cache)
       self.attributes = cache.select { |k,v| self[k.to_sym] && self[k.to_sym].cacheable?(app_specific_cache_enabled?)  }
    end 
+
+  def to_openstruct(addons: {})
+    context_attrs = Hash[*map { |a| [a.id.to_sym, a.value] }.flatten]
+    illegal_attrs = OpenStruct.new.methods & context_attrs.keys
+
+    raise "#{illegal_attrs.inspect} are keywords that cannot be used as names for form items" unless illegal_attrs.empty?
+
+    OpenStruct.new(context_attrs.merge(addons.symbolize_keys))
+  end
 
    private
     

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -70,7 +70,7 @@ module BatchConnect
     context_attrs = Hash[*map { |a| [a.id.to_sym, a.value] }.flatten]
     illegal_attrs = OpenStruct.new.methods & context_attrs.keys
 
-    raise "#{illegal_attrs.inspect} are keywords that cannot be used as names for form items" unless illegal_attrs.empty?
+    raise ArgumentError, "#{illegal_attrs.inspect} are keywords that cannot be used as names for form items" unless illegal_attrs.empty?
 
     OpenStruct.new(context_attrs.merge(addons.symbolize_keys))
   end

--- a/apps/dashboard/test/fixtures/sys_with_interactive_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_interactive_apps/bc_jupyter/form.yml
@@ -21,9 +21,12 @@ attributes:
       - ["any", ":ppn=28"]
       - ["gpu", ":ppn=28:gpus=1"]
       - ["hugemem", ":ppn=48:hugemem"]
+  partition:
+    value: "the-best-one"
 form:
   - bc_num_hours
   - bc_num_slots
   - node_type
   - bc_account
   - bc_email_on_started
+  - partition

--- a/apps/dashboard/test/fixtures/sys_with_interactive_apps/bc_jupyter/submit.yml.erb
+++ b/apps/dashboard/test/fixtures/sys_with_interactive_apps/bc_jupyter/submit.yml.erb
@@ -1,3 +1,4 @@
 ---
 script:
   error_path: "<%= staged_root %>/error.log"
+  queue: "<%= partition %>"

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -218,6 +218,8 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     Dir.mktmpdir do |dir|
       opts = app.submit_opts(app.build_session_context, staged_root: dir)
       assert_equal opts[:script][:error_path], "#{dir}/error.log"
+
+      assert_equal opts[:script][:queue], 'the-best-one'
     end
   end
 

--- a/apps/dashboard/test/models/batch_connect/session_context_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_context_test.rb
@@ -111,4 +111,49 @@ class BatchConnect::SessionContextTest < ActiveSupport::TestCase
 
      assert_equal ["PZS0714", "28"], [context["bc_account"].value, context["num_cores"].value]
    end
+
+  test "to_openstruct throws error when using OpenStruct methods" do
+    app = BatchConnect::App.new(router: nil)
+    app.stubs(:form_config).returns(attributes: { table: { value: "the_table" } }, form: ["bc_account", "table"])
+    context = app.build_session_context
+
+    assert_raises RuntimeError do
+      context.to_openstruct
+    end
+  end
+
+  test "to_openstruct accepts empty values" do
+    app = BatchConnect::App.new(router: nil)
+    app.stubs(:form_config).returns(attributes: { queue: { value: "gpu" } }, form: ["bc_account", "queue"])
+    context = app.build_session_context
+
+    assert_equal context.to_openstruct.to_h, {:bc_account => "", :queue => "gpu"}
+  end
+
+  test "to_openstruct accepts accepts hashes with string keys" do
+    app = BatchConnect::App.new(router: nil)
+    app.stubs(:form_config).returns(attributes: { queue: { value: "gpu" } }, form: ["bc_account", "queue"])
+    context = app.build_session_context
+    struct = context.to_openstruct(addons: {"new_thing": "some_new_thing"})
+
+    assert_equal struct.to_h, {:bc_account => "", :queue => "gpu", :new_thing=>"some_new_thing"}
+  end
+
+  test "to_openstruct accepts accepts hashes with symbol keys" do
+    app = BatchConnect::App.new(router: nil)
+    app.stubs(:form_config).returns(attributes: { queue: { value: "gpu" } }, form: ["bc_account", "queue"])
+    context = app.build_session_context
+    struct = context.to_openstruct(addons: {:new_thing => "some_new_thing"})
+
+    assert_equal struct.to_h, {:bc_account => "", :queue => "gpu", :new_thing=>"some_new_thing"}
+  end
+
+  test "to_openstruct responds to get_binding" do
+    app = BatchConnect::App.new(router: nil)
+    app.stubs(:form_config).returns(attributes: { queue: { value: "gpu" } }, form: ["bc_account", "queue"])
+    context = app.build_session_context
+
+    assert context.to_openstruct.respond_to?(:get_binding)
+    assert_equal false, context.to_openstruct.get_binding.nil?
+  end
 end

--- a/apps/dashboard/test/models/batch_connect/session_context_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_context_test.rb
@@ -117,7 +117,7 @@ class BatchConnect::SessionContextTest < ActiveSupport::TestCase
     app.stubs(:form_config).returns(attributes: { table: { value: "the_table" } }, form: ["bc_account", "table"])
     context = app.build_session_context
 
-    assert_raises RuntimeError do
+    assert_raises ArgumentError do
       context.to_openstruct
     end
   end
@@ -146,14 +146,5 @@ class BatchConnect::SessionContextTest < ActiveSupport::TestCase
     struct = context.to_openstruct(addons: {:new_thing => "some_new_thing"})
 
     assert_equal struct.to_h, {:bc_account => "", :queue => "gpu", :new_thing=>"some_new_thing"}
-  end
-
-  test "to_openstruct responds to get_binding" do
-    app = BatchConnect::App.new(router: nil)
-    app.stubs(:form_config).returns(attributes: { queue: { value: "gpu" } }, form: ["bc_account", "queue"])
-    context = app.build_session_context
-
-    assert context.to_openstruct.respond_to?(:get_binding)
-    assert_equal false, context.to_openstruct.get_binding.nil?
   end
 end


### PR DESCRIPTION
Fixes #605 by passing rendering off to an open struct instead of an object that is enumerable (i.e., SmartAttributes).  As a additional safety step - it checks for form items that _it_ has methods on (like `table`) and throws an error if one is trying to use one of these APIs/form fields.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203093865670232) by [Unito](https://www.unito.io)
