### PR TITLE
Dynanic batch connect with slashes bugfix

### DIFF
--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -26,7 +26,7 @@ const setValueLookup = {};
 const hideLookup = {};
 
 // the regular expression for mountain casing
-const mcRex = /[-_]([a-z])|([_-][0-9])/g;
+const mcRex = /[-_]([a-z])|([_-][0-9])|([\/])/g;
 
 function bcElement(name) {
   return `${bcPrefix}_${name.toLowerCase()}`;
@@ -61,8 +61,14 @@ function shortId(elementId) {
 function mountainCaseWords(str) {
   const lower = str.toLowerCase();
   const first = lower.charAt(0).toUpperCase();
-  const rest = lower.slice(1).replace(mcRex, function(_all, letter, prefixedNumber) {
-    return letter ? letter.toUpperCase() : prefixedNumber.replace('_','-');
+  const rest = lower.slice(1).replace(mcRex, function(_all, letter, prefixedNumber, slash) {
+    if(letter){
+      return letter.toUpperCase();
+    }else if(prefixedNumber){
+      return prefixedNumber.replace('_','-');
+    }else if(slash){
+      return '_';
+    }
   });
 
   return  `${first}${rest}`;

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -124,6 +124,7 @@ attributes:
     options:
       - [ 'Physics 1234', 'physics_1234' ]
       - [ 'Astronomy 5678', 'astronomy_5678' ]
+      - [ 'Economics 8846', 'astronomy-with/other-characters/8846.31.4' ]
   classroom_size:
     widget: select
     options:
@@ -131,10 +132,12 @@ attributes:
       - [
           'medium', 'medium',
           data-option-for-classroom-astronomy-5678: false,
+          data-option-for-classroom-astronomy-with/other-characters/8846.31.4: false,
         ]
       - [
           'large', 'large',
           data-option-for-classroom-astronomy-5678: false,
+          data-option-for-classroom-astronomy-with/other-characters/8846.31.4: false,
         ]
 form:
   - bc_num_hours

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -402,7 +402,7 @@ class BatchConnectTest < ApplicationSystemTestCase
     assert_equal '3.6', find("##{bc_ele_id('python_version')}").value
   end
 
-  test 'options with numbers' do
+  test 'options with numbers and slashes' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 
     # defaults
@@ -413,6 +413,19 @@ class BatchConnectTest < ApplicationSystemTestCase
 
     # now change the classroom and see the other sizes disappear
     select('Astronomy 5678', from: bc_ele_id('classroom'))
+    assert_equal 'display: none;', find_option_style('classroom_size', 'medium')
+    assert_equal 'display: none;', find_option_style('classroom_size', 'large')
+
+    # go back to default
+    select('Physics 1234', from: bc_ele_id('classroom'))
+    assert_equal 'physics_1234', find_value('classroom')
+    assert_equal 'small', find_value('classroom_size')
+    assert_equal '', find_option_style('classroom_size', 'medium')
+    assert_equal '', find_option_style('classroom_size', 'large')
+
+    # choose the option with slashes, and large and medium are gone
+    select('Economics 8846', from: bc_ele_id('classroom'))
+    assert_equal 'small', find_value('classroom_size')
     assert_equal 'display: none;', find_option_style('classroom_size', 'medium')
     assert_equal 'display: none;', find_option_style('classroom_size', 'large')
   end


### PR DESCRIPTION
Fixes a bug from discourse https://discourse.openondemand.org/t/implementing-a-case-statement-in-form-yml-erb/2306  where `data-for-option` directives cannot handle options with a forward slash (`/`).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203168202959244) by [Unito](https://www.unito.io)
