### PR TITLE
actually disable security checks

### DIFF
--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -30,7 +30,7 @@ http {
   passenger_default_user <%= user %>;
   passenger_load_shell_envvars off;
   # users can't update passenger anyhow
-  passenger_disable_security_update_check off;
+  passenger_disable_security_update_check on;
 
   <%- if disable_bundle_user_config? -%>
   passenger_env_var BUNDLE_USER_CONFIG /dev/null;


### PR DESCRIPTION
Fixes #2000. Confusingly, we have to set this option to true to disable the check.  I.e., enabling it disables the security check.

Looks like #2459 didn't actually resolve this issue because I still see the checks in the logs in 2.1.0.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204186168209349) by [Unito](https://www.unito.io)
