### PR TITLE
make nginx_clean safe to run against deleted users

### DIFF
--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -30,7 +30,9 @@ describe 'Nginx stage' do
       expect(browser.title).to eq('Dashboard - Open OnDemand')
 
       # Note there's no error here about 'deleted_user'
-      expect { `/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force` }.to output('ood\n').to_stdout
+      on hosts, '/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force' do
+        assert_equal stdout, 'ood\n'
+      end
     end
   end
 end

--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -16,7 +16,7 @@ describe 'Nginx stage' do
     before(:all) do
       on hosts, 'mkdir /var/run/ondemand-nginx/deleted_user'
       on hosts, 'chmod 600 /var/run/ondemand-nginx/deleted_user'
-      on hosts, 'echo -n 74 > /var/run/ondemand-nginx/deleted_user/passenger.pid'
+      on hosts, 'echo -n 11111111 > /var/run/ondemand-nginx/deleted_user/passenger.pid'
     end
 
     after(:all) do

--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -30,7 +30,7 @@ describe 'Nginx stage' do
       expect(browser.title).to eq('Dashboard - Open OnDemand')
 
       # Note there's no error here about 'deleted_user'
-      expect { `/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force` }.to output('ood\n')
+      expect { `/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force` }.to output('ood\n').to_stdout
     end
   end
 end

--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -31,7 +31,7 @@ describe 'Nginx stage' do
 
       # Note there's no error here about 'deleted_user'
       on hosts, '/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force' do
-        assert_equal stdout, 'ood\n'
+        assert_equal stdout, "ood\n"
       end
     end
   end

--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -15,7 +15,7 @@ describe 'Nginx stage' do
   context 'missing users' do
     before(:all) do
       on hosts, 'mkdir /var/run/ondemand-nginx/deleted_user'
-      on hosts, 'chmow 600 /var/run/ondemand-nginx/deleted_user'
+      on hosts, 'chmod 600 /var/run/ondemand-nginx/deleted_user'
       on hosts, 'echo -n 74 > /var/run/ondemand-nginx/deleted_user/passenger.pid'
     end
 

--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper_e2e'
+
+describe 'Nginx stage' do
+  def browser
+    @browser ||= new_browser
+  end
+
+  after(:each) do
+    browser.close
+    on hosts, '/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force'
+  end
+
+  context 'missing users' do
+    before(:all) do
+      on hosts, 'mkdir /var/run/ondemand-nginx/deleted_user'
+      on hosts, 'chmow 600 /var/run/ondemand-nginx/deleted_user'
+      on hosts, 'echo -n 74 > /var/run/ondemand-nginx/deleted_user/passenger.pid'
+    end
+
+    before(:all) do
+      on hosts, 'rm -rf /var/run/ondemand-nginx/deleted_user'
+    end
+
+    it 'does not crash login when pre hook is misconfigured' do
+      # get the 'ood' users' pun ready
+      browser_login(browser)
+      browser.goto ctr_base_url
+      expect(browser.title).to eq('Dashboard - Open OnDemand')
+
+      # Note there's no error here about 'deleted_user'
+      expect { `/opt/ood/nginx_stage/sbin/nginx_stage nginx_clean --force` }.to output('ood\n')
+    end
+  end
+end

--- a/spec/e2e/nginx_stage_spec.rb
+++ b/spec/e2e/nginx_stage_spec.rb
@@ -19,7 +19,7 @@ describe 'Nginx stage' do
       on hosts, 'echo -n 74 > /var/run/ondemand-nginx/deleted_user/passenger.pid'
     end
 
-    before(:all) do
+    after(:all) do
       on hosts, 'rm -rf /var/run/ondemand-nginx/deleted_user'
     end
 


### PR DESCRIPTION
Fixes #1833 by rescuing when we cannot find a valid user for a given `pun_pid_path`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203451113806981) by [Unito](https://www.unito.io)
