### PR TITLE
allow for configurable facl domain

### DIFF
--- a/apps/dashboard/app/models/permission.rb
+++ b/apps/dashboard/app/models/permission.rb
@@ -89,7 +89,8 @@ class Permission
   def acl_entry(principle)
     flags = []
     flags << :g if group
-    OodSupport::ACLs::Nfs4Entry.new(type: :A, flags: flags, principle: principle.to_s, domain: 'osc.edu',
+    domain = Configuration.facl_domain
+    OodSupport::ACLs::Nfs4Entry.new(type: :A, flags: flags, principle: principle.to_s, domain: domain,
                                     permissions: [:r, :x])
   end
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -56,6 +56,7 @@ class ConfigurationSingleton
     {
       :module_file_dir      => nil,
       :user_settings_file   => '.ood',
+      :facl_domain => nil,
     }.freeze
   end
 

--- a/apps/dashboard/test/fixtures/config/ondemand.d/string.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/string.yml
@@ -1,2 +1,3 @@
 module_file_dir: 'string from file'
 user_settings_file: 'string from file'
+facl_domain: 'string from file'


### PR DESCRIPTION
Allow for configurable facl domain because `osc.edu` is hard coded here.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203466062673806) by [Unito](https://www.unito.io)
