### PR TITLE
backport #2319 - allow for multiple min & max settings

### DIFF
--- a/apps/dashboard/app/javascript/packs/batchConnect.js
+++ b/apps/dashboard/app/javascript/packs/batchConnect.js
@@ -187,7 +187,7 @@ function addMinMaxForHandler(optionId, option, key,  configValue) {
   const table = minMaxLookup[id];
   table.put(option, secondDimValue, {[minOrMax(key)] : configValue });
 
-  let cacheKey = `${optionId}_${secondDimId}`;
+  let cacheKey = `${id}_${optionId}_${secondDimId}`;
   if(!minMaxHandlerCache.includes(cacheKey)) {
     const changeElement = $(`#${optionId}`);
 
@@ -198,7 +198,7 @@ function addMinMaxForHandler(optionId, option, key,  configValue) {
     minMaxHandlerCache.push(cacheKey);
   }
 
-  cacheKey = `${secondDimId}_${optionId}`;
+  cacheKey = `${id}_${secondDimId}_${optionId}`;
   if(secondDimId !== undefined && !minMaxHandlerCache.includes(cacheKey)){
     const secondEle = $(`#${secondDimId}`);
 

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -21,6 +21,9 @@ attributes:
   bc_num_slots:
     max: 20
     min: 1
+  bc_num_hours:
+    max: 20
+    min: 1
   node_type:
     widget: select
     label: "Node type"
@@ -51,6 +54,11 @@ attributes:
           data-min-bc-num-slots-for-cluster-owens: 2,
           data-max-bc-num-slots-for-cluster-oakley: 40,
           data-min-bc-num-slots-for-cluster-oakley: 3,
+
+          data-max-bc-num-hours-for-cluster-owens: 88,
+          data-min-bc-num-hours-for-cluster-owens: 80,
+          data-max-bc-num-hours-for-cluster-oakley: 99,
+          data-min-bc-num-hours-for-cluster-oakley: 90,
         ]
       - [
           "hugemem",
@@ -73,7 +81,9 @@ attributes:
           data-hide-cuda-version: true,
           data-hide-advanced-options: true,
           data-min-bc-num-slots: 100,
-          data-max-bc-num-slots: 200
+          data-max-bc-num-slots: 200,
+          data-min-bc-num-hours: 444,
+          data-max-bc-num-hours: 555,
         ]
       - [
           "other-40ish-option",

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -165,6 +165,48 @@ class BatchConnectTest < ApplicationSystemTestCase
     assert_equal '100', find_value('bc_num_slots')
   end
 
+  test 'can set multiple min/maxes' do
+    # ensure defaults
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+    assert_equal 1, find_min('bc_num_hours')
+    assert_equal 20, find_max('bc_num_hours')
+    assert_equal 3, find_min('bc_num_slots')
+    assert_equal 7, find_max('bc_num_slots')
+    assert_equal 'any', find_value('node_type')
+
+    # changing the same node changes both bc_num_slots and bc_num_hours
+    select('same', from: bc_ele_id('node_type'))
+    assert_equal 100, find_min('bc_num_slots')
+    assert_equal 200, find_max('bc_num_slots')
+    assert_equal 444, find_min('bc_num_hours')
+    assert_equal 555, find_max('bc_num_hours')
+  end
+
+  test 'can set multiple min/maxes with for clauses' do
+    # ensure defaults
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+    assert_equal 1, find_min('bc_num_hours')
+    assert_equal 20, find_max('bc_num_hours')
+    assert_equal 3, find_min('bc_num_slots')
+    assert_equal 7, find_max('bc_num_slots')
+    assert_equal 'any', find_value('node_type')
+    assert_equal 'owens', find_value('cluster')
+
+    # changing to the gpu node changes both bc_num_slots and bc_num_hours
+    select('gpu', from: bc_ele_id('node_type'))
+    assert_equal 2, find_min('bc_num_slots')
+    assert_equal 28, find_max('bc_num_slots')
+    assert_equal 80, find_min('bc_num_hours')
+    assert_equal 88, find_max('bc_num_hours')
+
+    # change the cluster and these change again (the for clause)
+    select('oakley', from: bc_ele_id('cluster'))
+    assert_equal 3, find_min('bc_num_slots')
+    assert_equal 40, find_max('bc_num_slots')
+    assert_equal 90, find_min('bc_num_hours')
+    assert_equal 99, find_max('bc_num_hours')
+  end
+
   test 'nothing applied to broken node type' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
     assert_equal 7, find_max('bc_num_slots')


### PR DESCRIPTION
backport #2319 to release 2.0.

change min/max cache key to allow for that choice to modify more than one other elements.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203230813474492) by [Unito](https://www.unito.io)
