### PR TITLE
upgrade ood_core for apptainer patch (for release 2.0)

### DIFF
--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       ood_core (~> 0.1)
       rails (> 4.0.7, < 6.0)
       redcarpet (~> 3.2)
-    ood_core (0.22.0)
+    ood_core (0.23.0)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       ood_core (~> 0.1)
       rails (> 4.0.7, < 6.0)
       redcarpet (~> 3.2)
-    ood_core (0.23.0)
+    ood_core (0.23.1)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       ood_core (~> 0.1)
       rails (> 4.0.7, < 6.0)
       redcarpet (~> 3.2)
-    ood_core (0.22.0)
+    ood_core (0.23.0)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       ood_core (~> 0.1)
       rails (> 4.0.7, < 6.0)
       redcarpet (~> 3.2)
-    ood_core (0.23.0)
+    ood_core (0.23.1)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)


### PR DESCRIPTION
Before (or while) we release 2.1, we should patch 2.0 for the apptainer bug that affects linux host adapters. Some folks may take their time in upgrading and without this patch the linux host adapter is basically useless.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203869088746924) by [Unito](https://www.unito.io)
