### PR TITLE
Fixed custom help menu alignment

### DIFF
--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -43,18 +43,18 @@
             <%= render partial: 'layouts/nav/sessions', nav_groups: @nav_groups if Configuration.app_development_enabled? || @nav_groups.any?(&:has_batch_connect_apps?) %>
             <%= render partial: 'layouts/nav/all_apps' if @user_configuration.show_all_apps_link %>
           <% else %>
-            <%= render partial: "layouts/nav/custom_navigation", locals: { navigation: @nav_bar }%>
+            <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @nav_bar }%>
           <% end %>
         </ul>
 
         <ul class="navbar-nav">
           <% if @help_bar.empty? %>
             <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
-            <%= render partial: "layouts/nav/help_dropdown" %>
-            <%= render partial: "layouts/nav/user" %>
-            <%= render partial: "layouts/nav/log_out" %>
+            <%= render partial: 'layouts/nav/help_dropdown' %>
+            <%= render partial: 'layouts/nav/user' %>
+            <%= render partial: 'layouts/nav/log_out' %>
           <% else %>
-            <%= render partial: "layouts/nav/custom_navigation", locals: { navigation: @help_bar }%>
+            <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @help_bar, menu_alignment: 'dropdown-menu-right' }%>
           <% end %>
         </ul>
       </div>

--- a/apps/dashboard/app/views/layouts/nav/_custom_navigation.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_custom_navigation.html.erb
@@ -1,3 +1,5 @@
 <% navigation.each do |nav_item| %>
-  <%= render partial: nav_item.partial_path, locals: nav_item.to_h %>
+  <% nav_item_data = nav_item.to_h %>
+  <% nav_item_data[:menu_alignment] = local_assigns.fetch(:menu_alignment, '') %>
+  <%= render partial: nav_item.partial_path, locals: nav_item_data %>
 <% end %>

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -1,7 +1,7 @@
 <li class="nav-item dropdown" title="<%= group.title %>">
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, '') %>">
     <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, sort: group.sort).each_with_index do |g, index| %>
       <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
       <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>

--- a/apps/dashboard/test/integration/custom_help_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_help_navigation_test.rb
@@ -2,64 +2,71 @@
 
 require 'test_helper'
 
-class CustomNavigationTest < ActionDispatch::IntegrationTest
-  test 'should render a custom navigation menu when nav_bar is defined in UserConfiguration' do
+class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
+  test 'should render a custom help navigation menu when help_bar is defined in UserConfiguration' do
     # Mock the sys installed applications
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
     SysRouter.stubs(:base_path).returns(Rails.root.join('test/fixtures/sys_with_interactive_apps'))
     # Test a navigation item of each type
     stub_user_configuration(
       {
-        nav_bar: [
-          { title: 'Custom Menu',
+        nav_bar:  [{ url: '/test' }],
+        help_bar: [
+          { title: 'Help Menu',
             links: [
-              { group: 'Custom Menu Dropdown Header' },
+              { group: 'Help Menu Dropdown Header' },
               { title:   'Menu Link',
                 url:     '/menu/link',
                 new_tab: false },
               { title:   'Profile Link',
                 profile: 'profile1' }
             ] },
-          { title: 'Custom Apps',
+          { title: 'Docs Menu',
             links: [
-              { group: 'Custom Apps Dropdown Header' },
+              { group: 'Docs Menu Dropdown Header' },
               { apps: ['sys/bc_jupyter'] }
             ] },
-          { title:    'Custom Link',
+          { title:    'Custom Help Link',
             url:      '/custom/link',
             icon_uri: 'fa://desktop',
             new_tab:  true },
-          'sys/bc_paraview',
-          'all_apps'
+          'user',
+          'log_out'
         ]
       }
     )
 
     get root_path
     assert_response :success
-    # Check nav menus
-    assert_select '#navbar li.dropdown[title]', 3 # +1 here is 'Help'
-    # Check nav links
-    assert_select '#navbar > ul > a.nav-link[title]', 2
 
-    assert_select nav_menu(1), text: 'Custom Menu'
-    assert_select nav_menu_header('Custom Menu'), text: 'Custom Menu Dropdown Header'
-    assert_select nav_menu_links('Custom Menu') do |elements|
+    # Check nav menus
+    assert_select '#navbar li.dropdown[title]', 2
+
+    # Check custom "Help Menu"
+    assert_select nav_menu(1) do |menu|
+      assert_select menu.first, 'a', text: 'Help Menu'
+      assert_select menu.first, 'ul' do |menu_items|
+        menu_items.first['class'].include?('dropdown-menu-right')
+      end
+    end
+    assert_select nav_menu_header('Help Menu'), text: 'Help Menu Dropdown Header'
+    assert_select nav_menu_links('Help Menu') do |elements|
       assert_equal 2, elements.size
       assert_match(/Menu Link/, elements[0].text)
       assert_equal '/menu/link', elements[0]['href']
       assert_nil elements[0]['target']
       check_icon(elements[0], 'fa-cog')
-
-      assert_match(/Profile Link/, elements[1].text)
-      assert_equal '/settings?settings%5Bprofile%5D=profile1', elements[1]['href']
-      assert_nil elements[1]['target']
-      check_icon(elements[1], 'fa-cog')
     end
 
-    assert_select nav_menu(2), text: 'Custom Apps'
-    assert_select nav_menu_header('Custom Apps'), text: 'Custom Apps Dropdown Header'
-    assert_select nav_menu_links('Custom Apps') do |elements|
+    # Check custom 'Docs Menu'
+    assert_select nav_menu(2) do |menu|
+      assert_select menu.first, 'a', text: 'Docs Menu'
+      assert_select menu.first, 'ul' do |menu_items|
+        menu_items.first['class'].include?('dropdown-menu-right')
+      end
+    end
+    assert_select nav_menu_header('Docs Menu'), text: 'Docs Menu Dropdown Header'
+    assert_select nav_menu_links('Docs Menu') do |elements|
       assert_equal 1, elements.size
       assert_match(/Jupyter Notebook/, elements[0].text)
       assert_equal '/batch_connect/sys/bc_jupyter/session_contexts/new', elements[0]['href']
@@ -67,26 +74,30 @@ class CustomNavigationTest < ActionDispatch::IntegrationTest
       check_icon(elements[0], 'fa-gear')
     end
 
-    assert_select nav_link('Paraview'), text: 'Paraview'
-    assert_select nav_link('Paraview') do |link|
-      assert_equal '/batch_connect/sys/bc_paraview/session_contexts/new', link.first['href']
-      assert_nil link.first['target']
-      check_icon(link.first, 'fa-gear')
-    end
-
-    assert_select nav_link('Custom Link'), text: 'Custom Link'
-    assert_select nav_link('Custom Link') do |link|
+    # Check custom link
+    assert_select nav_link('Custom Help Link'), text: 'Custom Help Link'
+    assert_select nav_link('Custom Help Link') do |link|
       assert_equal '/custom/link', link.first['href']
       assert_equal '_blank', link.first['target']
       check_icon(link.first, 'fa-desktop')
     end
 
-    # Check all_apps static link.
-    assert_select "#navbar .navbar-nav li.nav-item[title='All Apps']", text: 'All Apps'
+    # User
+    assert_select '#navbar .navbar-nav a.nav-link.disabled' do |link|
+      assert_match(/Logged in as/, link.first.text.strip)
+      check_icon(link.first, 'fa-user')
+    end
+
+    # Log out link
+    assert_select "#navbar .navbar-nav a.nav-link[href='/logout']" do |link|
+      assert_equal '/logout', link.first['href']
+      assert_equal 'Log Out', link.first.text.strip
+      check_icon(link.first, 'fa-sign-out-alt')
+    end
   end
 
   def nav_menu(order)
-    "#navbar .navbar-nav li.dropdown:nth-of-type(#{order}) a"
+    "#navbar .navbar-nav li.dropdown:nth-of-type(#{order})"
   end
 
   def nav_menu_links(title)


### PR DESCRIPTION
Fixes to the custom help menu alignment.
Applied rubocop to the custom navigation tests

Fixes #2417

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203535177647161) by [Unito](https://www.unito.io)
