### PR TITLE
use inline style with a nonce

### DIFF
--- a/apps/dashboard/app/javascript/packs/application.js
+++ b/apps/dashboard/app/javascript/packs/application.js
@@ -31,8 +31,6 @@ import 'bootstrap/dist/js/bootstrap';
 // FIXME: confim modals don't work in esbuild.
 // import 'data-confirm-modal';
 
-import { setNavbarColor } from './config';
-
 // lot's of inline scripts and stuff rely on jquery just being available
 window.jQuery = jQuery;
 window.$ = jQuery;

--- a/apps/dashboard/app/javascript/packs/application.js
+++ b/apps/dashboard/app/javascript/packs/application.js
@@ -60,6 +60,4 @@ jQuery(function(){
 
   $('[data-toggle="popover"]').popover();
   $('[data-toggle="tooltip"]').tooltip();
-
-  setNavbarColor();
 });

--- a/apps/dashboard/app/javascript/packs/config.js
+++ b/apps/dashboard/app/javascript/packs/config.js
@@ -6,38 +6,6 @@ function configData() {
   return document.getElementById(CONFIG_ID).dataset;
 }
 
-function setNavbarColor() {
-  const cfgData = configData();
-  const styles = document.styleSheets[0];
-
-  const bgLightColor = cfgData['bgColor'] === '' ? 'rgb(248, 248, 248)' : cfgData['bgColor'];
-  const bgDarkColor = cfgData['bgColor'] === '' ? 'rgb(83, 86, 90)' : cfgData['bgColor'];
-
-  const linkLightColor = cfgData['linkBgColor'] === '' ? 'rgb(231, 231, 231)' : cfgData['linkBgColor'];
-  const linkDarkColor = cfgData['linkBgColor'] === '' ? 'rgb(59, 61, 63)' : cfgData['linkBgColor'];
-
-  styles.insertRule(navbar('light', bgLightColor), styles.rules.length);
-  styles.insertRule(navbar('dark', bgDarkColor), styles.rules.length);
-  
-  styles.insertRule(navbarHighlight('light', linkLightColor), styles.rules.length);
-  styles.insertRule(navbarHighlight('dark', linkDarkColor), styles.rules.length);
-}
-
-function navbar(theme, color){
-  return `
-    .navbar-${theme} {
-      background-color: ${color};
-    }`;
-}
-
-function navbarHighlight(theme, color) {
-  return `
-    .navbar-${theme} ul.navbar-nav > li.nav-item > a:focus, .navbar-${theme} ul.navbar-nav > li.nav-item.show > a {
-      background-color: ${color};
-      border-radius: 0.25em;
-    }`;
-}
-
 function maxFileSize () {
   const cfgData = configData();
 
@@ -65,8 +33,7 @@ function csrfToken() {
   return csrf_token;
 }
 
-export { 
-  setNavbarColor, 
+export {
   maxFileSize, 
   transfersPath, 
   csrfToken 

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
 
   <%= javascript_include_tag 'application', nonce: true %>
   <%= stylesheet_link_tag 'application', nonce: content_security_policy_nonce, media: 'all' %>
+  <%= render partial: '/layouts/nav/styles', locals: { bg_color: @user_configuration.brand_bg_color, link_active_color:  @user_configuration.brand_link_active_bg_color } %>
   <% custom_css_paths.each do |path| %>
     <link rel="stylesheet" media="all" href="<%= path %>" nonce="<%= content_security_policy_nonce %>" />
   <% end %>

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -10,6 +10,7 @@
   <%= javascript_include_tag 'application', nonce: true %>
   <%= javascript_include_tag 'editor', nonce: true %>
   <%= stylesheet_link_tag 'application', nonce: true, media: 'all' %>
+  <%= render partial: '/layouts/nav/styles', locals: { bg_color: @user_configuration.brand_bg_color, link_active_color:  @user_configuration.brand_link_active_bg_color } %>
 
   <%= csrf_meta_tags %>
 

--- a/apps/dashboard/app/views/layouts/nav/_styles.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_styles.html.erb
@@ -1,0 +1,18 @@
+<style nonce="<%= content_security_policy_nonce %>">
+.navbar-dark {
+  background-color: <%= bg_color || 'rgb(83, 86, 90)' %>;
+}
+
+.navbar-light {
+  background-color: <%= bg_color || 'rgb(248, 248, 248)' %>;
+}
+
+.navbar-dark ul.navbar-nav > li.nav-item > a:focus, .navbar-dark ul.navbar-nav > li.nav-item.show > a {
+  background-color: <%= link_active_color || 'rgb(59, 61, 63)' %>;
+  border-radius: 0.25em;
+}
+.navbar-light ul.navbar-nav > li.nav-item > a:focus, .navbar-light ul.navbar-nav > li.nav-item.show > a {
+  background-color: <%= link_active_color || 'rgb(231, 231, 231)' %>;
+  border-radius: 0.25em;
+}
+</style>


### PR DESCRIPTION
The only reason we worked on #1863 was due to inline `style-src` being restricted as a part of our content security policy.

As we've went through this exercise we've learned that we can use `content_security_policy` within partials.  As we've found #2615 there seems to be a timing issue involved in adding the style through javascript.

Well, this PR is to simply add the `<style>` partial back in and simply add a nonce to it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204070234836611) by [Unito](https://www.unito.io)
