### PR TITLE
fix node proxy location match pattern

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -135,7 +135,7 @@ Listen 8080
   #     https://test.server.name:8080/configured-node/HOST/PORT/index.html
   #     #=> http://HOST:PORT/configured-node/HOST/PORT/index.html
   #
-  <LocationMatch "^/configured-node/(?<host>[\w.-]+\.site\.edu)/(?<port>\d+)(/|$)">
+  <LocationMatch "^/configured-node/(?<host>[\w.-]+\.site\.edu)/(?<port>\d+)(/|\?|$)">
     AuthType openid-connect
     Require valid-user
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -135,7 +135,7 @@ Listen 8080
   #     https://test.server.name:8080/configured-node/HOST/PORT/index.html
   #     #=> http://HOST:PORT/configured-node/HOST/PORT/index.html
   #
-  <LocationMatch "^/configured-node/(?<host>[\w.-]+\.site\.edu)/(?<port>\d+)">
+  <LocationMatch "^/configured-node/(?<host>[\w.-]+\.site\.edu)/(?<port>\d+)(/|$)">
     AuthType openid-connect
     Require valid-user
 

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -214,7 +214,7 @@ Listen <%= addr_port %>
   #     <%= @ssl ? "https" : "http" %>://<%= @servername || "localhost" %>:<%= @port %><%= @node_uri %>/HOST/PORT/index.html
   #     #=> http://HOST:PORT<%= @node_uri %>/HOST/PORT/index.html
   #
-  <LocationMatch "^<%= @node_uri %>/(?<host><%= @host_regex %>)/(?<port>\d+)(/|$)">
+  <LocationMatch "^<%= @node_uri %>/(?<host><%= @host_regex %>)/(?<port>\d+)(/|\?|$)">
     <%- @auth.each do |line| -%>
     <%= line %>
     <%- end -%>

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -214,7 +214,7 @@ Listen <%= addr_port %>
   #     <%= @ssl ? "https" : "http" %>://<%= @servername || "localhost" %>:<%= @port %><%= @node_uri %>/HOST/PORT/index.html
   #     #=> http://HOST:PORT<%= @node_uri %>/HOST/PORT/index.html
   #
-  <LocationMatch "^<%= @node_uri %>/(?<host><%= @host_regex %>)/(?<port>\d+)">
+  <LocationMatch "^<%= @node_uri %>/(?<host><%= @host_regex %>)/(?<port>\d+)(/|$)">
     <%- @auth.each do |line| -%>
     <%= line %>
     <%- end -%>


### PR DESCRIPTION
This PR fix a problem that when there is path token that start with number in the node proxy URI, for example `/node/c01-s100/1234/myapp/123-abc`,  will leads to issue describe in https://discourse.openondemand.org/t/502-proxy-error-when-opening-file-in-jupyter-notebook/2662/9  if `host_regex` contain greedy match pattern, for example `c.*`.

Though this problem can be avoided by carefully setting the `host_regex`  by using non-greedy match `c.*?`,  but I think it would be better to avoid such error from OOD's side as it can be difficult for the user to realize that it was caused by an incorrect `host_regex` configuration.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204489818194959) by [Unito](https://www.unito.io)
