### PR TITLE
catch errors from account queries

### DIFF
--- a/apps/dashboard/app/lib/account_cache.rb
+++ b/apps/dashboard/app/lib/account_cache.rb
@@ -13,6 +13,10 @@ module AccountCache
       # only Slurm support in ood_core
       cluster = Configuration.job_clusters.select(&:slurm?).first
       cluster.nil? ? [] : cluster.job_adapter.accounts
+    rescue StandardError => e
+      Rails.logger.warn("Did not get accounts from system with error #{e}")
+      Rails.logger.warn(e.backtrace.join("\n"))
+      []
     end
   end
 
@@ -69,6 +73,10 @@ module AccountCache
 
         [queue_name, queue_name, data]
       end
+    rescue StandardError => e
+      Rails.logger.warn("Did not get queues from system with error #{e}")
+      Rails.logger.warn(e.backtrace.join("\n"))
+      []
     end
   end
 


### PR DESCRIPTION
This will catch errors bubbling up from `ood_core` like this one that can happen because of an `ood_core` bug.

https://github.com/OSC/ood_core/issues/806

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204364892830709) by [Unito](https://www.unito.io)
