### PR TITLE
add workflow and rake task to randomly lint a file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: Lint Random File
+
+on:
+  workflow_dispatch:
+  schedule:
+    # every 3 days
+    - cron:  '0 2 */3 * 1'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update-dependencies:
+    strategy:
+      fail-fast: false
+    runs-on: 'ubuntu-latest'
+    name: Lint Random File
+
+    steps:
+      - name: Checkout ${{ github.sha	}}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.1"
+          bundler: "2.1.4"
+          bundler-cache: true
+
+      - name: Lint a file
+        run: bundle exec rake lint:random
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
+          commit-message: lint a random file
+          committer: OSC ROBOT <osc.robot@gmail.com>
+          author: osc-bot <osc.robot@gmail.com>
+          delete-branch: true
+          title: 'Lint a random file'
+          push-to-fork: osc-bot/ondemand
+          branch: osc-bot/random-linted-file
+          body: |
+            The result of linting a random file.
+

--- a/lib/tasks/lint.rb
+++ b/lib/tasks/lint.rb
@@ -7,18 +7,31 @@ namespace :lint do
   require_relative 'rake_helper'
   include RakeHelper
 
+  DEFAULT_PATTERNS = [
+    "apps/**/*.rb",
+    "lib/**/*.rb",
+    "nginx_stage/**/*.rb",
+    "ood-portal-generator/**/*.rb",
+    "spec/**/*.rb",
+  ]
+
   begin
     require 'rubocop/rake_task'
     RuboCop::RakeTask.new(:rubocop, [:path]) do |t, args|
       t.options = ["--config=#{PROJ_DIR.join(".rubocop.yml")}"]
-      default_patterns = [
-        "apps/**/*.rb",
-        "lib/**/*.rb",
-        "nginx_stage/**/*.rb",
-        "ood-portal-generator/**/*.rb",
-        "spec/**/*.rb",
-      ]
-      t.patterns = args[:path].nil? ? default_patterns : [args[:path]]
+      t.patterns = args[:path].nil? ? DEFAULT_PATTERNS : [args[:path]]
+    end
+  rescue LoadError
+  end
+
+  begin
+    require 'rubocop/rake_task'
+    RuboCop::RakeTask.new(:random) do |t, args|
+      all_files = Dir.glob(DEFAULT_PATTERNS).reject { |f| f.include?('vendor/bundle') }
+      one_file = all_files[Random.rand(all_files.size)]
+
+      t.options = ["--config=#{PROJ_DIR.join(".rubocop.yml")}", "-A"]
+      t.patterns = [one_file]
     end
   rescue LoadError
   end


### PR DESCRIPTION
Add workflow and rake task to randomly lint a file so that over time our files will not have so many linting errors. Current schedule is every 3 days.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203428702523468) by [Unito](https://www.unito.io)
