### PR TITLE
only have distribution in e2e test names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
         dist: ["el7", "el8", "el9", "ubuntu-20.04", "ubuntu-22.04"]
         version: ["3.0"]
     runs-on: "ubuntu-latest"
-    name: E2E test ${{ matrix.dist }} (ondemand-${{ matrix.version }})
+    name: E2E test ${{ matrix.dist }}
 
     steps:
       - name: Checkout ${{ github.sha	}}


### PR DESCRIPTION
#2683 showed us that having version in the name of e2e tests may be a bit flaky when having to update the version.

Distributions on the other hand are likely to be more stable, so let's just key off of distributions.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204228624415238) by [Unito](https://www.unito.io)
