### PR TITLE
remove /nginx/noop

### DIFF
--- a/mod_ood_proxy/lib/nginx.lua
+++ b/mod_ood_proxy/lib/nginx.lua
@@ -58,9 +58,6 @@ function nginx_handler(r)
     else
       return err and http.http404(r, err) or http.http200(r)
     end
-  elseif task == "noop" then
-    -- do nothing
-    return redir and http.http307(r, redir) or http.http200(r)
   else
     return http.http404(r, "invalid nginx task")
   end

--- a/mod_ood_proxy/lib/pun_proxy.lua
+++ b/mod_ood_proxy/lib/pun_proxy.lua
@@ -62,9 +62,6 @@ function pun_proxy_handler(r)
   -- setup request for reverse proxy
   proxy.set_reverse_proxy(r, conn)
 
-  -- handle if backend server isn't completely started yet
-  r:custom_response(502, nginx_uri .. "/noop?redir=" .. r:escape(r.unparsed_uri))
-
   -- let the proxy handler do this instead
   return apache2.DECLINED
 end

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -180,34 +180,5 @@ describe 'Node and Rnode proxies' do
   #  browser.goto "#{ctr_base_url}/nginx/init?redir=/nothing"
   # end
 
-  it 'node correctly returns "Success" in browser when no redirect is given on noop' do
-    url = "#{ctr_base_url}/nginx/noop"
-    browser.goto "#{ctr_base_url}/nginx/noop"
-    expect(browser.text).to eq('Success')
-    expect(browser.url).to eq(url)
-  end 
-
-  # TODO expand "noop" logic in nginx.lua to handle redir for remaining noop tests
-  # it 'node correctly redirects to /pun/sys/dashboard with 307 when no redirect is given on noop' do
-  #   # Currently returns Success
-  #   browser.goto "#{ctr_base_url}/nginx/noop"
-  #   expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard")
-  # end 
-
-  # it 'node correctly returns "bad redir error" when redirect to "github.com" given on noop' do
-  #   browser.goto "#{ctr_base_url}/nginx/noop?redir=github.com"
-  #   expect(browser.text).to eq('Error -- bad `redir` request (github.com)')
-  # end
-
-  # it 'node correctly returns "bad redir error" when redirect to "https://github.com" given on noop' do
-  #   browser.goto "#{ctr_base_url}/nginx/noop?redir=https://github.com"
-  #   expect(browser.text).to eq('Error -- bad `redir` request (https://github.com)')
-  # end
-
-  # it 'node correctly returns "bad redir error" when redirect to "/node/localhost/5001" is given on noop' do
-  #   browser.goto "#{ctr_base_url}/nginx/noop?redir=/node/localhost/5001"
-  #   expect(browser.text).to eq('Error -- bad `redir` request ()')
-  # end
-
   # TODO: check content of page.
 end


### PR DESCRIPTION
remove /nginx/noop because it serves no real purpose.

I tracked it down to this commit (which is not noop, it tries to boot the pun). 

https://github.com/OSC/mod_ood_proxy/commit/120a2acbddda49c048639f69755fc4c61e816b90

Where I believe this is also left over from something erroneous. The commit message reads `do ... if 502` implying they thought this `r:custom_response` set the custom response _if_ the response was already 502?
```
  -- handle if backend server isn't completely started yet
  r:custom_response(502, nginx_uri .. "/noop?redir=" .. r:escape(r.unparsed_uri))
```

I'm not sure, in any case, I believe the `noop` functionality is completely useless. Just send the 302 directly instead of through this api.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203367194622007) by [Unito](https://www.unito.io)
