### PR TITLE
Added support to attach menu items to existing navigation

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -62,7 +62,8 @@ class ApplicationController < ActionController::Base
   end
 
   def sys_app_groups
-    OodAppGroup.groups_for(apps: nav_sys_apps)
+    navbar_attachment = NavBar.items(@user_configuration.navbar_attachment).reject{|item| ['help', 'development'].include? item.title.downcase}.map(&:apps).flatten
+    OodAppGroup.groups_for(apps: nav_sys_apps + navbar_attachment)
   end
 
   def set_pinned_apps

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -76,16 +76,14 @@ module ApplicationHelper
     end
   end
 
-  # Creates the list of profile links to add to the help menu
-  def profile_links
-    create_menu_links(@user_configuration.profile_links.select{ |item| item.is_a?(Hash) && !item[:profile].nil? })
+  # Creates the list of links to add to the help menu
+  def help_links
+    NavBar.items(@user_configuration.navbar_attachment.select{ |item| item.is_a?(Hash) && item[:title].downcase == 'help' }).first
   end
 
-  # Utility method to create links specific to an existing navigation menu
-  def create_menu_links(link_items)
-    links = NavBar.items(link_items)
-    # 'dropdown-item' class is needed to render the links using the existing 'layouts/nav/link' template
-    links.map(&:to_h).each{|l| l[:class] = 'dropdown-item'}
+  # Creates the list of links to add to the development menu
+  def development_links
+    NavBar.items(@user_configuration.navbar_attachment.select{ |item| item.is_a?(Hash) && item[:title].downcase == 'development' }).first
   end
 
   def custom_css_paths

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -38,9 +38,6 @@ class UserConfiguration
     ConfigurationProperty.property(name: :pinned_apps_menu_length, default_value: 6),
     ConfigurationProperty.property(name: :pinned_apps_group_by, default_value: nil, read_from_env: true),
 
-    # Links to change profile under the Help navigation menu
-    ConfigurationProperty.property(name: :profile_links, default_value: []),
-
     # Custom CSS files to add to the application.html.erb template
     # The files need to be deployed to the Apache public directory: /var/www/ood/public
     # The URL path will be prepended with the public_url property
@@ -56,6 +53,7 @@ class UserConfiguration
     ConfigurationProperty.property(name: :nav_bar, default_value: []),
     ConfigurationProperty.property(name: :help_bar, default_value: []),
     ConfigurationProperty.property(name: :interactive_apps_menu, default_value: []),
+    ConfigurationProperty.property(name: :navbar_attachment, default_value: []),
 
     # Custom pages configuration property
     ConfigurationProperty.property(name: :custom_pages, default_value: {}),

--- a/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -10,5 +10,9 @@
     <% if Configuration.app_sharing_enabled? %>
       <%= nav_link(products_title(:usr), "share-alt", products_path(type: "usr")) %>
     <% end %>
+
+    <% if development_links %>
+      <%= render partial: 'layouts/nav/group_items', locals: development_links.to_h %>
+    <% end %>
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -4,30 +4,6 @@
   </a>
 
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, '') %>">
-    <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, sort: group.sort).each_with_index do |g, index| %>
-      <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
-      <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
-      <% g.apps.each do |app| %>
-        <% app.links.each do |link| %>
-          <li>
-            <%=
-              link_to(
-                link.url.to_s,
-                title: link.title,
-                class: "dropdown-item",
-                target: link.new_tab? ? "_blank" : nil,
-                aria: ({ current: ('page' if (current_page?(link.url))) }),
-                data: link.data
-              ) do
-            %>
-            <%= icon_tag(link.icon_uri) %> <%= link.title %>
-            <% if link.subtitle.present? %>
-              <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
-            <% end %>
-          <% end %>
-          </li>
-        <% end %>
-      <% end %>
-    <% end %>
+    <%= render partial: 'layouts/nav/group_items', locals: local_assigns %>
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
@@ -1,0 +1,25 @@
+<% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, sort: group.sort).each_with_index do |g, index| %>
+  <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
+  <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
+  <% g.apps.each do |app| %>
+    <% app.links.each do |link| %>
+      <li>
+        <%=
+          link_to(
+            link.url.to_s,
+            title: link.title,
+            class: "dropdown-item",
+            target: link.new_tab? ? "_blank" : nil,
+            aria: ({ current: ('page' if (current_page?(link.url))) }),
+            data: link.data
+          ) do
+        %>
+          <%= icon_tag(link.icon_uri) %> <%= link.title %>
+          <% if link.subtitle.present? %>
+            <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
+<% end %>

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -15,13 +15,9 @@
       <%= nav_link(t('dashboard.nav_help_support_ticket'), "medkit", support_path, new_tab: false) %>
     <% end %>
     <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
-    <% unless profile_links.empty? %>
-      <li class="dropdown-divider" role="separator"></li>
-      <li class="dropdown-header"><%= t('dashboard.profile_links_title') %></li>
-      <% profile_links.each do | profile_link | %>
-        <%= render partial: 'layouts/nav/link', locals: profile_link %>
-      <% end %>
-    <% end %>
 
+    <% if help_links %>
+      <%= render partial: 'layouts/nav/group_items', locals: help_links.to_h %>
+    <% end %>
   </ul>
 </li>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -214,8 +214,6 @@ en:
 
     settings_updated: "Settings updated"
 
-    profile_links_title: "Profiles"
-
     breadcrumbs_support_ticket: "Support Ticket"
     support_ticket:
       title: "Support Ticket"


### PR DESCRIPTION
Draft PR to add menu items to default Dashboard navigation.

This is just to see if you like the idea an implementation.
The implementation can be limited to just the `help` and `development` menus and extend to the left `navbar` later

Will address the tests if we like this idea and/or implementation.

See discussion in issue: https://github.com/OSC/ondemand/issues/2472

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203720420316702) by [Unito](https://www.unito.io)
