### PR TITLE
Initialize tracking jobs

### DIFF
--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -155,13 +155,13 @@ class Script
   def most_recent_job
     job_data.sort_by do |data|
       data['submit_time']
-    end.reverse.first
+    end.reverse.first.to_h
   end
 
   def update_job_log(job_id)
     new_job_data = job_data + [{
       'id'          => job_id,
-      'submit_time' => Time.now.utc.to_i
+      'submit_time' => Time.now.to_i
     }]
 
     File.write(job_log_file.to_s, new_job_data.to_yaml)

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -1,7 +1,5 @@
-<%= bootstrap_form_tag  do |form| %>
-
 <div class='page-header text-center'>
-  <h1>Project Space</h1>
+  <h1><%= @project.title %></h1>
 </div> 
 <br>
 <div class='row row-cols-1 row-cols-md-2'>
@@ -13,17 +11,19 @@
 <div class='card'>
   <h3 class='card-header'>Scripts</h3>
   <div class='card-body'>
-    <table class='table table-borderless'>
+    <table class='table table-bordered table-hover'>
       <thead>
         <tr>
-          <th>Script Name</th>
-          <th>Actions</th>
-        <tr>
+          <th scope='col' class='text-center'>Job Info</th>
+          <th scope='col' class='text-center'>Script Name</th>
+          <th scope='col' class='text-center'>Actions</th>
+        </tr>
       </thead>
       <tbody>
       <% @scripts.each do |script| %>
         <tr>
-          <td><%= script.title %></td>
+          <td class='text-center'><%= script.most_recent_job_id %></td>
+          <td class='text-center'><%= script.title %></td>
           <td>
             <%= link_to(
                   'Show',
@@ -31,7 +31,7 @@
                   class: 'btn btn-success'
                 )
             %>
-          <td>
+          </td>
         <tr>
       <% end %>
       </tbody>
@@ -44,5 +44,3 @@
     %>
   </div>
 </div>
-
-<% end %>

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -78,7 +78,7 @@ class ProjectsTest < ApplicationSystemTestCase
       setup_project(dir)
 
       find('[href="/projects/1"]').click
-      assert_selector 'h1', text: 'Project Space'
+      assert_selector 'h1', text: 'Test Project'
       assert_selector '.btn.btn-default', text: 'Back'
     end
   end
@@ -208,6 +208,7 @@ class ProjectsTest < ApplicationSystemTestCase
       assert_equal 'oakley', find('#script_cluster').value
       assert_equal 'pzs0715', find('#script_auto_accounts').value
       assert_equal "#{dir}/my_cool_script.sh", find('#script_auto_scripts').value
+      assert_nil YAML.safe_load(File.read("#{script_dir}/1_job_log"))
 
       select('owens', from: 'script_cluster')
       select('pas2051', from: 'script_auto_accounts')
@@ -219,8 +220,14 @@ class ProjectsTest < ApplicationSystemTestCase
               { stdin_data: "hostname\n" })
         .returns(['job-id-123', '', exit_success])
 
+      Time
+        .stubs(:now)
+        .returns(Time.at(1_679_943_564))
+
       click_on 'Launch'
       assert_selector('.alert-success', text: 'job-id-123')
+      assert_equal [{ 'id' => 'job-id-123', 'submit_time' => 1_679_943_564 }],
+                   YAML.safe_load(File.read("#{script_dir}/1_job_log"))
     end
   end
 
@@ -245,6 +252,7 @@ class ProjectsTest < ApplicationSystemTestCase
       assert_equal 'oakley', find('#script_cluster').value
       assert_equal 'pzs0715', find('#script_auto_accounts').value
       assert_equal "#{dir}/my_cool_script.sh", find('#script_auto_scripts').value
+      assert_nil YAML.safe_load(File.read("#{script_dir}/1_job_log"))
 
       select('owens', from: 'script_cluster')
       select('pas2051', from: 'script_auto_accounts')
@@ -258,6 +266,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
       click_on 'Launch'
       assert_selector('.alert-danger', text: "×\nClose\nsome error message")
+      assert_nil YAML.safe_load(File.read("#{script_dir}/1_job_log"))
     end
   end
 end


### PR DESCRIPTION
This starts work on #2653 by keeping a log file of all the jobs that a script has submitted.

It added a column to `projects#show` so there's a little updates to that page as well.

To test simply submit a job with a given script and see the job id listed in the new column.  Submitting another job updates the column so that the most recent job id is there.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204276144165791) by [Unito](https://www.unito.io)
