### PR TITLE
only use tranfers_path if its available

### DIFF
--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     data-bg-color="<%= @user_configuration.brand_bg_color %>"
     data-link-bg-color="<%= @user_configuration.brand_link_active_bg_color %>"
     data-max-file-size="<%= Configuration.file_upload_max %>"
-    data-transfers-path="<%= transfers_path(format: "json") %>"
+    data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
   />
 </head>
 <body>


### PR DESCRIPTION
Fix #2588  and only use `tranfers_path` if its available.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1203987184886869) by [Unito](https://www.unito.io)
