### PR TITLE
change OOD_PUN_RAILS_CONFIG_HOSTS to ALLOWED_HOSTS

### DIFF
--- a/apps/dashboard/config/environments/production.rb
+++ b/apps/dashboard/config/environments/production.rb
@@ -100,5 +100,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new \
     min_threads: 1, max_threads: 1
 
-  config.hosts = ENV['OOD_PUN_RAILS_CONFIG_HOSTS'].nil? ? nil : ENV['OOD_PUN_RAILS_CONFIG_HOSTS'].split(',')
+  config.hosts = ENV['ALLOWED_HOSTS'].nil? ? nil : ENV['ALLOWED_HOSTS'].split(',')
 end

--- a/apps/myjobs/config/environments/production.rb
+++ b/apps/myjobs/config/environments/production.rb
@@ -105,5 +105,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  config.hosts = ENV['OOD_PUN_RAILS_CONFIG_HOSTS'].nil? ? nil : ENV['OOD_PUN_RAILS_CONFIG_HOSTS'].split(',')
+  config.hosts = ENV['ALLOWED_HOSTS'].nil? ? nil : ENV['ALLOWED_HOSTS'].split(',')
 end

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -143,7 +143,8 @@ module NginxStage
       # this is not a typo => the editor is /edit off of the base url
       "OOD_EDITOR_URL" => "/pun/sys/dashboard/files",
       "RAILS_LOG_TO_STDOUT" => "true",
-      "ALLOWED_HOSTS" => ENV['ALLOWED_HOSTS'],
+      # name change here because only OOD_* from apache is allowed through sudo rules
+      "ALLOWED_HOSTS" => ENV['OOD_ALLOWED_HOSTS'],
     }.merge(pun_custom_env).merge(preserve_env_declarations.map { |k| [ k, ENV[k] ] }.to_h))
   end
 

--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -143,7 +143,7 @@ module NginxStage
       # this is not a typo => the editor is /edit off of the base url
       "OOD_EDITOR_URL" => "/pun/sys/dashboard/files",
       "RAILS_LOG_TO_STDOUT" => "true",
-      "OOD_PUN_RAILS_CONFIG_HOSTS" => ENV['OOD_PUN_RAILS_CONFIG_HOSTS'],
+      "ALLOWED_HOSTS" => ENV['ALLOWED_HOSTS'],
     }.merge(pun_custom_env).merge(preserve_env_declarations.map { |k| [ k, ENV[k] ] }.to_h))
   end
 

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -24,7 +24,7 @@ module OodPortalGenerator
       @servername       = opts.fetch(:servername, nil)
       @server_aliases   = opts.fetch(:server_aliases, [])
       @proxy_server     = opts.fetch(:proxy_server, servername)
-      @rails_config_hosts = rails_config_hosts
+      @allowed_hosts    = allowed_hosts
       @port             = opts.fetch(:port, @ssl ? "443" : "80")
       if OodPortalGenerator.debian?
         @logroot        = opts.fetch(:logroot, "/var/log/apache2")
@@ -129,7 +129,7 @@ module OodPortalGenerator
       "#{@logroot}/#{prefix}#{suffix}"
     end
 
-    def rails_config_hosts
+    def allowed_hosts
       config_hosts = []
       config_hosts << @servername unless @servername.nil?
       config_hosts << @proxy_server unless @proxy_server.nil?

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -112,7 +112,7 @@ Listen 8080
   # Environment variables to export to the PUN pre hook.
   SetEnv OOD_PUN_PRE_HOOK_EXPORTS "OIDC_ACCESS_TOKEN,OIDC_CLAIM_EMAIL"
 
-  SetEnv ALLOWED_HOSTS "foo.example.com,test.proxy.name,test.server.name"
+  SetEnv OOD_ALLOWED_HOSTS "foo.example.com,test.proxy.name,test.server.name"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -112,7 +112,7 @@ Listen 8080
   # Environment variables to export to the PUN pre hook.
   SetEnv OOD_PUN_PRE_HOOK_EXPORTS "OIDC_ACCESS_TOKEN,OIDC_CLAIM_EMAIL"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "foo.example.com,test.proxy.name,test.server.name"
+  SetEnv ALLOWED_HOSTS "foo.example.com,test.proxy.name,test.server.name"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -96,7 +96,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -96,7 +96,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -116,7 +116,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -116,7 +116,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -116,7 +116,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -116,7 +116,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
@@ -110,7 +110,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
@@ -110,7 +110,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -78,7 +78,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -78,7 +78,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -69,7 +69,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -69,7 +69,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -98,7 +98,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "ondemand.example.com"
+  SetEnv ALLOWED_HOSTS "ondemand.example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -98,7 +98,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "ondemand.example.com"
+  SetEnv OOD_ALLOWED_HOSTS "ondemand.example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -114,7 +114,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "ondemand.example.com"
+  SetEnv ALLOWED_HOSTS "ondemand.example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -114,7 +114,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "ondemand.example.com"
+  SetEnv OOD_ALLOWED_HOSTS "ondemand.example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -116,7 +116,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example-proxy.com,example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example-proxy.com,example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -116,7 +116,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example-proxy.com,example.com"
+  SetEnv ALLOWED_HOSTS "example-proxy.com,example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/output/auth.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth.conf
@@ -76,7 +76,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/output/auth.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth.conf
@@ -76,7 +76,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/output/auth_deb.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth_deb.conf
@@ -76,7 +76,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "example.com"
+  SetEnv ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/fixtures/output/auth_deb.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth_deb.conf
@@ -76,7 +76,7 @@
   #
   SetEnv OOD_PUN_STAGE_CMD "sudo /opt/ood/nginx_stage/sbin/nginx_stage"
 
-  SetEnv ALLOWED_HOSTS "example.com"
+  SetEnv OOD_ALLOWED_HOSTS "example.com"
 
   #
   # Below is used for sub-uri's this Open OnDemand portal supports

--- a/ood-portal-generator/spec/ood_portal_generator_view_spec.rb
+++ b/ood-portal-generator/spec/ood_portal_generator_view_spec.rb
@@ -15,7 +15,7 @@ describe OodPortalGenerator::View do
       example_config_opts -= %w(dex) 
       
       # delete inst vars that are not actual options in the example file
-      config_opts -= %w(protocol rails_config_hosts oidc_redirect_uri oidc_crypto_passphrase dex_http_port)
+      config_opts -= %w(protocol allowed_hosts oidc_redirect_uri oidc_crypto_passphrase dex_http_port)
 
       expect(config_opts + example_config_opts - (config_opts & example_config_opts)).to be_empty
     end

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -186,8 +186,8 @@ Listen <%= addr_port %>
   <%- end -%>
 
   <%- end -%>
-  <%- if @rails_config_hosts -%>
-  SetEnv OOD_PUN_RAILS_CONFIG_HOSTS "<%= @rails_config_hosts.join(',') %>"
+  <%- if @allowed_hosts -%>
+  SetEnv ALLOWED_HOSTS "<%= @allowed_hosts.join(',') %>"
 
   <%- end -%>
   #

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -187,7 +187,7 @@ Listen <%= addr_port %>
 
   <%- end -%>
   <%- if @allowed_hosts -%>
-  SetEnv ALLOWED_HOSTS "<%= @allowed_hosts.join(',') %>"
+  SetEnv OOD_ALLOWED_HOSTS "<%= @allowed_hosts.join(',') %>"
 
   <%- end -%>
   #


### PR DESCRIPTION
change OOD_PUN_RAILS_CONFIG_HOSTS to ALLOWED_HOSTS to fix #2552.

I could have just added a duplicate environment variable in `nginx_stage` but I figured it'd be easier to just manage/remember 1 thing instead of having to recall that there's a duplicate.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203940749335895) by [Unito](https://www.unito.io)
