### PR TITLE
projects to use numeric ids instead of directories

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -8,13 +8,14 @@ class ScriptsController < ApplicationController
   end
 
   def show
-    @script = Script.find(show_script_params[:id], show_script_params[:project_id])
+    project = Project.find(show_script_params[:project_id])
+    @script = Script.find(show_script_params[:id], project.directory)
   end
 
   # POST  /dashboard/projects/:project_id/scripts
   def create
-    dir = create_script_params[:project_id]
-    opts = { project_dir: dir }.merge(create_script_params[:script])
+    project = Project.find(show_script_params[:project_id])
+    opts = { project_dir: project.directory }.merge(create_script_params[:script])
     @script = Script.new(opts)
 
     if @script.save

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -9,13 +9,19 @@ class Script
 
   class << self
 
+    def scripts_dir(project_dir)
+      @scripts_dir ||= Pathname.new("#{project_dir}/.ondemand/scripts").tap do |path|
+        path.mkpath unless path.exist?
+      end
+    end
+
     def find(id, project_dir)
-      file = "#{Project.dataroot}/#{project_dir}/.ondemand/scripts/#{id}.yml"
+      file = "#{scripts_dir(project_dir)}/#{id}.yml"
       Script.from_yaml(file, project_dir)
     end
 
     def all(project_dir)
-      Dir.glob("#{Project.dataroot}/#{project_dir}/.ondemand/scripts/*.yml").map do |file|
+      Dir.glob("#{scripts_dir(project_dir)}/*.yml").map do |file|
         Script.from_yaml(file, project_dir)
       end
     end
@@ -62,10 +68,7 @@ class Script
 
   def save
     @id = Script.next_id(project_dir)
-    script_dir = Pathname.new("#{Project.dataroot}/#{project_dir}/.ondemand/scripts/").tap do |path|
-      path.mkpath unless path.exist?
-    end
-    File.write("#{script_dir}/#{id}.yml", to_yaml)
+    File.write("#{Script.scripts_dir(project_dir)}/#{id}.yml", to_yaml)
 
     true
   rescue StandardError => e

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -18,13 +18,13 @@
       <% @projects.each do |project| %>
         <tr>
           <td><%= project.title %></td>
-          <td><%= link_to 'Work in', project_path(project.directory), class: 'btn btn-success', 
+          <td><%= link_to 'Work in', project_path(project.id), class: 'btn btn-success',
           title: 'View project directory contents' %>
-          <td><%= link_to 'Edit', edit_project_path(project.directory), class: 'btn btn-info',
+          <td><%= link_to 'Edit', edit_project_path(project.id), class: 'btn btn-info',
           title: 'Edit project directory' %>
-          <td><%= link_to 'Delete', project_path(project.directory), class: 'btn btn-danger', :method => :delete,
+          <td><%= link_to 'Delete', project_path(project.id), class: 'btn btn-danger', :method => :delete,
           data: {confirm: I18n.t('dashboard.jobs_project_delete_project_confirmation')} %>
-          <td><%= link_to fa_icon(project.icon_class), project_path(project.directory), class: 'btn',
+          <td><%= link_to fa_icon(project.icon_class), project_path(project.id), class: 'btn',
           title: 'View project directory contents' %>
         <tr>
       <% end %>

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -27,7 +27,7 @@
           <td>
             <%= link_to(
                   'Show',
-                  project_script_path(@project.directory, script.id),
+                  project_script_path(@project.id, script.id),
                   class: 'btn btn-success'
                 )
             %>
@@ -38,7 +38,7 @@
     </table>
 
     <%= link_to('New Script', 
-          new_project_script_path(@project.directory),
+          new_project_script_path(@project.id),
           class: 'btn btn-info',  
           title: I18n.t('dashboard.jobs_project_create_new_project_directory'))
     %>

--- a/apps/dashboard/test/integration/projects_controller_test.rb
+++ b/apps/dashboard/test/integration/projects_controller_test.rb
@@ -23,14 +23,13 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test "should get edit" do
-    # I think the project needs to exist to edit, :dir is missing in template
+  test 'should redirect from edit when it cannot find the project' do
     Dir.mktmpdir do |dir|
-      Project.stubs(dir).returns(Pathname.new("#{dir}/projects/project_1"))
-      assert  !Dir.exist?("#{dir}/projects/project_1")
+      OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
+      assert !Dir.exist?("#{dir}/projects/1")
 
-      get edit_project_path(dir)
-      assert_response :success
+      get edit_project_path('1')
+      assert_response :redirect
     end
   end
 
@@ -42,13 +41,13 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test "makes the directory if it doesnt exist" do
     Dir.mktmpdir do |dir|
-        OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
-        assert  !Dir.exist?("#{dir}/projects")
+      OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
+      assert !Dir.exist?("#{dir}/projects")
 
-        get projects_path
-        assert_response :success
+      get projects_path
+      assert_response :success
 
-        assert Dir.exist?("#{dir}/projects")
+      assert Dir.exist?("#{dir}/projects")
     end
   end
 end

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -7,11 +7,11 @@ class ProjectsTest < ActiveSupport::TestCase
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
-      attrs = { name: 'test project', icon: 'fas://arrow-right' }
+      attrs = { name: 'test-project', icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
-      project.save(attrs)
 
-      assert Dir.entries("#{projects_path}/projects").include?('test_project')
+      assert project.save(attrs), project.errors.inspect
+      assert Dir.entries("#{projects_path}/projects").include?('1')
     end
   end
 
@@ -20,7 +20,7 @@ class ProjectsTest < ActiveSupport::TestCase
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
 
-      attrs = { name: "b@d-$ym?o|'s", icon: 'fas://arrow-right' }
+      attrs = { name: "b@d-$ym?o|'s", icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
 
       assert !project.save(attrs)
@@ -33,7 +33,7 @@ class ProjectsTest < ActiveSupport::TestCase
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
 
-      attrs = { name: 'test project', icon: 'fas://arrow-right' }
+      attrs = { name: "test project", icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
       project.save(attrs)
 
@@ -42,8 +42,8 @@ class ProjectsTest < ActiveSupport::TestCase
       assert !project.update(bad_attrs)
       assert_equal project.errors[:name].last, 'Name format invalid'
 
-      good_attrs = { name: 'good-symbols', icon: 'fas://arrow-right' }
-      manifest_path = Pathname.new("#{projects_path}/projects/#{project.directory}/.ondemand/manifest.yml")
+      good_attrs = { name: 'good-symbols', icon: 'fas://arrow-right', id: 1 }
+      manifest_path = Pathname.new("#{project.directory}/.ondemand/manifest.yml")
 
       expected_manifest_yml = <<~HEREDOC
         ---
@@ -51,7 +51,7 @@ class ProjectsTest < ActiveSupport::TestCase
         icon: fas://arrow-right
       HEREDOC
 
-      assert project.update(good_attrs)
+      assert project.update(good_attrs), project.errors.inspect
       assert expected_manifest_yml, File.read(manifest_path)
     end
   end
@@ -60,13 +60,11 @@ class ProjectsTest < ActiveSupport::TestCase
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
-      attrs = { name: 'test project', icon: 'fas://arrow-right' }
+      attrs = { name: 'test-project', icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
-      project.save(attrs)
 
-      dot_ondemand_path = Pathname.new("#{projects_path}/projects/#{project.directory}")
-
-      assert Dir.entries(dot_ondemand_path).include?('.ondemand')
+      assert project.save(attrs)
+      assert Dir.entries(project.directory).include?('.ondemand')
     end
   end
 
@@ -74,13 +72,13 @@ class ProjectsTest < ActiveSupport::TestCase
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
-      attrs = { name: 'test-project', icon: 'fas://arrow-right' }
+      attrs = { name: 'test-project', icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
-      project.save(attrs)
 
-      assert_equal 'test-project', project.directory
+      assert project.save(attrs), project.errors.inspect
+      assert_equal "#{projects_path}/projects/1", project.directory.to_s
 
-      manifest_path = Pathname.new("#{projects_path}/projects/#{project.directory}/.ondemand/manifest.yml")
+      manifest_path = Pathname.new("#{projects_path}/projects/1/.ondemand/manifest.yml")
 
       assert File.file?(manifest_path)
 
@@ -98,14 +96,14 @@ class ProjectsTest < ActiveSupport::TestCase
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
-      attrs = { name: 'test-project', icon: 'fas://arrow-right' }
+      attrs = { name: 'test-project', icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
 
-      project.save(attrs)
-      assert Dir.entries("#{projects_path}/projects/").include?('test-project')
+      assert project.save(attrs)
+      assert Dir.entries("#{projects_path}/projects/").include?('1')
 
       project.destroy!
-      assert_not Dir.entries("#{projects_path}/projects/").include?('test-project')
+      assert_not Dir.entries("#{projects_path}/projects/").include?('1')
     end
   end
 
@@ -113,9 +111,9 @@ class ProjectsTest < ActiveSupport::TestCase
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(projects_path)
-      attrs = { name: 'test-project', icon: 'fas://arrow-right' }
+      attrs = { name: 'test-project', icon: 'fas://arrow-right', id: 1 }
       project = Project.new(attrs)
-      project.save(attrs)
+      assert project.save(attrs)
 
       name          = 'test-project-2'
       description   = 'my test project'
@@ -132,7 +130,7 @@ class ProjectsTest < ActiveSupport::TestCase
 
       puts "project: #{project.inspect}"
 
-      project.update(test_attributes)
+      assert project.update(test_attributes)
 
       puts "project: #{project.inspect}"
 
@@ -146,10 +144,10 @@ class ProjectsTest < ActiveSupport::TestCase
     Dir.mktmpdir do |tmp|
       project_path = Pathname.new(tmp)
       OodAppkit.stubs(:dataroot).returns(project_path)
-      attrs = { name: 'test-project', description: 'test description' }
+      attrs = { name: 'test-project', description: 'test description', id: 1 }
 
       project = Project.new(attrs)
-      project.save(attrs)
+      assert project.save(attrs), project.errors.inspect
 
       manifest_yml = <<~HEREDOC
         ---

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -15,7 +15,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
       assert_selector '.alert-success', text: 'Project successfully created!'
       assert_selector 'tbody tr td', text: 'Test Project'
-      assert File.directory? File.join("#{dir}/projects", 'test-project')
+      assert File.directory? File.join("#{dir}/projects", '1')
     end
   end
 
@@ -23,7 +23,7 @@ class ProjectsTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       setup_project(dir)
 
-      assert File.directory? File.join("#{dir}/projects", 'test-project/.ondemand')
+      assert File.directory? File.join("#{dir}/projects", '1/.ondemand')
     end
   end
 
@@ -37,7 +37,7 @@ class ProjectsTest < ApplicationSystemTestCase
       
       assert_selector '.alert-success', text: 'Project successfully deleted!'
       assert_no_selector 'tbody tr td', text: 'Test Project'
-      assert_not File.directory? File.join("#{dir}/projects", 'test-project')
+      assert_not File.directory? File.join("#{dir}/projects", '1')
     end
   end
 


### PR DESCRIPTION
Fixes #2578 

This enhances projects to use numeric ids instead of directories for a variety of reasons. 
* Notably to decouple the URLs from the initial directory name (opening us up to allow for spaces). 
* What's more is it'll allow us to use directories _outside_ of the dataroot because the full path is in the lookup file (#2558 or #2301)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204008884166928) by [Unito](https://www.unito.io)
