### PR TITLE
dont log error, instead defer and html update

### DIFF
--- a/apps/dashboard/app/javascript/packs/projects.js
+++ b/apps/dashboard/app/javascript/packs/projects.js
@@ -39,7 +39,9 @@ function pollForJobInfo(element) {
         setTimeout(pollForJobInfo, 10000, element);
       }
     })
-    .catch((error) => { console.log(error) });
+    .catch((error) => { 
+      // TODO, show an error in the HTML
+     });
 }
 
 function jobInfoDiv(jobId, state) {


### PR DESCRIPTION
Don't log error, instead defer and html update.

This is making tests a bit flaky, which test for console messages. So let's just catch it and defer the HTML update.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204309217669179) by [Unito](https://www.unito.io)
