### PR TITLE
Updated sessions widget to not render if there are no active sessions

### DIFF
--- a/apps/dashboard/app/views/widgets/_sessions.html.erb
+++ b/apps/dashboard/app/views/widgets/_sessions.html.erb
@@ -5,25 +5,21 @@
   session_selection = active_sessions.first(max_sessions)
 -%>
 
-<%= javascript_include_tag 'sessions_poller', nonce: true %>
+<%- unless session_selection.empty? %>
+  <%= javascript_include_tag 'sessions_poller', nonce: true %>
 
-<div class="active-sessions-header">
-  <h3>
-    <%= t('dashboard.active_sessions_title') %>
-    <small><%= t('dashboard.active_sessions_caption_html', all_sessions_url: batch_connect_sessions_path, number_of_sessions: active_sessions.length) %></small>
-  </h3>
-</div>
+  <div class="active-sessions-header">
+    <h3>
+      <%= t('dashboard.active_sessions_title') %>
+      <small><%= t('dashboard.active_sessions_caption_html', all_sessions_url: batch_connect_sessions_path, number_of_sessions: active_sessions.length) %></small>
+    </h3>
+  </div>
 
-<div class="active-sessions-content">
-<% if session_selection.empty? %>
-  <p class="lead">
-     <%= t('dashboard.active_sessions_no_sessions') %>
-  </p>
-<% else %>
-  <div id="batch_connect_sessions" class="row" data-toggle="poll" data-url="<%= batch_connect_sessions_path(format: :js) %>" data-delay="<%= poll_delay %>">
-    <div class="col-md-12">
-      <%= render partial: "/batch_connect/sessions/panel", collection: session_selection, as: :session %>
+  <div class="active-sessions-content">
+    <div id="batch_connect_sessions" class="row" data-toggle="poll" data-url="<%= batch_connect_sessions_path(format: :js) %>" data-delay="<%= poll_delay %>">
+      <div class="col-md-12">
+        <%= render partial: "/batch_connect/sessions/panel", collection: session_selection, as: :session %>
+      </div>
     </div>
   </div>
 <% end %>
-</div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -190,7 +190,6 @@ en:
     development_apps_caption: "Sandbox App"
 
     active_sessions_title: 'Active interactive sessions'
-    active_sessions_no_sessions: 'You have no active sessions.'
     active_sessions_caption_html: '<a href="%{all_sessions_url}"> view all (%{number_of_sessions})</a>'
 
     recently_used_apps_title: 'Recently Used Apps'

--- a/apps/dashboard/test/integration/active_sessions_widget_test.rb
+++ b/apps/dashboard/test/integration/active_sessions_widget_test.rb
@@ -11,13 +11,12 @@ class ActiveSessionsWidgetTest < ActionDispatch::IntegrationTest
     })
   end
 
-  test 'should render active sessions widget with empty message' do
+  test 'should not render active sessions widget when no active sessions' do
     BatchConnect::Session.stubs(:all).returns([])
 
     get '/'
 
-    assert_select 'div.active-sessions-header h3', 1
-    assert_select 'div.active-sessions-content p.lead', text: I18n.t('dashboard.active_sessions_no_sessions')
+    assert_select 'div.active-sessions-header h3', 0
   end
 
   test 'should render active sessions widget with session card' do


### PR DESCRIPTION
We had an internal review of the active sessions widget and think that it is a better behaviour to not display it when there are no active sessions.

This will make the widget consistent with the pinned apps widget that is not rendered when there are no pinned apps configured.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204041285740648) by [Unito](https://www.unito.io)
