### PR TITLE
Ensure ondemand-gems name includes the release

### DIFF
--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -11,7 +11,7 @@
 %define selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 %global selinux_module_version %{package_version}.%{package_release}
 %global gem_home %{scl_ondemand_core_gem_home}/%{version}
-%global gems_name ondemand-gems-%{version}
+%global gems_name ondemand-gems-%{version}-%{package_release}
 
 %define __brp_mangle_shebangs /bin/true
 


### PR DESCRIPTION
This ensures that RC releases will require the correct gem RPM

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203886257516660) by [Unito](https://www.unito.io)
