### PR TITLE
rescue SyntaxErrors in announcements

### DIFF
--- a/apps/dashboard/app/models/announcement.rb
+++ b/apps/dashboard/app/models/announcement.rb
@@ -47,7 +47,7 @@ class Announcement
                 end
       @opts.symbolize_keys.compact
     rescue Errno::ENOENT, SyntaxError # File does not exist or syntax errors
-      @opts = { }
+      @opts = {}
     rescue => e
       Rails.logger.warn "Error parsing announcement file '#{@path}': #{e.message}"
       @opts = {}

--- a/apps/dashboard/app/models/announcement.rb
+++ b/apps/dashboard/app/models/announcement.rb
@@ -46,8 +46,8 @@ class Announcement
                   {}
                 end
       @opts.symbolize_keys.compact
-    rescue Errno::ENOENT  # File does not exist
-      @opts = {}
+    rescue Errno::ENOENT, SyntaxError # File does not exist or syntax errors
+      @opts = { }
     rescue => e
       Rails.logger.warn "Error parsing announcement file '#{@path}': #{e.message}"
       @opts = {}

--- a/apps/dashboard/test/models/announcements_test.rb
+++ b/apps/dashboard/test/models/announcements_test.rb
@@ -67,6 +67,16 @@ class AnnouncementsTest < ActiveSupport::TestCase
     assert_equal 0, announcements.select(&:valid?).count
   end
 
+  test "does not crash when there are syntax errors" do
+    f = Tempfile.open(["announcement", ".yml"])
+    f.write "<%- end %>"
+    f.close
+
+    announcements = Announcements.all(f.path)
+    assert_equal 1, announcements.count
+    assert_equal 0, announcements.select(&:valid?).count
+  end
+
   test "should create invalid announcement for invalid yaml file" do
     f = Tempfile.open(["announcement", ".yml"])
     f.write %{INVALID: YAML\nINVALID YAML}


### PR DESCRIPTION
Fixes #2634 to catch a SyntaxError in an announcement.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204149453120476) by [Unito](https://www.unito.io)
