### PR TITLE
work on script initialization and serialization.

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -147,6 +147,19 @@ module SmartAttributes
       field_options(fmt: fmt).merge(html_options)
     end
 
+    # Hash of field options to serialize (to yaml). Similar to
+    # field_options, with the exception that it does not filter
+    # reserved_keys.
+    #
+    # It's basically calling opts with some keys updated for convenience.
+    def options_to_serialize(fmt: nil)
+      opts.merge({
+        label:    label(fmt: fmt),
+        help:     help_html(fmt: fmt),
+        required: required
+      }).compact
+    end
+
     # Array of choices for select fields used to build <option> tags
     # @return [Array] choices in form [name, value], [name, value]
     def select_choices

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_scripts.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_scripts.rb
@@ -46,6 +46,16 @@ module SmartAttributes
         content = File.read(value)
         { script: { content: content } }
       end
+
+      # Hash of both field options and html options
+      # @return [Hash] key value pairs are field and html options
+      def all_options(fmt: nil)
+        super(fmt: fmt).merge({ directory: directory })
+      end
+
+      def directory
+        opts[:directory]
+      end
     end
   end
 end


### PR DESCRIPTION
There's some wonkiness in Script initialization. namely in adding require fields like cluster and auto_scripts. This updates all that to force cluster and auto_scripts to be a part of the script and serialize correctly. I've added Attribute#options_to_serialize to help with writing these objects out to yaml as it was filtering critical options and not writing them to yaml.

In draft while I work on updating tests as well.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202821104799596/1204526234881462) by [Unito](https://www.unito.io)
