### PR TITLE
Add localization for Uppy

### DIFF
--- a/apps/dashboard/app/javascript/packs/config.js
+++ b/apps/dashboard/app/javascript/packs/config.js
@@ -38,9 +38,15 @@ function csrfToken() {
   return csrf_token;
 }
 
+function uppyLocale() {
+  const cfgData = configData();
+  return JSON.parse(cfgData['uppyLocale']);
+}
+
 export {
   maxFileSize,
   transfersPath,
   jobsInfoPath,
-  csrfToken 
+  csrfToken,
+  uppyLocale
 };

--- a/apps/dashboard/app/javascript/packs/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/packs/files/uppy_ops.js
@@ -3,7 +3,7 @@ import Dashboard from '@uppy/dashboard'
 import XHRUpload from '@uppy/xhr-upload'
 import _ from 'lodash';
 import {CONTENTID, EVENTNAME as DATATABLE_EVENTNAME} from './data_table.js';
-import { maxFileSize, csrfToken } from '../config.js';
+import { maxFileSize, csrfToken, uppyLocale } from '../config.js';
 
 let uppy = null;
 
@@ -70,6 +70,7 @@ jQuery(function() {
       maxFileSize: maxFileSize(),
     },
     onBeforeUpload: updateEndpoint,
+    locale: uppyLocale(),
   });
   
   uppy.use(EmptyDirCreator);

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
     data-max-file-size="<%= Configuration.file_upload_max %>"
     data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
     data-jobs-info-path="<%= jobs_info_path('delme', 'delme').gsub(/[\/]*delme[\/]*/,'') %>"
+    data-uppy-locale="<%= I18n.t('dashboard.uppy', :default => {}).to_json %>"
   />
 </head>
 <body>


### PR DESCRIPTION
Fixes #2764.

Adds possibility to add localization to Uppy through the locale files. Full list of possible options [here](https://github.com/transloadit/uppy/blob/96ae2bf04981f73b63ebc034156bcf418ded11a5/packages/@uppy/locales/src/en_US.js).

Example locale file:
```
# config/locales/en.yml
en:
  dashboard:
    uppy:
      strings:
        exceedsSize: '%{file} exceeds...'
```
![image](https://user-images.githubusercontent.com/61623634/233079086-d65e9536-e51d-40eb-bf42-2fc41bc8a3e1.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204432436718528) by [Unito](https://www.unito.io)
