### PR TITLE
use bundler environment vars instead of deprecated --without flag

### DIFF
--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -17,7 +17,6 @@ override_dh_auto_configure:
 	# nothing to configure
 
 override_dh_auto_build:
-	env
 	BUNDLE_WITHOUT='test package' bundle install
 	rake --trace -mj$(NCPUS) build
 	rm -rf $(GEM_HOME)/cache

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -18,7 +18,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	env
-	bundle install --without test package
+	BUNDLE_WITHOUT='test package' bundle install
 	rake --trace -mj$(NCPUS) build
 	rm -rf $(GEM_HOME)/cache
 	rm -rf apps/*/node_modules/.cache

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -121,7 +121,7 @@ set -x
 set -e
 export GEM_HOME=$(pwd)/gems-build
 export GEM_PATH=$(pwd)/gems-build:$GEM_PATH
-bundle install --without test package
+BUNDLE_WITHOUT='test package' bundle install
 rake --trace -mj%{ncpus} build
 rm -rf ${GEM_HOME}/cache
 rm -rf apps/*/node_modules/.cache


### PR DESCRIPTION
Fixes #1544 by using the environment variables instead of --without CLI flag.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203429454484873) by [Unito](https://www.unito.io)
