### PR TITLE
reorder tests to install gems first

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,14 +45,14 @@ jobs:
       - name: Setup rclone
         run: sudo apt-get update && sudo apt-get install rclone
 
+      - name: Run unit tests
+        run: bundle exec rake test:unit
+
       - name: Run ShellCheck
         run: bundle exec rake test:shellcheck
 
       - name: Run Zeitwerk check
         run: cd apps/dashboard; bundle exec rake zeitwerk:check
-
-      - name: Run unit tests
-        run: bundle exec rake test:unit
 
       - name: Run lint tests
         run: bundle exec rake lint || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           bundle config path ~/vendor/bundle
           bundle install
+          gem install rake
 
       - name: Setup rclone
         run: sudo apt-get update && sudo apt-get install rclone


### PR DESCRIPTION
tests are failing on #2400 because it can't find `rake`.  Not quite sure what's up but maybe it's the order of tests (unit tests install gems)? and having to force install rake?

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203473977852663) by [Unito](https://www.unito.io)
