### PR TITLE
rm this include to safely dl large directories

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -1,6 +1,5 @@
 # The controller for all the files pages /dashboard/files
 class FilesController < ApplicationController
-  # include ActionController::Live
   include ZipTricks::RailsStreaming
 
   def fs

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -1,6 +1,6 @@
 # The controller for all the files pages /dashboard/files
 class FilesController < ApplicationController
-  include ActionController::Live
+  # include ActionController::Live
   include ZipTricks::RailsStreaming
 
   def fs


### PR DESCRIPTION
Remove this include to safely download large directories.  This include is not working well for writing large zips.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204102282887894) by [Unito](https://www.unito.io)
