### PR TITLE
Added session relaunch feature

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -51,9 +51,9 @@ module ApplicationHelper
     ENV['OOD_DASHBOARD_HELP_CUSTOM_URL']
   end
 
-  def fa_icon(icon, fa_style: 'fas', id: '', classes: 'app-icon')
+  def fa_icon(icon, fa_style: 'fas', id: '', classes: 'app-icon', title: "FontAwesome icon specified: #{icon}")
     content_tag(:i, '', id: id, class: [fa_style, "fa-#{icon}", 'fa-fw'].concat(Array(classes)),
-                title: "FontAwesome icon specified: #{icon}", "aria-hidden": true)
+                title: title, "aria-hidden": true)
   end
 
   def app_icon_tag(app)

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -197,7 +197,7 @@ module BatchConnect::SessionsHelper
   end
 
   def relaunch(status_array, session)
-    return unless Configuration.relaunch_session_enabled && session.completed?
+    return unless session.completed?
 
     batch_connect_app = session.app
     return unless batch_connect_app.valid?
@@ -211,6 +211,7 @@ module BatchConnect::SessionsHelper
       class: %w[btn px-1 py-0 btn-outline-dark relaunch],
       form_class: %w[d-inline relaunch],
       title: title,
+      'aria-label': title,
       data: { toggle: "tooltip", placement: "left" },
       params: params
     ) do
@@ -227,24 +228,28 @@ module BatchConnect::SessionsHelper
   end
 
   def delete(session)
+    title = "#{t('dashboard.batch_connect_sessions_delete_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}"
     button_to(
       batch_connect_session_path(session.id),
       method: :delete,
       class: "btn btn-danger float-right btn-delete",
-      title: "#{t('dashboard.batch_connect_sessions_delete_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
-      data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom", selector: true }
+      title: title,
+      'aria-label': title,
+      data: { confirm: t('dashboard.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
     ) do
       "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_delete_title')}</span>".html_safe
     end
   end
 
   def cancel(session)
+    title = "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}"
     button_to(
       batch_connect_cancel_session_path(session.id),
       method: :post,
       class: "btn btn-danger float-right btn-cancel",
-      title: "#{t('dashboard.batch_connect_sessions_cancel_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}",
-      data: { confirm: t('dashboard.batch_connect_sessions_cancel_confirm'), toggle: "tooltip", placement: "bottom", selector: true }
+      title: title,
+      'aria-label': title,
+      data: { confirm: t('dashboard.batch_connect_sessions_cancel_confirm'), toggle: "tooltip", placement: "bottom" }
     ) do
       "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.batch_connect_sessions_cancel_title')}</span>".html_safe
     end

--- a/apps/dashboard/app/javascript/packs/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect_sessions.js
@@ -31,3 +31,14 @@ function installSettingHandlers(name) {
 
 window.installSettingHandlers = installSettingHandlers;
 window.tryUpdateSetting = tryUpdateSetting;
+
+jQuery(function (){
+  function showSpinner() {
+    $('body').addClass('modal-open');
+    $('#full-page-spinner').removeClass('d-none');
+  }
+
+  $('button.relaunch').each((index, element) => {
+    $(element).on('click', showSpinner);
+  });
+});

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -101,6 +101,8 @@ class UserConfiguration
 
   # The current user profile. Used to select the configuration properties.
   def profile
+    return CurrentUser.user_settings[:profile_override].to_sym if CurrentUser.user_settings[:profile_override]
+
     if Configuration.host_based_profiles
       request_hostname
     else

--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -52,3 +52,6 @@ locals: {
     </div>
   <%- end -%>
 </div>
+<div id="full-page-spinner" class="d-none">
+  <div class="spinner-border" role="status"></div>
+</div>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
   <%= yield :head %>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="profile" content="<%= @user_configuration.profile %>">
 
   <!-- configuration options exposed to javascript -->
   <meta id="ood_config"

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -50,7 +50,6 @@ class ConfigurationSingleton
       :disable_bc_shell             => false,
       :cancel_session_enabled       => false,
       :hide_app_version             => false,
-      :relaunch_session_enabled     => false,
     }.freeze
   end
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -50,6 +50,7 @@ class ConfigurationSingleton
       :disable_bc_shell             => false,
       :cancel_session_enabled       => false,
       :hide_app_version             => false,
+      :relaunch_session_enabled     => false,
     }.freeze
   end
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
     batch_connect_sessions_delete_title: "Delete"
     batch_connect_sessions_cancel_confirm: "Are you sure?"
     batch_connect_sessions_cancel_title: "Cancel"
+    batch_connect_sessions_relaunch_confirm: "Are you sure?"
+    batch_connect_sessions_relaunch_title: "Relaunch"
     batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:"
     batch_connect_sessions_errors_submission: "Failed to submit session with the following error:"
     batch_connect_sessions_novnc_launch: "Launch %{app_title}"

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -108,7 +108,6 @@ en:
     batch_connect_sessions_delete_title: "Delete"
     batch_connect_sessions_cancel_confirm: "Are you sure?"
     batch_connect_sessions_cancel_title: "Cancel"
-    batch_connect_sessions_relaunch_confirm: "Are you sure?"
     batch_connect_sessions_relaunch_title: "Relaunch"
     batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:"
     batch_connect_sessions_errors_submission: "Failed to submit session with the following error:"

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -11,5 +11,3 @@ disable_bc_shell: true
 cancel_session_enabled: true
 bc_clean_old_dirs: true
 hide_app_version: true
-relaunch_session_enabled: true
-

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -11,4 +11,5 @@ disable_bc_shell: true
 cancel_session_enabled: true
 bc_clean_old_dirs: true
 hide_app_version: true
+relaunch_session_enabled: true
 

--- a/apps/dashboard/test/helpers/batch_connect/sessions_helper_test.rb
+++ b/apps/dashboard/test/helpers/batch_connect/sessions_helper_test.rb
@@ -53,15 +53,7 @@ class BatchConnect::SessionsHelperTest < ActionView::TestCase
     assert_equal delete_session_title, button['title']
   end
 
-  test 'relaunch should ignore sessions when relaunch_session_enabled is false' do
-    Configuration.stubs(:relaunch_session_enabled).returns(false)
-    status_array = []
-    relaunch(status_array, create_session(:completed))
-    assert_equal [], status_array
-  end
-
   test 'relaunch should ignore sessions when session is not completed' do
-    Configuration.stubs(:relaunch_session_enabled).returns(true)
     OodCore::Job::Status.states.each do |state|
       next if state == :completed
 
@@ -72,14 +64,12 @@ class BatchConnect::SessionsHelperTest < ActionView::TestCase
   end
 
   test 'relaunch should ignore sessions when session application is not valid' do
-    Configuration.stubs(:relaunch_session_enabled).returns(true)
     status_array = []
     relaunch(status_array, create_session(:completed, valid: false))
     assert_equal [], status_array
   end
 
-  test 'relaunch should add relaunch form when session is completed and relaunch_session_enabled is true' do
-    Configuration.stubs(:relaunch_session_enabled).returns(true)
+  test 'relaunch should add relaunch form when session is completed' do
     status_array = []
     relaunch(status_array, create_session(:completed))
 

--- a/apps/dashboard/test/integration/sessions_controller_test.rb
+++ b/apps/dashboard/test/integration/sessions_controller_test.rb
@@ -97,8 +97,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'should render session panel with relaunch button when relaunch_session_enabled is true' do
-    Configuration.stubs(:relaunch_session_enabled).returns(true)
+  test 'should render session panel with relaunch button' do
     value = '{"id":"1234","job_id":"1","created_at":1669139262,"token":"sys/token","title":"session title","cache_completed":true}'
     session = BatchConnect::Session.new.from_json(value)
     session.stubs(:status).returns(OodCore::Job::Status.new(state: :completed))

--- a/apps/dashboard/test/integration/sessions_controller_test.rb
+++ b/apps/dashboard/test/integration/sessions_controller_test.rb
@@ -96,4 +96,20 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       assert_equal batch_connect_cancel_session_path('1234'), form.first['action']
     end
   end
+
+  test 'should render session panel with relaunch button when relaunch_session_enabled is true' do
+    Configuration.stubs(:relaunch_session_enabled).returns(true)
+    value = '{"id":"1234","job_id":"1","created_at":1669139262,"token":"sys/token","title":"session title","cache_completed":true}'
+    session = BatchConnect::Session.new.from_json(value)
+    session.stubs(:status).returns(OodCore::Job::Status.new(state: :completed))
+    session.stubs(:app).returns(stub(valid?: true, token: 'sys/token', attributes: [], session_info_view: nil))
+    BatchConnect::Session.stubs(:all).returns([session])
+
+    get batch_connect_sessions_path
+    assert_response :success
+
+    assert_select 'div#id_1234 div.card-heading div.float-right form.relaunch' do |form|
+      assert_equal batch_connect_session_contexts_path(token: 'sys/token'), form.first['action']
+    end
+  end
 end


### PR DESCRIPTION
Added session relaunch button to session panel.
This will start a new interactive session based on the user context data available in a previously completed session.

Added as a experimental feature behind a feature toggle: `relaunch_session_enabled`

Implements https://github.com/OSC/ondemand/issues/2522

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203866900601621) by [Unito](https://www.unito.io)
