### PR TITLE
Improvements to the configuration for the support ticket form

### DIFF
--- a/apps/dashboard/app/apps/request_tracker_service.rb
+++ b/apps/dashboard/app/apps/request_tracker_service.rb
@@ -18,7 +18,8 @@ class RequestTrackerService
 
     ticket_template_context = {
       session:     session,
-      description: support_ticket_request.description
+      description: support_ticket_request.description,
+      username:    support_ticket_request.username
     }
 
     template = rt_config.fetch(:template, 'rt_ticket_content.text.erb')

--- a/apps/dashboard/app/helpers/support_ticket_helper.rb
+++ b/apps/dashboard/app/helpers/support_ticket_helper.rb
@@ -2,6 +2,10 @@
 
 # helper for the support ticket pages, email, and request tracker content.
 module SupportTicketHelper
+  def support_ticket_description_text
+    ::Configuration.support_ticket_config[:description]
+  end
+
   def filter_session_parameters(session_info)
     filter_parameters = [:ood_connection_info]
     session_info.to_h.reject { |key, _| filter_parameters.include?(key.to_sym) }

--- a/apps/dashboard/app/mailers/support_ticket_mailer.rb
+++ b/apps/dashboard/app/mailers/support_ticket_mailer.rb
@@ -6,6 +6,7 @@
 class SupportTicketMailer < ActionMailer::Base
   helper :support_ticket
   default template_path: ['support_ticket/email']
+  default template_name: 'email_layout'
 
   def support_email(context)
     @context = context
@@ -24,7 +25,6 @@ class SupportTicketMailer < ActionMailer::Base
       settings[:to] = email_service_config.fetch(:to)
       settings[:cc] = @context.support_ticket.cc
       settings[:subject] = @context.support_ticket.subject
-      settings[:template_name] = email_service_config.fetch(:email_template, 'default')
 
       # Override Rails delivery settings with support ticket configuration if provided
       # This will allow admins to use standard Rails configuration settings if required.

--- a/apps/dashboard/app/views/support_ticket/email/_email.text.erb
+++ b/apps/dashboard/app/views/support_ticket/email/_email.text.erb
@@ -1,9 +1,11 @@
-Support ticket submitted from the dashboard application
+Support ticket submitted from the dashboard application.
+
+Username: <%= @context.support_ticket.username %>
 <% if @context.session %>
-  User selected session: <%= @context.session.id %>
-  Title: <%=@context.session.title %>
-  Job id: <%= @context.session.job_id %>
-  Status: <%= @context.session.status.to_sym %>
+User selected session: <%= @context.session.id %>
+Title: <%=@context.session.title %>
+Job id: <%= @context.session.job_id %>
+Status: <%= @context.session.status.to_sym %>
 <% end %>
 
 Description:

--- a/apps/dashboard/app/views/support_ticket/email/email_layout.text.erb
+++ b/apps/dashboard/app/views/support_ticket/email/email_layout.text.erb
@@ -1,0 +1,2 @@
+
+<%= render partial: "support_ticket/email/email" %>

--- a/apps/dashboard/app/views/support_ticket/email_service_template.html.erb
+++ b/apps/dashboard/app/views/support_ticket/email_service_template.html.erb
@@ -29,7 +29,7 @@
   <div id="support-ticket-content-container" class="mb-4">
     <h2><%= t('dashboard.support_ticket.header') %></h2>
     <p>
-      <%= t('dashboard.support_ticket.description_html') %>
+      <%= support_ticket_description_text %>
     </p>
   </div>
 

--- a/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
+++ b/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
@@ -1,4 +1,5 @@
 Ticket submitted from dashboard application
+Username: <%= context[:username] %>
 <% if context[:session] %>
 User selected session:<%= context[:session].id %>
 Title: <%= context[:session].title %>

--- a/apps/dashboard/config/environments/development.rb
+++ b/apps/dashboard/config/environments/development.rb
@@ -30,9 +30,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/apps/dashboard/config/environments/test.rb
+++ b/apps/dashboard/config/environments/test.rb
@@ -34,11 +34,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -219,8 +219,7 @@ en:
     breadcrumbs_support_ticket: "Support Ticket"
     support_ticket:
       title: "Support Ticket"
-      header: "Support Ticket Header"
-      description_html: "Support Ticket Description with HTML"
+      header: "Support Ticket"
       creation_success: "Support ticket email sent to: %{to}"
       generic_error: "There was an error processing your request: %{error}"
       validation_error: "Invalid Request. Please review the error messages below"

--- a/apps/dashboard/test/fixtures/config/views/support_ticket/email/email_template_override.text.erb
+++ b/apps/dashboard/test/fixtures/config/views/support_ticket/email/email_template_override.text.erb
@@ -1,1 +1,0 @@
-support ticket email override

--- a/apps/dashboard/test/helpers/support_ticket_helper_test.rb
+++ b/apps/dashboard/test/helpers/support_ticket_helper_test.rb
@@ -1,24 +1,31 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SupportTicketHelperTest < ActionView::TestCase
-
   include SupportTicketHelper
 
-  test "filter_session_parameters should filter known parameters" do
-    known_parameters = ["ood_connection_info"]
+  test 'support_ticket_description_text should read content from support_ticket configuration' do
+    expected_description = 'This is description text'
+    Configuration.stubs(:support_ticket_config).returns({ description: expected_description })
+    ::Configuration.support_ticket_config[:description]&.html_safe
+    assert_equal expected_description, support_ticket_description_text
+  end
+
+  test 'filter_session_parameters should filter known parameters' do
+    known_parameters = ['ood_connection_info']
     expected_session_parameters = {
-      "job_name": "job",
-      "job_owner": "owner",
-      "accounting_id": "account",
-      "procs": "process",
-      "queue_name": "queue",
+      "job_name":      'job',
+      "job_owner":     'owner',
+      "accounting_id": 'account',
+      "procs":         'process',
+      "queue_name":    'queue'
     }
 
     known_parameters.each do |parameter|
       session_info = expected_session_parameters.clone
-      session_info[parameter]= {}
+      session_info[parameter] = {}
       assert_equal expected_session_parameters, filter_session_parameters(session_info)
     end
   end
-
 end

--- a/apps/dashboard/test/integration/request_tracker_integration_test.rb
+++ b/apps/dashboard/test/integration/request_tracker_integration_test.rb
@@ -10,11 +10,6 @@ class RequestTrackerIntegrationTest < ActionDispatch::IntegrationTest
         priority: 10,
       }
     })
-
-    Rails.application.routes.append do
-      get "/support", to: "support_ticket#new"
-      post "/support", to: "support_ticket#create"
-    end
     Rails.application.reload_routes!
   end
 

--- a/apps/dashboard/test/integration/support_ticket_integration_test.rb
+++ b/apps/dashboard/test/integration/support_ticket_integration_test.rb
@@ -7,12 +7,9 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
     Configuration.stubs(:support_ticket_config).returns({
       email: {
         to: "to_address@support.ticket.com",
+        delivery_method: 'test'
       }
     })
-    Rails.application.routes.append do
-      get "/support", to: "support_ticket#new"
-      post "/support", to: "support_ticket#create"
-    end
     Rails.application.reload_routes!
   end
 

--- a/apps/dashboard/test/mailers/support_ticket_mailer_test.rb
+++ b/apps/dashboard/test/mailers/support_ticket_mailer_test.rb
@@ -51,20 +51,4 @@ class SupportTicketMailerTest < ActionMailer::TestCase
     assert_equal ["override@example.com"], email.from
   end
 
-  test 'email template can be overridden with configuration' do
-    Configuration.stubs(:support_ticket_config).returns({
-      email: {
-        email_template: "email_template_override",
-        to: "to_address@support.ticket.com",
-      }
-    })
-    email = SupportTicketMailer.support_email(@context)
-
-    assert_emails 1 do
-      email.deliver_now
-    end
-
-    assert_match 'support ticket email override', email.body.encoded
-  end
-
 end


### PR DESCRIPTION
While creating the documentation for the new support ticket feature, I found a couple of items to improve:
 * Update Header text so that is ready to use without updates.
 * Make default Header description empty and move the configuration to the `support_ticket` property.
 * Add username to the email and RT ticket bodies.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203750309735033) by [Unito](https://www.unito.io)
