### PR TITLE
Migrated announcements_path property to UserConfiguration object

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -70,7 +70,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_announcements
-    @announcements = Announcements.all(::Configuration.announcement_path)
+    @announcements = Announcements.all(@user_configuration.announcement_path)
   rescue => e
     logger.warn "Error parsing announcements: #{e.message}"
     @announcements = []

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -91,6 +91,17 @@ class UserConfiguration
     path.start_with?('/') ? Pathname.new(path) : Pathname.new('/public')
   end
 
+  # The file system path to the announcements
+  # @return [Pathname, Array<Pathname>] announcement path or paths
+  def announcement_path
+    if path = ENV["OOD_ANNOUNCEMENT_PATH"]
+      Pathname.new(path)
+    else
+      paths = fetch(:announcement_path, ['/etc/ood/config/announcement.md', '/etc/ood/config/announcement.yml', '/etc/ood/config/announcements.d'])
+      Array.wrap(paths).map { |p| Pathname.new(p.to_s) }
+    end
+  end
+
   # Filtering is controlled with NavConfig.categories_allowlist? unless the configuration property categories is defined.
   # If categories are defined, filter_nav_categories? will always be true.
   def filter_nav_categories?

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -139,20 +139,6 @@ class ConfigurationSingleton
     to_bool(ENV["OOD_LOAD_EXTERNAL_BC_CONFIG"] || (rails_env == "production"))
   end
 
-  # The file system path to the announcements
-  # @return [Pathname, Array<Pathname>] announcement path or paths
-  def announcement_path
-    if path = ENV["OOD_ANNOUNCEMENT_PATH"]
-      Pathname.new(path)
-    else
-      [
-        "/etc/ood/config/announcement.md",
-        "/etc/ood/config/announcement.yml",
-        "/etc/ood/config/announcements.d"
-      ].map {|p| Pathname.new(p)}
-    end
-  end
-
   # The paths to the JSON files that store the quota information
   # Can be URL or File path. colon delimited string; though colon in URL is
   # ignored if URL has format: scheme://path (colons preceeding // are ignored)

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -200,23 +200,6 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     end
   end
 
-  test "should have default announcement paths" do
-    assert_equal(
-      [
-        Pathname.new("/etc/ood/config/announcement.md"),
-        Pathname.new("/etc/ood/config/announcement.yml"),
-        Pathname.new("/etc/ood/config/announcements.d")
-      ],
-      ConfigurationSingleton.new.announcement_path
-    )
-  end
-
-  test "can configure announcement path" do
-    with_modified_env(OOD_ANNOUNCEMENT_PATH: '/path/to/announcement') do
-      assert_equal Pathname.new('/path/to/announcement'), ConfigurationSingleton.new.announcement_path
-    end
-  end
-
   test "should have default developer docs url" do
     assert_equal "https://go.osu.edu/ood-app-dev", ConfigurationSingleton.new.developer_docs_url
   end

--- a/apps/dashboard/test/integration/announcement_views_test.rb
+++ b/apps/dashboard/test/integration/announcement_views_test.rb
@@ -6,14 +6,14 @@ class AnnouncementViewsTest < ActionDispatch::IntegrationTest
     f.write %{Test announcement.}
     f.close
 
-    Configuration.stubs(:announcement_path).returns(f.path)
+    stub_user_configuration({announcement_path: [f.path]})
 
     begin
       get "/"
       assert_response :success
       assert_select "div.announcement", "Test announcement."
     ensure
-      Configuration.unstub(:announcement_path)
+      stub_user_configuration({})
     end
   end
 end

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -34,6 +34,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
     'OOD_NAVBAR_TYPE' => [:navbar_type, "light"],
     'OOD_PINNED_APPS_GROUP_BY' => [:pinned_apps_group_by, "setup-#{SecureRandom.uuid}"],
     'OOD_PUBLIC_URL' => [:public_url, Pathname.new("/#{SecureRandom.uuid}")],
+    'OOD_ANNOUNCEMENT_PATH' => [:announcement_path, Pathname.new("/#{SecureRandom.uuid}")],
 
     'SHOW_ALL_APPS_LINK' => [:show_all_apps_link, true],
   }
@@ -52,6 +53,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       custom_css_files: [],
       dashboard_title: "Open OnDemand",
       public_url: Pathname.new("/public"),
+      announcement_path: [Pathname.new('/etc/ood/config/announcement.md'), Pathname.new('/etc/ood/config/announcement.yml'), Pathname.new('/etc/ood/config/announcements.d')],
 
       brand_bg_color: nil,
       brand_link_active_bg_color: nil,
@@ -144,6 +146,20 @@ class UserConfigurationTest < ActiveSupport::TestCase
     target = UserConfiguration.new
 
     assert_equal Pathname.new("/test/valid/path"), target.public_url
+  end
+
+  test "announcement_path supports string property" do
+    Configuration.stubs(:config).returns({announcement_path: "/string/path" })
+    target = UserConfiguration.new
+
+    assert_equal [Pathname.new("/string/path")], target.announcement_path
+  end
+
+  test "announcement_path supports array property" do
+    Configuration.stubs(:config).returns({announcement_path: ["/array/path/1", "/array/path/2"] })
+    target = UserConfiguration.new
+
+    assert_equal [Pathname.new("/array/path/1"), Pathname.new("/array/path/2")], target.announcement_path
   end
 
   test "filter_nav_categories? should return true when categories is set in config" do


### PR DESCRIPTION
Moved `announcement_path` to UserConfiguration to allow for profile based configuration.

This will allow to have different announcements per profile.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204033258533071) by [Unito](https://www.unito.io)
