### PR TITLE
Updated can_access_core_app? to use SysRouter.base_path

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -370,7 +370,7 @@ class ConfigurationSingleton
   private
 
   def can_access_core_app?(name)
-    app_dir = Rails.root.realpath.parent.join(name)
+    app_dir = SysRouter.base_path.join(name)
     app_dir.directory? && app_dir.join('manifest.yml').readable?
   end
 

--- a/apps/dashboard/test/integration/files_app_test.rb
+++ b/apps/dashboard/test/integration/files_app_test.rb
@@ -3,6 +3,11 @@ require 'test_helper'
 
 class FilesAppTest < ActionDispatch::IntegrationTest
 
+  def setup
+    Configuration.stubs(:can_access_files?).returns(true)
+    Rails.application.reload_routes!
+  end
+
   test "Files app displays terminal button when configuration is set to true" do
     Configuration.stubs(:files_enable_shell_button).returns(true)
 

--- a/apps/dashboard/test/integration/files_test.rb
+++ b/apps/dashboard/test/integration/files_test.rb
@@ -10,6 +10,8 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def setup
+    Configuration.stubs(:can_access_files?).returns(true)
+    Rails.application.reload_routes!
     # lot's of setup here to get a valid csrf-token
     get files_path
     assert :success

--- a/apps/dashboard/test/integration/remote_files_test.rb
+++ b/apps/dashboard/test/integration/remote_files_test.rb
@@ -11,6 +11,8 @@ class RemoteFilesIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def setup
+    Configuration.stubs(:can_access_files?).returns(true)
+    Rails.application.reload_routes!
     # lot's of setup here to get a valid csrf-token
     get files_path
     assert :success

--- a/apps/dashboard/test/integration/request_tracker_integration_test.rb
+++ b/apps/dashboard/test/integration/request_tracker_integration_test.rb
@@ -10,11 +10,6 @@ class RequestTrackerIntegrationTest < ActionDispatch::IntegrationTest
         priority: 10,
       }
     })
-
-    Rails.application.routes.append do
-      get "/support", to: "support_ticket#new"
-      post "/support", to: "support_ticket#create"
-    end
     Rails.application.reload_routes!
   end
 

--- a/apps/dashboard/test/integration/support_ticket_integration_test.rb
+++ b/apps/dashboard/test/integration/support_ticket_integration_test.rb
@@ -9,10 +9,6 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
         to: "to_address@support.ticket.com",
       }
     })
-    Rails.application.routes.append do
-      get "/support", to: "support_ticket#new"
-      post "/support", to: "support_ticket#create"
-    end
     Rails.application.reload_routes!
   end
 

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -4,6 +4,12 @@ class FilesTest < ApplicationSystemTestCase
 
   MAX_WAIT = 120
 
+  def setup
+    Configuration.stubs(:can_access_files?).returns(true)
+    Configuration.stubs(:can_access_file_editor?).returns(true)
+    Rails.application.reload_routes!
+  end
+
   test "visiting files app doesn't raise js errors" do
     visit files_url(Rails.root.to_s)
 

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -4,6 +4,12 @@ require 'rclone_helper'
 class RemoteFilesTest < ApplicationSystemTestCase
   MAX_WAIT = 120
 
+  def setup
+    Configuration.stubs(:can_access_files?).returns(true)
+    Configuration.stubs(:can_access_file_editor?).returns(true)
+    Rails.application.reload_routes!
+  end
+
   test "visiting files app doesn't raise js errors" do
     with_rclone_conf(Rails.root.to_s) do
       visit files_url('alias_remote', '/')


### PR DESCRIPTION
can_access_core_app? uses `Rails.root` to find out the applications directory. This is usually correct, but when applications are deployed outside the sys directory, like in development, this is not correct.

I think using the SysRouter is better as the code will use it to get information about the other applications regardless of where the Dashboard is installed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203712721441786) by [Unito](https://www.unito.io)
