### PR TITLE
add file to deb dependencies

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -13,7 +13,7 @@ Package: ondemand
 Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends},
-  ruby, apache2, sudo, lsof, lua-posix, tzdata, file
+  ruby, apache2, sudo, lsof, lua-posix, tzdata, file,
   nodejs (>= 14.0), nodejs (<< 15.0),
   ondemand-nginx (= 1.20.2.p6.0.14.ood2.1), ondemand-passenger (= 6.0.14.ood2.1)
 Recommends: rclone

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -13,7 +13,7 @@ Package: ondemand
 Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends},
-  ruby, apache2, sudo, lsof, lua-posix, tzdata,
+  ruby, apache2, sudo, lsof, lua-posix, tzdata, file
   nodejs (>= 14.0), nodejs (<< 15.0),
   ondemand-nginx (= 1.20.2.p6.0.14.ood2.1), ondemand-passenger (= 6.0.14.ood2.1)
 Recommends: rclone


### PR DESCRIPTION
Add `file` to deb dependencies to fix #241 because we do indeed use this command here:


https://github.com/OSC/ondemand/blob/dda7c0dd579765c5f983874f6f139f083804f883/apps/dashboard/app/models/posix_file.rb#L162

rpm packages already correctly depend on this package.
https://github.com/OSC/ondemand/blob/dda7c0dd579765c5f983874f6f139f083804f883/packaging/rpm/ondemand.spec#L60

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204169923391279) by [Unito](https://www.unito.io)
