### PR TITLE
ternary should have a space here

### DIFF
--- a/apps/myjobs/app/models/resource_mgr_adapter.rb
+++ b/apps/myjobs/app/models/resource_mgr_adapter.rb
@@ -32,7 +32,7 @@ class ResourceMgrAdapter
       content: script_path.read,
       accounting_id: account_string,
       job_array_request: workflow.job_array_request.presence,
-      copy_environment: workflow.copy_environment.eql?("1") ? true: false
+      copy_environment: workflow.copy_environment.eql?("1") ? true : false
     )
     adapter(cluster).submit( script, **depends_on)
 


### PR DESCRIPTION
For whatever reason, this works but still - we should have the space.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203230813906240) by [Unito](https://www.unito.io)
