### PR TITLE
Added support to add links to the help menu dropdown

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -76,16 +76,10 @@ module ApplicationHelper
     end
   end
 
-  # Creates the list of profile links to add to the help menu
-  def profile_links
-    create_menu_links(@user_configuration.profile_links.select{ |item| item.is_a?(Hash) && !item[:profile].nil? })
-  end
-
-  # Utility method to create links specific to an existing navigation menu
-  def create_menu_links(link_items)
-    links = NavBar.items(link_items)
-    # 'dropdown-item' class is needed to render the links using the existing 'layouts/nav/link' template
-    links.map(&:to_h).each{|l| l[:class] = 'dropdown-item'}
+  # Creates the list of links to add to the help menu
+  def help_links
+    help_items = ["restart"] + @user_configuration.profile_links + @user_configuration.help_menu
+    NavBar.menu_items({ links: help_items }) unless help_items.empty?
   end
 
   def custom_css_paths

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -55,6 +55,7 @@ class UserConfiguration
     # New navigation definition properties
     ConfigurationProperty.property(name: :nav_bar, default_value: []),
     ConfigurationProperty.property(name: :help_bar, default_value: []),
+    ConfigurationProperty.property(name: :help_menu, default_value: []),
     ConfigurationProperty.property(name: :interactive_apps_menu, default_value: []),
 
     # Custom pages configuration property

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -4,30 +4,6 @@
   </a>
 
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, '') %>">
-    <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, sort: group.sort).each_with_index do |g, index| %>
-      <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
-      <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
-      <% g.apps.each do |app| %>
-        <% app.links.each do |link| %>
-          <li>
-            <%=
-              link_to(
-                link.url.to_s,
-                title: link.title,
-                class: "dropdown-item",
-                target: link.new_tab? ? "_blank" : nil,
-                aria: ({ current: ('page' if (current_page?(link.url))) }),
-                data: link.data
-              ) do
-            %>
-            <%= icon_tag(link.icon_uri) %> <%= link.title %>
-            <% if link.subtitle.present? %>
-              <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
-            <% end %>
-          <% end %>
-          </li>
-        <% end %>
-      <% end %>
-    <% end %>
+    <%= render partial: 'layouts/nav/group_items', locals: local_assigns %>
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
@@ -1,0 +1,25 @@
+<% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, sort: group.sort).each_with_index do |g, index| %>
+  <%= content_tag(:li, nil, class: ["dropdown-divider"], role: "separator") if index > 0 %>
+  <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
+  <% g.apps.each do |app| %>
+    <% app.links.each do |link| %>
+      <li>
+        <%=
+          link_to(
+            link.url.to_s,
+            title: link.title,
+            class: "dropdown-item",
+            target: link.new_tab? ? "_blank" : nil,
+            aria: ({ current: ('page' if (current_page?(link.url))) }),
+            data: link.data
+          ) do
+        %>
+          <%= icon_tag(link.icon_uri) %> <%= link.title %>
+          <% if link.subtitle.present? %>
+            <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
+<% end %>

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -14,14 +14,9 @@
     <% if Configuration.support_ticket_enabled? %>
       <%= nav_link(t('dashboard.nav_help_support_ticket'), "medkit", support_path, new_tab: false) %>
     <% end %>
-    <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
-    <% unless profile_links.empty? %>
-      <li class="dropdown-divider" role="separator"></li>
-      <li class="dropdown-header"><%= t('dashboard.profile_links_title') %></li>
-      <% profile_links.each do | profile_link | %>
-        <%= render partial: 'layouts/nav/link', locals: profile_link %>
-      <% end %>
-    <% end %>
 
+    <% if help_links %>
+      <%= render partial: 'layouts/nav/group_items', locals: help_links.to_h %>
+    <% end %>
   </ul>
 </li>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -216,8 +216,6 @@ en:
 
     settings_updated: "Settings updated"
 
-    profile_links_title: "Profiles"
-
     breadcrumbs_support_ticket: "Support Ticket"
     support_ticket:
       title: "Support Ticket"

--- a/apps/dashboard/test/helpers/application_helper_test.rb
+++ b/apps/dashboard/test/helpers/application_helper_test.rb
@@ -8,30 +8,32 @@ class ApplicationHelperTest < ActionView::TestCase
     @user_configuration = nil
   end
 
-  test "profile_links should ignore configurations without profile property" do
-    @user_configuration = stub(:profile_links => ['a', 'b', {profile: 'test_profile', title: 'My Profile'}, {page: 'c'}])
+  test "help_links should include server restart" do
+    @user_configuration = stub({ profile_links: [], help_menu: [] })
 
-    result = profile_links
+    result = help_links
 
-    assert_equal 1, result.size
-    assert_equal 'My Profile', result[0][:title]
+    assert_equal 1,  result.apps.size
+    assert_equal I18n.t('dashboard.nav_restart_server'),  result.apps[0].title
   end
 
-  test "profile_links should add css class for dropdown items" do
-    @user_configuration = stub(:profile_links => [{profile: 'test_profile', title: 'My Profile'}])
+  test "help_links should combine server restart with profile_links and help_menu" do
+    @user_configuration = stub({ profile_links: [{title: "profile link", url: "/path"}], help_menu: [{title: "help link", url: "/path"}] })
 
-    result = profile_links
+    result = help_links
 
-    assert_equal 1, result.size
-    assert_equal 'dropdown-item', result[0][:class]
+    assert_equal 3,  result.apps.size
+    assert_equal I18n.t('dashboard.nav_restart_server'),  result.apps[0].title
+    assert_equal "profile link",  result.apps[1].title
+    assert_equal "help link",  result.apps[2].title
   end
 
-  test "profile_links should delegate to NavBar to create links" do
-    config = [{profile: 'test_profile', title: 'My Profile'}]
-    @user_configuration = stub(:profile_links => config)
+  test "help_links should delegate to NavBar to create links" do
+    config = { links: ["restart"] }
+    @user_configuration = stub({ profile_links: [], help_menu: [] })
 
-    NavBar.expects(:items).with(config).returns([])
-    profile_links
+    NavBar.expects(:menu_items).with(config)
+    help_links
   end
 
   test "custom_css_paths should prepend public_url to all custom css file paths" do

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -62,6 +62,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       nav_categories: ["Apps", "Files", "Jobs", "Clusters", "Interactive Apps"],
       nav_bar: [],
       help_bar: [],
+      help_menu: [],
       interactive_apps_menu: [],
       custom_pages: {},
     }


### PR DESCRIPTION
Added a new profile property called `help_menu` to add links to the Help dropdown menu.
Link definitions are consistent with the new custom `navbar`, uses the same logic.

See discussion in issue: https://github.com/OSC/ondemand/issues/2472

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203837213308996) by [Unito](https://www.unito.io)
