### PR TITLE
add the ability to disable the shell for bc apps

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -519,7 +519,7 @@ module BatchConnect
     # Path to login shell used by the script
     # @return [Pathname] shell path
     def shell_path
-      Pathname.new("/bin/bash")
+      Configuration.disable_bc_shell? ? nil : Pathname.new('/bin/bash')
     end
 
     # The connection information for this session (job must be running)

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -45,6 +45,7 @@ class ConfigurationSingleton
       :jobs_app_alpha               => false,
       :files_app_remote_files       => false,
       :host_based_profiles          => false,
+      :disable_bc_shell             => false,
     }.freeze
   end
 

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -6,3 +6,4 @@ file_navigator: true
 jobs_app_alpha: true
 files_app_remote_files: true
 host_based_profiles: true
+disable_bc_shell: true


### PR DESCRIPTION
Fixes #722 by adding a configuration option to disable the default /bin/bash shell for batch connect apps.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203536562688943) by [Unito](https://www.unito.io)
