### PR TITLE
Profile links configuration made consistent with custom navigation

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -76,13 +76,16 @@ module ApplicationHelper
     end
   end
 
+  # Creates the list of profile links to add to the help menu
   def profile_links
-    @user_configuration.profile_links
+    create_menu_links(@user_configuration.profile_links.select{ |item| item.is_a?(Hash) && !item[:profile].nil? })
   end
 
-  def profile_link(profile_info)
-    profile_id = profile_info[:id]
-    nav_link(profile_info.fetch(:name, profile_id), profile_info.fetch(:icon, "user"), settings_path("settings[profile]" => profile_id), data: {method: "post"}) if profile_id
+  # Utility method to create links specific to an existing navigation menu
+  def create_menu_links(link_items)
+    links = NavBar.items(link_items)
+    # 'dropdown-item' class is needed to render the links using the existing 'layouts/nav/link' template
+    links.map(&:to_h).each{|l| l[:class] = 'dropdown-item'}
   end
 
   def custom_css_paths

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -39,15 +39,6 @@ class UserConfiguration
     ConfigurationProperty.property(name: :pinned_apps_group_by, default_value: nil, read_from_env: true),
 
     # Links to change profile under the Help navigation menu
-    # example:
-    # profile_links:
-    #   - id: default
-    #     name: "Default"
-    #     icon: "cog"
-    #   - id: profile1
-    #     name: "Team2"
-    #     icon: "user"
-    #
     ConfigurationProperty.property(name: :profile_links, default_value: []),
 
     # Custom CSS files to add to the application.html.erb template

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -18,8 +18,8 @@
     <% unless profile_links.empty? %>
       <li class="dropdown-divider" role="separator"></li>
       <li class="dropdown-header"><%= t('dashboard.profile_links_title') %></li>
-      <% profile_links.each do | profile_info | %>
-        <%= profile_link(profile_info) %>
+      <% profile_links.each do | profile_link | %>
+        <%= render partial: 'layouts/nav/link', locals: profile_link %>
       <% end %>
     <% end %>
 

--- a/apps/dashboard/test/helpers/application_helper_test.rb
+++ b/apps/dashboard/test/helpers/application_helper_test.rb
@@ -8,36 +8,30 @@ class ApplicationHelperTest < ActionView::TestCase
     @user_configuration = nil
   end
 
-  test "profile_links should delegate to user_configuration object" do
-    expected_result = ["a", "b", "c"]
-    @user_configuration = stub(:profile_links => expected_result)
+  test "profile_links should ignore configurations without profile property" do
+    @user_configuration = stub(:profile_links => ['a', 'b', {profile: 'test_profile', title: 'My Profile'}, {page: 'c'}])
 
-    assert_equal expected_result, profile_links
+    result = profile_links
+
+    assert_equal 1, result.size
+    assert_equal 'My Profile', result[0][:title]
   end
 
-  test "profile_link should return nil when id is missing" do
-    invalid_profile_link = {
-      name: "test name",
-      icon: "user"
-    }
+  test "profile_links should add css class for dropdown items" do
+    @user_configuration = stub(:profile_links => [{profile: 'test_profile', title: 'My Profile'}])
 
-    assert_nil profile_link(invalid_profile_link)
+    result = profile_links
+
+    assert_equal 1, result.size
+    assert_equal 'dropdown-item', result[0][:class]
   end
 
-  test "profile_link should return a link with data-method set to post containing an icon and text" do
-    profile_link = {
-      id: "test",
-      name: "test name",
-      icon: "user"
-    }
-    result = profile_link(profile_link)
+  test "profile_links should delegate to NavBar to create links" do
+    config = [{profile: 'test_profile', title: 'My Profile'}]
+    @user_configuration = stub(:profile_links => config)
 
-    html_doc = Nokogiri::HTML(result)
-
-    refute_nil html_doc.at_css('a[data-method="post"]')
-    refute_nil html_doc.at_css('a[data-method="post"] i')
-    assert_equal true, html_doc.at_css('a[data-method="post"] i')["class"].include?(profile_link[:icon])
-    assert_equal profile_link[:name], html_doc.at_css('a[data-method="post"]').text.strip
+    NavBar.expects(:items).with(config).returns([])
+    profile_links
   end
 
   test "custom_css_paths should prepend public_url to all custom css file paths" do


### PR DESCRIPTION
Changed how to configure profile links so that they are consistent with how the custom navigation configuration is done.

The new configuration will look like:
```yaml
profile_links:
  - title: "Default"
    profile: ""
    icon_uri: fas://user
  - title: "Team 1"
    profile: "team1"
  - title: "Team 2"
    profile: "team2"
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203673422093106) by [Unito](https://www.unito.io)
