### PR TITLE
batch connect radio compatibility

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -19,7 +19,20 @@ module BatchConnect::SessionContextsHelper
       end
     when 'radio', 'radio_button'
       form.form_group attrib.id, help: field_options[:help] do
-        form.collection_radio_buttons attrib.id, attrib.select_choices, :first, :second, { label: label_tag(attrib.id, attrib.label), checked: (attrib.value.presence || attrib.field_options[:checked]) }
+        opts = {
+          label:   label_tag(attrib.id, attrib.label),
+          checked: (attrib.value.presence || attrib.field_options[:checked])
+        }
+        label_values = if Configuration.bc_radio_3_0_compatible?
+                         [:first, :second]
+                       else
+                         msg = 'Radio button options will be in the form ["value", "label"] in 3.0.'\
+                               ' You currently have ["label", "value"]. Use the ondemand.d option'\
+                               ' bc_radio_3_0_compatible to upgrade before 3.0.'.freeze
+                         ActiveSupport::Deprecation.warn(msg) unless Rails.env.test?
+                         [:second, :first]
+                       end
+        form.collection_radio_buttons(attrib.id, attrib.select_choices, *label_values, **opts)
       end
     when 'file_navigator'
       if Configuration.file_navigator?

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -40,6 +40,7 @@ class ConfigurationSingleton
       :csp_enabled                  => false,
       :csp_report_only              => false,
       :bc_dynamic_js                => false,
+      :bc_radio_3_0_compatible      => false,
       :per_cluster_dataroot         => false,
       :file_navigator               => false,
       :jobs_app_alpha               => false,

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -1,6 +1,7 @@
 csp_enabled: true
 csp_report_only: true
 bc_dynamic_js: true
+bc_radio_3_0_compatible: true
 per_cluster_dataroot: true
 file_navigator: true
 jobs_app_alpha: true

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -12,7 +12,7 @@ attributes:
     value: "1"
     options:
       - ["1","Jupyter Lab"]
-      - ["0", "Jupyter Notebook"]
+      - ["0","Jupyter Notebook"]
   hidden_change_thing:
     widget: 'hidden_field'
     value: 'default'

--- a/apps/dashboard/test/integration/batch_connect_test.rb
+++ b/apps/dashboard/test/integration/batch_connect_test.rb
@@ -13,13 +13,34 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
     stub_sys_apps
   end
 
-  test 'radio buttons and labels appear correctly' do
-    get new_batch_connect_session_context_url('sys/bc_jupyter')
-    assert_select 'form input[id="batch_connect_session_context_mode_0"]'
-    assert_select 'form input[id="batch_connect_session_context_mode_1"]'
-    assert_equal 'The Mode', css_select('label[for="batch_connect_session_context_mode"]').text
-    assert_equal 'Jupyter Lab', css_select('label[for="batch_connect_session_context_mode_1"]').text
-    assert_equal 'Jupyter Notebook', css_select('label[for="batch_connect_session_context_mode_0"]').text
+  test 'radio buttons and labels appear correctly with 3.0 compatability' do
+    with_modified_env({'OOD_BC_RADIO_3_0_COMPATIBLE': 'true'}) do
+      get new_batch_connect_session_context_url('sys/bc_jupyter')
+      assert_select 'form input[id="batch_connect_session_context_mode_0"]'
+      assert_select 'form input[id="batch_connect_session_context_mode_1"]'
+      assert_equal 'The Mode', css_select('label[for="batch_connect_session_context_mode"]').text
+      assert_equal 'Jupyter Lab', css_select('label[for="batch_connect_session_context_mode_1"]').text
+      assert_equal 'Jupyter Notebook', css_select('label[for="batch_connect_session_context_mode_0"]').text
+    end
+  end
+
+  # same as test above but for 2.0- form definitions
+  test 'radio buttons and labels appear correctly with 2.0 compatability' do
+    with_modified_env({'OOD_BC_RADIO_3_0_COMPATIBLE': 'false'}) do
+      file = 'test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml'
+
+      `sed -i 's#"1","Jupyter Lab"#"Jupyter Lab", "1"#g' #{file}`
+      `sed -i 's#"0","Jupyter Notebook"#"Jupyter Notebook", "0"#g' #{file}`
+
+      get new_batch_connect_session_context_url('sys/bc_jupyter')
+      assert_select 'form input[id="batch_connect_session_context_mode_0"]'
+      assert_select 'form input[id="batch_connect_session_context_mode_1"]'
+      assert_equal 'The Mode', css_select('label[for="batch_connect_session_context_mode"]').text
+      assert_equal 'Jupyter Lab', css_select('label[for="batch_connect_session_context_mode_1"]').text
+      assert_equal 'Jupyter Notebook', css_select('label[for="batch_connect_session_context_mode_0"]').text
+
+      `git checkout #{file}`
+    end
   end
 
   test 'default application menu renders correctly when nav_bar property defined' do


### PR DESCRIPTION
Starts the compatibility that #2464 will remove.

Right now in 2.0 radio buttons are defined as 
```
- [ 'description (label)', 'value' ]
```

At some point we changed that to follow how select options are defined. 
```
- ['value', 'description (label)']
```

This change now defaults to 2.0 compatibility with the option to change the behavior before 3.0.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203659012092359) by [Unito](https://www.unito.io)
