### PR TITLE
navconfig to use allowlist to deprecate whitelist

### DIFF
--- a/apps/dashboard/app/apps/nav_config.rb
+++ b/apps/dashboard/app/apps/nav_config.rb
@@ -6,11 +6,11 @@
 class NavConfig
   class << self
     attr_accessor :categories, :categories_allowlist
-    alias categories_allowlist? :categories_allowlist
+    alias categories_allowlist? categories_allowlist
 
-    alias categories_whitelist :categories_allowlist
-    alias categories_whitelist= :categories_allowlist=
-    alias categories_whitelist? :categories_allowlist?
+    alias categories_whitelist categories_allowlist
+    alias categories_whitelist= categories_allowlist=
+    alias categories_whitelist? categories_allowlist?
   end
 
   self.categories = ['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps']

--- a/apps/dashboard/app/apps/nav_config.rb
+++ b/apps/dashboard/app/apps/nav_config.rb
@@ -1,11 +1,18 @@
+# frozen_string_literal: true
+
 #
 # Deprecated.
 # This is now configurable through configuration. See UserConfiguration class.
 class NavConfig
-    class << self
-      attr_accessor :categories, :categories_whitelist
-      alias_method :categories_whitelist?, :categories_whitelist
-    end
-    self.categories = ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"]
-    self.categories_whitelist = false
+  class << self
+    attr_accessor :categories, :categories_allowlist
+    alias categories_allowlist? :categories_allowlist
+
+    alias categories_whitelist :categories_allowlist
+    alias categories_whitelist= :categories_allowlist=
+    alias categories_whitelist? :categories_allowlist?
+  end
+
+  self.categories = ['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps']
+  self.categories_allowlist = false
 end

--- a/apps/dashboard/test/apps/nav_config_test.rb
+++ b/apps/dashboard/test/apps/nav_config_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NavConfigTest < ActiveSupport::TestCase
+  def setup
+    # reset defaults for every test
+    NavConfig.categories = ['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps']
+    NavConfig.categories_allowlist = false
+  end
+
+  test 'default values' do
+    assert_equal(false, NavConfig.categories_allowlist?)
+    assert_equal(false, NavConfig.categories_allowlist)
+    assert_equal(['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps'], NavConfig.categories)
+
+    assert_equal(false, NavConfig.categories_whitelist?)
+    assert_equal(false, NavConfig.categories_whitelist)
+  end
+
+  test 'can set allowlist' do
+    NavConfig.categories = ['the only one']
+    NavConfig.categories_allowlist = true
+
+    assert_equal(true, NavConfig.categories_allowlist?)
+    assert_equal(true, NavConfig.categories_allowlist)
+    assert_equal(true, NavConfig.categories_whitelist?)
+    assert_equal(true, NavConfig.categories_whitelist)
+    assert_equal(['the only one'], NavConfig.categories)
+  end
+
+  test 'can set whitelist' do
+    NavConfig.categories = ['the only one']
+    NavConfig.categories_whitelist = true
+
+    assert_equal(true, NavConfig.categories_allowlist?)
+    assert_equal(true, NavConfig.categories_allowlist)
+    assert_equal(true, NavConfig.categories_whitelist?)
+    assert_equal(true, NavConfig.categories_whitelist)
+    assert_equal(['the only one'], NavConfig.categories)
+  end
+end


### PR DESCRIPTION
Fix #1458 by renaming whitelist to allowlist in the NavConfig object.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203429604886100) by [Unito](https://www.unito.io)
