### PR TITLE
allow for duplicate option values

### DIFF
--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -643,10 +643,15 @@ function nodeListToQueryString(nodeList) {
 
   for(i = 0; i < len; i++) {
     let item = nodeList[i];
-    query += `[${item.name}='${item.value}']`;
+    query += `[${sanitizeQuery(item.name)}='${item.value}']`;
   }
 
   return query;
+}
+
+// simple function to sanitize css query strings
+function sanitizeQuery(item) {
+  return item.replace('.', '\\.');
 }
 
 

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -651,7 +651,7 @@ function nodeListToQueryString(nodeList) {
 
 // simple function to sanitize css query strings
 function sanitizeQuery(item) {
-  return item.replace('.', '\\.');
+  return item.replaceAll('.', '\\.');
 }
 
 


### PR DESCRIPTION
`auto_accounts` is going to create big lists of duplicates.

I.e., `auto_accounts` are going to generate an account per cluster, like so:

```
pzs0714|ascend||ascend-default
pzs0714|owens||owens-default
pzs0714|pitzer||pitzer-default
```

Generating form options like so. Obviously there are 3 options for value `PZS0714`, so this PR accounts for those duplciate options.

![image](https://user-images.githubusercontent.com/4874123/213303539-5720b63b-4af6-4d7d-b869-bfd49007f823.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203777315915537) by [Unito](https://www.unito.io)
