### PR TITLE
Path selector form options

### DIFF
--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -92,7 +92,7 @@ jQuery(function () {
                 return isDirectory && !isHidden;
             
             } else if(total == 1 ) {
-                // show everything but files, even hidden
+                // show all directories, even if hidden
                 return !isFile;
             
             } else if(total == 2 ) {

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -31,7 +31,7 @@ jQuery(function () {
         let url = $(WORKINGDIRECTORY).val() ? $(WORKINGDIRECTORY).val() : $('#path_selector_home_dir').text();
         let path = $('#path_selector_url').text();
         url = path + url;
-        
+        table.weightedValue = table.getShowDotFiles() + table.getShowFiles();
         let eventData = {
             'url': url,
         }
@@ -84,25 +84,23 @@ jQuery(function () {
 
     $.fn.dataTable.ext.search.push(
         function (settings, data, dataIndex) {
-            let total = table.getShowDotFiles() + table.getShowFiles();
-
             let isDirectory = (data[0].trim() == "dir");
             let isFile = !isDirectory;
             let isHidden = data[1].startsWith('.');
 
-            if( total == 0 ) {
+            if( table.weightedValue == 0 ) {
                 // show only non-hidden directories
                 return isDirectory && !isHidden;
             
-            } else if(total == 1 ) {
+            } else if( table.weightedValue == 1 ) {
                 // show all directories, even if hidden
                 return !isFile;
             
-            } else if(total == 2 ) {
+            } else if( table.weightedValue == 2 ) {
                 // show everything except hidden
                 return !isHidden;
             
-            } else if(total == 3 ) {
+            } else if( table.weightedValue == 3 ) {
                 // show everything
                 return true;
             
@@ -118,6 +116,7 @@ class DataTable {
     _table = null;
     _url = null;
     _currentWorkingDirectory = null;
+    weightedValue = 0;
 
     constructor(url) {
         this.loadDataTable();

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -37,6 +37,7 @@ jQuery(function () {
         }
         
         $(CONTENTID).trigger(EVENTNAME.reloadTable, eventData);
+        $(CONTAINERCONTENTID).show();        
     });
 
     $(CONTENTID).on(EVENTNAME.reloadTable, function (e, options) {

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -31,10 +31,12 @@ jQuery(function () {
         let url = $(WORKINGDIRECTORY).val() ? $(WORKINGDIRECTORY).val() : $('#path_selector_home_dir').text();
         let path = $('#path_selector_url').text();
         url = path + url;
-        table._options = $('#path_selector_options').text().split(',');
-        table.setVisibility();
-        table.reloadTable(url);
-        $(CONTAINERCONTENTID).show();
+        
+        let eventData = {
+            'url': url,
+        }
+        
+        $(CONTENTID).trigger(EVENTNAME.reloadTable, eventData);
     });
 
     $(CONTENTID).on(EVENTNAME.reloadTable, function (e, options) {
@@ -83,6 +85,7 @@ jQuery(function () {
     $.fn.dataTable.ext.search.push(
         function (settings, data, dataIndex) {
             let total = table.getShowDotFiles() + table.getShowFiles();
+
             let isDirectory = (data[0].trim() == "dir");
             let isFile = !isDirectory;
             let isHidden = data[1].startsWith('.');
@@ -115,7 +118,6 @@ class DataTable {
     _table = null;
     _url = null;
     _currentWorkingDirectory = null;
-    _options = [];
 
     constructor(url) {
         this.loadDataTable();
@@ -263,36 +265,11 @@ class DataTable {
         $('.datatables-status').html(`${msg} - ${rows} rows selected`);
     }
 
-
-    setShowDotFiles(weight) {
-        localStorage.setItem('show-dotfiles', weight);
-    }
-
     getShowDotFiles() {
-        return parseInt(localStorage.getItem('show-dotfiles'));
-    }
-
-    setShowFiles(weight) {
-        localStorage.setItem('show-files', weight);
+        return $('#modal-path-selector').data('pathSelectorShowHidden') === true ? 1 : 0;
     }
 
     getShowFiles() {
-        return parseInt(localStorage.getItem('show-files'));
-    }
-
-    setVisibility() {
-        if( this._options.includes('hidden')) {
-            this.setShowDotFiles(1);
-        } else {
-            this.setShowDotFiles(0);
-        };
-    
-    
-        if( this._options.includes('files')) {
-            this.setShowFiles(2);
-        } else {
-            this.setShowFiles(0);
-        }
-    
+        return $('#modal-path-selector').data('pathSelectorShowFiles') === true ? 2 : 0;
     }
 }

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -1,3 +1,4 @@
+import isDOMElement from '@uppy/utils/lib/isDOMElement';
 import Handlebars from 'handlebars';
 import {EVENTNAME as SWAL_EVENTNAME} from './sweet_alert.js';
 
@@ -30,6 +31,8 @@ jQuery(function () {
         let url = $(WORKINGDIRECTORY).val() ? $(WORKINGDIRECTORY).val() : $('#path_selector_home_dir').text();
         let path = $('#path_selector_url').text();
         url = path + url;
+        table._options = $('#path_selector_options').text().split(',');
+        table.setVisibility();
         table.reloadTable(url);
         $(CONTAINERCONTENTID).show();
     });
@@ -70,31 +73,6 @@ jQuery(function () {
     });
 
 
-    $('#show-dotfiles').on('change', function() {
-        table.setShowDotFiles(this.checked);
-        table.updateDotFileVisibility();
-    });
-    $('#show-dotfiles').on('keypress', function(event) {
-        if (event.which === 13) {
-          this.checked = !this.checked;
-          this.dispatchEvent(new Event('change'));
-        }
-    });
-
-
-    $('#show-files').on('change', function() {
-        table.setShowFiles(this.checked);
-        table.updateDotFileVisibility();
-    });
-
-    $('#show-files').on('keypress', function(event) {
-        if (event.which === 13) {
-          this.checked = !this.checked;
-          this.dispatchEvent(new Event('change'));
-        }
-    });
-
-
     /* END TABLE ACTIONS */
 
     /* DATATABLE LISTENERS */
@@ -104,14 +82,33 @@ jQuery(function () {
 
     $.fn.dataTable.ext.search.push(
         function (settings, data, dataIndex) {
-            if(table.getShowFiles()) {
-                return table.getShowDotFiles() || !data[1].startsWith('.');
+            let total = table.getShowDotFiles() + table.getShowFiles();
+            let isDirectory = (data[0].trim() == "dir");
+            let isFile = ! isDirectory;
+            let isHidden = data[1].startsWith('.');
+
+            if( total == 0 ) {
+                // show only non-hidden directories
+                return isDirectory && ! isHidden;
+            
+            } else if(total == 1 ) {
+                // show everything but files, even hidden
+                return ! isFile;
+            
+            } else if(total == 2 ) {
+                // show everything except hidden
+                return ! isHidden;
+            
+            } else if(total == 3 ) {
+                // show everything
+                return true;
+            
             } else {
-                if(data[0].trim() == "dir") {
-                    return table.getShowDotFiles() || !data[1].startsWith('.');
-                    return data[1];
-                }
+                return false;
             }
+            
+            // shouldn't get here, but just in case.
+            return false;
 
         }
     );    
@@ -122,6 +119,7 @@ class DataTable {
     _table = null;
     _url = null;
     _currentWorkingDirectory = null;
+    _options = [];
 
     constructor(url) {
         this.loadDataTable();
@@ -133,6 +131,7 @@ class DataTable {
     }
 
     loadDataTable() {
+    
         this._table = $(CONTENTID).on('xhr.dt', function (e, settings, json, xhr) {
             // new ajax request for new data so update date/time
             // if(json && json.time){
@@ -205,19 +204,6 @@ class DataTable {
             ]
         });
         
-        /*
-            These 2 checkboxes will go away once the ability to pass in options from the form is written.
-            They are here now to show functionality of hiding/show files/directories
-        */
-        $('#directory-contents_filter').prepend(
-            `<label for="show-dotfiles">
-                <input type="checkbox" id="show-dotfiles" ${this.getShowDotFiles() ? 'checked' : ''}> Show Dotfiles</label>`);
-
-        $('#directory-contents_filter').prepend(
-            `<label style="margin-right: 20px" for="show-files">
-                <input type="checkbox" id="show-files" ${this.getShowFiles() ? 'checked' : ''}> Show Files</label>`);
-        
-
     }
 
     async reloadTable(url) {
@@ -282,25 +268,35 @@ class DataTable {
     }
 
 
-    setShowDotFiles(visible) {
-        localStorage.setItem('show-dotfiles', new Boolean(visible));
+    setShowDotFiles(weight) {
+        localStorage.setItem('show-dotfiles', weight);
     }
 
     getShowDotFiles() {
-        return localStorage.getItem('show-dotfiles') == 'true'
+        return parseInt(localStorage.getItem('show-dotfiles'));
     }
 
-    setShowFiles(visible) {
-        localStorage.setItem('show-files', new Boolean(visible));
+    setShowFiles(weight) {
+        localStorage.setItem('show-files', weight);
     }
 
     getShowFiles() {
-        return localStorage.getItem('show-files') == 'true'
+        return parseInt(localStorage.getItem('show-files'));
     }
 
-
-    updateDotFileVisibility() {
-        this.reloadTable();
+    setVisibility() {
+        if( this._options.includes('hidden')) {
+            this.setShowDotFiles(1);
+        } else {
+            this.setShowDotFiles(0);
+        };
+    
+    
+        if( this._options.includes('files')) {
+            this.setShowFiles(2);
+        } else {
+            this.setShowFiles(0);
+        }
+    
     }
-
 }

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -84,7 +84,7 @@ jQuery(function () {
         function (settings, data, dataIndex) {
             let total = table.getShowDotFiles() + table.getShowFiles();
             let isDirectory = (data[0].trim() == "dir");
-            let isFile = ! isDirectory;
+            let isFile = !isDirectory;
             let isHidden = data[1].startsWith('.');
 
             if( total == 0 ) {

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -1,5 +1,3 @@
-import isDOMElement from '@uppy/utils/lib/isDOMElement';
-import Handlebars from 'handlebars';
 import {EVENTNAME as SWAL_EVENTNAME} from './sweet_alert.js';
 
 export { CONTENTID, EVENTNAME };

--- a/apps/dashboard/app/javascript/packs/path_selector/data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/data_table.js
@@ -89,15 +89,15 @@ jQuery(function () {
 
             if( total == 0 ) {
                 // show only non-hidden directories
-                return isDirectory && ! isHidden;
+                return isDirectory && !isHidden;
             
             } else if(total == 1 ) {
                 // show everything but files, even hidden
-                return ! isFile;
+                return !isFile;
             
             } else if(total == 2 ) {
                 // show everything except hidden
-                return ! isHidden;
+                return !isHidden;
             
             } else if(total == 3 ) {
                 // show everything
@@ -106,10 +106,6 @@ jQuery(function () {
             } else {
                 return false;
             }
-            
-            // shouldn't get here, but just in case.
-            return false;
-
         }
     );    
 

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -11,7 +11,7 @@ end
 </button>
 <span id='path_selector_home_dir' class="d-none"><%= Dir.home %></span>
 <span id='path_selector_url' class="d-none"><%= files_path %></span>
-<span id='path_selector_options' class="d-none"><%= attrib.opts[:options].join(",") %></span>
+<span id='path_selector_options' class="d-none"><%= attrib.opts[:options].is_a?(Array) ? attrib.opts[:options].join(",") : '' %></span>
 
 <!-- Modal -->
 <div class="modal fade h-75" id="modal-path-selector" tabindex="-1" role="dialog" aria-labelledby="modal-path-selector" aria-hidden="true">

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -6,23 +6,25 @@ end
 
 <%= label attrib.id, "#{field_options[:label]}" %>
 <%= text_field :batch_connect_session_context, attrib.id, class: 'form-control' %>
-<button type="button" class="btn btn-primary mt-2" data-toggle="modal" data-target="#modalPathSelector" id='select-nav-path'>
+<button type="button" class="btn btn-primary mt-2" data-toggle="modal" data-target="#modal-path-selector" id='select-nav-path'>
   Select Path
 </button>
 <span id='path_selector_home_dir' class="d-none"><%= Dir.home %></span>
 <span id='path_selector_url' class="d-none"><%= files_path %></span>
+<span id='path_selector_options' class="d-none"><%= attrib.opts[:options].join(",") %></span>
 
 <!-- Modal -->
-<div class="modal fade h-75" id="modalPathSelector" tabindex="-1" role="dialog" aria-labelledby="modalPathSelector" aria-hidden="true">
+<div class="modal fade h-75" id="modal-path-selector" tabindex="-1" role="dialog" aria-labelledby="modal-path-selector" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="modalPathSelectorTitle">Select Your Working Directory</h5>
+        <h5 class="modal-title" id="modal-path-selector-title">Select Your Working Directory</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body">        <div id="container-directory-contents">
+      <div class="modal-body">        
+        <div id="container-directory-contents">
             <ol id="path-breadcrumbs" class="breadcrumb breadcrumb-no-delimiter">
             </ol>
             <table class="table table-striped table-condensed w-100" id="directory-contents">

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -9,12 +9,20 @@ end
 <button type="button" class="btn btn-primary mt-2" data-toggle="modal" data-target="#modal-path-selector" id='select-nav-path'>
   Select Path
 </button>
+<%
+  show_hidden = false
+  show_files = false
+  if attrib.opts[:options].is_a?(Array)
+    show_hidden = attrib.opts[:options].include? 'hidden'
+    show_files = attrib.opts[:options].include? 'files'
+  end
+%>
+
 <span id='path_selector_home_dir' class="d-none"><%= Dir.home %></span>
 <span id='path_selector_url' class="d-none"><%= files_path %></span>
-<span id='path_selector_options' class="d-none"><%= attrib.opts[:options].is_a?(Array) ? attrib.opts[:options].join(",") : '' %></span>
 
 <!-- Modal -->
-<div class="modal fade h-75" id="modal-path-selector" tabindex="-1" role="dialog" aria-labelledby="modal-path-selector" aria-hidden="true">
+<div class="modal fade h-75" id="modal-path-selector" tabindex="-1" role="dialog" aria-labelledby="modal-path-selector" aria-hidden="true" data-path-selector-show-files="<%= show_files %>" data-path-selector-show-hidden="<%= show_hidden %>">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
To test this.  It is best to use Code Server, but technically it will work with any form, i suppose.

Add the following to your App's form.

If you remove all of the "options", you will get the default of showing directories only.

```
  working_dir:
    widget: "path_selector"
    label: "Working Directory"
    help: "Select your project directory; defaults to $HOME"
    options:
      - files
      - hidden

```
┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204254857145488) by [Unito](https://www.unito.io)
