### PR TITLE
Updated recently_used_apps widget to only select valid applications

### DIFF
--- a/apps/dashboard/app/helpers/recently_used_apps_helper.rb
+++ b/apps/dashboard/app/helpers/recently_used_apps_helper.rb
@@ -22,8 +22,8 @@ module RecentlyUsedAppsHelper
     sys_apps_index = {}
     # These apps variables are initialized in the ApplicationController class for all requests
     (@sys_apps + @dev_apps + @usr_apps).select(&:batch_connect_app?).each do |ood_app|
-      ood_app.sub_app_list.select do |batch_connect_app|
-        sys_apps_index[batch_connect_app.cache_file] = batch_connect_app
+      ood_app.sub_app_list.each do |batch_connect_app|
+        sys_apps_index[batch_connect_app.cache_file] = batch_connect_app if batch_connect_app.valid?
       end
     end
 


### PR DESCRIPTION
Fixed `recently_used_apps` widget to filter out `BatchConnect` apps that are not valid.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203865288161734) by [Unito](https://www.unito.io)
