### PR TITLE
Added support for empty icons for custom navigation items

### DIFF
--- a/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
@@ -14,7 +14,7 @@
             data: link.data
           ) do
         %>
-          <%= icon_tag(link.icon_uri) %> <%= link.title %>
+          <%= icon_tag(link.icon_uri) unless link.icon_uri.to_s.blank? %> <%= link.title %>
           <% if link.subtitle.present? %>
             <%= content_tag(:small, link.subtitle, style: "text-indent: 20px", class: 'visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline') %>
           <% end %>

--- a/apps/dashboard/app/views/layouts/nav/_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_link.html.erb
@@ -11,6 +11,7 @@ data - optional, data parameter for the link_to helper
 <%
   title = local_assigns.fetch(:title, 'No title')
   url = local_assigns.fetch(:url)
+  icon_uri = local_assigns.fetch(:icon_uri, URI("fas://cog"))
 %>
 <%=
   link_to(
@@ -22,7 +23,7 @@ data - optional, data parameter for the link_to helper
     data: local_assigns.fetch(:data, nil)
   ) do
 %>
-  <%= icon_tag(local_assigns.fetch(:icon_uri, URI("fas://cog"))) %>
+  <%= icon_tag(icon_uri) unless icon_uri.to_s.blank? %>
   <%= tag.span do %>
     <%= title %>
   <% end %>


### PR DESCRIPTION
Currently it is not possible to create custom navigation links without having an icon. The code will default to having the `fas://cog` icon when no icon is defined or when null icon is set.

We have a requirement for IQSS to create top level links without having an icon.

Update: keep the default as `fas://cog` when no icon is defined, but allow admins to set an empty string to remove the icon from rendering:

```yaml
    help_bar:
      - title: "About"
        url: "https://www.iq.harvard.edu/research-computing#AboutSidNG"
        icon: ""
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203977669800188) by [Unito](https://www.unito.io)
