### PR TITLE
Added support for customizing left hand side applications menu

### DIFF
--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -41,6 +41,10 @@ class OodAppGroup
     @nav_limit || apps.size
   end
 
+  def links
+    apps.map(&:links).flatten
+  end
+
   def to_h
     {
       :group => self,

--- a/apps/dashboard/app/apps/ood_app_link.rb
+++ b/apps/dashboard/app/apps/ood_app_link.rb
@@ -33,8 +33,8 @@ class OodAppLink
     end
   end
 
-  def categorize(category: nil, subcategory: nil)
-    LinkCategorizer.new(self, category: category, subcategory: subcategory)
+  def categorize(category: '', subcategory: '', show_in_menu: false)
+    LinkCategorizer.new(self, category: category, subcategory: subcategory, show_in_menu: show_in_menu)
   end
 
   private
@@ -44,14 +44,19 @@ class OodAppLink
   class LinkCategorizer < SimpleDelegator
     attr_reader :category, :subcategory
 
-    def initialize(link, category: nil, subcategory: nil)
+    def initialize(link, category: '', subcategory: '', show_in_menu: false)
       super(link)
       @category = category
       @subcategory = subcategory
+      @show_in_menu = show_in_menu
     end
 
     def links
       [self]
+    end
+
+    def show_in_menu?
+      @show_in_menu
     end
   end
 end

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -61,6 +61,7 @@ class BatchConnect::SessionContextsController < ApplicationController
       @sys_app_groups = bc_sys_app_groups
       @usr_app_groups = bc_usr_app_groups
       @dev_app_groups = bc_dev_app_groups
+      @apps_menu_group = bc_custom_apps_group
     end
 
     # Set the session context from the app

--- a/apps/dashboard/app/controllers/batch_connect/sessions_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/sessions_controller.rb
@@ -41,5 +41,6 @@ class BatchConnect::SessionsController < ApplicationController
       @sys_app_groups = bc_sys_app_groups
       @usr_app_groups = bc_usr_app_groups
       @dev_app_groups = bc_dev_app_groups
+      @apps_menu_group = bc_custom_apps_group
     end
 end

--- a/apps/dashboard/app/controllers/concerns/batch_connect_concern.rb
+++ b/apps/dashboard/app/controllers/concerns/batch_connect_concern.rb
@@ -22,4 +22,16 @@ module BatchConnectConcern
       apps: nav_dev_apps.select(&:batch_connect_app?)
     )
   end
+
+  def bc_custom_apps_group
+    if !@user_configuration.interactive_apps_menu.empty?
+      # Apps menu override takes precedence
+      NavBar.menu_items(@user_configuration.interactive_apps_menu)
+    elsif !@nav_bar.empty?
+      # Create a custom list of batch connect applications based on the custom navigation defined
+      links = @nav_bar.map(&:links).flatten.select(&:show_in_menu?)
+      OodAppGroup.new(apps: links, title: t('dashboard.batch_connect_apps_menu_title'), sort: true)
+    end
+    # Return nil otherwise
+  end
 end

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -64,6 +64,7 @@ class UserConfiguration
     # New navigation definition properties
     ConfigurationProperty.property(name: :nav_bar, default_value: []),
     ConfigurationProperty.property(name: :help_bar, default_value: []),
+    ConfigurationProperty.property(name: :interactive_apps_menu, default_value: []),
 
     # Custom pages configuration property
     ConfigurationProperty.property(name: :custom_pages, default_value: {}),

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -65,6 +65,7 @@ locals: {
           sys_app_groups: @sys_app_groups,
           usr_app_groups: @usr_app_groups,
           dev_app_groups: @dev_app_groups,
+          apps_menu_group: @apps_menu_group,
           current_url: new_batch_connect_session_context_path(token: @app.token)
         }
       )

--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -27,7 +27,8 @@ locals: {
           locals: {
             sys_app_groups: @sys_app_groups,
             usr_app_groups: @usr_app_groups,
-            dev_app_groups: @dev_app_groups
+            dev_app_groups: @dev_app_groups,
+            apps_menu_group: @apps_menu_group
           }
         )
       %>

--- a/apps/dashboard/app/views/batch_connect/shared/_app_list.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_app_list.html.erb
@@ -4,7 +4,8 @@
   <%-
     OodAppGroup.groups_for(
       apps: apps,
-      group_by: local_assigns.fetch(:group_by, :subcategory)
+      group_by: local_assigns.fetch(:group_by, :subcategory),
+      sort: local_assigns.fetch(:sort, true),
     ).each do |app_group|
   -%>
     <%=
@@ -12,7 +13,7 @@
         "p",
         app_group.title,
         class: "list-group-item mb-0 header"
-      ) unless app_group.title.empty?
+      ) unless app_group.title.blank?
     %>
     <%=
       render(

--- a/apps/dashboard/app/views/batch_connect/shared/_app_menu.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_app_menu.html.erb
@@ -1,39 +1,53 @@
-<%- usr_app_groups.each do |app_group| -%>
+<%- if apps_menu_group -%>
   <%=
     render(
-        partial: "batch_connect/shared/app_list",
-        locals: {
-          title: app_group.title,
-          apps: app_group.apps,
-          current_url: local_assigns[:current_url],
-          group_by: :category,
-          show_owner: true
-        }
+      partial: "batch_connect/shared/app_list",
+      locals: {
+        title: apps_menu_group.title,
+        apps: apps_menu_group.apps,
+        current_url: local_assigns[:current_url],
+        sort: apps_menu_group.sort,
+      }
     )
   %>
-<%- end -%>
-<%- sys_app_groups.each do |app_group| -%>
-  <%=
-    render(
-        partial: "batch_connect/shared/app_list",
-        locals: {
-          title: app_group.title,
-          apps: app_group.apps,
-          current_url: local_assigns[:current_url]
-        }
-    )
-  %>
-<%- end -%>
-<%- dev_app_groups.each do |app_group| -%>
-  <%=
-    render(
-        partial: "batch_connect/shared/app_list",
-        locals: {
-          title: "#{app_group.title}" + t('dashboard.batch_connect_sandbox'),
-          apps: app_group.apps,
-          current_url: local_assigns[:current_url],
-          style: "sandbox-apps-header"
-        }
-    )
-  %>
+<%- else -%>
+  <%- usr_app_groups.each do |app_group| -%>
+    <%=
+      render(
+          partial: "batch_connect/shared/app_list",
+          locals: {
+            title: app_group.title,
+            apps: app_group.apps,
+            current_url: local_assigns[:current_url],
+            group_by: :category,
+            show_owner: true
+          }
+      )
+    %>
+  <%- end -%>
+  <%- sys_app_groups.each do |app_group| -%>
+    <%=
+      render(
+          partial: "batch_connect/shared/app_list",
+          locals: {
+            title: app_group.title,
+            apps: app_group.apps,
+            current_url: local_assigns[:current_url]
+          }
+      )
+    %>
+  <%- end -%>
+  <%- dev_app_groups.each do |app_group| -%>
+    <%=
+      render(
+          partial: "batch_connect/shared/app_list",
+          locals: {
+            title: "#{app_group.title}" + t('dashboard.batch_connect_sandbox'),
+            apps: app_group.apps,
+            current_url: local_assigns[:current_url],
+            style: "sandbox-apps-header"
+          }
+      )
+    %>
+  <%- end -%>
 <%- end -%>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -128,6 +128,7 @@ en:
       take a few minutes.
 
     batch_connect_sessions_status_completed: "For debugging purposes, this card will be retained for %{days} more days"
+    batch_connect_apps_menu_title: "Interactive Apps"
     breadcrumbs_all_apps: "All Apps"
     breadcrumbs_home: "Home"
     breadcrumbs_my_sessions: "My Interactive Sessions"

--- a/apps/dashboard/test/apps/ood_app_link_test.rb
+++ b/apps/dashboard/test/apps/ood_app_link_test.rb
@@ -46,11 +46,20 @@ class OodAppLinkTest < ActiveSupport::TestCase
     assert_equal({ method: "post" },  result[:data])
   end
 
-  test "OodAppLink.categorize should create an OodAppLink with category and subcategory" do
-    result = OodAppLink.new(@default_link_data).categorize(category: "test_category", subcategory: "test_subcategory")
+  test "OodAppLink.categorize should create an OodAppLink with category, subcategory, and show_in_menu?" do
+    result = OodAppLink.new(@default_link_data).categorize(category: "test_category", subcategory: "test_subcategory", show_in_menu: true)
     check_default_link_data(result)
     assert_equal "test_category",  result.category
     assert_equal "test_subcategory",  result.subcategory
+    assert_equal true,  result.show_in_menu?
+  end
+
+  test "OodAppLink.categorize check defaults" do
+    result = OodAppLink.new(@default_link_data).categorize
+    check_default_link_data(result)
+    assert_equal "",  result.category
+    assert_equal "",  result.subcategory
+    assert_equal false,  result.show_in_menu?
   end
 
   def check_default_link_data(link)

--- a/apps/dashboard/test/controllers/concerns/batch_connect_concern_test.rb
+++ b/apps/dashboard/test/controllers/concerns/batch_connect_concern_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class BatchConnectConcernTest < ActiveSupport::TestCase
+
+  class TestClass
+    include BatchConnectConcern
+
+    attr_accessor :user_configuration, :nav_bar
+  end
+
+  def setup
+    # Defaults
+    @target = TestClass.new
+    @target.user_configuration = stub(:interactive_apps_menu => [])
+    @target.nav_bar = []
+  end
+
+  test "bc_custom_apps_group should return nil when no interactive_apps_menu and nav_bar defined" do
+    assert_nil @target.bc_custom_apps_group
+  end
+
+  test "bc_custom_apps_group should return a navigation menu based on interactive_apps_menu property when defined" do
+    @target.user_configuration = stub(:interactive_apps_menu => {title: "Custom Apps Menu", links: []})
+
+    result = @target.bc_custom_apps_group
+
+    assert_equal 'Custom Apps Menu', result.title
+    assert_equal [], result.apps
+    # Sorting should be disabled. Use the order in the configuration
+    assert_equal false, result.sort
+  end
+
+  test "bc_custom_apps_group should return a navigation menu based on @nav_bar when interactive_apps_menu is not defined and @nav_bar is" do
+    nav_item = OodAppGroup.new(apps: [], title: "test title")
+    @target.nav_bar = [nav_item]
+    @target.expects(:t).with('dashboard.batch_connect_apps_menu_title').returns('menu title from translation')
+
+    result = @target.bc_custom_apps_group
+
+    assert_equal 'menu title from translation', result.title
+    assert_equal [], result.apps
+    # Sorting should be enabled. Apps come from different menus in the navigation
+    assert_equal true, result.sort
+  end
+
+end

--- a/apps/dashboard/test/integration/sessions_test.rb
+++ b/apps/dashboard/test/integration/sessions_test.rb
@@ -3,27 +3,13 @@
 require 'html_helper'
 require 'test_helper'
 
-# Test the new radio button functionality in the Jupyter Job Form
-# Testing that radio button with value 0 exists
-# Testing that radio button with value 1 exists
-# Testing that radio button label exists
-
-class BatchConnectTest < ActionDispatch::IntegrationTest
+class SessionsTest < ActionDispatch::IntegrationTest
   def setup
     stub_sys_apps
   end
 
-  test 'radio buttons and labels appear correctly' do
-    get new_batch_connect_session_context_url('sys/bc_jupyter')
-    assert_select 'form input[id="batch_connect_session_context_mode_0"]'
-    assert_select 'form input[id="batch_connect_session_context_mode_1"]'
-    assert_equal 'The Mode', css_select('label[for="batch_connect_session_context_mode"]').text
-    assert_equal 'Jupyter Lab', css_select('label[for="batch_connect_session_context_mode_1"]').text
-    assert_equal 'Jupyter Notebook', css_select('label[for="batch_connect_session_context_mode_0"]').text
-  end
-
   test 'default application menu renders correctly when nav_bar property defined' do
-    BatchConnect::SessionContextsController.any_instance.expects(:t).with('dashboard.batch_connect_apps_menu_title').returns('Translations title')
+    BatchConnect::SessionsController.any_instance.expects(:t).with('dashboard.batch_connect_apps_menu_title').returns('Translations title')
     stub_user_configuration({nav_bar: [
       {title: 'Custom Apps',
        links: [
@@ -33,7 +19,7 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
        ]}
     ]})
 
-    get new_batch_connect_session_context_url('sys/bc_jupyter')
+    get batch_connect_sessions_url
     assert_response :success
 
     assert_select 'div.card div.card-header', text: 'Translations title'
@@ -51,16 +37,16 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
 
   test 'interactive_apps_menu override renders correctly' do
     stub_user_configuration({
-      interactive_apps_menu: {
-        title: 'Menu Title',
-        links: [
-          {group: 'Submenu Title'},
-          {apps: 'sys/bc_jupyter'},
-          {apps: 'sys/bc_paraview'}
-        ]}
+    interactive_apps_menu: {
+      title: 'Menu Title',
+      links: [
+        {group: 'Submenu Title'},
+        {apps: 'sys/bc_jupyter'},
+        {apps: 'sys/bc_paraview'}
+      ]}
     })
 
-    get new_batch_connect_session_context_url('sys/bc_jupyter')
+    get batch_connect_sessions_url
     assert_response :success
 
     assert_select 'div.card div.card-header', text: 'Menu Title'

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -62,6 +62,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       nav_categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
       nav_bar: [],
       help_bar: [],
+      interactive_apps_menu: [],
       custom_pages: {},
     }
 


### PR DESCRIPTION
Changes to generate the left hand side applications navigation in `Interactive Apps` and `Interactive Sessions` pages by discovering the `sys` applications that have been configured in a custom top level navigation.

As well, to add support for a custom configuration to define the navigation.

Fixes: #2326

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203412125609234) by [Unito](https://www.unito.io)
