### PR TITLE
Added configuration to disable the dashboard welcome message

### DIFF
--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -21,6 +21,8 @@ class UserConfiguration
 
   USER_PROPERTIES = [
     ConfigurationProperty.property(name: :dashboard_header_img_logo, read_from_env: true),
+    # Whether we display the Dashboard welcome message
+    ConfigurationProperty.property(name: :disable_dashboard_welcome_message, default_value: false),
     # Whether we display the Dashboard logo image
     ConfigurationProperty.with_boolean_mapper(name: :disable_dashboard_logo, default_value: false, read_from_env: true, env_names: ['OOD_DISABLE_DASHBOARD_LOGO', 'DISABLE_DASHBOARD_LOGO']),
     # URL to the Dashboard logo image

--- a/apps/dashboard/app/views/dashboard/index.html.erb
+++ b/apps/dashboard/app/views/dashboard/index.html.erb
@@ -2,7 +2,7 @@
   <%= javascript_include_tag 'dashboard', nonce: true %>
   <%= javascript_include_tag 'pinned_apps', nonce: true %>
 <%- end -%>
-<%= render partial: 'shared/welcome' %>
+<%= render partial: 'shared/welcome' unless @user_configuration.disable_dashboard_welcome_message%>
 
 <%- dashboard_layout.fetch(:rows, []).each do |row| -%>
 <div class="row">

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -41,6 +41,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
   test "properties expected defaults" do
     defaults = {
       dashboard_header_img_logo: nil,
+      disable_dashboard_welcome_message: false,
       disable_dashboard_logo: false,
       dashboard_logo: nil,
       dashboard_logo_height: nil,


### PR DESCRIPTION
For our IQSS dashboard, we want to configure the homepage to display only widgets without showing the welcome message. Currently, there is no way of removing the welcome message without updating the `I18N` text. This solution is not profile friendly.

Added property to disable the welcome message

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203986030689007) by [Unito](https://www.unito.io)
