### PR TITLE
use SHA1 instead of MD5 for FIPs systems (#2325)

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -528,7 +528,7 @@ module BatchConnect
         connect: running? ? connect.to_h : nil,
         time: info.wallclock_time.to_i / 60     # only update every minute
       }
-      Digest::MD5.hexdigest(hsh.to_json)
+      Digest::SHA1.hexdigest(hsh.to_json)
     end
 
     private

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
@@ -1,5 +1,5 @@
 <%# Random port from 10000 - 65535 deterministically generated %>
-<% localport = Digest::MD5.hexdigest("#{connect.host}:#{connect.port}").to_i(16) % 55535 + 10000 %>
+<% localport = Digest::SHA1.hexdigest("#{connect.host}:#{connect.port}").to_i(16) % 55535 + 10000 %>
 
 <% if browser.platform == :windows %>
 


### PR DESCRIPTION
Backport #2325 so folks don't have to patch their systems every time they update.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203152209687182) by [Unito](https://www.unito.io)
