### PR TITLE
Add the ability to track job state in projects

### DIFF
--- a/apps/dashboard/app/controllers/jobs_controller.rb
+++ b/apps/dashboard/app/controllers/jobs_controller.rb
@@ -1,0 +1,25 @@
+# The controller for activejobs pages /dashboard/activejobs
+class JobsController < ApplicationController
+  def info
+    respond_to do |format|
+      format.json do
+        cluster = OodAppkit.clusters[info_params[:cluster].to_sym]
+        render_404 if cluster.nil?
+
+        job_info = cluster.job_adapter.info(info_params[:id].to_s)
+        info = {
+          state: job_info.status.state
+        }
+        render :json => info
+      end
+    end
+  end
+
+  def render_404
+    render :json => {}, :status => 404
+  end
+
+  def info_params
+    params.permit(:cluster, :id)
+  end
+end

--- a/apps/dashboard/app/javascript/packs/config.js
+++ b/apps/dashboard/app/javascript/packs/config.js
@@ -27,6 +27,11 @@ function transfersPath() {
   return transfersPath;
 }
 
+function jobsInfoPath(){
+  const cfgData = configData();
+  return cfgData['jobsInfoPath'];
+}
+
 function csrfToken() {
   const csrf_token = document.querySelector('meta[name="csrf-token"]').content;
 
@@ -34,7 +39,8 @@ function csrfToken() {
 }
 
 export {
-  maxFileSize, 
-  transfersPath, 
+  maxFileSize,
+  transfersPath,
+  jobsInfoPath,
   csrfToken 
 };

--- a/apps/dashboard/app/javascript/packs/projects.js
+++ b/apps/dashboard/app/javascript/packs/projects.js
@@ -1,0 +1,50 @@
+import { jobsInfoPath } from './config.js';
+import { cssBadgeForState } from './utils.js';
+
+
+jQuery(function() {
+  $('[data-job-poller="true"]').each((_index, ele) => {
+    pollForJobInfo(ele);
+  });
+});
+
+function pollForJobInfo(element) {
+
+  const jobId = element.dataset['jobId'];
+  const jobCluster = element.dataset['jobCluster'];
+  const url = `${jobsInfoPath()}/${jobCluster}/${jobId}`;
+
+  if(jobId === "" || jobCluster === "") {
+    element.innerHTML = "";
+    return;
+  }
+
+  fetch(url, { headers: { 'Accept': 'application/json' }, cache: 'no-store' })
+    .then((response) => { 
+      if (!response.ok) {
+        if(response.status === 404) {
+          // TODO
+        } else{
+          throw new Error('Not 2xx response while looking for job', { cause: response });
+        }
+      } else {
+        return response.json();
+      }
+    })
+    .then((data) => {
+      const state = data['state'];
+      element.innerHTML = jobInfoDiv(jobId, state);
+      if(state !== 'completed') {
+        // keep going
+        setTimeout(pollForJobInfo, 10000, element);
+      }
+    })
+    .catch((error) => { console.log(error) });
+}
+
+function jobInfoDiv(jobId, state) {
+  return `<div>
+            <span class="mr-2">${jobId}</span>
+            <span class="badge ${cssBadgeForState(state)}">${state.toUpperCase()}</span>
+          </div>`;
+}

--- a/apps/dashboard/app/javascript/packs/utils.js
+++ b/apps/dashboard/app/javascript/packs/utils.js
@@ -1,0 +1,20 @@
+
+
+export function cssBadgeForState(state){
+  switch (state) {
+    case 'completed':
+      return 'badge-success';
+    case 'running':
+      return 'badge-primary'
+    case 'queued':
+      return 'badge-info';
+    case 'queued_held':
+      return 'badge-warning';
+    case 'suspended':
+      return 'badge-warning';
+    default:
+      return 'badge-warning';
+  }
+}
+
+

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -137,7 +137,7 @@ class Script
     job_id = Dir.chdir(project_dir) do
       adapter.submit(job_script)
     end
-    update_job_log(job_id)
+    update_job_log(job_id, options[:cluster].to_s)
 
     job_id
   rescue StandardError => e
@@ -150,6 +150,10 @@ class Script
     most_recent_job['id']
   end
 
+  def most_recent_job_cluster
+    most_recent_job['cluster']
+  end
+
   private
 
   def most_recent_job
@@ -158,10 +162,11 @@ class Script
     end.reverse.first.to_h
   end
 
-  def update_job_log(job_id)
+  def update_job_log(job_id, cluster)
     new_job_data = job_data + [{
       'id'          => job_id,
-      'submit_time' => Time.now.to_i
+      'submit_time' => Time.now.to_i,
+      'cluster'     => cluster.to_s
     }]
 
     File.write(job_log_file.to_s, new_job_data.to_yaml)

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
     data-link-bg-color="<%= @user_configuration.brand_link_active_bg_color %>"
     data-max-file-size="<%= Configuration.file_upload_max %>"
     data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
+    data-jobs-info-path="<%= jobs_info_path('delme', 'delme').gsub(/[\/]*delme[\/]*/,'') %>"
   />
 </head>
 <body>

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag 'projects', nonce: true %>
+
 <div class='page-header text-center'>
   <h1><%= @project.title %></h1>
 </div> 
@@ -22,9 +24,16 @@
       <tbody>
       <% @scripts.each do |script| %>
         <tr>
-          <td class='text-center'><%= script.most_recent_job_id %></td>
-          <td class='text-center'><%= script.title %></td>
-          <td>
+          <td
+            class='text-center col-md-4'
+            data-job-id="<%= script.most_recent_job_id %>"
+            data-job-cluster="<%= script.most_recent_job_cluster %>"
+            data-job-poller='true'
+          >
+            <div class="spinner-border"></div>
+          </td>
+          <td class='text-center col-md-4'><%= script.title %></td>
+          <td class='col-md-4'>
             <%= link_to(
                   'Show',
                   project_script_path(@project.id, script.id),

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -91,6 +91,8 @@ Rails.application.routes.draw do
     delete "/activejobs" => "active_jobs#delete_job",  as: 'delete_job'
   end
 
+  get '/jobs/info/:cluster/:id' => 'jobs#info', :defaults => { :format => 'json' }, :as => 'jobs_info'
+
   post "settings", :to => "settings#update"
 
   # Support ticket routes


### PR DESCRIPTION
This adds the ability to track job state in projects. It includes a new controller and routes for getting the job information. It also includes a little javascript to update the projects#show page with the information that it's queried from the jobs controller.