### PR TITLE
optimize auto_accounts so it doesnt show duplicates

### DIFF
--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -636,10 +636,8 @@ class BatchConnectTest < ApplicationSystemTestCase
       assert_equal '', find_option_style('auto_accounts', 'pas1754')
       assert_equal '', find_option_style('auto_accounts', 'pas1604')
 
-      # pzs1124 exists on both, so one should be hidden and the other available
-      id = bc_ele_id('auto_accounts')
-      assert_equal 'display: none;', find("##{id} option[data-option-for-cluster-owens='false'][value='pzs1124']")['style'].to_s
-      assert_equal '', find("##{id} option[data-option-for-cluster-oakley='false'][value='pzs1124']")['style'].to_s
+      # pzs1124 exists on both, so it's available
+      assert_equal '', find_option_style('auto_accounts', 'pzs1124')
 
       # pzs0715 is available on oakely, so switching clusters should keep the same value.
       select('oakley', from: bc_ele_id('cluster'))
@@ -649,10 +647,8 @@ class BatchConnectTest < ApplicationSystemTestCase
       assert_equal 'display: none;', find_option_style('auto_accounts', 'pas1754')
       assert_equal 'display: none;', find_option_style('auto_accounts', 'pas1604')
 
-      # pzs1124 exists on both, so now, they flip visibility
-      id = bc_ele_id('auto_accounts')
-      assert_equal '', find("##{id} option[data-option-for-cluster-owens='false'][value='pzs1124']")['style'].to_s
-      assert_equal 'display: none;', find("##{id} option[data-option-for-cluster-oakley='false'][value='pzs1124']")['style'].to_s
+      # pzs1124 exists on both, so it's still available
+      assert_equal '', find_option_style('auto_accounts', 'pzs1124')
     end
   end
 
@@ -779,7 +775,7 @@ class BatchConnectTest < ApplicationSystemTestCase
       assert_equal 'display: none;', find_option_style('auto_qos', 'gpt')
 
       # select the right account, and now they're available
-      find("##{bc_ele_id('auto_accounts')} option[value='pzs1124'][data-option-for-cluster-oakley='false']").select_option
+      select('pzs1124', from: bc_ele_id('auto_accounts'))
       assert_equal '', find_option_style('auto_qos', 'staff')
       assert_equal '', find_option_style('auto_qos', 'phoenix')
       assert_equal '', find_option_style('auto_qos', 'geophys')


### PR DESCRIPTION
optimize auto_accounts so it doesnt show duplicates.

Right now `auto_accounts` populates a huge list that requires `cluster` be set for dynamic hiding of the duplicates

Use this very simple form
```yaml
form:
  - auto_accounts
```
and you'll see duplicates. One for each cluster.
![image](https://user-images.githubusercontent.com/4874123/219735403-f608de5b-1806-43cb-a636-e6b7a1119823.png)


This optimizes that a bit and only shows 1 account only and adds the appropriate `data-option-for` directives to hide them when a given cluster is chosen.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203995919330176) by [Unito](https://www.unito.io)
