### PR TITLE
ood-portal-generator: Serve any /public/maintenance/ file in maint mode

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -240,7 +240,7 @@ Listen 8080
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/assets/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/assets/maintenance/.*$
     RewriteRule ^.*$ /assets/maintenance/index.html [R=503,L]
     ErrorDocument 503 /assets/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.default
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.default
@@ -154,7 +154,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -177,7 +177,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -195,7 +195,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -195,7 +195,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-proxy
@@ -201,7 +201,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -156,7 +156,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -185,7 +185,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -199,7 +199,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -195,7 +195,7 @@
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !/public/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
     RewriteRule ^.*$ /public/maintenance/index.html [R=503,L]
     ErrorDocument 503 /public/maintenance/index.html
   </Directory>

--- a/ood-portal-generator/spec/fixtures/sum.default
+++ b/ood-portal-generator/spec/fixtures/sum.default
@@ -1,1 +1,1 @@
-5469faf1d24def9ce0693da1d892b39c17451904ce90d249f728970c5a9b8cbb /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf
+af5a288d2e2f7f8ed68bd29e7e293c1d0fc33ea90c0d6bcc5fe7e960298034eb /opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -332,7 +332,7 @@ Listen <%= addr_port %>
     RewriteCond /etc/ood/maintenance.enable !-f
     ReWriteRule ^.*$ /
 
-    RewriteCond %{REQUEST_URI} !<%= @public_uri %>/maintenance/index\.html$
+    RewriteCond %{REQUEST_URI} !<%= @public_uri %>/maintenance/.*$
     RewriteRule ^.*$ <%= @public_uri %>/maintenance/index.html [R=503,L]
     ErrorDocument 503 <%= @public_uri %>/maintenance/index.html
   </Directory>


### PR DESCRIPTION
- While in maintenance mode, do not redirect request URIs which start with "/public/maintenance/"

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203563876451004) by [Unito](https://www.unito.io)
