### PR TITLE
add the ability to launch scripts

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -25,6 +25,15 @@ class ScriptsController < ApplicationController
     end
   end
 
+  # POST   /projects/:project_id/scripts/:id/submit
+  # submit the job
+  def submit
+    project = Project.find(params[:project_id])
+    @script = Script.find(params[:id], project.directory)
+
+    redirect_to project_path(params[:project_id]), notice: 'TODO'
+  end
+
   private
 
   def create_script_params

--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -30,8 +30,13 @@ class ScriptsController < ApplicationController
   def submit
     project = Project.find(params[:project_id])
     @script = Script.find(params[:id], project.directory)
+    opts = submit_script_params[:script].to_h.symbolize_keys
 
-    redirect_to project_path(params[:project_id]), notice: 'TODO'
+    if (job_id = @script.submit(opts))
+      redirect_to(project_path(params[:project_id]), notice: "Successfully submited job #{job_id}.")
+    else
+      redirect_to(project_path(params[:project_id]), alert: @script.errors[:submit].last)
+    end
   end
 
   private
@@ -42,5 +47,10 @@ class ScriptsController < ApplicationController
 
   def show_script_params
     params.permit(:id, :project_id)
+  end
+
+  def submit_script_params
+    keys = @script.smart_attributes.map { |sm| sm.id.to_s }
+    params.permit({ script: keys }, :project_id, :id)
   end
 end

--- a/apps/dashboard/app/helpers/scripts_helper.rb
+++ b/apps/dashboard/app/helpers/scripts_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ScriptsHelper
+  include BatchConnect::SessionContextsHelper
+end

--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -9,6 +9,7 @@ module SmartAttributes
   require "smart_attributes/attributes/auto_primary_group"
   require "smart_attributes/attributes/auto_queues"
   require "smart_attributes/attributes/auto_qos"
+  require "smart_attributes/attributes/auto_scripts"
   require "smart_attributes/attributes/bc_account"
   require "smart_attributes/attributes/bc_email_on_started"
   require "smart_attributes/attributes/bc_num_hours"

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_scripts.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_scripts.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module SmartAttributes
+  class AttributeFactory
+    # Build this attribute object. Must specify a valid directory in opts
+    #
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::AutoScripts] the attribute object
+    def self.build_auto_scripts(opts = {})
+      dir = Pathname.new(opts[:directory].to_s)
+      options = if dir.directory? && dir.readable?
+                  Dir.glob("#{dir}/*.{sh,csh,bash,slurm,sbatch,qsub}").map do |file|
+                    [File.basename(file), file]
+                  end
+                else
+                  []
+                end
+
+      static_opts = {
+        options: options
+      }.merge(opts.without(:options).to_h)
+
+      Attributes::AutoScripts.new('auto_scripts', static_opts)
+    end
+  end
+
+  module Attributes
+    class AutoScripts < Attribute
+      def widget
+        'select'
+      end
+
+      def label(*)
+        (opts[:label] || 'Script').to_s
+      end
+
+      # Submission hash describing how to submit this attribute
+      # @param fmt [String, nil] formatting of hash
+      # @return [Hash] submission hash
+      def submit(*)
+        content = File.read(value)
+        { script: { content: content } }
+      end
+    end
+  end
+end

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -53,12 +53,13 @@ class Script
     @project_dir = opts[:project_dir] || raise(StandardError, 'You must set the project directory')
     @id = opts[:id]
     @title = opts[:title].to_s
-    @smart_attributes = build_smart_attributes(opts[:form] || [])
+    @smart_attributes = build_smart_attributes(opts[:form] || [], opts[:attributes] || {})
   end
 
-  def build_smart_attributes(form_list)
+  def build_smart_attributes(form_list, attribute_hash)
     form_list.map do |form_item_id|
-      SmartAttributes::AttributeFactory.build(form_item_id, {})
+      attrs = attribute_hash[form_item_id].to_h.symbolize_keys
+      SmartAttributes::AttributeFactory.build(form_item_id, attrs)
     end
   end
 

--- a/apps/dashboard/app/views/scripts/show.html.erb
+++ b/apps/dashboard/app/views/scripts/show.html.erb
@@ -2,8 +2,13 @@
 <h1><%= @script.title %></h1>
 
 
-<%= link_to 'Back', project_path(params[:project_id]), class: 'btn btn-default mt-3',  title: 'Return to projects page' %>
+<%= link_to 'Back', project_path(params[:project_id]), class: 'btn btn-default my-3',  title: 'Return to projects page' %>
 
-<hr>
-<%= @script.smart_attributes %>
-<hr>
+<%= bootstrap_form_for(@script, url: submit_project_script_path) do |f| %>
+  <% @script.smart_attributes.each do |attrib| %>
+    <%# TODO generate render_format %>
+    <%= create_widget(f, attrib, format: nil) %>
+  <% end %>
+
+  <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
+<% end %>

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   if Configuration.jobs_app_alpha?
     resources :projects do
       root 'projects#index'
-      resources :scripts
+      resources :scripts do
+        post 'submit', on: :member
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #2576 by actually launching the job once you press the 'Launch' button in the `scripts#show` page. 

In draft at the moment because it depends on #2661 and I'll need to rebase once that's merged.

You can use the same script form as below. Note that your directory will have to be different and you'll actually need to provide a shell script in that directory.
```yaml
---
title: 'some title'

form:
  - auto_accounts
  - auto_scripts

attributes:
  auto_scripts:
    directory: '/users/PZS0714/johrstrom/ondemand/dev/dashboard/data/projects/2'

```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204205975503055) by [Unito](https://www.unito.io)
