### PR TITLE
use correct Date api to get the day of the month

### DIFF
--- a/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
@@ -112,7 +112,7 @@ var helpers = {
     // month/day
     let d = new Date(this.start_time_ts*1000),
         month = d.getMonth()+1,
-        day = d.getDay()+1;
+        day = d.getUTCDate();
 
     return `${month}/${day}`;
   },


### PR DESCRIPTION
Fixes #1956 by using the correct javascript Date API to get the numeric day of the month.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203451648779933) by [Unito](https://www.unito.io)
