### PR TITLE
fix #2644 by never caching the files controllers' json response

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -20,6 +20,7 @@ class FilesController < ApplicationController
         end
 
         format.json do
+          response.headers['Cache-Control'] = 'no-store'
           if params[:can_download]
             # check to see if this directory can be downloaded as a zip
             can_download, error_message = @path.can_download_as_zip?

--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -249,7 +249,7 @@ class DataTable {
         var request_url = url || history.state.currentDirectoryUrl;
 
         try {
-            const response = await fetch(request_url, { headers: { 'Accept': 'application/json' } });
+            const response = await fetch(request_url, { headers: { 'Accept': 'application/json' }, cache: 'no-store' });
             const data = await this.dataFromJsonResponse(response);
             history.state.currentFilenames = Array.from(data.files, x => x.name);
             $('#shell-wrapper').replaceWith((data.shell_dropdown_html));


### PR DESCRIPTION
Fix #2644 by never caching the files controllers' json response.

So the issue in #2644 is the json response is cached and we're navigating back to it. So the simple solution is to just never cache it at all.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204140193860403) by [Unito](https://www.unito.io)
