### PR TITLE
also disable when hidning for Safari

### DIFF
--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -689,6 +689,9 @@ function optionForFromToken(str) {
       newSelectedOption.prop('selected', true);
     }
   }
+
+  // now that we're done, propogate this change to data-set or data-hide handlers
+  $(`#${elementId}`).trigger('change');
 };
 
 // Return exactly 1 jquery object for this id's option

--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -646,6 +646,7 @@ function optionForFromToken(str) {
 
     if(hide) {
       optionElement.hide();
+      optionElement.prop('disabled', true);
 
       if(optionElement.prop('selected')) {
         optionElement.prop('selected', false);
@@ -653,6 +654,7 @@ function optionForFromToken(str) {
       }
     } else {
       optionElement.show();
+      optionElement.prop('disabled', false);
     }
   });
 

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -357,8 +357,14 @@ class BatchConnectTest < ApplicationSystemTestCase
 
   test 'python choice sets hidden change thing' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
-    select('advanced', from: bc_ele_id('node_type'))
+
+    # defaults
+    assert_equal '2.7', find_value('python_version')
+    assert_equal 'any', find_value('node_type')
     assert_equal 'default', find_value('hidden_change_thing', visible: false)
+
+    select('advanced', from: bc_ele_id('node_type'))
+    assert_equal 'python36', find_value('hidden_change_thing', visible: false)
 
     select('3.6', from: bc_ele_id('python_version'))
     assert_equal 'python36', find_value('hidden_change_thing', visible: false)

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -360,10 +360,6 @@ class BatchConnectTest < ApplicationSystemTestCase
     select('advanced', from: bc_ele_id('node_type'))
     assert_equal 'default', find_value('hidden_change_thing', visible: false)
 
-    select('3.1', from: bc_ele_id('python_version'))
-    assert_equal 'python31', find_value('bc_account')
-    assert_equal 'default', find_value('hidden_change_thing', visible: false)
-
     select('3.6', from: bc_ele_id('python_version'))
     assert_equal 'python36', find_value('hidden_change_thing', visible: false)
 


### PR DESCRIPTION
Fixes #2543 by disabling the option even if Safari is going to force us to show it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204122235609044) by [Unito](https://www.unito.io)
