### PR TITLE
better caching for scontrol

### DIFF
--- a/apps/dashboard/app/lib/account_cache.rb
+++ b/apps/dashboard/app/lib/account_cache.rb
@@ -118,9 +118,11 @@ module AccountCache
   end
 
   def queues_per_cluster
-    {}.tap do |hash|
-      Configuration.job_clusters.each do |cluster|
-        hash[cluster.id] = cluster.job_adapter.queues
+    Rails.cache.fetch('queues_per_cluster', expires_in: 24.hours) do
+      {}.tap do |hash|
+        Configuration.job_clusters.each do |cluster|
+          hash[cluster.id] = cluster.job_adapter.queues
+        end
       end
     end
   end


### PR DESCRIPTION
Without caching this function call, we're lighting up `scontrol` calling it a whopping 240 times.

With this cache it'll only call it `scontrol` for as many clusters as we have (in our case 3).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203878498181959) by [Unito](https://www.unito.io)
