### PR TITLE
use a button for deleting & canceling instead of link

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -210,7 +210,7 @@ module BatchConnect::SessionsHelper
       method: :delete,
       class: "btn btn-danger float-right btn-delete",
       title: "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
-      data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
+      data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom", selector: true }
     ) do
       "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_cancel_title')}</span>".html_safe
     end
@@ -222,7 +222,7 @@ module BatchConnect::SessionsHelper
       method: :post,
       class: "btn btn-danger float-right btn-cancel",
       title: "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
-      data: { confirm: t('dashboard.batch_connect_sessions_cancel_confirm'), toggle: "tooltip", placement: "bottom"},
+      data: { confirm: t('dashboard.batch_connect_sessions_cancel_confirm'), toggle: "tooltip", placement: "bottom", selector: true }
     ) do
       "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_cancel_title')}</span>".html_safe
     end

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -205,25 +205,27 @@ module BatchConnect::SessionsHelper
   end
 
   def delete(session)
-    link_to(
-      fa_icon('trash-alt', classes: nil) << ' ' << t('dashboard.batch_connect_sessions_delete_title'),
+    button_to(
       batch_connect_session_path(session.id),
       method: :delete,
       class: "btn btn-danger float-right btn-delete",
-      title: t('dashboard.batch_connect_sessions_delete_hover'),
+      title: "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
       data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
-    )
+    ) do
+      "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_cancel_title')}</span>".html_safe
+    end
   end
 
   def cancel(session)
-    link_to(
-      fa_icon('times-circle', classes: nil) << ' ' << t('dashboard.batch_connect_sessions_cancel_title'),
+    button_to(
       batch_connect_cancel_session_path(session.id),
       method: :post,
       class: "btn btn-danger float-right btn-cancel",
-      title: t('dashboard.batch_connect_sessions_cancel_hover'),
-      data: { confirm: t('dashboard.batch_connect_sessions_cancel_confirm'), toggle: "tooltip", placement: "bottom"}
-    )
+      title: "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
+      data: { confirm: t('dashboard.batch_connect_sessions_cancel_confirm'), toggle: "tooltip", placement: "bottom"},
+    ) do
+      "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_cancel_title')}</span>".html_safe
+    end
   end
 
   def novnc_link(connect, view_only: false)

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -209,10 +209,10 @@ module BatchConnect::SessionsHelper
       batch_connect_session_path(session.id),
       method: :delete,
       class: "btn btn-danger float-right btn-delete",
-      title: "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
+      title: "#{t('dashboard.batch_connect_sessions_delete_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
       data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom", selector: true }
     ) do
-      "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_cancel_title')}</span>".html_safe
+      "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_delete_title')}</span>".html_safe
     end
   end
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
     batch_connect_missing_cluster: |
       The cluster was never set. Either set it in form.yml.erb with `cluster` or `form.cluster` or
       set `cluster` in submit.yml.erb.
+    batch_connect_sessions_word: 'Session'
     batch_connect_sessions_data_html: |
       The %{title} session data for this session can be accessed
       under the %{data_link_tag}.
@@ -104,10 +105,8 @@ en:
       please ask your administrator to configure OnDemand to set the
       environment variable OOD_JOB_NAME_ILLEGAL_CHARS.
     batch_connect_sessions_delete_confirm: "Are you sure?"
-    batch_connect_sessions_delete_hover: "Delete Session"
     batch_connect_sessions_delete_title: "Delete"
     batch_connect_sessions_cancel_confirm: "Are you sure?"
-    batch_connect_sessions_cancel_hover: "Cancel Session"
     batch_connect_sessions_cancel_title: "Cancel"
     batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:"
     batch_connect_sessions_errors_submission: "Failed to submit session with the following error:"

--- a/apps/dashboard/test/helpers/batch_connect/sessions_helper_test.rb
+++ b/apps/dashboard/test/helpers/batch_connect/sessions_helper_test.rb
@@ -11,20 +11,22 @@ class BatchConnect::SessionsHelperTest < ActionView::TestCase
       next if state == :completed
 
       html = Nokogiri::HTML(cancel_or_delete(create_session(state)))
-      link = html.at_css('a')
-      assert_equal true, link['class'].include?('btn-cancel')
-      assert_equal I18n.t('dashboard.batch_connect_sessions_cancel_title'), link.text.strip
-      assert_equal batch_connect_cancel_session_path('1234'), link['href']
+      button = html.at_css('button')
+      assert_equal true, button['class'].include?('btn-cancel')
+      assert_equal I18n.t('dashboard.batch_connect_sessions_cancel_title'), button.text.strip
+      assert_equal batch_connect_cancel_session_path('1234'), button.parent['action']
+      assert_equal cancel_session_title, button['title']
     end
   end
 
   test 'cancel_or_delete should generate delete button when cancel_session_enabled is true and state completed' do
     Configuration.stubs(:cancel_session_enabled).returns(true)
     html = Nokogiri::HTML(cancel_or_delete(create_session(:completed)))
-    link = html.at_css('a')
-    assert_equal true, link['class'].include?('btn-delete')
-    assert_equal I18n.t('dashboard.batch_connect_sessions_delete_title'), link.text.strip
-    assert_equal batch_connect_session_path('1234'), link['href']
+    button = html.at_css('button')
+    assert_equal true, button['class'].include?('btn-delete')
+    assert_equal I18n.t('dashboard.batch_connect_sessions_delete_title'), button.text.strip
+    assert_equal batch_connect_session_path('1234'), button.parent['action']
+    assert_equal delete_session_title, button['title']
   end
 
   test 'cancel_or_delete should generate delete button when cancel_session_enabled is false and state not completed' do
@@ -33,27 +35,36 @@ class BatchConnect::SessionsHelperTest < ActionView::TestCase
       next if state == :completed
 
       html = Nokogiri::HTML(cancel_or_delete(create_session(state)))
-      link = html.at_css('a')
-      assert_equal true, link['class'].include?('btn-delete')
-      assert_equal I18n.t('dashboard.batch_connect_sessions_delete_title'), link.text.strip
-      assert_equal batch_connect_session_path('1234'), link['href']
+      button = html.at_css('button')
+      assert_equal true, button['class'].include?('btn-delete')
+      assert_equal I18n.t('dashboard.batch_connect_sessions_delete_title'), button.text.strip
+      assert_equal batch_connect_session_path('1234'), button.parent['action']
+      assert_equal delete_session_title, button['title']
     end
   end
 
   test 'cancel_or_delete should generate delete button when cancel_session_enabled is false and state completed' do
     Configuration.stubs(:cancel_session_enabled).returns(false)
     html = Nokogiri::HTML(cancel_or_delete(create_session(:completed)))
-    link = html.at_css('a')
-    assert_equal true, link['class'].include?('btn-delete')
-    assert_equal  I18n.t('dashboard.batch_connect_sessions_delete_title'), link.text.strip
-    assert_equal batch_connect_session_path('1234'), link['href']
+    button = html.at_css('button')
+    assert_equal true, button['class'].include?('btn-delete')
+    assert_equal  I18n.t('dashboard.batch_connect_sessions_delete_title'), button.text.strip
+    assert_equal batch_connect_session_path('1234'), button.parent['action']
+    assert_equal delete_session_title, button['title']
   end
 
   def create_session(state = :running)
-    value = '{"id":"1234","job_id":"1","created_at":1669139262,"token":"sys/token","title":"session title","cache_completed":false}'
+    value = '{"id":"1234","job_id":"1","created_at":1669139262,"token":"sys/token","title":"AppName","cache_completed":false}'
     BatchConnect::Session.new.from_json(value).tap do |session|
       session.stubs(:status).returns(OodCore::Job::Status.new(state: state))
     end
   end
 
+  def cancel_session_title
+    "#{I18n.t('dashboard.batch_connect_sessions_cancel_title')} AppName #{I18n.t('dashboard.batch_connect_sessions_word')}"
+  end
+
+  def delete_session_title
+    "#{I18n.t('dashboard.batch_connect_sessions_delete_title')} AppName #{I18n.t('dashboard.batch_connect_sessions_word')}"
+  end
 end

--- a/apps/dashboard/test/integration/sessions_controller_test.rb
+++ b/apps/dashboard/test/integration/sessions_controller_test.rb
@@ -79,9 +79,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     get batch_connect_sessions_path
     assert_response :success
 
-    assert_select 'div#id_1234 div.card-body div.float-right a' do |link|
-      assert_equal I18n.t('dashboard.batch_connect_sessions_delete_title'), link.first.text.strip
-      assert_equal batch_connect_session_path('1234'), link.first['href']
+    assert_select 'div#id_1234 div.card-body div.float-right form' do |form|
+      assert_equal I18n.t('dashboard.batch_connect_sessions_delete_title'), form.first.text.strip
+      assert_equal batch_connect_session_path('1234'), form.first['action']
     end
   end
 
@@ -91,9 +91,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     get batch_connect_sessions_path
     assert_response :success
 
-    assert_select 'div#id_1234 div.card-body div.float-right a' do |link|
-      assert_equal I18n.t('dashboard.batch_connect_sessions_cancel_title'), link.first.text.strip
-      assert_equal batch_connect_cancel_session_path('1234'), link.first['href']
+    assert_select 'div#id_1234 div.card-body div.float-right form' do |form|
+      assert_equal I18n.t('dashboard.batch_connect_sessions_cancel_title'), form.first.text.strip
+      assert_equal batch_connect_cancel_session_path('1234'), form.first['action']
     end
   end
 end


### PR DESCRIPTION
We should be using `button` tags here to delete & cancel sessions for accessibility reasons (so they can cycle through `b` buttons).

So this changes those elements from an `a` (link) to a button.

This has the added benefit of fixing a bug.

Fixes #659 by using a button that will always use `post` method. The issue in #659 is a race condition where the user clicks the button before the javascript has been attached to the element that toggles between an HTTP GET and an HTTP POST. Buttons directly use POST so there's no way to get into that bad state.

Holding in draft for the moment as tooltips seems to be interfering with the initial state of these elements.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203651238710489) by [Unito](https://www.unito.io)
