### PR TITLE
Added support for images from /public location

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -71,6 +71,8 @@ module ApplicationHelper
   def icon_tag(icon_uri, classes: ['app-icon'])
     if ['fa', 'fas', 'far', 'fab', 'fal'].include?(icon_uri.scheme)
       fa_icon(icon_uri.host, fa_style: icon_uri.scheme, classes: classes)
+    elsif icon_uri.to_s.starts_with?(@user_configuration.public_url.to_s)
+      content_tag(:img, '', src: icon_uri.to_s, class: classes, title: icon_uri.to_s, "aria-hidden": true)
     else
       image_tag icon_uri.to_s, class: classes, title: icon_uri.to_s, "aria-hidden": true
     end

--- a/apps/dashboard/app/javascript/stylesheets/pinned_apps.scss
+++ b/apps/dashboard/app/javascript/stylesheets/pinned_apps.scss
@@ -169,8 +169,16 @@
     text-align: center;
     padding-top: 1rem;
     width: unset;
-    height: 1.2em;
     font-size: 6.25rem;
+  }
+
+  i {
+    height: 1.2em;
+  }
+
+  img {
+    max-width: 90%;
+    margin-bottom: 0.2em;
   }
 
   p.app-title {

--- a/apps/dashboard/test/helpers/application_helper_test.rb
+++ b/apps/dashboard/test/helpers/application_helper_test.rb
@@ -67,4 +67,40 @@ class ApplicationHelperTest < ActionView::TestCase
     @user_configuration = stub(:custom_css_files => [''], :public_url => Pathname.new('/public'))
     assert_equal [], custom_css_paths
   end
+
+  test "icon_tag should should render icon tag for known icon schemas" do
+    @user_configuration = stub({ public_url: Pathname.new('/public') })
+    ['fa', 'fas', 'far', 'fab', 'fal'].each do |icon_schema|
+      image_uri = URI("#{icon_schema}://icon_name")
+      html = Nokogiri::HTML(icon_tag(image_uri))
+
+      icon_html = html.at_css('i')
+      assert_equal true, icon_html['class'].include?(icon_schema)
+      assert_equal true, icon_html['class'].include?('icon_name')
+    end
+  end
+
+  test "icon_tag should should render image tag prefixing relative_url_root if image URI does not start with public_url" do
+    @user_configuration = stub({ public_url: Pathname.new('/public') })
+    config.stubs(:relative_url_root).returns('/prefix')
+    image_uri = URI('/path/to/image.png')
+    html = Nokogiri::HTML(icon_tag(image_uri))
+
+    image_html = html.at_css('img')
+    assert_equal 'app-icon', image_html['class']
+    assert_equal image_uri.to_s, image_html['title']
+    assert_equal '/prefix/path/to/image.png', image_html['src']
+  end
+
+  test "icon_tag should should render image tag without prefixing relative_url_root if image URI starts with public_url" do
+    @user_configuration = stub({ public_url: Pathname.new('/public') })
+    config.stubs(:relative_url_root).returns('/prefix')
+    image_uri = URI('/public/path/image.png')
+    html = Nokogiri::HTML(icon_tag(image_uri))
+
+    image_html = html.at_css('img')
+    assert_equal 'app-icon', image_html['class']
+    assert_equal image_uri.to_s, image_html['title']
+    assert_equal image_uri.to_s, image_html['src']
+  end
 end


### PR DESCRIPTION
Added support to use images from` /public` location (eg: `/var/www/ood/public`).
 - By default, `icon_tag` helper prefixes image URIs with the application path, `/pun/sys/dashboard`. This was not allowing to use image deployed in the public Apache folder.
 - This helper is used for pinned apps images and navigation items.
 
```yaml
tile:
  title: "RStudio 400"
  icon_uri: "/public/images/rstudio_logo.png"
  border_color: "blue "
  sub_caption: |
    Custom Text Line 1
    Line 2
    Line 3
```

Pinned apps fixes to the image width when the custom image is wider than the tile.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203971746162607) by [Unito](https://www.unito.io)
