### PR TITLE
Fixed spinner for pinned apps opening in a new tab

### DIFF
--- a/apps/dashboard/app/views/widgets/pinned_apps/_app.html.erb
+++ b/apps/dashboard/app/views/widgets/pinned_apps/_app.html.erb
@@ -3,7 +3,7 @@
 <%- tile_data = link.tile -%>
 
 <div class="col-sm-3 col-md-3 app-launcher-container">
-  <div class="app-launcher app-launcher-hover" data-toggle="launcher-button">
+  <div class="app-launcher app-launcher-hover" data-toggle="<%= link.new_tab? ? '' : 'launcher-button' %>">
   <%=
     link_to(
       link.url.to_s,


### PR DESCRIPTION
The spinner should not appear for pinned apps that open in a new tab.

This fix will remove the `data-toggle` for apps that open in a new tab

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203457795213479) by [Unito](https://www.unito.io)
