### PR TITLE
show smart attributes in a form and start a #submit API

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -25,6 +25,15 @@ class ScriptsController < ApplicationController
     end
   end
 
+  # POST   /projects/:project_id/scripts/:id/submit
+  # submit the job
+  def submit
+    project = Project.find(params[:project_id])
+    @script = Script.find(params[:id], project.directory)
+
+    redirect_to project_path(params[:project_id]), notice: 'TODO'
+  end
+
   private
 
   def create_script_params

--- a/apps/dashboard/app/helpers/scripts_helper.rb
+++ b/apps/dashboard/app/helpers/scripts_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ScriptsHelper
+  include BatchConnect::SessionContextsHelper
+end

--- a/apps/dashboard/app/views/scripts/show.html.erb
+++ b/apps/dashboard/app/views/scripts/show.html.erb
@@ -2,8 +2,13 @@
 <h1><%= @script.title %></h1>
 
 
-<%= link_to 'Back', project_path(params[:project_id]), class: 'btn btn-default mt-3',  title: 'Return to projects page' %>
+<%= link_to 'Back', project_path(params[:project_id]), class: 'btn btn-default my-3',  title: 'Return to projects page' %>
 
-<hr>
-<%= @script.smart_attributes %>
-<hr>
+<%= bootstrap_form_for(@script, url: submit_project_script_path) do |f| %>
+  <% @script.smart_attributes.each do |attrib| %>
+    <%# TODO generate render_format %>
+    <%= create_widget(f, attrib, format: nil) %>
+  <% end %>
+
+  <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
+<% end %>

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   if Configuration.jobs_app_alpha?
     resources :projects do
       root 'projects#index'
-      resources :scripts
+      resources :scripts do
+        post 'submit', on: :member
+      end
     end
   end
 


### PR DESCRIPTION
Show smart attributes in a form and start a #submit API.

Fixes #2574 - so if you have edited a script like so:

```yaml
---
title: 'some title'

form:
  - auto_accounts

```

The `#show` page will then render that form and submit it (although the #submit is currently just a TODO message)

![image](https://user-images.githubusercontent.com/4874123/224366164-a4c985ac-a69f-4641-b964-e6d48540ba59.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204155189343444) by [Unito](https://www.unito.io)
