### PR TITLE
Remove inline-styles

### DIFF
--- a/apps/dashboard/app/javascript/stylesheets/application.scss
+++ b/apps/dashboard/app/javascript/stylesheets/application.scss
@@ -139,6 +139,10 @@ small.form-text {
   white-space: pre-wrap;
 }
 
+.mw-150px {
+  max-width: 150px;
+}
+
 // Your custom css styles below (must be manually added)
 
 @import "dashboard";

--- a/apps/dashboard/app/javascript/stylesheets/application.scss
+++ b/apps/dashboard/app/javascript/stylesheets/application.scss
@@ -134,6 +134,11 @@ small.form-text {
    font-size: 96%;
 }
 
+// Adds bootstrap-like text-prewrap
+.text-prewrap {
+  white-space: pre-wrap;
+}
+
 // Your custom css styles below (must be manually added)
 
 @import "dashboard";

--- a/apps/dashboard/app/javascript/stylesheets/application.scss
+++ b/apps/dashboard/app/javascript/stylesheets/application.scss
@@ -143,6 +143,13 @@ small.form-text {
   max-width: 150px;
 }
 
+// Add width classes for every whole percentage between 0 and 100
+@for $i from 1 through 100 {
+  .w-#{$i} {
+    width: $i * 1%;
+  }
+}
+
 // Your custom css styles below (must be manually added)
 
 @import "dashboard";

--- a/apps/dashboard/app/javascript/stylesheets/files.scss
+++ b/apps/dashboard/app/javascript/stylesheets/files.scss
@@ -20,3 +20,15 @@
 div.datatables-status, div.transfers-status {
   display: inline;
 }
+
+.color-gold {
+  color: gold;
+}
+
+.color-lightgrey {
+  color: lightgrey;
+}
+
+.z-index-999 {
+  z-index: 999;
+}

--- a/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
@@ -27,13 +27,13 @@
   </div>
     <% if data.submit_args %>
     <div class="card-body">
-      <p class="card-text">Submit Args: <pre class="card bg-light p-2" style="white-space: pre-wrap;"><%= data.submit_args %></pre></p>
+      <p class="card-text">Submit Args: <pre class="card bg-light p-2 text-prewrap"><%= data.submit_args %></pre></p>
     </div>
     <% end %>
     <% if data.output_path %>
     <div class="card-body">
       <%# FIXME: can use form element input with label and disabled %>
-      <p class="card-text">Output Location: <pre class="card bg-light p-2" style="white-space: pre-wrap;"><%= data.output_path %></pre></p>
+      <p class="card-text">Output Location: <pre class="card bg-light p-2 text-prewrap"><%= data.output_path %></pre></p>
     </div>
     <% end %>
     <div class="card-body">

--- a/apps/dashboard/app/views/apps/_app.html.erb
+++ b/apps/dashboard/app/views/apps/_app.html.erb
@@ -15,7 +15,7 @@
         target: link.new_tab? ? "_blank" : nil
       ) do
     %>
-      <div class="center-block" style="text-align: center">
+      <div class="center-block text-center">
         <%= icon_tag(link.icon_uri) %>
         <%= content_tag(:p, link.title) %>
         <%=

--- a/apps/dashboard/app/views/files/_copy_move_popup.html.erb
+++ b/apps/dashboard/app/views/files/_copy_move_popup.html.erb
@@ -3,14 +3,14 @@
 <div class="card mb-3">
   <div class="card-body">
     <button id="clipboard-clear" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    <p style="margin-top: 30px">Copy or move the files below from <code>{{from}}</code> to the current directory:</p>
+    <p class="mt-4">Copy or move the files below from <code>{{from}}</code> to the current directory:</p>
   </div>
   <ul class="list-group list-group-flush">
     {{#each files}}
       {{#if directory}}
-        <li class="list-group-item"><span title="directory" class="fa fa-folder" style="color: gold"></span> {{name}}</li>
+        <li class="list-group-item"><span title="directory" class="fa fa-folder color-gold"></span> {{name}}</li>
       {{else}}
-        <li class="list-group-item"><span title="file" class="fa fa-file" style="color: lightgrey"></span> {{name}}</li>
+        <li class="list-group-item"><span title="file" class="fa fa-file color-lightgrey"></span> {{name}}</li>
       {{/if}}
     {{/each}}
   </ul>

--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -6,7 +6,7 @@
       <%= render partial: 'breadcrumb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path } %>
     </ol>
 
-    <table class="table table-striped table-condensed" id="directory-contents" style="width:100%">
+    <table class="table table-striped table-condensed w-100" id="directory-contents">
       <thead>
         <tr>
           <th><span class="sr-only">Select</span></th>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -1,6 +1,6 @@
 <%# z-index:999 cause dropdowns are 1000 default sticky-top is 1020 https://getbootstrap.com/docs/4.6/layout/overview/#z-index %>
 
-<div class="text-right sticky-top bg-white border-bottom p-2 m-3" style="z-index: 999">
+<div class="text-right sticky-top bg-white border-bottom p-2 m-3 z-index-999">
   <!-- terminal button href is set via JavaScript because the URL is based on the current directory -->
   <% if Configuration.files_enable_shell_button %>
     <%= render partial: 'shell_dropdown' %>

--- a/apps/dashboard/app/views/shared/_insufficient_quota_progress_bar.html.erb
+++ b/apps/dashboard/app/views/shared/_insufficient_quota_progress_bar.html.erb
@@ -1,10 +1,9 @@
 <div class="progress">
-  <div class="progress-bar bg-danger"
+<div class="progress-bar bg-danger w-<%= percent.round %>"
     role="progressbar"
     aria-valuenow="<%= percent %>"
     aria-valuemin="0"
     aria-valuemax="100"
-    style="width: <%= percent %>%;"
   >
     <%= percent %>%
   </div>

--- a/apps/dashboard/app/views/support_ticket/email_service_template.html.erb
+++ b/apps/dashboard/app/views/support_ticket/email_service_template.html.erb
@@ -45,7 +45,7 @@
   </div>
 
 </div>
-<div id="full-page-spinner" style="display:none;">
+<div id="full-page-spinner" class="d-none">
   <div class="spinner-border" role="status"></div>
 </div>
 

--- a/apps/dashboard/app/views/widgets/_xdmod_widget_job_efficiency.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_job_efficiency.html.erb
@@ -19,9 +19,9 @@
       {{else}}
       <p class="d-flex justify-content-between card-text font-weight-bold"><span class="text-success">{{good_percent}}% efficient</span> <span class="text-danger">{{bad_percent}}% inefficient</span></p>
       <div class="progress progress-custom">
-        <div class="progress-bar bg-success" role="progressbar" aria-label="percent efficient" aria-valuenow="{{good_percent}}" aria-valuemin="0" aria-valuemax="100" style="width: {{good_percent}}%">
+        <div class="progress-bar bg-success w-{{good_percent}}" role="progressbar" aria-label="percent efficient" aria-valuenow="{{good_percent}}" aria-valuemin="0" aria-valuemax="100">
         </div>
-        <div class="progress-bar bg-danger" role="progressbar" aria-label="percent inefficient" aria-valuenow="{{bad_percent}}" aria-valuemin="0" aria-valuemax="100" style="width: {{bad_percent}}%">
+        <div class="progress-bar bg-danger w-{{bad_percent}}" role="progressbar" aria-label="percent inefficient" aria-valuenow="{{bad_percent}}" aria-valuemin="0" aria-valuemax="100">
         </div>
       </div>
       <p class="card-text text-center mt-2">
@@ -76,10 +76,10 @@ var helpers = {
     return '<%= Configuration.xdmod_host %>';
   },
   bad_percent: function(){
-    return (parseFloat(this.bad_ratio)).toFixed(1)
+    return (parseFloat(this.bad_ratio)).toFixed()
   },
   good_percent: function(){
-    return (100 - parseFloat(this.bad_ratio)).toFixed(1)
+    return (100 - parseFloat(this.bad_ratio)).toFixed()
   }
 };
 

--- a/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
@@ -34,7 +34,7 @@
             {{#each results}}
             <tr title="{{job_name}} - {{local_job_id}}">
               <td class="text-nowrap"><a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span></a></td>
-              <td class="overflow-hidden d-inline-block text-truncate" style="max-width: 150px;">{{job_name}}</td>
+              <td class="overflow-hidden d-inline-block text-truncate mw-150px">{{job_name}}</td>
               <td>{{date}}</td>
               <td>{{cpu_label cpu_user}}</td>
             </tr>

--- a/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
@@ -34,7 +34,7 @@
             {{#each results}}
             <tr title="{{job_name}} - {{local_job_id}}">
               <td class="text-nowrap"><a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span></a></td>
-              <td style="max-width: 150px; text-overflow: ellipsis; overflow: hidden;">{{job_name}}</td>
+              <td class="overflow-hidden d-inline-block text-truncate" style="max-width: 150px;">{{job_name}}</td>
               <td>{{date}}</td>
               <td>{{cpu_label cpu_user}}</td>
             </tr>

--- a/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
@@ -33,7 +33,7 @@
           <tbody>
             {{#each results}}
             <tr title="{{job_name}} - {{local_job_id}}">
-              <td style="white-space: no-wrap"><a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span></a></td>
+              <td class="text-nowrap"><a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span></a></td>
               <td style="max-width: 150px; text-overflow: ellipsis; overflow: hidden;">{{job_name}}</td>
               <td>{{date}}</td>
               <td>{{cpu_label cpu_user}}</td>


### PR DESCRIPTION
Removed inline-styles from every file in the ondemand source code.
* Styles replaced with their bootstrap equivalent or near-equivalents. 
* Added some custom styles
* Added  a scss function to generate classes for width percents between 0 and 100 with format `w-${i}`.

Part of an effort to make ondemand compliant with [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203571489358983) by [Unito](https://www.unito.io)
