### PR TITLE
rename remote files config to remote_files_enabled

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -176,7 +176,7 @@ class FilesController < ApplicationController
     if filesystem == 'fs'
       @path = PosixFile.new(normal_path)
       @filesystem = 'fs'
-    elsif ::Configuration.files_app_remote_files? && filesystem != 'fs'
+    elsif ::Configuration.remote_files_enabled? && filesystem != 'fs'
       @path = RemoteFile.new(normal_path, filesystem)
       @filesystem = filesystem
     else

--- a/apps/dashboard/app/controllers/transfers_controller.rb
+++ b/apps/dashboard/app/controllers/transfers_controller.rb
@@ -26,7 +26,7 @@ class TransfersController < ApplicationController
 
     if from_fs == RcloneUtil::LOCAL_FS_NAME && to_fs == RcloneUtil::LOCAL_FS_NAME
       @transfer = PosixTransfer.build(action: body_params[:command], files: body_params[:files])
-    elsif ::Configuration.files_app_remote_files?
+    elsif ::Configuration.remote_files_enabled?
       @transfer = RemoteTransfer.build(action: body_params[:command], files: body_params[:files], src_remote: from_fs, dest_remote: to_fs)
     else
       render json: { error_message: "Remote file support is not enabled" }

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -43,7 +43,7 @@ class ConfigurationSingleton
       :per_cluster_dataroot         => false,
       :file_navigator               => false,
       :jobs_app_alpha               => false,
-      :files_app_remote_files       => false,
+      :remote_files_enabled         => false,
       :host_based_profiles          => false,
       :disable_bc_shell             => false,
       :cancel_session_enabled       => false,

--- a/apps/dashboard/config/initializers/rclone.rb
+++ b/apps/dashboard/config/initializers/rclone.rb
@@ -1,6 +1,8 @@
 require 'rclone_util'
 
 Rails.application.config.after_initialize do |_|
+  break unless Configuration.remote_files_enabled?
+
   remotes = RcloneUtil.list_remotes.map { |r| FavoritePath.new('', title: r, filesystem: r) }
 
   OodFilesApp.candidate_favorite_paths.tap do |paths|

--- a/apps/dashboard/test/controllers/files_controller_test.rb
+++ b/apps/dashboard/test/controllers/files_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class FilesControllerTest < ActionController::TestCase
 
   def setup
-    Configuration.stubs(:files_app_remote_files?).returns(true)
+    Configuration.stubs(:remote_files_enabled?).returns(true)
   end
 
   test "empty path is parsed" do

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -4,7 +4,7 @@ bc_dynamic_js: true
 per_cluster_dataroot: true
 file_navigator: true
 jobs_app_alpha: true
-files_app_remote_files: true
+remote_files_enabled: true
 host_based_profiles: true
 disable_bc_shell: true
 cancel_session_enabled: true

--- a/apps/dashboard/test/rclone_helper.rb
+++ b/apps/dashboard/test/rclone_helper.rb
@@ -6,7 +6,7 @@ class ActiveSupport::TestCase
   # and posix file system
   def remote_files_conf(root_dir)
     {
-      OOD_FILES_APP_REMOTE_FILES:        'true',
+      OOD_REMOTE_FILES_ENABLED:        'true',
       RCLONE_CONFIG_LOCAL_REMOTE_TYPE:   'local',
       RCLONE_CONFIG_ALIAS_REMOTE_TYPE:   'alias',
       RCLONE_CONFIG_ALIAS_REMOTE_REMOTE: "local_remote:#{root_dir}",


### PR DESCRIPTION
I was looking to document this feature and found this config a little laking. So Let's change the name and check in the initializer if it's enabled.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203603412068026) by [Unito](https://www.unito.io)
