### PR TITLE
Improvements to logic for displaying form parameters in session cards

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -151,13 +151,12 @@ module BatchConnect::SessionsHelper
   end
 
   def display_choices(session)
-    session_content = session.display_choices || {}
-    # Hash to an array with the labels and values
-    session_content.to_a.map do |label, value|
+    user_context = session.user_context
+    session.app.attributes.select(&:display?).map do |attribute|
       content_tag(:p) do
-        concat content_tag(:strong, "#{label}:")
+        concat content_tag(:strong, "#{attribute.label}:")
         concat " "
-        concat value
+        concat user_context.fetch(attribute.id, '')
       end
     end.join.html_safe
   end

--- a/apps/dashboard/app/views/support_ticket/email/default.text.erb
+++ b/apps/dashboard/app/views/support_ticket/email/default.text.erb
@@ -20,6 +20,7 @@ Interactive Session Information:
           createdAt: Time.at(@context.session.created_at).iso8601,
           token: @context.session.token,
           title: @context.session.title,
+          user_context: @context.session.user_context,
           info: filter_session_parameters(@context.session.info),
           deletedInDays: @context.session.days_till_old,
         })

--- a/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
+++ b/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
@@ -20,6 +20,7 @@ Session Information:
         createdAt: Time.at(context[:session].created_at).iso8601,
         token: context[:session].token,
         title: context[:session].title,
+        user_context: context[:session].user_context,
         info: helpers.filter_session_parameters(context[:session].info),
         deletedInDays: context[:session].days_till_old,
       })


### PR DESCRIPTION
After looking more in detail at the BatchConnect::Session object, I think this is a better implementation to displaying the form parameters in the session card.

It does not require a new field, instead relies on the existing `user_defined_context` file that is already saved by the session.

As well, it adds the `user_defined_context` to the support ticket as this information will be useful fir debugging.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203432325440412) by [Unito](https://www.unito.io)
