### PR TITLE
Created new navigation menu for user related items

### DIFF
--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -160,10 +160,11 @@ class NavBar
     hash[['all_apps', 'all apps']] = 'layouts/nav/all_apps'
     hash[['featured_apps', 'apps', 'pinned_apps', 'pinned apps', 'featured apps']] = 'layouts/nav/featured_apps'
     hash[['sessions', 'my_interactive_sessions', 'my interactive sessions']] = 'layouts/nav/sessions'
-    hash[['develop']] = 'layouts/nav/develop_dropdown'
+    hash[['develop', 'development']] = 'layouts/nav/develop_dropdown'
     hash[['help']] = 'layouts/nav/help_dropdown'
     hash[['log_out', 'logout', 'log out']] = 'layouts/nav/log_out'
     hash[['user']] = 'layouts/nav/user'
+    hash[['user_dropdown', 'user dropdown']] = 'layouts/nav/user_dropdown'
   end.freeze
 
   url_helpers =  Rails.application.routes.url_helpers

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -80,8 +80,14 @@ module ApplicationHelper
 
   # Creates the list of links to add to the help menu
   def help_links
-    help_items = ["restart"] + @user_configuration.profile_links + @user_configuration.help_menu
+    help_items = ["restart"] + @user_configuration.help_menu
     NavBar.menu_items({ links: help_items }) unless help_items.empty?
+  end
+
+  # Creates the list of links to add to the user menu
+  def user_links
+    user_items = ["logout"] + @user_configuration.user_menu
+    NavBar.menu_items({ links: user_items }) unless user_items.empty?
   end
 
   def custom_css_paths

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -44,9 +44,6 @@ class UserConfiguration
     ConfigurationProperty.property(name: :pinned_apps_menu_length, default_value: 6),
     ConfigurationProperty.property(name: :pinned_apps_group_by, default_value: nil, read_from_env: true),
 
-    # Links to change profile under the Help navigation menu
-    ConfigurationProperty.property(name: :profile_links, default_value: []),
-
     # Custom CSS files to add to the application.html.erb template
     # The files need to be deployed to the Apache public directory: /var/www/ood/public
     # The URL path will be prepended with the public_url property
@@ -62,8 +59,14 @@ class UserConfiguration
     # New navigation definition properties
     ConfigurationProperty.property(name: :nav_bar, default_value: []),
     ConfigurationProperty.property(name: :help_bar, default_value: []),
+    # Links to add to the Help menu
     ConfigurationProperty.property(name: :help_menu, default_value: []),
+    # Links to add to the new user menu
+    ConfigurationProperty.property(name: :user_menu, default_value: []),
     ConfigurationProperty.property(name: :interactive_apps_menu, default_value: []),
+    # Feature toggle for new user navigation
+    # TODO: remove the toggle for 2.2 release
+    ConfigurationProperty.property(name: :new_user_menu, default_value: false),
 
     # Custom pages configuration property
     ConfigurationProperty.property(name: :custom_pages, default_value: {}),

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -55,8 +55,9 @@
           <% if @help_bar.empty? %>
             <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
             <%= render partial: 'layouts/nav/help_dropdown' %>
-            <%= render partial: 'layouts/nav/user' %>
-            <%= render partial: 'layouts/nav/log_out' %>
+            <%= render partial: 'layouts/nav/user' unless @user_configuration.new_user_menu %>
+            <%= render partial: 'layouts/nav/log_out' unless @user_configuration.new_user_menu %>
+            <%= render partial: 'layouts/nav/user_dropdown' if @user_configuration.new_user_menu %>
           <% else %>
             <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @help_bar, menu_alignment: 'dropdown-menu-right' }%>
           <% end %>

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -6,8 +6,10 @@
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, 'dropdown-menu-right') %>" role="menu">
     <%= nav_link(t('dashboard.nav_help_support'), "question-circle", support_url, new_tab: true) %>
     <%= nav_link(t('dashboard.nav_help_docs'), "info-circle", docs_url, new_tab: true) %>
-    <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, new_tab: true) %>
-    <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, new_tab: true) %>
+    <% unless @user_configuration.new_user_menu %>
+      <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, new_tab: true) %>
+      <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, new_tab: true) %>
+    <% end %>
     <% if help_custom_url %>
       <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, new_tab: true) %>
     <% end %>
@@ -15,8 +17,6 @@
       <%= nav_link(t('dashboard.nav_help_support_ticket'), "medkit", support_path, new_tab: false) %>
     <% end %>
 
-    <% if help_links %>
-      <%= render partial: 'layouts/nav/group_items', locals: help_links.to_h %>
-    <% end %>
+    <%= render partial: 'layouts/nav/group_items', locals: help_links.to_h %>
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_user_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_user_dropdown.html.erb
@@ -1,0 +1,12 @@
+<li class="nav-item dropdown" title="<%= @user.name %>" >
+  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+    <i class="fas fa-user" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= @user.name %></span><span class="caret"></span>
+  </a>
+
+  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, 'dropdown-menu-right') %>" role="menu">
+    <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, new_tab: true) %>
+    <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, new_tab: true) %>
+
+    <%= render partial: 'layouts/nav/group_items', locals: user_links.to_h %>
+  </ul>
+</li>

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -439,10 +439,11 @@ class NavBarTest < ActiveSupport::TestCase
         'all_apps', 'all apps',
         'featured_apps', 'apps', 'pinned_apps', 'pinned apps', 'featured apps',
         'sessions', 'my_interactive_sessions', 'my interactive sessions',
-        'develop',
+        'develop', 'development',
         'help',
         'log_out', 'logout', 'log out',
-        'user'].include?(name.to_s)
+        'user',
+        'user_dropdown', 'user dropdown'].include?(name.to_s)
     end
   end
 

--- a/apps/dashboard/test/helpers/application_helper_test.rb
+++ b/apps/dashboard/test/helpers/application_helper_test.rb
@@ -10,7 +10,7 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test 'help_links should include server restart' do
-    @user_configuration = stub({ profile_links: [], help_menu: [] })
+    @user_configuration = stub({ help_menu: [] })
 
     result = help_links
 
@@ -18,24 +18,49 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal I18n.t('dashboard.nav_restart_server'), result.apps[0].title
   end
 
-  test 'help_links should combine server restart with profile_links and help_menu' do
-    @user_configuration = stub({ profile_links: [{ title: 'profile link', url: '/path' }],
-                                 help_menu:     [{ title: 'help link', url: '/path' }] })
+  test 'help_links should combine server restart with help_menu' do
+    @user_configuration = stub({ help_menu: [{ title: 'help link', url: '/path' }] })
 
     result = help_links
 
-    assert_equal 3, result.apps.size
+    assert_equal 2, result.apps.size
     assert_equal I18n.t('dashboard.nav_restart_server'), result.apps[0].title
-    assert_equal 'profile link', result.apps[1].title
-    assert_equal 'help link', result.apps[2].title
+    assert_equal 'help link', result.apps[1].title
   end
 
   test 'help_links should delegate to NavBar to create links' do
     config = { links: ['restart'] }
-    @user_configuration = stub({ profile_links: [], help_menu: [] })
+    @user_configuration = stub({ help_menu: [] })
 
     NavBar.expects(:menu_items).with(config)
     help_links
+  end
+
+  test 'user_links should include user logout' do
+    @user_configuration = stub({ user_menu: [] })
+
+    result = user_links
+
+    assert_equal 1, result.apps.size
+    assert_equal I18n.t('dashboard.nav_logout'), result.apps[0].title
+  end
+
+  test 'user_links should combine user logout with user_menu' do
+    @user_configuration = stub({ user_menu: [{ title: 'user link', url: '/path' }] })
+
+    result = user_links
+
+    assert_equal 2, result.apps.size
+    assert_equal I18n.t('dashboard.nav_logout'), result.apps[0].title
+    assert_equal 'user link', result.apps[1].title
+  end
+
+  test 'user_links should delegate to NavBar to create links' do
+    config = { links: ['logout'] }
+    @user_configuration = stub({ user_menu: [] })
+
+    NavBar.expects(:menu_items).with(config)
+    user_links
   end
 
   test 'custom_css_paths should prepend public_url to all custom css file paths' do
@@ -68,7 +93,7 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal [], custom_css_paths
   end
 
-  test "icon_tag should should render icon tag for known icon schemas" do
+  test 'icon_tag should should render icon tag for known icon schemas' do
     @user_configuration = stub({ public_url: Pathname.new('/public') })
     ['fa', 'fas', 'far', 'fab', 'fal'].each do |icon_schema|
       image_uri = URI("#{icon_schema}://icon_name")
@@ -80,7 +105,7 @@ class ApplicationHelperTest < ActionView::TestCase
     end
   end
 
-  test "icon_tag should should render image tag prefixing relative_url_root if image URI does not start with public_url" do
+  test 'icon_tag should should render image tag prefixing relative_url_root if image URI does not start with public_url' do
     @user_configuration = stub({ public_url: Pathname.new('/public') })
     config.stubs(:relative_url_root).returns('/prefix')
     image_uri = URI('/path/to/image.png')
@@ -92,7 +117,7 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal '/prefix/path/to/image.png', image_html['src']
   end
 
-  test "icon_tag should should render image tag without prefixing relative_url_root if image URI starts with public_url" do
+  test 'icon_tag should should render image tag without prefixing relative_url_root if image URI starts with public_url' do
     @user_configuration = stub({ public_url: Pathname.new('/public') })
     config.stubs(:relative_url_root).returns('/prefix')
     image_uri = URI('/public/path/image.png')

--- a/apps/dashboard/test/integration/nav_test.rb
+++ b/apps/dashboard/test/integration/nav_test.rb
@@ -24,4 +24,26 @@ class NavTest < ActionDispatch::IntegrationTest
    assert link, 'Job Composer link not found on index page'
    refute link['target'], 'Job Composer link should be set to open in same window'
  end
+
+ test "user menu dropdown is rendered when new_user_menu property is true" do
+   SysRouter.stubs(:base_path).returns(Rails.root.parent)
+   stub_user_configuration({ new_user_menu: true })
+
+   get '/'
+
+   assert_select "#navbar li.dropdown[title=\"#{CurrentUser.name}\"] a[data-toggle]", text: CurrentUser.name
+   assert_select "#navbar ul.navbar-nav > li.nav-item a.nav-link", text: I18n.t('dashboard.nav_user', username: CurrentUser.name), count: 0
+   assert_select "#navbar ul.navbar-nav > li.nav-item a.nav-link", text: I18n.t('dashboard.nav_logout'), count: 0
+ end
+
+ test "logged in user and logout links are rendered when new_user_menu property is false" do
+   SysRouter.stubs(:base_path).returns(Rails.root.parent)
+   stub_user_configuration({ new_user_menu: false })
+
+   get '/'
+
+   assert_select "#navbar li.dropdown[title=\"#{CurrentUser.name}\"]", 0
+   assert_select "#navbar ul.navbar-nav > li.nav-item a.nav-link", text: I18n.t('dashboard.nav_user', username: CurrentUser.name), count: 1
+   assert_select "#navbar ul.navbar-nav > li.nav-item a.nav-link", text: I18n.t('dashboard.nav_logout'), count: 1
+ end
 end

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -49,7 +49,6 @@ class UserConfigurationTest < ActiveSupport::TestCase
       dashboard_layout: nil,
       pinned_apps: [],
       pinned_apps_menu_length: 6,
-      profile_links: [],
       custom_css_files: [],
       dashboard_title: "Open OnDemand",
       public_url: Pathname.new("/public"),
@@ -66,7 +65,9 @@ class UserConfigurationTest < ActiveSupport::TestCase
       nav_bar: [],
       help_bar: [],
       help_menu: [],
+      user_menu: [],
       interactive_apps_menu: [],
+      new_user_menu: false,
       custom_pages: {},
       support_ticket: {},
     }


### PR DESCRIPTION
New navigation menu for user related items.
This replaces the `Logged as` and `Log Out` top level navigation items.

Fixes: https://github.com/OSC/ondemand/issues/2486

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203781012316634) by [Unito](https://www.unito.io)
