### PR TITLE
Fixed support ticket spinner after Rails upgrade

### DIFF
--- a/apps/dashboard/app/javascript/packs/support_ticket.js
+++ b/apps/dashboard/app/javascript/packs/support_ticket.js
@@ -26,7 +26,7 @@ jQuery(function (){
 
         //SHOW FULL PAGE SPINNER
         $("body").addClass("modal-open");
-        $("#full-page-spinner").show();
+        $("#full-page-spinner").removeClass('d-none');
     }
 
     function clearAttachmentsError() {


### PR DESCRIPTION
The spinner was not showing after the Rails upgrade.

Using a different mechanism to show the spinner

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203867114919981) by [Unito](https://www.unito.io)
