### PR TITLE
Removed redundant method=get for pinned apps

### DIFF
--- a/apps/dashboard/app/views/widgets/pinned_apps/_app.html.erb
+++ b/apps/dashboard/app/views/widgets/pinned_apps/_app.html.erb
@@ -1,5 +1,4 @@
 <%- link = app.links.first -%>
-<%- link_data = {:method => "get"}.merge link.data -%>
 <%- tile_data = link.tile -%>
 
 <div class="col-sm-3 col-md-3 app-launcher-container">
@@ -9,7 +8,7 @@
       link.url.to_s,
       class: ['launcher-click', tile_data[:border_color]],
       target: link.new_tab? ? "_blank" : nil,
-      data: link_data
+      data: link.data
     ) do
   %>
       <%= render partial: "/widgets/pinned_apps/app_content", locals: { link: link } %>


### PR DESCRIPTION
Removed `method=get` on pinned apps links that are not preset. This is to avoid Rails JS creating and submitting a form.
This will remove the browser message to re-submit the form when refreshing the page after selecting a pinned app.

Fixes #2705

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204293578283656) by [Unito](https://www.unito.io)
