### PR TITLE
Removed duplicated applications from interactive apps menu

### DIFF
--- a/apps/dashboard/app/controllers/concerns/batch_connect_concern.rb
+++ b/apps/dashboard/app/controllers/concerns/batch_connect_concern.rb
@@ -29,7 +29,7 @@ module BatchConnectConcern
       NavBar.menu_items(@user_configuration.interactive_apps_menu)
     elsif !@nav_bar.empty?
       # Create a custom list of batch connect applications based on the custom navigation defined
-      links = @nav_bar.map(&:links).flatten.select(&:show_in_menu?)
+      links = @nav_bar.map(&:links).flatten.select(&:show_in_menu?).uniq(&:url)
       OodAppGroup.new(apps: links, title: t('dashboard.batch_connect_apps_menu_title'), sort: true)
     end
     # Return nil otherwise


### PR DESCRIPTION
Added code to remove duplicated applications from the `interactive apps` and `my interactive sessions ` left hand navigation.

Fixes #2728

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204343462275185) by [Unito](https://www.unito.io)
