### PR TITLE
Myjobs: Add ENV override for showing job array

### DIFF
--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -141,12 +141,12 @@ class Workflow < ApplicationRecord
       @folder_contents = []
     end
   end
-  
+
   # Return a nested array of valid files for job script field in the job options form
   # Each file is an array with 2 elements: [relative_file_path, file_path]
   # Relative file path to the staged dir is at index 0, which will be used as the text for the option element
   # Full file path is at index 1, which will be used as the value for the option element
-  # 
+  #
   # Files grouped under the same categroy are in the same array: [[relative_file_path, file_path]]
   #
   # Valid abd suggested files are grouped under "Suggested file(s)" in the dropdown
@@ -162,7 +162,7 @@ class Workflow < ApplicationRecord
       "Other valid file(s)" => folder_contents.select(&:valid_script?).reject(&:suggested_script?).map { |f| [f.relative_path, f.path] },
     }.reject {|k,v| v.empty?}
   end
-  
+
   # Returns the pbsid of the last job in the workflow
   #
   # @return [String, nil] the pbsid or nil if no jobs on the workflow
@@ -321,8 +321,10 @@ class Workflow < ApplicationRecord
       end
     end
   end
-  
+
   def self.show_job_arrays?
+    return false if Configuration.hide_job_arrays?
+
     OODClusters.any? { |cluster| cluster.job_adapter.supports_job_arrays? }
   end
 

--- a/apps/myjobs/config/configuration_singleton.rb
+++ b/apps/myjobs/config/configuration_singleton.rb
@@ -58,6 +58,11 @@ class ConfigurationSingleton
     to_bool(ENV.fetch('OOD_SHOW_JOB_OPTIONS_ACCOUNT_FIELD', true))
   end
 
+  # Override variable for (not) showing job array in the job composer
+  def hide_job_arrays?
+    to_bool(ENV.fetch('OOD_HIDE_JOB_ARRAYS', false))
+  end
+
   # Load the dotenv local files first, then the /etc dotenv files and
   # the .env and .env.production or .env.development files.
   #


### PR DESCRIPTION
Hi, 

We are exploring ondemand at Kuleuven and we would like to not show the job array in the myjobs app due to a competing implementation.

This pr would add an environment variable acting as an override for showing the job array. 
Is this the best way to go about it?

Thank you in advance.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203150488889195) by [Unito](https://www.unito.io)
