### PR TITLE
add auto_qos batch connect option.

### DIFF
--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -609,7 +609,6 @@ function optionForFromToken(str) {
  function toggleOptionsFor(_event, elementId) {
   const options = $(`#${elementId} option`);
   let hideSelectedValue = undefined;
-  let newSelectedOption = undefined;
 
   options.each(function(_i, option) {
     // the variable 'option' is just a data structure. it has no attr, data, show
@@ -648,22 +647,16 @@ function optionForFromToken(str) {
       }
     } else {
       optionElement.show();
-
-      // just a backup if we have to choose _something_
-      if(!newSelectedOption) {
-        newSelectedOption = optionElement;
-      }
     }
   });
 
   // now that we've hidden/shown everything, let's choose what should now
-  // be the current selected value.
-
-  // first - you may have hidden what _was_ selected, so let's try to find
-  // another option of the same value.
+  // be the current selected value if you've hidden what _was_ selected.
   if(hideSelectedValue !== undefined) {
     let others = $(`#${elementId} option[value='${hideSelectedValue}']`);
+    let newSelectedOption = undefined;
 
+    // You have hidden what _was_ selected, so try to find a duplicate option that is visible
     if(others.length > 1) {
       others.each((_i, ele) => {
         if(ele.style['display'] === '') {
@@ -671,11 +664,21 @@ function optionForFromToken(str) {
           return;
         }
       });
-    }
-  }
 
-  if(newSelectedOption !== undefined) {
-    newSelectedOption.prop('selected', true);
+    // no duplciates are visible, so just pick the first visible option
+    } else {
+      others = $(`#${elementId} option`)
+      others.each((_i, ele) => {
+        if(ele.style['display'] === '') {
+          newSelectedOption = $(`#${elementId} ${nodeListToQueryString(ele.attributes)}`);
+          return;
+        }
+      });
+    }
+
+    if(newSelectedOption !== undefined) {
+      newSelectedOption.prop('selected', true);
+    }
   }
 };
 

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -623,13 +623,14 @@ function optionForFromToken(str) {
     // option-for- directives apply.
     for (const [key, _value] of Object.entries(data)) {
 
-      // it's some other directive type, so just keep going
-      if(!key.startsWith('optionFor')) {
+      let optionFor = optionForFromToken(key);
+      let optionForId = idFromToken(key.replace(/^optionFor/,''));
+
+      // it's some other directive type, so just keep going and/or not real
+      if(!key.startsWith('optionFor') || optionForId === undefined) {
         continue;
       }
 
-      let optionFor = optionForFromToken(key);
-      let optionForId = idFromToken(key.replace(/^optionFor/,''));
       let optionForValue =  mountainCaseWords($(`#${optionForId}`)[0].value);
 
       hide = data[`optionFor${optionFor}${optionForValue}`] === false;

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -669,9 +669,8 @@ function optionForFromToken(str) {
     } else {
       others = $(`#${elementId} option`)
       others.each((_i, ele) => {
-        if(ele.style['display'] === '') {
+        if(newSelectedOption === undefined && ele.style['display'] === '') {
           newSelectedOption = exactlyOneOption(elementId, ele);
-          return;
         }
       });
     }

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -651,7 +651,8 @@ function optionForFromToken(str) {
   });
 
   // now that we've hidden/shown everything, let's choose what should now
-  // be the current selected value if you've hidden what _was_ selected.
+  // be the current selected value.
+  // if you've hidden what _was_ selected.
   if(hideSelectedValue !== undefined) {
     let others = $(`#${elementId} option[value='${hideSelectedValue}']`);
     let newSelectedOption = undefined;
@@ -664,9 +665,10 @@ function optionForFromToken(str) {
           return;
         }
       });
+    }
 
     // no duplciates are visible, so just pick the first visible option
-    } else {
+    if(newSelectedOption === undefined) {
       others = $(`#${elementId} option`)
       others.each((_i, ele) => {
         if(newSelectedOption === undefined && ele.style['display'] === '') {

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -622,6 +622,12 @@ function optionForFromToken(str) {
     // something else entirely. We're going to hide this option if _any_ of the
     // option-for- directives apply.
     for (const [key, _value] of Object.entries(data)) {
+
+      // it's some other directive type, so just keep going
+      if(!key.startsWith('optionFor')) {
+        continue;
+      }
+
       let optionFor = optionForFromToken(key);
       let optionForId = idFromToken(key.replace(/^optionFor/,''));
       let optionForValue =  mountainCaseWords($(`#${optionForId}`)[0].value);
@@ -655,7 +661,6 @@ function optionForFromToken(str) {
   // first - you may have hidden what _was_ selected, so let's try to find
   // another option of the same value.
   if(hideSelectedValue !== undefined) {
-    console.log('made it here');
     let others = $(`#${elementId} option[value='${hideSelectedValue}']`);
 
     if(others.length > 1) {

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -613,7 +613,7 @@ function optionForFromToken(str) {
   options.each(function(_i, option) {
     // the variable 'option' is just a data structure. it has no attr, data, show
     // or hide methods so we have to query for it again
-    let optionElement = $(`#${elementId} ${nodeListToQueryString(option.attributes)}`);
+    let optionElement = exactlyOneOption(elementId, option);
     let data = optionElement.data();
     let hide = false;
 
@@ -660,7 +660,7 @@ function optionForFromToken(str) {
     if(others.length > 1) {
       others.each((_i, ele) => {
         if(ele.style['display'] === '') {
-          newSelectedOption = $(`#${elementId} ${nodeListToQueryString(ele.attributes)}`);
+          newSelectedOption = exactlyOneOption(elementId, ele);
           return;
         }
       });
@@ -670,7 +670,7 @@ function optionForFromToken(str) {
       others = $(`#${elementId} option`)
       others.each((_i, ele) => {
         if(ele.style['display'] === '') {
-          newSelectedOption = $(`#${elementId} ${nodeListToQueryString(ele.attributes)}`);
+          newSelectedOption = exactlyOneOption(elementId, ele);
           return;
         }
       });
@@ -682,19 +682,20 @@ function optionForFromToken(str) {
   }
 };
 
-// Turn a NodeList of attributes into a query string.
-// i.e., <option data-foo='bar' value='abc123'>
-// returns option[data-foo='bar'][value='abc123']
-function nodeListToQueryString(nodeList) {
-  const len = nodeList.length;
-  let query = 'option';
+// Return exactly 1 jquery object for this id's option
+function exactlyOneOption(id, option) {
+  let optionElement = $(`#${id} option[value='${option.value}']`);
 
-  for(i = 0; i < len; i++) {
-    let item = nodeList[i];
-    query += `[${sanitizeQuery(item.name)}='${item.value}']`;
+  if(optionElement.length > 1) {
+    optionElement.each((_i, ele) => {
+      if(option.attributes == ele.attributes){
+        optionElement = $(ele);
+        return;
+      }
+    });
   }
 
-  return query;
+  return optionElement;
 }
 
 // simple function to sanitize css query strings

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -643,7 +643,7 @@ function optionForFromToken(str) {
       optionElement.show();
 
       // just a backup if we have to choose _something_
-      if(!newSelectedOption){
+      if(!newSelectedOption) {
         newSelectedOption = optionElement;
       }
     }
@@ -662,7 +662,7 @@ function optionForFromToken(str) {
       others.each((_i, ele) => {
         if(ele.style['display'] === '') {
           newSelectedOption = $(`#${elementId} ${nodeListToQueryString(ele.attributes)}`);
-          break;
+          return;
         }
       });
     }

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -564,7 +564,6 @@ function minOrMax(key) {
  * @param {*} str
  * @returns
  */
-
 function idFromToken(str) {
   return formTokens.map((token) => {
     let match = str.match(`^${token}{1}`);
@@ -578,6 +577,28 @@ function idFromToken(str) {
   })[0];
 }
 
+
+/**
+ * Extract the option for out of an option for directive.
+ *
+ * @example
+ *  optionForClusterOakley -> Cluster
+ *
+ * @param {*} str
+ * @returns - the option for string
+ */
+function optionForFromToken(str) {
+  return formTokens.map((token) => {
+    let match = str.match(`^optionFor${token}`);
+
+    if (match && match.length >= 1) {
+      return token;
+    }
+  }).filter((id) => {
+    return id !== undefined;
+  })[0];
+}
+
 /**
  * Hide or show options of an element based on which cluster is
  * currently selected and the data-option-for-CLUSTER attributes
@@ -585,53 +606,54 @@ function idFromToken(str) {
  *
  * @param      {string}  element_name  The name of the element with options to toggle
  */
- function toggleOptionsFor(event, elementId) {
+ function toggleOptionsFor(_event, elementId) {
   const options = $(`#${elementId} option`);
-
-  // If I'm changing cluster to 'oakely', optionFor is 'Cluster'
-  // and optionTo is 'Oakley'.
-  const optionTo = mountainCaseWords(event.target.value);
-  const optionFor = optionForEvent(event.target);
+  let firstVisibleOption = undefined;
+  let hideSelected = false;
 
   options.each(function(_i, option) {
     // the variable 'option' is just a data structure. it has no attr, data, show
     // or hide methods so we have to query for it again
     let optionElement = $(`#${elementId} ${nodeListToQueryString(option.attributes)}`);
     let data = optionElement.data();
-    let hide = data[`optionFor${optionFor}${optionTo}`] === false;
-    let foundNext = false;
+    let hide = false;
+
+    // even though an event occured - an option may be hidden based on the value of
+    // something else entirely. We're going to hide this option if _any_ of the
+    // option-for- directives apply.
+    for (const [key, _value] of Object.entries(data)) {
+      let optionFor = optionForFromToken(key);
+      let optionForId = idFromToken(key.replace(/^optionFor/,''));
+      let optionForValue =  mountainCaseWords($(`#${optionForId}`)[0].value);
+
+      hide = data[`optionFor${optionFor}${optionForValue}`] === false;
+      if(hide === true) {
+        break;
+      }
+    }
 
     if(hide) {
       optionElement.hide();
 
       if(optionElement.prop('selected')) {
         optionElement.prop('selected', false);
-
-
-        let others = $(`#${elementId} option[value='${option.value}`);
-
-        // there could be other options of the same value, so let's
-        // select one of those if we can
-        if(others.length > 1) {
-          others.each((_i, ele) => {
-            let hideOther = ele.dataset[`optionFor${optionFor}${optionTo}`] === false;
-            if(!hideOther) {
-              ele.selected = true;
-              foundNext = true;
-            }
-          });
-
-        // when de-selecting something, the default is to fallback to the very first
-        // option. But there's an edge case where you want to hide the very first option,
-        // and deselecting it does nothing.
-        } else if(optionElement.next() && !foundNext){
-          optionElement.next().prop('selected', true);
-        }
+        hideSelected = true;
       }
     } else {
       optionElement.show();
+      if(!firstVisibleOption) {
+        firstVisibleOption = optionElement;
+      }
     }
   });
+
+  // when de-selecting something, the default is to fallback to the very first
+  // option. But there's an edge case where you want to hide the very first option,
+  // and deselecting it does nothing.  In any case, let's select the first option
+  // we found that's visible.
+  if(hideSelected && firstVisibleOption !== undefined) {
+    firstVisibleOption.prop('selected', true);
+  }
 };
 
 // Turn a NodeList of attributes into a query string.

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -608,8 +608,8 @@ function optionForFromToken(str) {
  */
  function toggleOptionsFor(_event, elementId) {
   const options = $(`#${elementId} option`);
-  let firstVisibleOption = undefined;
-  let hideSelected = false;
+  let hideSelectedValue = undefined;
+  let newSelectedOption = undefined;
 
   options.each(function(_i, option) {
     // the variable 'option' is just a data structure. it has no attr, data, show
@@ -637,22 +637,39 @@ function optionForFromToken(str) {
 
       if(optionElement.prop('selected')) {
         optionElement.prop('selected', false);
-        hideSelected = true;
+        hideSelectedValue = optionElement.text();
       }
     } else {
       optionElement.show();
-      if(!firstVisibleOption) {
-        firstVisibleOption = optionElement;
+
+      // just a backup if we have to choose _something_
+      if(!newSelectedOption){
+        newSelectedOption = optionElement;
       }
     }
   });
 
-  // when de-selecting something, the default is to fallback to the very first
-  // option. But there's an edge case where you want to hide the very first option,
-  // and deselecting it does nothing.  In any case, let's select the first option
-  // we found that's visible.
-  if(hideSelected && firstVisibleOption !== undefined) {
-    firstVisibleOption.prop('selected', true);
+  // now that we've hidden/shown everything, let's choose what should now
+  // be the current selected value.
+
+  // first - you may have hidden what _was_ selected, so let's try to find
+  // another option of the same value.
+  if(hideSelectedValue !== undefined) {
+    console.log('made it here');
+    let others = $(`#${elementId} option[value='${hideSelectedValue}']`);
+
+    if(others.length > 1) {
+      others.each((_i, ele) => {
+        if(ele.style['display'] === '') {
+          newSelectedOption = $(`#${elementId} ${nodeListToQueryString(ele.attributes)}`);
+          break;
+        }
+      });
+    }
+  }
+
+  if(newSelectedOption !== undefined) {
+    newSelectedOption.prop('selected', true);
   }
 };
 

--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -8,6 +8,7 @@ module SmartAttributes
   require "smart_attributes/attributes/auto_modules"
   require "smart_attributes/attributes/auto_primary_group"
   require "smart_attributes/attributes/auto_queues"
+  require "smart_attributes/attributes/auto_qos"
   require "smart_attributes/attributes/bc_account"
   require "smart_attributes/attributes/bc_email_on_started"
   require "smart_attributes/attributes/bc_num_hours"

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_qos.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_qos.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SmartAttributes
+  class AttributeFactory
+
+    extend AccountCache
+
+    # Build this attribute object. No 'options' are used as this Attribute
+    # is meant to be dynamically generated from the users' available accounts
+    # from a given scheduler.
+    #
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::AutoQueues] the attribute object
+    def self.build_auto_qos(opts = {})
+
+      static_opts = {
+        options: dynamic_qos
+      }.merge(opts.without(:options).to_h)
+
+      Attributes::AutoQos.new('auto_qos', static_opts)
+    end
+  end
+
+  module Attributes
+    class AutoQos < Attribute
+      def widget
+        'select'
+      end
+
+      def label(*)
+        (opts[:label] || 'QoS').to_s
+      end
+
+      # Submission hash describing how to submit this attribute
+      # @param fmt [String, nil] formatting of hash
+      # @return [Hash] submission hash
+      def submit(*)
+        { script: { qos: value } }
+      end
+    end
+  end
+end

--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -13,6 +13,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     find("##{bc_ele_id(ele)} option[value='#{opt}']")['style'].to_s
   end
 
+  def find_all_options(ele, opt)
+    all("##{bc_ele_id(ele)} option[value='#{opt}']")
+  end
+
   def find_max(ele)
     find("##{bc_ele_id(ele)}")['max'].to_i
   end


### PR DESCRIPTION
This adds the `auto_qos` options that are cluster and account aware.

Because of the complexity involved in duplicate qos options, batch_connet.js has to account for not only duplicate option values, but also logic that would hide that option based off of some other option's value.

In draft right now while I write some tests.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203840805461116) by [Unito](https://www.unito.io)
