### PR TITLE
Fix Rails session store using wrong username in some cases

### DIFF
--- a/apps/dashboard/config/initializers/session_store.rb
+++ b/apps/dashboard/config/initializers/session_store.rb
@@ -2,7 +2,7 @@
 
 if Rails.application.config.session_store.nil?
   begin
-    dir = "/var/tmp/#{Etc.getlogin}"
+    dir = "/var/tmp/#{Etc.getpwuid.name}"
     Dir.mkdir(dir, 0o0700) unless Dir.exist?(dir)
 
     Rails.application.config.session_store(:cache_store, cache: ActiveSupport::Cache::FileStore.new(dir))


### PR DESCRIPTION
This PR fixes a bug with OOD running in a container with multiple users accessing the dashboard.

`Etc.getlogin` returns root in some cases, which causes the Rails session store (#2434) to attempt to use the same directory for all users, as seen below:
```
[ood@027a5853a2cc ~]$ ls -la /var/tmp/
total 20
drwxrwxrwt.  4 root root 4096 Mar 15 13:24 .
drwxr-xr-x. 20 root root 4096 Mar 15 13:24 ..
drwxr-xr-x.  3 root root 4096 Mar 15 13:24 ondemand-nginx
drwx------.  3 ood  ood  4096 Mar 15 13:24 root
```
When some user other than `ood` in this case tries to access the dashboard, they get an error due to not being able to create a directory under `/var/tmp/root/`.

Minimal example of `Etc.getlogin` behaviour with rootless Podman:
```
[rkarlsso@blahake ~]$ podman run -ti ruby:latest /bin/bash
root@dff2f47f115d:/# useradd -m -s /bin/bash ood
root@dff2f47f115d:/# su - ood
ood@dff2f47f115d:~$ irb
irb(main):001:0> Etc.getlogin
=> "root"
irb(main):002:0> Etc.getpwuid.name
=> "ood"
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204192178506840) by [Unito](https://www.unito.io)
