### PR TITLE
fix bc radio button definitions to be label then value

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -19,7 +19,11 @@ module BatchConnect::SessionContextsHelper
       end
     when 'radio', 'radio_button'
       form.form_group attrib.id, help: field_options[:help] do
-        form.collection_radio_buttons attrib.id, attrib.select_choices, :first, :second, { label: label_tag(attrib.id, attrib.label), checked: (attrib.value.presence || attrib.field_options[:checked]) }
+        opts = {
+          label:   label_tag(attrib.id, attrib.label),
+          checked: (attrib.value.presence || attrib.field_options[:checked])
+        }
+        form.collection_radio_buttons(attrib.id, attrib.select_choices, :second, :first, **opts)
       end
     when 'file_navigator'
       if Configuration.file_navigator?

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -11,8 +11,8 @@ attributes:
     label: "The Mode"
     value: "1"
     options:
-      - ["1","Jupyter Lab"]
-      - ["0", "Jupyter Notebook"]
+      - ["Jupyter Lab", "1"]
+      - ["Jupyter Notebook", "0"]
   hidden_change_thing:
     widget: 'hidden_field'
     value: 'default'


### PR DESCRIPTION
Fix bc radio button definitions to be label then value which is how select options are.