### PR TITLE
Renamed icon_uri yaml property to icon

### DIFF
--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -13,7 +13,7 @@ class NavBar
           extend_link(nav_link(nav_item))
         elsif nav_item[:apps] && nav_item[:title]
           matched_apps = nav_apps(nav_item, nav_item[:title], nil)
-          extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon_uri]), sort: true)
+          extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon]), sort: true)
         elsif nav_item[:profile]
           extend_link(nav_profile(nav_item))
         elsif !nav_item[:page].blank?
@@ -31,7 +31,7 @@ class NavBar
 
   def self.nav_menu(hash_item)
     menu_title = hash_item.fetch(:title, '')
-    menu_icon = hash_item.fetch(:icon_uri, nil)
+    menu_icon = hash_item.fetch(:icon, nil)
     menu_items = hash_item.fetch(:links, [])
 
     group_title = ''
@@ -64,6 +64,7 @@ class NavBar
 
   def self.nav_link(item, category='', subcategory='')
     link_data = item.clone
+    link_data[:icon_uri] = item.fetch(:icon, nil)
     link_data[:new_tab] = item.fetch(:new_tab, false)
     OodAppLink.new(link_data).categorize(category: category, subcategory: subcategory)
   end
@@ -81,6 +82,7 @@ class NavBar
     profile_data = item.clone
     profile_data[:title] = item.fetch(:title, profile.titleize)
     profile_data[:url] = Rails.application.routes.url_helpers.settings_path('settings[profile]' => profile)
+    profile_data[:icon_uri] = item.fetch(:icon, nil)
     profile_data[:data] = { method: 'post' }
     profile_data[:new_tab] = item.fetch(:new_tab, false)
     OodAppLink.new(profile_data).categorize(category: category, subcategory: subcategory)
@@ -89,9 +91,10 @@ class NavBar
   def self.nav_page(item, category='', subcategory='')
     page_code = item.fetch(:page)
     page_data = item.clone
-    page_data[:title] = page_data.fetch(:title, page_code.titleize)
+    page_data[:title] = item.fetch(:title, page_code.titleize)
     page_data[:url] = Rails.application.routes.url_helpers.custom_pages_path(page_code)
-    page_data[:new_tab] = page_data.fetch(:new_tab, false)
+    page_data[:icon_uri] = item.fetch(:icon, nil)
+    page_data[:new_tab] = item.fetch(:new_tab, false)
     OodAppLink.new(page_data).categorize(category: category, subcategory: subcategory)
   end
 

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -108,7 +108,7 @@ module BatchConnect
     end
 
     def icon_uri
-      form_config.fetch(:icon_uri, ood_app.icon_uri)
+      form_config.fetch(:icon, ood_app.icon_uri)
     end
 
     def caption

--- a/apps/dashboard/app/views/widgets/pinned_apps/_app_content.html.erb
+++ b/apps/dashboard/app/views/widgets/pinned_apps/_app_content.html.erb
@@ -1,6 +1,6 @@
 <%- tile_data = link.tile -%>
 <div class="center-block text-center">
-  <%= icon_tag(URI(tile_data.fetch(:icon_uri, link.icon_uri).to_s)) %>
+  <%= icon_tag(URI(tile_data.fetch(:icon, link.icon_uri).to_s)) %>
   <%= content_tag(:p, tile_data.fetch(:title, link.title), class: "app-title") %>
 
   <% if tile_data.blank? %>

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -91,7 +91,7 @@ class NavBarTest < ActiveSupport::TestCase
   test "NavBar.items should return navigation group with sort=true when nav_item has apps and title property" do
     nav_item = {
       title: "Custom Apps",
-      icon_uri: "fa://test",
+      icon: "fa://test",
       apps: "sys/bc_jupyter"
     }
 
@@ -106,7 +106,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal URI("fa://test"),  result[0].icon_uri
   end
 
-  test "icon_uri should be null for apps navigation group when nav_item has no icon_uri property" do
+  test "icon_uri should be null for apps navigation group when nav_item has no icon property" do
     nav_item = {
       title: "Custom Apps",
       apps: "sys/bc_jupyter"
@@ -122,7 +122,7 @@ class NavBarTest < ActiveSupport::TestCase
   test "NavBar.items should return navigation group with sort=true when nav_item has apps array and title property" do
     nav_item = {
       title: "Custom Apps",
-      icon_uri: "fa://test",
+      icon: "fa://test",
       apps: ["sys/bc_jupyter"]
     }
 
@@ -140,7 +140,7 @@ class NavBarTest < ActiveSupport::TestCase
   test "NavBar.items should return navigation group when nav_item has links property" do
     nav_item = {
       title: "menu title",
-      icon_uri: "fa://test",
+      icon: "fa://test",
       links: []
     }
 
@@ -153,7 +153,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal URI("fa://test"),  result[0].icon_uri
   end
 
-  test "icon_uri should be null for links navigation group when nav_item has no icon_uri property" do
+  test "icon_uri should be null for links navigation group when nav_item has no icon property" do
     nav_item = {
       title: "menu title",
       links: []
@@ -231,7 +231,7 @@ class NavBarTest < ActiveSupport::TestCase
       title: "menu title",
       links: [
         {group: "subcategory"},
-        {title: "link title", url: "/path"},
+        {title: "link title", url: "/path", icon: "/test/image.png"},
       ]
     }
 
@@ -244,6 +244,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal "subcategory",  result[0].apps[0].subcategory
     assert_equal "link title",  result[0].apps[0].title
     assert_equal "/path",  result[0].apps[0].url
+    assert_equal URI("/test/image.png"),  result[0].apps[0].icon_uri
   end
 
   test "links array should support app links" do
@@ -270,7 +271,7 @@ class NavBarTest < ActiveSupport::TestCase
       title: "menu title",
       links: [
         {group: "subcategory"},
-        {title: "link title", profile: "profile"},
+        {title: "link title", profile: "profile", icon: "/test/image.png"},
       ]
     }
 
@@ -283,6 +284,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal "subcategory",  result[0].apps[0].subcategory
     assert_equal "link title",  result[0].apps[0].title
     assert_equal Rails.application.routes.url_helpers.settings_path("settings[profile]" => "profile"),  result[0].apps[0].url
+    assert_equal URI("/test/image.png"),  result[0].apps[0].icon_uri
   end
 
   test "links array should support page links" do
@@ -290,7 +292,7 @@ class NavBarTest < ActiveSupport::TestCase
       title: "menu title",
       links: [
         {group: "subcategory"},
-        {title: "link title", page: "page_code"},
+        {title: "link title", page: "page_code", icon: "/test/image.png"},
       ]
     }
 
@@ -303,12 +305,14 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal "subcategory",  result[0].apps[0].subcategory
     assert_equal "link title",  result[0].apps[0].title
     assert_equal Rails.application.routes.url_helpers.custom_pages_path("page_code"),  result[0].apps[0].url
+    assert_equal URI("/test/image.png"),  result[0].apps[0].icon_uri
   end
 
   test "NavBar.items should return navigation link when nav_item has url property" do
     nav_item = {
       title: "Link Title",
       url: "/path/test",
+      icon: "/test/image.png",
       new_tab: true
     }
 
@@ -319,6 +323,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal "Link Title",  result[0].title
     assert_equal "/path/test",  result[0].url
     assert_equal true,  result[0].new_tab?
+    assert_equal URI("/test/image.png"),  result[0].icon_uri
   end
 
   test "navigation link new_tab? defaults to false" do
@@ -338,6 +343,7 @@ class NavBarTest < ActiveSupport::TestCase
     nav_item = {
       title: "Profile Title",
       profile: "profile1",
+      icon: "/test/image.png",
       new_tab: true
     }
     expected_data_property = { method: 'post' }
@@ -349,6 +355,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal Rails.application.routes.url_helpers.settings_path("settings[profile]" => "profile1"),  result[0].url
     assert_equal expected_data_property,  result[0].data
     assert_equal true,  result[0].new_tab?
+    assert_equal URI("/test/image.png"),  result[0].icon_uri
   end
 
   test "navigation profile new_tab? defaults to false" do
@@ -368,6 +375,7 @@ class NavBarTest < ActiveSupport::TestCase
     nav_item = {
       title: "Page Title",
       page: "page_code",
+      icon: "/test/image.png",
       new_tab: true,
     }
     result = NavBar.items([nav_item])
@@ -377,6 +385,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal "Page Title",  result[0].title
     assert_equal Rails.application.routes.url_helpers.custom_pages_path("page_code"),  result[0].url
     assert_equal true,  result[0].new_tab?
+    assert_equal URI("/test/image.png"),  result[0].icon_uri
   end
 
   test "navigation page new_tab? defaults to false" do

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_desktop/local/oakley.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_desktop/local/oakley.yml
@@ -3,7 +3,7 @@ title: "Oakley Desktop"
 tile:
   title: "Configuration Title"
   sub_caption: "Configuration Sub Caption"
-  icon_uri: fa://configuration-icon
+  icon: fa://configuration-icon
   border_color: "css_class_value"
 cluster: "oakley"
 attributes:

--- a/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/owens.yml
+++ b/apps/dashboard/test/fixtures/usr/shared/bc_with_subapps/local/owens.yml
@@ -1,7 +1,7 @@
 ---
 title: "Owens Desktop"
 description: "Owens Description"
-icon_uri: fa://clock
+icon: fa://clock
 caption: 'gnome desktop on the owens cluster'
 cluster: "owens"
 attributes:

--- a/apps/dashboard/test/integration/custom_help_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_help_navigation_test.rb
@@ -28,7 +28,7 @@ class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
             ] },
           { title:    'Custom Help Link',
             url:      '/custom/link',
-            icon_uri: 'fa://desktop',
+            icon: 'fa://desktop',
             new_tab:  true },
           'user',
           'log_out'

--- a/apps/dashboard/test/integration/custom_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_navigation_test.rb
@@ -30,7 +30,7 @@ class CustomNavigationTest < ActionDispatch::IntegrationTest
             ] },
           { title:    'Custom Link',
             url:      '/custom/link',
-            icon_uri: 'fa://desktop',
+            icon: 'fa://desktop',
             new_tab:  true },
           'sys/bc_paraview',
           'all_apps'

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -295,7 +295,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     end
   end
 
-  test 'subapps can override title, description, icon_uri, and caption from form' do
+  test 'subapps can override title, description, icon, and caption from form' do
     r = PathRouter.new('test/fixtures/usr/shared/bc_with_subapps/')
     app = BatchConnect::App.new(router: r)
     sub_apps = app.sub_app_list


### PR DESCRIPTION
Renamed `icon_uri` yaml property to `icon` to make it consistent with app manifest.

Will update the documentation if this PR passes review and is merged.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203975466181385) by [Unito](https://www.unito.io)
