### PR TITLE
restore defaults when tearing down this test

### DIFF
--- a/apps/dashboard/test/apps/nav_config_test.rb
+++ b/apps/dashboard/test/apps/nav_config_test.rb
@@ -9,6 +9,12 @@ class NavConfigTest < ActiveSupport::TestCase
     NavConfig.categories_allowlist = false
   end
 
+  def teardown
+    # reset defaults for every test
+    NavConfig.categories = ['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps']
+    NavConfig.categories_allowlist = false
+  end
+
   test 'default values' do
     assert_equal(false, NavConfig.categories_allowlist?)
     assert_equal(false, NavConfig.categories_allowlist)


### PR DESCRIPTION
Our tests are currently pretty flaky. I believe it's because this test is modifying NavConfig but then never restoring it's defaults.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203460706615771) by [Unito](https://www.unito.io)
