### PR TITLE
Fixed navbar links sorting for application links + images

### DIFF
--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -13,7 +13,7 @@ class NavBar
           extend_link(nav_link(nav_item))
         elsif nav_item[:apps] && nav_item[:title]
           matched_apps = nav_apps(nav_item, nav_item[:title], nil)
-          extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon_uri], sort: true))
+          extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon_uri]), sort: true)
         elsif nav_item[:profile]
           extend_link(nav_profile(nav_item))
         elsif !nav_item[:page].blank?
@@ -126,8 +126,8 @@ class NavBar
     end.flatten
   end
 
-  def self.extend_group(group)
-    group.sort = false
+  def self.extend_group(group, sort: false)
+    group.sort = sort
     NavItemDecorator.new(group, 'layouts/nav/group')
   end
 

--- a/apps/dashboard/app/apps/ood_app_group.rb
+++ b/apps/dashboard/app/apps/ood_app_group.rb
@@ -65,7 +65,7 @@ class OodAppGroup
     }.map { |k,v|
       OodAppGroup.new(title: k, apps: sort ? v.sort_by { |a| a.title } : v, nav_limit: nav_limit)
     }
-    sort ? groups.sort_by { |g| [ g.title.nil? ? 1 : 0, g.title ] } : groups # make sure that the ungroupable app is always last
+    sort ? groups.sort_by { |g| [ g.title.to_s.empty? ? 1 : 0, g.title ] } : groups # make sure that the ungroupable app is always last
   end
 
   # Select a subset of groups by the specified array of titles

--- a/apps/dashboard/app/javascript/stylesheets/apps.scss
+++ b/apps/dashboard/app/javascript/stylesheets/apps.scss
@@ -39,6 +39,11 @@ tr.app {
    font-size: 14px;
 }
 
+.navbar img.menu-icon {
+  width: 14px;
+  height: 14px;
+}
+
 .apps-table .app-icon {
   width: 24px;
   height: 24px;

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown" title="<%= group.title %>">
   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <%= icon_tag(group.icon_uri, classes: nil) if group.icon_uri %><span> <%= group.title %></span><span class="caret"></span>
+    <%= icon_tag(group.icon_uri, classes: 'menu-icon') if group.icon_uri %><span> <%= group.title %></span><span class="caret"></span>
   </a>
 
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, '') %>">

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -73,6 +73,7 @@ class NavBarTest < ActiveSupport::TestCase
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
     assert_equal "layouts/nav/group",  result[0].partial_path
+    assert_equal false,  result[0].sort
     assert_equal "Interactive Apps",  result[0].title
     assert_equal 4,  result[0].apps.size
   end
@@ -87,7 +88,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal 4,  result[0].apps.size
   end
 
-  test "NavBar.items should return navigation group when nav_item has apps and title property" do
+  test "NavBar.items should return navigation group with sort=true when nav_item has apps and title property" do
     nav_item = {
       title: "Custom Apps",
       icon_uri: "fa://test",
@@ -97,6 +98,7 @@ class NavBarTest < ActiveSupport::TestCase
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
     assert_equal "layouts/nav/group",  result[0].partial_path
+    assert_equal true,  result[0].sort
     assert_equal 1,  result[0].links.size
     assert_equal 'Custom Apps',  result[0].links[0].category
     assert_equal 'Apps',  result[0].links[0].subcategory
@@ -117,7 +119,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_nil result[0].icon_uri
   end
 
-  test "NavBar.items should return navigation group when nav_item has apps array and title property" do
+  test "NavBar.items should return navigation group with sort=true when nav_item has apps array and title property" do
     nav_item = {
       title: "Custom Apps",
       icon_uri: "fa://test",
@@ -127,6 +129,7 @@ class NavBarTest < ActiveSupport::TestCase
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
     assert_equal "layouts/nav/group",  result[0].partial_path
+    assert_equal true,  result[0].sort
     assert_equal 1,  result[0].links.size
     assert_equal 'Custom Apps',  result[0].links[0].category
     assert_equal 'Apps',  result[0].links[0].subcategory
@@ -144,6 +147,7 @@ class NavBarTest < ActiveSupport::TestCase
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
     assert_equal "layouts/nav/group",  result[0].partial_path
+    assert_equal false,  result[0].sort
     assert_equal 0,  result[0].apps.size
     assert_equal "menu title",  result[0].title
     assert_equal URI("fa://test"),  result[0].icon_uri

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -99,14 +99,14 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     dditems = dropdown_list_items(dd)
     assert dditems.any?, "dropdown list items not found"
     assert_equal [
-      "Broken App", 
-      :divider,
       {header: "Apps"},
       "Jupyter Notebook",
       "Paraview",
       :divider,
       {header: "Desktops"},
-      "Oakley Desktop"], dditems
+      "Oakley Desktop",
+      :divider,
+      "Broken App"], dditems
 
     assert_select dd, "li a", "Oakley Desktop" do |link|
       assert_equal "/batch_connect/sys/bc_desktop/oakley/session_contexts/new", link.first['href'], "Desktops link is incorrect"

--- a/apps/dashboard/test/models/ood_app_group_test.rb
+++ b/apps/dashboard/test/models/ood_app_group_test.rb
@@ -61,11 +61,12 @@ class OodAppGroupTest < ActiveSupport::TestCase
     desktops = groups.last
     subgroups = OodAppGroup.groups_for(apps: desktops.apps, group_by: :subcategory)
     assert_equal 3, subgroups.count
-    assert_equal "", subgroups[0].title
-    assert_equal "IHPC", subgroups[1].title
-    assert_equal 5, subgroups[1].apps.count
-    assert_equal "VDI", subgroups[2].title
-    assert_equal 3, subgroups[2].apps.count
+    assert_equal "IHPC", subgroups[0].title
+    assert_equal 5, subgroups[0].apps.count
+    assert_equal "VDI", subgroups[1].title
+    assert_equal 3, subgroups[1].apps.count
+    assert_equal "", subgroups[2].title
+    assert_equal 1, subgroups[2].apps.count
 
     # test selecting a set of subgroups
     subgroups2 = OodAppGroup.select(titles: ["VDI", "IHPC"], groups: subgroups)


### PR DESCRIPTION
 1.- Fix for the sorting of subcategories when application links are configured.
eg:
```yaml
nav_bar:
 - title: "My Apps"
    apps: "sys/*"
```

This should create sorted subcategory groupings for all matched apps.

 2.- Fix for the image width and height for the custom navigation menu image

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203960947382686) by [Unito](https://www.unito.io)
