### PR TITLE
add initializer to sync cache files from 2.0 to 2.1

### DIFF
--- a/apps/dashboard/config/initializers/upgrade_to_2.1.rb
+++ b/apps/dashboard/config/initializers/upgrade_to_2.1.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Rails.application.reloader.to_prepare do
+  # Since https://github.com/OSC/ondemand/pull/1526 all the batch connect cache files
+  # have moved. So, when folks upgrade to 2.1, let's sync these old files so that
+  # they don't lose their cached choices.
+  old_context_files = "#{Configuration.dataroot}/batch_connect/**/*/context.json"
+  cache_root = BatchConnect::Session.cache_root
+
+  Dir.glob(old_context_files).map do |old_file|
+    new_filename = old_file.gsub(%r{.*/batch_connect/}, '').gsub('/context.json', '').gsub('/', '_')
+    new_filename = "#{new_filename}.json"
+
+    new_file = "#{cache_root}/#{new_filename}"
+    if !File.exist?(new_file)
+      FileUtils.cp(old_file, new_file)
+    elsif File.mtime(old_file) > File.mtime(new_file)
+      FileUtils.cp(old_file, new_file)
+    end
+  end
+end


### PR DESCRIPTION
Since https://github.com/OSC/ondemand/pull/1526 all the batch connect cache files have moved. So, when folks upgrade to 2.1, let's sync these old files so that they don't lose their cached choices.

This is just a quality of life thing for folks when they upgrade they'll keep all their cached choices from 2.0.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203596885828344) by [Unito](https://www.unito.io)
