### PR TITLE
start support for project templates

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -19,10 +19,12 @@ class ProjectsController < ApplicationController
 
   # GET /projects/new
   def new
+    @templates = templates
+
     if name_or_icon_nil?
       @project = Project.new
     else
-      returned_params = { name: params[:name], icon: params[:icon] }
+      returned_params = { name: new_project_params[:name], icon: new_project_params[:icon] }
       @project = Project.new(returned_params)
     end
   end
@@ -75,8 +77,12 @@ class ProjectsController < ApplicationController
 
   private
 
+  def templates
+    return [] if new_project_params[:template] == 'true'
+  end
+
   def name_or_icon_nil?
-    params[:name].nil? || params[:icon].nil?
+    new_project_params[:name].nil? || new_project_params[:icon].nil?
   end
 
   def project_params
@@ -87,5 +93,9 @@ class ProjectsController < ApplicationController
 
   def show_project_params
     params.permit(:id)
+  end
+
+  def new_project_params
+    params.permit(:template, :icon, :name)
   end
 end

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -57,6 +57,9 @@ class Project
 
   delegate :icon, :name, :description, to: :manifest
 
+  # the template you created this project from
+  attr_accessor :template
+
   def initialize(attributes = {})
     if attributes.empty?
       @manifest = Manifest.new({})

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -5,7 +5,7 @@
   <div class='card-group'>
       <div class='card'>
       <div class='card-body'>
-        <div class="col-md-9">
+        <div class="col">
           <div class="field">
             <%= form.text_field :name, placeholder: "Project name", 
                     help: I18n.t('dashboard.jobs_project_name_validation') %>
@@ -13,6 +13,12 @@
           <div class="field">
             <%= form.text_area :description, placeholder: "Project description" %>
           </div>
+
+          <%- unless @templates.nil? -%>
+          <div class="field">
+            <%= form.select(:template, @templates) %>
+          </div>
+          <%- end -%>
         </div>
       </div>
       </div>

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -26,16 +26,29 @@
       <% end %>
     </div>
   </div>
-  <div class="col-md-3 mt-3 d-flex align-items-center">
-    <div class="col d-flex justify-content-center text-center project-icon">
-      <%= button_to(new_project_path,
-                    title: I18n.t('dashboard.jobs_project_create_new_project_directory'),
-                    class: 'text-dark btn btn-link',
-                    method: 'get') do
-      %>
-        <%= icon_tag(URI.parse("fas://plus")) %><br>
-        <%= I18n.t('dashboard.jobs_project_create_new_project_directory') %>
-      <% end %>
-    </div>
+  <div class="col-md-3">
+
+      <div class="mt-5 justify-content-center text-center project-icon">
+        <%= link_to(new_project_path,
+                      title: I18n.t('dashboard.jobs_create_blank_project'),
+                      class: 'text-dark btn btn-link',
+                      method: 'get') do
+        %>
+          <%= icon_tag(URI.parse("fas://plus")) %><br>
+          <%= I18n.t('dashboard.jobs_create_blank_project') %>
+        <% end %>
+      </div>
+
+      <div class="mt-5 justify-content-center text-center project-icon">
+        <%= link_to(new_project_path({template: true}),
+                      title: I18n.t('dashboard.jobs_create_template_project'),
+                      class: 'text-dark btn btn-link',
+                      method: 'get') do
+        %>
+          <%= icon_tag(URI.parse("fas://plus")) %><br>
+          <%= I18n.t('dashboard.jobs_create_template_project') %>
+        <% end %>
+      </div>
+
   </div>
 </div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -212,7 +212,8 @@ en:
     jobs_project_delete_project_confirmation: "Delete all contents of project directory?"
     jobs_project_manifest_updated: "Project manifest updated!"
     jobs_project_name_validation: "Project name may only contain letters, digits, dashes, underscores, and spaces"
-    jobs_project_create_new_project_directory: "Create a new project directory"
+    jobs_create_blank_project: "Create a new project"
+    jobs_create_template_project: "Create a new project from a template"
 
     settings_updated: "Settings updated"
 

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -20,7 +20,7 @@ class ProjectsTest < ApplicationSystemTestCase
     proj = 'test-project'
     icon = 'fas://arrow-right'
     visit projects_path
-    click_on I18n.t('dashboard.jobs_project_create_new_project_directory')
+    click_on I18n.t('dashboard.jobs_create_blank_project')
     find('#project_name').set(proj)
     find('#product_icon_select').set(icon)
     click_on 'Save'
@@ -103,7 +103,7 @@ class ProjectsTest < ApplicationSystemTestCase
       proj = 'test-project'
       icon = ''
       visit projects_path
-      click_on I18n.t('dashboard.jobs_project_create_new_project_directory')
+      click_on I18n.t('dashboard.jobs_create_blank_project')
       find('#project_name').set(proj)
       find('#product_icon_select').set(icon)
       click_on 'Save'
@@ -118,7 +118,7 @@ class ProjectsTest < ApplicationSystemTestCase
       proj = 'test-project'
       icon = 'fas://bad&icon8'
       visit projects_path
-      click_on I18n.t('dashboard.jobs_project_create_new_project_directory')
+      click_on I18n.t('dashboard.jobs_create_blank_project')
       find('#project_name').set(proj)
       find('#product_icon_select').set(icon)
       click_on 'Save'


### PR DESCRIPTION
This starts the work for project templates in #2720.It doesn't do anything now, it just lays the foundation for template support.There's an extra button on `projects#index` and if you choose to create a project from a template, you'll see an additional dropdown select for the template to create the project from. Only this select field is empty right now.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204311629738788) by [Unito](https://www.unito.io)
