### PR TITLE
Moved support_ticket configuration to UserConfiguration class

### DIFF
--- a/apps/dashboard/app/apps/request_tracker_client.rb
+++ b/apps/dashboard/app/apps/request_tracker_client.rb
@@ -15,20 +15,6 @@ require 'rest_client'
 class RequestTrackerClient
   # THIS CLIENT IS BASED ON https://github.com/uidzip/rt-client
 
-  def self.create
-    rt_config = ::Configuration.support_ticket_config.fetch(:rt_api, {})
-
-    new({
-          server:     rt_config[:server],
-          user:       rt_config[:user],
-          pass:       rt_config[:pass],
-          auth_token: rt_config[:auth_token],
-          timeout:    rt_config[:timeout],
-          verify_ssl: rt_config[:verify_ssl],
-          proxy:      rt_config[:proxy]
-        })
-  end
-
   UA = 'Open OnDemand ruby RT Client'
   attr_reader :server, :rt_client, :resource, :timeout, :verify_ssl
 

--- a/apps/dashboard/app/controllers/support_ticket_controller.rb
+++ b/apps/dashboard/app/controllers/support_ticket_controller.rb
@@ -40,17 +40,12 @@ class SupportTicketController < ApplicationController
 
   private
 
-  # Load support ticket service class based on the configuration
   def create_service_class
-    # Supported delivery mechanism
-    return SupportTicketEmailService.new if ::Configuration.support_ticket_config[:email]
-    return SupportTicketRtService.new if ::Configuration.support_ticket_config[:rt_api]
-
-    raise StandardError, 'No support ticket service class configured'
+    @user_configuration.support_ticket_service
   end
 
   def get_ui_template
-    ::Configuration.support_ticket_config.fetch(:ui_template, 'email_service_template')
+    @user_configuration.support_ticket.fetch(:ui_template, 'email_service_template')
   end
 
   def read_support_ticket_from_request

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -46,7 +46,7 @@ module BatchConnect::SessionsHelper
           concat created(session)
           concat session_time(session)
           concat id(session)
-          concat support_ticket(session) if Configuration.support_ticket_enabled?
+          concat support_ticket(session) unless @user_configuration.support_ticket.empty?
           concat display_choices(session)
           safe_concat custom_info_view(session) if session.app.session_info_view
         end

--- a/apps/dashboard/app/helpers/support_ticket_helper.rb
+++ b/apps/dashboard/app/helpers/support_ticket_helper.rb
@@ -3,7 +3,7 @@
 # helper for the support ticket pages, email, and request tracker content.
 module SupportTicketHelper
   def support_ticket_description_text
-    ::Configuration.support_ticket_config[:description]
+    @user_configuration.support_ticket[:description]
   end
 
   def filter_session_parameters(session_info)

--- a/apps/dashboard/app/mailers/support_ticket_mailer.rb
+++ b/apps/dashboard/app/mailers/support_ticket_mailer.rb
@@ -8,7 +8,7 @@ class SupportTicketMailer < ActionMailer::Base
   default template_path: ['support_ticket/email']
   default template_name: 'email_layout'
 
-  def support_email(context)
+  def support_email(support_ticket_config, context)
     @context = context
 
     unless @context.support_ticket.attachments.blank?
@@ -17,7 +17,7 @@ class SupportTicketMailer < ActionMailer::Base
       end
     end
 
-    email_service_config = ::Configuration.support_ticket_config.fetch(:email, {})
+    email_service_config = support_ticket_config.fetch(:email, {})
 
     mail_data = {}.tap do |settings|
       settings[:from] = email_service_config.fetch(:from, @context.support_ticket.email)

--- a/apps/dashboard/app/models/concerns/support_ticket_validator.rb
+++ b/apps/dashboard/app/models/concerns/support_ticket_validator.rb
@@ -7,21 +7,9 @@
 #  - email
 #  - attachments
 module SupportTicketValidator
-  # Common file sizes
-  # 2MB = 2097152
-  # 5MB = 5242880
-  # 6MB = 6291456
-  # 10MB = 10485760
-  def self.restrictions
-    @@restrictions ||= {}.tap do |hash|
-      config = ::Configuration.support_ticket_config.fetch(:attachments, {})
-      hash[:max_items] = config.fetch(:max_items, 4)
-      hash[:max_size] = config.fetch(:max_size, 6_291_456)
-    end
-  end
 
   def support_ticket_validation
-    @attributes.each do |attribute|
+    attributes.each do |attribute|
       validate_required(attribute) if attribute.required
       validate_email(attribute) if attribute.widget == 'email_field'
       validate_attachments(attribute) if attribute.widget == 'file_attachments'
@@ -42,15 +30,15 @@ module SupportTicketValidator
       return
     end
 
-    if attribute.value.size > SupportTicketValidator.restrictions[:max_items]
-      errors.add(attribute.id, I18n.t('dashboard.support_ticket.validation.attachments_items', id: attribute.id, items: attribute.value.size, max: SupportTicketValidator.restrictions[:max_items]))
+    if attribute.value.size > restrictions[:max_items]
+      errors.add(attribute.id, I18n.t('dashboard.support_ticket.validation.attachments_items', id: attribute.id, items: attribute.value.size, max: restrictions[:max_items]))
       return
     end
 
     attribute.value.each do |attachment|
-      next unless attachment.size > SupportTicketValidator.restrictions[:max_size]
+      next unless attachment.size > restrictions[:max_size]
 
-      errors.add(attribute.id, I18n.t('dashboard.support_ticket.validation.attachments_size', id: attribute.id, max: size_to_string(SupportTicketValidator.restrictions[:max_size])))
+      errors.add(attribute.id, I18n.t('dashboard.support_ticket.validation.attachments_size', id: attribute.id, max: size_to_string(restrictions[:max_size])))
       return
     end
   end

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -66,7 +66,9 @@ class UserConfiguration
     ConfigurationProperty.property(name: :interactive_apps_menu, default_value: []),
 
     # Custom pages configuration property
-    ConfigurationProperty.property(name: :custom_pages, default_value: {})
+    ConfigurationProperty.property(name: :custom_pages, default_value: {}),
+    # Support ticket configuration property
+    ConfigurationProperty.property(name: :support_ticket, default_value: {})
   ].freeze
 
   def initialize(request_hostname: nil)
@@ -118,6 +120,15 @@ class UserConfiguration
 
   def nav_categories
     fetch(:nav_categories, nil) || NavConfig.categories
+  end
+
+  # Create support ticket service class based on the configuration
+  def support_ticket_service
+    # Supported delivery mechanism
+    return SupportTicketEmailService.new(support_ticket) if support_ticket[:email]
+    return SupportTicketRtService.new(support_ticket) if support_ticket[:rt_api]
+
+    raise StandardError, 'No support ticket service class configured'
   end
 
   # The current user profile. Used to select the configuration properties.

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -11,7 +11,7 @@
     <% if help_custom_url %>
       <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, new_tab: true) %>
     <% end %>
-    <% if Configuration.support_ticket_enabled? %>
+    <% unless @user_configuration.support_ticket.empty? %>
       <%= nav_link(t('dashboard.nav_help_support_ticket'), "medkit", support_path, new_tab: false) %>
     <% end %>
 

--- a/apps/dashboard/app/views/support_ticket/email_service_template.html.erb
+++ b/apps/dashboard/app/views/support_ticket/email_service_template.html.erb
@@ -2,7 +2,7 @@
 
 <%= javascript_tag nonce: true do -%>
 
-    const SUPPORT_TICKET_RESTRICTIONS = <%= raw SupportTicketValidator.restrictions.to_json %>
+    const SUPPORT_TICKET_RESTRICTIONS = <%= raw @support_ticket.restrictions.to_json %>
     const SUPPORT_TICKET_MESSAGES = {
         "items.attachments": "<%= t('dashboard.support_ticket.validation.items.attachments_js') %>",
         "size.attachments": "<%= t('dashboard.support_ticket.validation.size.attachments_js') %>",

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -190,12 +190,8 @@ class ConfigurationSingleton
   end
 
   # Support ticket configuration
-  def support_ticket_config
-    config.fetch(:support_ticket, {})
-  end
-
   def support_ticket_enabled?
-    !support_ticket_config.empty?
+    config.has_key?(:support_ticket) || config.fetch(:profiles, {}).any? { |_, profile| profile.has_key?(:support_ticket) }
   end
 
   # Load the dotenv local files first, then the /etc dotenv files and

--- a/apps/dashboard/test/apps/request_tracker_client_test.rb
+++ b/apps/dashboard/test/apps/request_tracker_client_test.rb
@@ -71,31 +71,4 @@ class RequestTrackerClientTest < ActiveSupport::TestCase
     assert_equal(true, target.rt_client.options[:verify_ssl])
     assert_equal("proxy.com:8888", target.rt_client.options[:proxy])
   end
-
-  test "create should read properties from Configuration.support_ticket_config and create client" do
-    config = {
-      rt_api: {
-        server: "http://server.com",
-        user: "payload_username",
-        pass: "payload_password",
-        timeout: 90,
-        verify_ssl: true,
-        proxy: "proxy.com:8888",
-      }
-    }
-    Configuration.stubs(:support_ticket_config).returns(config)
-
-    expected_config = {
-      server: "http://server.com",
-      user: "payload_username",
-      pass: "payload_password",
-      timeout: 90,
-      verify_ssl: true,
-      proxy: "proxy.com:8888",
-      auth_token: nil,
-    }
-    RequestTrackerClient.expects(:new).with(expected_config)
-    RequestTrackerClient.create
-  end
-
 end

--- a/apps/dashboard/test/apps/request_tracker_service_test.rb
+++ b/apps/dashboard/test/apps/request_tracker_service_test.rb
@@ -4,36 +4,27 @@ class RequestTrackerServiceTest < ActiveSupport::TestCase
 
   test "should throw exception when queues is not provided" do
     config = {
-      rt_api: {
-        queues: nil,
-        priority: "33",
-      }
+      queues: nil,
+      priority: "33",
     }
-    Configuration.stubs(:support_ticket_config).returns(config)
 
-    assert_raises(ArgumentError) { RequestTrackerService.new }
+    assert_raises(ArgumentError) { RequestTrackerService.new(config) }
   end
 
   test "should throw exception when priority is not provided" do
     config = {
-      rt_api: {
-        queues: [ "Standard" ],
-        priority: nil,
-      }
+      queues: [ "Standard" ],
+      priority: nil,
     }
-    Configuration.stubs(:support_ticket_config).returns(config)
 
-    assert_raises(ArgumentError) { RequestTrackerService.new }
+    assert_raises(ArgumentError) { RequestTrackerService.new(config) }
   end
 
   test "create_ticket should run with no errors" do
     config = {
-      rt_api: {
-        queues: [ "Standard" ],
-        priority: "10",
-      }
+      queues: [ "Standard" ],
+      priority: "10",
     }
-    Configuration.stubs(:support_ticket_config).returns(config)
 
     support_ticket = SupportTicket.from_config({})
     support_ticket.attributes = {email: "email@example.com", cc: "cc@example.com", subject: "Subject"}
@@ -49,21 +40,18 @@ class RequestTrackerServiceTest < ActiveSupport::TestCase
     .returns("support_ticket_id")
 
     session = BatchConnect::Session.new(id: 'session', created_at: Time.now)
-    RequestTrackerClient.stubs(:create).returns(mock_rt_client)
+    RequestTrackerClient.stubs(:new).returns(mock_rt_client)
 
-    result = RequestTrackerService.new.create_ticket(support_ticket, session)
+    result = RequestTrackerService.new(config).create_ticket(support_ticket, session)
 
     assert_equal "support_ticket_id", result
   end
 
   test "create_ticket should run with no errors when selecting an alternate queue" do
     config = {
-      rt_api: {
-        queues: [ "Standard", "Alternate" ],
-        priority: "10",
-      }
+      queues: [ "Standard", "Alternate" ],
+      priority: "10",
     }
-    Configuration.stubs(:support_ticket_config).returns(config)
 
     support_ticket = SupportTicket.from_config({})
     support_ticket.attributes = {email: "email@example.com", cc: "cc@example.com", subject: "Subject", queue: "Alternate"}
@@ -79,27 +67,24 @@ class RequestTrackerServiceTest < ActiveSupport::TestCase
     .returns("support_ticket_id")
 
     session = BatchConnect::Session.new(id: 'session', created_at: Time.now)
-    RequestTrackerClient.stubs(:create).returns(mock_rt_client)
+    RequestTrackerClient.stubs(:new).returns(mock_rt_client)
 
-    result = RequestTrackerService.new.create_ticket(support_ticket, session)
+    result = RequestTrackerService.new(config).create_ticket(support_ticket, session)
 
     assert_equal "support_ticket_id", result
   end
 
   test "create_ticket should raise an error when selecting an invalid queue" do
     config = {
-      rt_api: {
-        queues: [ "Standard", "Alternate" ],
-        priority: "10",
-      }
+      queues: [ "Standard", "Alternate" ],
+      priority: "10",
     }
-    Configuration.stubs(:support_ticket_config).returns(config)
 
     support_ticket = SupportTicket.from_config({})
     support_ticket.attributes = {email: "email@example.com", cc: "cc@example.com", subject: "Subject", queue: "Not_A_Queue"}
     session = BatchConnect::Session.new(id: 'session', created_at: Time.now)
 
-    assert_raises(ArgumentError) { RequestTrackerService.new.create_ticket(support_ticket, session) }
+    assert_raises(ArgumentError) { RequestTrackerService.new(config).create_ticket(support_ticket, session) }
 
   end
 end

--- a/apps/dashboard/test/apps/support_ticket_email_service_test.rb
+++ b/apps/dashboard/test/apps/support_ticket_email_service_test.rb
@@ -3,12 +3,12 @@ require "test_helper"
 class SupportTicketEmailServiceTest < ActiveSupport::TestCase
 
   def setup
-    Configuration.stubs(:support_ticket_config).returns({
+    config = {
       email: {
         to: "to_address@support.ticket.com"
       }
-    })
-    @target = SupportTicketEmailService.new
+    }
+    @target = SupportTicketEmailService.new(config)
     attachment_mock = stub({size: 100})
     @params = {
       username: "username",
@@ -84,14 +84,15 @@ class SupportTicketEmailServiceTest < ActiveSupport::TestCase
   end
 
   test "deliver_support_ticket should delegate to SupportTicketMailer class and return success message override when provided" do
-    Configuration.stubs(:support_ticket_config).returns({
+    config = {
       email: {
         to: "to_address@support.ticket.com",
         success_message: "success message override"
       }
-    })
+    }
+    target = SupportTicketEmailService.new(config)
     SupportTicketMailer.expects(:support_email).returns(stub(:deliver_now => nil))
-    result = @target.deliver_support_ticket(SupportTicket.new)
+    result = target.deliver_support_ticket(SupportTicket.new)
 
     assert_equal "success message override", result
   end

--- a/apps/dashboard/test/apps/support_ticket_rt_service_test.rb
+++ b/apps/dashboard/test/apps/support_ticket_rt_service_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SupportTicketRtServiceTest < ActiveSupport::TestCase
 
   def setup
-    @target = SupportTicketRtService.new
+    @target = SupportTicketRtService.new({})
     attachment_mock = stub({size: 100})
     @params = {
       username: "username",
@@ -73,13 +73,14 @@ class SupportTicketRtServiceTest < ActiveSupport::TestCase
   end
 
   test "deliver_support_ticket should delegate to RequestTrackerService class and return success message override when provided" do
-    Configuration.stubs(:support_ticket_config).returns({
-    rt_api: {
-        success_message: "success message override"
-      }
-    })
+    rt_config = {
+      rt_api: {
+          success_message: "success message override"
+        }
+    }
+    target = SupportTicketRtService.new(rt_config)
     RequestTrackerService.expects(:new).returns(stub(:create_ticket => "123"))
-    result = @target.deliver_support_ticket(SupportTicket.new)
+    result = target.deliver_support_ticket(SupportTicket.new)
 
     assert_equal "success message override", result
   end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -210,6 +210,24 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     end
   end
 
+  test "support_ticket_enabled? is false by default" do
+    assert_equal false, ConfigurationSingleton.new.support_ticket_enabled?
+  end
+
+  test "support_ticket_enabled? is true when support_ticket_property is defined" do
+    target = ConfigurationSingleton.new
+    target.stubs(:config).returns({support_ticket: {}})
+
+    assert_equal true, target.support_ticket_enabled?
+  end
+
+  test "support_ticket_enabled? is true when support_ticket_property is defined inside a profile" do
+    target = ConfigurationSingleton.new
+    target.stubs(:config).returns({profiles: {test: {support_ticket: {}}}})
+
+    assert_equal true, target.support_ticket_enabled?
+  end
+
   test "should have default dataroot under app if not production" do
     assert_equal Rails.root.join("data"), ConfigurationSingleton.new.dataroot
   end

--- a/apps/dashboard/test/helpers/support_ticket_helper_test.rb
+++ b/apps/dashboard/test/helpers/support_ticket_helper_test.rb
@@ -5,10 +5,14 @@ require 'test_helper'
 class SupportTicketHelperTest < ActionView::TestCase
   include SupportTicketHelper
 
+  def setup
+    @user_configuration = nil
+  end
+
   test 'support_ticket_description_text should read content from support_ticket configuration' do
     expected_description = 'This is description text'
-    Configuration.stubs(:support_ticket_config).returns({ description: expected_description })
-    ::Configuration.support_ticket_config[:description]&.html_safe
+    stub_user_configuration({ support_ticket: {description:  expected_description} })
+    @user_configuration = UserConfiguration.new
     assert_equal expected_description, support_ticket_description_text
   end
 

--- a/apps/dashboard/test/integration/support_ticket_integration_test.rb
+++ b/apps/dashboard/test/integration/support_ticket_integration_test.rb
@@ -4,12 +4,15 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
 
   def setup
     Configuration.stubs(:support_ticket_enabled?).returns(true)
-    Configuration.stubs(:support_ticket_config).returns({
-      email: {
-        to: "to_address@support.ticket.com",
-        delivery_method: 'test'
-      }
-    })
+    stub_user_configuration(
+      {
+        support_ticket: {
+          email: {
+            to: "to_address@support.ticket.com",
+            delivery_method: 'test'
+          }
+        }
+      })
     Rails.application.reload_routes!
   end
 

--- a/apps/dashboard/test/mailers/support_ticket_mailer_test.rb
+++ b/apps/dashboard/test/mailers/support_ticket_mailer_test.rb
@@ -3,12 +3,6 @@ require "test_helper"
 class SupportTicketMailerTest < ActionMailer::TestCase
 
   def setup
-    Configuration.stubs(:support_ticket_config).returns({
-      email: {
-        to: "to_address@support.ticket.com",
-      }
-    })
-
     @support_ticket = SupportTicket.from_config({})
     @support_ticket.attributes = {
       email: "user_email@example.com",
@@ -21,7 +15,12 @@ class SupportTicketMailerTest < ActionMailer::TestCase
   end
 
   test 'generates email with all expected fields' do
-    email = SupportTicketMailer.support_email(@context)
+    support_ticket_config = {
+      email: {
+        to: "to_address@support.ticket.com",
+      }
+    }
+    email = SupportTicketMailer.support_email(support_ticket_config, @context)
 
     assert_emails 1 do
       email.deliver_now
@@ -36,13 +35,13 @@ class SupportTicketMailerTest < ActionMailer::TestCase
   end
 
   test 'from address can be overridden with configuration' do
-    Configuration.stubs(:support_ticket_config).returns({
+    support_ticket_config = {
       email: {
         from: "override@example.com",
         to: "to_address@support.ticket.com",
       }
-    })
-    email = SupportTicketMailer.support_email(@context)
+    }
+    email = SupportTicketMailer.support_email(support_ticket_config, @context)
 
     assert_emails 1 do
       email.deliver_now

--- a/apps/dashboard/test/models/support_ticket_test.rb
+++ b/apps/dashboard/test/models/support_ticket_test.rb
@@ -102,7 +102,7 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:description].blank?
   end
 
-  test "only 4 attachments are allowed" do
+  test "only 4 attachments are allowed by default" do
     attachment_mock = stub({size: 100})
     @valid_hash[:attachments] = [attachment_mock, attachment_mock, attachment_mock, attachment_mock, attachment_mock]
     target = SupportTicket.from_config({})
@@ -112,7 +112,7 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:attachments].blank?
   end
 
-  test "attachments size should be smaller than 6MB" do
+  test "attachments size should be smaller than 6MB by default" do
     #10MB = 10485760
     attachment_mock = stub({size: 10485760})
     @valid_hash[:attachments] = [attachment_mock]
@@ -121,6 +121,20 @@ class SupportTicketTest < ActiveSupport::TestCase
 
     assert_equal false, target.valid?
     assert_equal false, target.errors[:attachments].blank?
+  end
+
+  test "validate default restrictions" do
+    target = SupportTicket.from_config({})
+
+    assert_equal 6_291_456, target.restrictions[:max_size]
+    assert_equal 4, target.restrictions[:max_items]
+  end
+
+  test "restrictions should be overridden from configuration" do
+    target = SupportTicket.from_config({attachments: {max_size: 1234, max_items: 100}})
+
+    assert_equal 1234, target.restrictions[:max_size]
+    assert_equal 100, target.restrictions[:max_items]
   end
 
 end

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -68,6 +68,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       help_menu: [],
       interactive_apps_menu: [],
       custom_pages: {},
+      support_ticket: {},
     }
 
     # ensure all properties are tested
@@ -174,6 +175,25 @@ class UserConfigurationTest < ActiveSupport::TestCase
 
     NavConfig.stubs(:categories_whitelist?).returns(true)
     assert_equal true, UserConfiguration.new.filter_nav_categories?
+  end
+
+  test "create_service_class returns SupportTicketEmailService when email configuration object defined" do
+    Configuration.stubs(:config).returns({support_ticket: {email: {}}})
+    service = UserConfiguration.new.support_ticket_service
+    assert_equal "SupportTicketEmailService", service.class.name
+  end
+
+  test "create_service_class returns SupportTicketRtService when rt_api configuration object defined" do
+    Configuration.stubs(:config).returns({support_ticket: {rt_api: {}}})
+    service = UserConfiguration.new.support_ticket_service
+    assert_equal "SupportTicketRtService", service.class.name
+  end
+
+  test "create_service_class throws exception when no service class configured" do
+    Configuration.stubs(:config).returns({})
+    assert_raise StandardError do
+      UserConfiguration.new.support_ticket_service
+    end
   end
 
   test "profile should delegate to CurrentUser settings when Configuration.host_based_profiles is false" do


### PR DESCRIPTION
Migrated `support_ticket` configuration from `ConfigurationSingleton` to `UserConfiguration` to add profile support.

We were doing an internal review and realized that different profiles might have different email or config settings for the support ticket configuration. Or one profile might want to disable the functionality.

The PR looks bigger than it is. It is just that the config was used in a lot of places.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204092217715450) by [Unito](https://www.unito.io)
