### PR TITLE
ood-portal-generator: Add maintenance_extra_uris option

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -41,6 +41,7 @@ module OodPortalGenerator
       # Maintenance configuration
       @use_maintenance          = opts.fetch(:use_maintenance, true)
       @maintenance_ip_whitelist = Array(opts.fetch(:maintenance_ip_whitelist, []))
+      @maintenance_extra_uris   = Array(opts.fetch(:maintenance_extra_uris, []))
 
       # Security configuration
       @security_csp_frame_ancestors = opts.fetch(:security_csp_frame_ancestors, "#{@protocol}#{@servername ?  @servername : OodPortalGenerator.fqdn}")

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -333,6 +333,13 @@ Listen <%= addr_port %>
     ReWriteRule ^.*$ /
 
     RewriteCond %{REQUEST_URI} !<%= @public_uri %>/maintenance/index\.html$
+    <%- if @maintenance_extra_uris -%>
+    # Extra maintenance URIs (i.e., paths allowed during maintenance mode):
+      <%- @maintenance_extra_uris.each do |maint_extra_uri| -%>
+      <%- escaped_maint_extra_uri = Regexp.escape(maint_extra_uri) -%>
+    RewriteCond %{REQUEST_URI} !<%= escaped_maint_extra_uri %>$
+      <%- end -%>
+    <%- end -%>
     RewriteRule ^.*$ <%= @public_uri %>/maintenance/index.html [R=503,L]
     ErrorDocument 503 <%= @public_uri %>/maintenance/index.html
   </Directory>


### PR DESCRIPTION
- Add a new configuration option to ood_portal.yml, called `maintenance_extra_uris`. The option takes an array of strings and generates URIs to ignore (i.e., not redirect) while maintenance mode is activated.

- The URIs given as maintenance_extra_uris should have the format like for example:
  ```yaml
  maintenance_extra_uris:
    - "/public/maintenance/favicon.ico"
    - "/public/maintenance/logo.png"
    - "/public/maintenance/style.css"
  ```

- The template will automatically do `Regexp.escape()` for the input strings, so that the configured paths are exactly what is matched.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203563686953830) by [Unito](https://www.unito.io)
