### PR TITLE
filter files that have non utf-8 characters in their filenames

### DIFF
--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -86,9 +86,9 @@ class PosixFile
     path.each_child.map do |child_path|
       PosixFile.stat(child_path)
     end.select do |stats|
-      ascii_only = stats[:name].to_s.ascii_only?
-      Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless ascii_only
-      ascii_only
+      valid_encoding = stats[:name].to_s.valid_encoding?
+      Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless valid_encoding
+      valid_encoding
     end.sort_by { |p| p[:directory] ? 0 : 1 }
   end
 

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -85,6 +85,10 @@ class PosixFile
   def ls
     path.each_child.map do |child_path|
       PosixFile.stat(child_path)
+    end.select do |stats|
+      ascii_only = stats[:name].to_s.ascii_only?
+      Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless ascii_only
+      ascii_only
     end.sort_by { |p| p[:directory] ? 0 : 1 }
   end
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -41,9 +41,9 @@ class RemoteFile
         dev: 0,
       }
     end.select do |stats|
-      ascii_only = stats[:name].to_s.ascii_only?
-      Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless ascii_only
-      ascii_only
+      valid_encoding = stats[:name].to_s.valid_encoding?
+      Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless valid_encoding
+      valid_encoding
     end.sort_by { |p| p[:directory] ? 0 : 1 }
   end
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -40,6 +40,10 @@ class RemoteFile
         mode: "",
         dev: 0,
       }
+    end.select do |stats|
+      ascii_only = stats[:name].to_s.ascii_only?
+      Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless ascii_only
+      ascii_only
     end.sort_by { |p| p[:directory] ? 0 : 1 }
   end
 


### PR DESCRIPTION
Fixes #2624 by hiding non ascii filenames.

We may be able to show them at some point, but will never be able to edit, download or update them.  We cannot build routes with non utf-8 characters.  We _may_ be able to map them to say question marks instead, but if you it'd be nearly impossible to know which file to choose if they're all `????`. 

In any case, this'll work in the interem and I can create a follow up ticket for CRUDing them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204092595862193) by [Unito](https://www.unito.io)
