### PR TITLE
add rlcone initializer to auto populate rclone remotes

### DIFF
--- a/apps/dashboard/config/initializers/rclone.rb
+++ b/apps/dashboard/config/initializers/rclone.rb
@@ -1,0 +1,11 @@
+require 'rclone_util'
+
+Rails.application.config.after_initialize do |_|
+  remotes = RcloneUtil.list_remotes.map { |r| FavoritePath.new('', title: r, filesystem: r) }
+
+  OodFilesApp.candidate_favorite_paths.tap do |paths|
+    paths.concat(remotes)
+  end
+rescue => e
+  Rails.logger.error(e.message)
+end


### PR DESCRIPTION
#2264 gave us a way to list remotes in an initializers. Let's go ahead and add it to the main repo so that sites with rclone installed and people how have rclone configurations will automatically have those added to their favorite path.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203395863573767) by [Unito](https://www.unito.io)
