### PR TITLE
Revert "Improvements to logic for displaying form parameters in session cards"

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -151,12 +151,13 @@ module BatchConnect::SessionsHelper
   end
 
   def display_choices(session)
-    user_context = session.user_context
-    session.app.attributes.select(&:display?).map do |attribute|
+    session_content = session.display_choices || {}
+    # Hash to an array with the labels and values
+    session_content.to_a.map do |label, value|
       content_tag(:p) do
-        concat content_tag(:strong, "#{attribute.label}:")
+        concat content_tag(:strong, "#{label}:")
         concat " "
-        concat user_context.fetch(attribute.id, '')
+        concat value
       end
     end.join.html_safe
   end

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -58,6 +58,10 @@ module BatchConnect
     # @return [String] error message
     attr_reader :render_info_view_error_message
 
+    # Application parameters provided by the user that will be displayed in the session card.
+    # @return [Hash] application display choices
+    attr_accessor :display_choices
+
     # Return parsed markdown from info.{md, html}.erb
     # @return [String, nil] return HTML if no error while parsing, else return nil
     def render_info_view
@@ -77,7 +81,7 @@ module BatchConnect
     # Attributes used for serialization
     # @return [Hash] attributes to be serialized
     def attributes
-      %w(id cluster_id job_id created_at token title view script_type cache_completed).map do |attribute|
+      %w(id cluster_id job_id created_at token title view script_type cache_completed display_choices).map do |attribute|
         [ attribute, nil ]
       end.to_h
     end
@@ -90,13 +94,6 @@ module BatchConnect
 
     def valid_session_fields?
       !( created_at.nil? || cluster_id.nil? || job_id.nil? )
-    end
-
-    def user_context
-      @user_context ||= user_defined_context_file.exist? ? JSON.parse(user_defined_context_file.read) : {}
-    rescue => e
-      Rails.logger.error("ERROR: Error parsing user_context file: '#{user_defined_context_file}' --- #{e.class} - #{e.message}")
-      {}
     end
 
     class << self
@@ -239,6 +236,7 @@ module BatchConnect
       self.view       = app.session_view
       self.created_at = Time.now.to_i
       self.cluster_id = context.try(:cluster).to_s
+      self.display_choices = app.attributes.select(&:display?).map{|a| [a.label, a.value]}.to_h
 
       submit_script = app.submit_opts(context, fmt: format, staged_root: staged_root) # could raise an exception
 

--- a/apps/dashboard/app/views/support_ticket/email/default.text.erb
+++ b/apps/dashboard/app/views/support_ticket/email/default.text.erb
@@ -20,7 +20,6 @@ Interactive Session Information:
           createdAt: Time.at(@context.session.created_at).iso8601,
           token: @context.session.token,
           title: @context.session.title,
-          user_context: @context.session.user_context,
           info: filter_session_parameters(@context.session.info),
           deletedInDays: @context.session.days_till_old,
         })

--- a/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
+++ b/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
@@ -20,7 +20,6 @@ Session Information:
         createdAt: Time.at(context[:session].created_at).iso8601,
         token: context[:session].token,
         title: context[:session].title,
-        user_context: context[:session].user_context,
         info: helpers.filter_session_parameters(context[:session].info),
         deletedInDays: context[:session].days_till_old,
       })

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -456,7 +456,7 @@ batch_connect: { ssh_allow: true } }))
     refute session.ssh_to_compute_node?
   end
 
-  test 'saves the cluster id in the staged_root path' do
+  test 'saves the cluser id in the staged_root path' do
     # stub open3 and system apps because :save stages and submits the job
     # and expects certain things - like a valid cluster.d directory
     stub_sys_apps
@@ -528,6 +528,7 @@ batch_connect: { ssh_allow: true } }))
         'view'            => nil,
         'script_type'     => 'basic',
         'cache_completed' => nil,
+        'display_choices' => {},
       }
       Timecop.freeze(now) do
         assert session.save(app: bc_jupyter_app, context: ctx), session.errors.each(&:to_s).to_s
@@ -539,44 +540,6 @@ batch_connect: { ssh_allow: true } }))
         assert_equal(expected_file, JSON.parse(File.read("#{db_dir}/test_id")).to_h)
         assert_equal('100600', File.stat("#{db_dir}/test_id").mode.to_s(8))
       end
-    end
-  end
-
-  test 'writes user_defined_context file correctly' do
-    stub_sys_apps
-    Open3.stubs(:capture3).returns(['the-job-id', '', exit_success])
-
-    Dir.mktmpdir('test_dir') do |dir|
-      OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
-      SecureRandom.stubs(:uuid).returns('test_id')
-
-      session = BatchConnect::Session.new
-      ctx = bc_jupyter_app.build_session_context
-      # Some attribute overrides
-      ctx.attributes = { 'cluster' => 'owens', 'bc_num_hours' => 100, 'cuda_version' => 'cuda_100' }
-
-      expected_user_context = {
-        'cluster'=>'owens',
-        'bc_num_hours'=>'100',
-        'bc_num_slots'=>'1',
-        'mode'=>'1',
-        'node_type'=>'',
-        'bc_account'=>'',
-        'bc_email_on_started'=>'',
-        'python_version'=>'',
-        'cuda_version'=>'cuda_100',
-        'hidden_change_thing'=>'default',
-        'classroom'=>'',
-        'classroom_size'=>'',
-        'advanced_options'=>'',
-        'auto_modules_app_jupyter'=>'',
-        'auto_modules_intel'=>''
-      }
-
-      assert session.save(app: bc_jupyter_app, context: ctx), session.errors.each(&:to_s).to_s
-
-      assert session.user_defined_context_file.exist?
-      assert_equal expected_user_context, session.user_context
     end
   end
 


### PR DESCRIPTION
Reverts OSC/ondemand#2381

@adaybujeda, thinking about this a second time, we've got to revert this.  This cache file is settings the _last submitted job_.  If you submit to jobs back to back with different settings - their cards should read with different settings. But since this cache file is only the most recent choices, the first job's card will have the second jobs values.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203457913954179) by [Unito](https://www.unito.io)
