### PR TITLE
show the default module for auto_modules. and fix the form value.

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
@@ -27,13 +27,24 @@ module SmartAttributes
       end
 
       def select_choices
-        HpcModule.all_versions(@hpc_module).map do |mod|
+        versions = HpcModule.all_versions(@hpc_module).map do |mod|
           data_opts = Configuration.job_clusters.map do |cluster|
             { "data-option-for-cluster-#{cluster.id}": false } unless mod.on_cluster?(cluster.id)
           end.compact
 
-          [mod.version, mod.version].concat(data_opts)
+          [mod.version, mod.to_s].concat(data_opts)
         end
+
+        if show_default?
+          versions.prepend(['default', @hpc_module])
+        else
+          versions
+        end
+      end
+
+      def show_default?
+        default = @opts[:default]
+        default.nil? ? true : default != false
       end
     end
   end

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
@@ -26,6 +26,10 @@ module SmartAttributes
         'select'
       end
 
+      def label(*)
+        @opts[:label] || "#{@hpc_module.titleize} version"
+      end
+
       def select_choices
         versions = HpcModule.all_versions(@hpc_module).map do |mod|
           data_opts = Configuration.job_clusters.map do |cluster|

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
@@ -27,7 +27,7 @@ module SmartAttributes
       end
 
       def label(*)
-        @opts[:label] || "#{@hpc_module.titleize} version"
+        @opts[:label] || @hpc_module.nil? ? 'Auto modules (none given)' : "#{@hpc_module.titleize} version"
       end
 
       def select_choices

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -179,6 +179,8 @@ attributes:
     min: 0
     max: 4
     value: 0
+  auto_modules_intel:
+    default: false
 form:
   - bc_num_hours
   - bc_num_slots

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -570,30 +570,30 @@ class BatchConnectTest < ApplicationSystemTestCase
     with_modified_env({ OOD_MODULE_FILE_DIR: 'test/fixtures/modules' }) do
       visit new_batch_connect_session_context_url('sys/bc_jupyter')
 
-      # defaults
-      assert_equal '3.0.17', find_value('auto_modules_app_jupyter')
-      assert_equal '2021.3.0', find_value('auto_modules_intel')
+      # defaults, note that intel doesn't show the default version
+      assert_equal 'app_jupyter', find_value('auto_modules_app_jupyter')
+      assert_equal 'intel/2021.3.0', find_value('auto_modules_intel')
       assert_equal 'owens', find_value('cluster')
       # versions not available on owens
-      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', '3.1.18')
-      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', '1.2.16')
-      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', '0.35.6')
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '18.0.4')
+      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', 'app_jupyter/3.1.18')
+      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', 'app_jupyter/1.2.16')
+      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', 'app_jupyter/0.35.6')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/18.0.4')
 
       # select oakley and now they're available
       select('oakley', from: bc_ele_id('cluster'))
-      assert_equal '3.0.17', find_value('auto_modules_app_jupyter')
-      assert_equal '', find_option_style('auto_modules_app_jupyter', '3.1.18')
-      assert_equal '', find_option_style('auto_modules_app_jupyter', '1.2.16')
-      assert_equal '', find_option_style('auto_modules_app_jupyter', '0.35.6')
+      assert_equal 'app_jupyter', find_value('auto_modules_app_jupyter')
+      assert_equal '', find_option_style('auto_modules_app_jupyter', 'app_jupyter/3.1.18')
+      assert_equal '', find_option_style('auto_modules_app_jupyter', 'app_jupyter/1.2.16')
+      assert_equal '', find_option_style('auto_modules_app_jupyter', 'app_jupyter/0.35.6')
 
       # and lots of intel versions aren't
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '18.0.2')
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '18.0.0')
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '17.0.5')
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '17.0.2')
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '16.0.8')
-      assert_equal 'display: none;', find_option_style('auto_modules_intel', '16.0.3')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/18.0.2')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/18.0.0')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/17.0.5')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/17.0.2')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/16.0.8')
+      assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/16.0.3')
     end
   end
 


### PR DESCRIPTION
This creates the `default` module version in the `auto_modules_` feature. Users will be able to disable the default version in the `attributes` section.

This also fixes a bug where the `module_name/version` needs to be passed to the server, not just `version` which is useless.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203859758667359) by [Unito](https://www.unito.io)
