### PR TITLE
correctly show alerts for download links

### DIFF
--- a/apps/dashboard/app/javascript/packs/files/file_ops.js
+++ b/apps/dashboard/app/javascript/packs/files/file_ops.js
@@ -58,6 +58,19 @@ jQuery(function() {
     }
   });
 
+  $('#directory-contents tbody').on('click', '.download-file', function(e){
+    e.preventDefault();
+
+    const table = $(CONTENTID).DataTable();
+    const row = e.currentTarget.dataset.rowIndex;
+
+    const eventData = {
+      selection:  table.rows(row).data()
+    };
+
+    $(CONTENTID).trigger(EVENTNAME.download, eventData);
+  });
+
   $("#refresh-btn").on("click", function () {
     $(CONTENTID).trigger(DATATABLE_EVENTNAME.reloadTable);
   });
@@ -418,13 +431,8 @@ class FileOps {
         }
       })
       .catch(e => {
-        const eventData = {
-          'title': 'Error while downloading',
-          'message': e.message,
-        };
-
         this.doneLoading();
-        this.alertError('Error while downloading', data.error_message);
+        this.alertError('Error while downloading', e.message);
       })
   }
   


### PR DESCRIPTION
This primarily fixes #2629 by correctly show alerts for download links and working through that workflow. This also fixes #2630.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204107104013047) by [Unito](https://www.unito.io)
