### PR TITLE
add the ability search icons

### DIFF
--- a/apps/dashboard/app/javascript/packs/icon_picker.js
+++ b/apps/dashboard/app/javascript/packs/icon_picker.js
@@ -26,7 +26,8 @@ function iconFromId(id) {
 function picked(event) {
   const icon = iconFromId(event.currentTarget.id);
   $(`#${ICON_SHOW_ID}`).attr("class", `fas fa-${icon} fa-fw app-icon`);
-  $(`#${ICON_SELECT_ID}`).val(`fas://${icon}`)
+  $(`#${ICON_SELECT_ID}`).val(`fas://${icon}`);
+  showAllIcons();
 }
 
 function populateList() {
@@ -43,6 +44,44 @@ function populateList() {
   });
 };
 
+function addSearch(){
+  $(`#${ICON_SELECT_ID}`).on('input', (event) => {
+    searchIcons(event);
+  });
+}
+
+function searchIcons(event){
+  const searchString = event.target.value;
+  const rex = new RegExp(searchString, "g");
+
+  ALL_ICONS.forEach(name => {
+    const ele = $(`#${iconId(name)}`)[0];
+    if(ele === undefined) {
+      return;
+    }
+
+    const show = rex.test(name);
+
+    if(show) {
+      ele.classList.remove('d-none');
+    } else {
+      ele.classList.add('d-none');
+    }
+  });
+}
+
+function showAllIcons(){
+  ALL_ICONS.forEach(name => {
+    const ele = $(`#${iconId(name)}`)[0];
+    if(ele === undefined) {
+      return;
+    }
+
+    ele.classList.remove('d-none');
+  });
+}
+
 jQuery(() => {
   populateList();
+  addSearch();
 })

--- a/apps/dashboard/app/javascript/stylesheets/icon_picker.scss
+++ b/apps/dashboard/app/javascript/stylesheets/icon_picker.scss
@@ -9,7 +9,7 @@
   list-style-type: none;
   padding: 0;
   max-height: 18em;
-  overflow: scroll;
+  overflow-y: scroll;
 
   // this is the main styling
   li {


### PR DESCRIPTION
Add the ability search icons in `projects#edit`

Now when you type in the input field it'll hide what isn't found. Then when you choose something, it'll show all the icons once again.

Here's an example of searching `arr` and you get all the arrow type icons.

![image](https://user-images.githubusercontent.com/4874123/228929321-62132fff-7524-400b-8273-5700702ca789.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204303342536010) by [Unito](https://www.unito.io)
