### PR TITLE
Fixed noVNC url + Improved spinner CSS

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -256,7 +256,7 @@ module BatchConnect::SessionsHelper
   end
 
   def novnc_link(connect, view_only: false)
-    version  = "1.1.0"
+    version  = "1.3.0"
     password = view_only ? connect.spassword : connect.password
     resize   = view_only ? "downscale" : "remote"
     asset_path("noVNC-#{version}/vnc.html?autoconnect=true&password=#{password}&path=rnode/#{connect.host}/#{connect.websocket}/websockify&resize=#{resize}", skip_pipeline: true)

--- a/apps/dashboard/app/javascript/stylesheets/support_ticket.scss
+++ b/apps/dashboard/app/javascript/stylesheets/support_ticket.scss
@@ -96,7 +96,7 @@ input[type="file"] {
   left: 0;
   right: 0;
   background: rgba(0, 0, 0, 0.6);
-  z-index: 10;
+  z-index: 10000;
 }
 #full-page-spinner .spinner-border{
   display: block;


### PR DESCRIPTION
Looks like the version of `noVNC` deployed with the Dashboard is `1.3.0`, the one the link was using is `1.1.0`, fixing.
https://github.com/OSC/ondemand/tree/master/apps/dashboard/public/noVNC-1.3.0

Fixing the spinner overlay not being on top of the relaunch session button tooltip.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203875324489408) by [Unito](https://www.unito.io)
