### PR TITLE
Fix google analytics

### DIFF
--- a/mod_ood_proxy/lib/analytics.lua
+++ b/mod_ood_proxy/lib/analytics.lua
@@ -1,4 +1,28 @@
 --[[
+  table_to_json
+
+  A simple helper function to turn a lua table into a json object.
+--]]
+function table_to_json(lua_table)
+  local result = {}
+
+  for key, value in pairs(lua_table) do
+      table.insert(result, string.format("\"%s\": \"%s\"", key, value))
+  end
+
+  return "{" .. table.concat(result, ",") .. "}"
+end
+
+--[[
+  ga_body
+
+  Google Analytics body - a simple helper function to generate json data for the GA API.
+--]]
+function ga_body(client_id, event_data)
+  return string.format("{ \"client_id\": \"%s\", \"events\": [%s] }", client_id, event_data))
+end
+
+--[[
   analytics_handler
 
   Hooks into the final logging stage to parse the response headers before
@@ -6,79 +30,41 @@
 --]]
 function analytics_handler(r)
   -- read in OOD specific settings defined in the Apache config
-  local tracking_url = r.subprocess_env['OOD_ANALYTICS_TRACKING_URL']
-  local tracking_id  = r.subprocess_env['OOD_ANALYTICS_TRACKING_ID']
+  local url = 'www.google-analytics.com/mp/collect'
+  local tracking_id  = r.subprocess_env['OOD_GA_TRACKING_ID'] or r.subprocess_env['OOD_ANALYTICS_TRACKING_ID']
+  local api_key      = r.subprocess_env['OOD_GA_API_SECRET']
 
   -- read in variables set previously in the request by mod_ood_proxy
   local user              = r.subprocess_env['MAPPED_USER'] -- set by the user mapping code
-  local time_user_map     = r.subprocess_env['OOD_TIME_USER_MAP'] -- set by the user mapping code
-  local time_begin_proxy  = r.subprocess_env['OOD_TIME_BEGIN_PROXY'] -- set by the proxy code
 
   -- only track HTML pages and authenticated users
   if (r.headers_out['Content-Type'] or ''):match('text/html') and user then
-    local version = '1'
-    local hit_type = 'pageview'
+    local data = {}
+    data['name']        = 'pageview'
 
     -- user
-    local client_id = user .. '@' .. r.server_name
-    local user_id   = user .. '@' .. r.server_name
+    local client_id     = r:md5(user)
 
     -- session
-    local user_ip    = r.useragent_ip
-    local user_agent = r.headers_in['User-Agent'] or ''
+    data['ip']          = r.useragent_ip
+    data['user_agent']  = r.headers_in['User-Agent'] or ''
 
     -- traffic sources
-    local doc_referrer = (r.headers_in['Referer'] or ''):match('^([^?]*)')
+    data['referrer']    = (r.headers_in['Referer'] or ''):match('^([^?]*)')
 
     -- system info
-    local doc_encoding  = ((r.headers_out['Content-Type'] or ''):match('charset=([%w-]+)') or ''):lower()
-    local user_language = ((r.headers_in['Accept-Language'] or ''):match('^([%w-]+)') or ''):lower()
+    data['encoding']    = ((r.headers_out['Content-Type'] or ''):match('charset=([%w-]+)') or ''):lower()
+    data['language']    = ((r.headers_in['Accept-Language'] or ''):match('^([%w-]+)') or ''):lower()
 
     -- content information
-    local doc_host = r.server_name
-    local doc_path = r.uri
+    data['host']        = r.server_name
+    data['path']        = r.uri
+    data['method']      = r.method
 
-    -- extra computed properties
-    local unique_id  = r:sha1(user .. user_ip .. doc_host .. doc_path .. r:clock())
-    local time_proxy = time_begin_proxy and math.floor((r:clock() - time_begin_proxy)/1000.0) or 0
-    local time_user_map = time_user_map and math.floor(time_user_map) or 0
+    post_body = ga_body(client_id, data)
+    full_url = string.format("%s?measurement_id=%s&api_secret=%s", url, tracking_id, api_key)
 
-    -- custom dimensions / metrics
-    local cd1 = user                     -- Username          (User)
-    local cd2 = unique_id                -- Session ID        (Session)
-    local cd3 = os.date('!%Y-%m-%dT%TZ') -- Timestamp         (Hit)
-    local cd4 = r.user                   -- Remote Username   (Hit)
-    local cd5 = r.method                 -- Request Method    (Hit)
-    local cd6 = tostring(r.status)       -- Request Status    (Hit)
-    local cd7 = doc_referrer             -- Document Referrer (Hit)
-    local cm1 = tostring(time_proxy)     -- Proxy Time        (Hit/Integer)
-    local cm2 = tostring(time_user_map)  -- User Map Time     (Hit/Integer)
-
-    -- process analytics
-    -- NB: Do not use the measurement protocol's document referrer as it can
-    --     start a new session when it changes (so we use a custom dimension)
-    local now = r:clock()
-    local query = 'v=' .. r:escape(version) ..
-      '&t='   .. r:escape(hit_type) ..
-      '&tid=' .. r:escape(tracking_id) ..
-      '&cid=' .. r:escape(client_id) ..
-      '&uid=' .. r:escape(user_id) ..
-      '&uip=' .. r:escape(user_ip) ..
-      '&ua='  .. r:escape(user_agent) ..
-      '&de='  .. r:escape(doc_encoding) ..
-      '&ul='  .. r:escape(user_language) ..
-      '&dh='  .. r:escape(doc_host) ..
-      '&dp='  .. r:escape(doc_path) ..
-      '&cd1=' .. r:escape(cd1) ..
-      '&cd2=' .. r:escape(cd2) ..
-      '&cd3=' .. r:escape(cd3) ..
-      '&cd4=' .. r:escape(cd4) ..
-      '&cd5=' .. r:escape(cd5) ..
-      '&cd6=' .. r:escape(cd6) ..
-      '&cd7=' .. r:escape(cd7) ..
-      '&cm1=' .. r:escape(cm1) ..
-      '&cm2=' .. r:escape(cm2)
-    local handle = io.popen("wget --post-data='" .. query .. "' " .. tracking_url .. " -O /dev/null -T 5 -nv 2>&1")
+    local handle = io.popen("wget --post-data='" .. post_body .. "' " .. full_url .. " -O /dev/null -T 5 -nv 2>&1")
     output = handle:read('*all'):match('^%s*(.-)%s*$')
     handle:close()
     r:debug("Analytics input: '" .. query .. "'")

--- a/mod_ood_proxy/lib/ood/json.lua
+++ b/mod_ood_proxy/lib/ood/json.lua
@@ -1,0 +1,28 @@
+--[[
+  table_to_json
+
+  A simple helper function to turn a lua table into a json object.
+--]]
+function table_to_json(lua_table)
+  local result = {}
+
+  for key, value in pairs(lua_table) do
+      table.insert(result, string.format("\"%s\": \"%s\"", key, value))
+  end
+
+  return "{" .. table.concat(result, ",") .. "}"
+end
+
+--[[
+  ga_body
+
+  Google Analytics body - a simple helper function to generate json data for the GA API.
+--]]
+function ga_body(client_id, event_data)
+  return string.format("{ \"client_id\": \"%s\", \"events\": [%s] }", client_id, event_data)
+end
+
+return {
+  table_to_json = table_to_json,
+  ga_body       = ga_body
+}

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -167,7 +167,7 @@
 # information on how to setup the GA property)
 # Example:
 #     analytics:
-#       url: 'http://www.google-analytics.com/collect'
+#       secret: 'my-google-analytics-secret'
 #       id: 'UA-79331310-4'
 # Default: null (do not track)
 #analytics: null

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -198,8 +198,8 @@ Listen 8080
     SetEnv OOD_PUN_MAX_RETRIES "3000"
     LuaHookFixups pun_proxy.lua pun_proxy_handler
 
-    SetEnv OOD_ANALYTICS_TRACKING_URL "http://www.google-analytics.com/collect"
-    SetEnv OOD_ANALYTICS_TRACKING_ID  "analytics-id"
+    SetEnv OOD_GA_API_SECRET "analytics-api-secret"
+    SetEnv OOD_GA_TRACKING_ID  "analytics-id"
     LuaHookLog analytics.lua analytics_handler
   </Location>
 

--- a/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
+++ b/ood-portal-generator/spec/fixtures/ood_portal.yaml.all
@@ -162,11 +162,11 @@ root_uri: '/other/dashboard'
 # information on how to setup the GA property)
 # Example:
 #     analytics:
-#       url: 'http://www.google-analytics.com/collect'
+#       secret: 'analytics-api-secret'
 #       id: 'UA-79331310-4'
 # Default: null (do not track)
 analytics:
-  url: 'http://www.google-analytics.com/collect'
+  secret: 'analytics-api-secret'
   id: 'analytics-id'
 
 #

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -285,8 +285,8 @@ Listen <%= addr_port %>
     LuaHookFixups pun_proxy.lua pun_proxy_handler
 
     <%- if @analytics -%>
-    SetEnv OOD_ANALYTICS_TRACKING_URL "<%= @analytics['url'] %>"
-    SetEnv OOD_ANALYTICS_TRACKING_ID  "<%= @analytics['id']  %>"
+    SetEnv OOD_GA_API_SECRET "<%= @analytics['secret'] %>"
+    SetEnv OOD_GA_TRACKING_ID  "<%= @analytics['id']  %>"
     LuaHookLog analytics.lua analytics_handler
     <%- end -%>
   </Location>


### PR DESCRIPTION
Google analytics has updated from UA (universal analytics) to what they call GA4. 

This does a couple things
* updates analytics.lua to POST a json body instead of sending everything in query parameters as that's what's required for GA4.
* adds a config for api secret as that's now a required field from google
* removes the url configuration because I'm not sure anyone would use a different url than google
* updates the environment variables to be a bit more google analytics (GA) centric.

I'm going to keep this in draft for a second. I wonder if having GA on the client's browser is a better solution than having all this nonsense here where we have to update and keep track of it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204517531504609) by [Unito](https://www.unito.io)
