### PR TITLE
add auto clusters

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -6,7 +6,7 @@ class ScriptsController < ApplicationController
   before_action :find_script, only: [:show, :edit, :submit, :save]
 
   SAVE_SCRIPT_KEYS = [
-    :cluster, :auto_accounts, :auto_scripts, :auto_queues,
+    :cluster, :auto_accounts, :auto_scripts, :auto_queues, :auto_batch_clusters,
     :bc_num_slots, :bc_num_slots_min, :bc_num_slots_max,
     :bc_num_hours, :bc_num_hours_min, :bc_num_hours_max
   ].freeze

--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -4,6 +4,7 @@ require "smart_attributes/attribute_factory"
 # The main namespace for SmartAttributes
 module SmartAttributes
   require "smart_attributes/attributes/auto_accounts"
+  require "smart_attributes/attributes/auto_batch_clusters"
   require "smart_attributes/attributes/auto_groups"
   require "smart_attributes/attributes/auto_modules"
   require "smart_attributes/attributes/auto_primary_group"

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_batch_clusters.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_batch_clusters.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SmartAttributes
+  class AttributeFactory
+
+    # Build this attribute object. Must specify a valid directory in opts
+    #
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::AutoBatchClusters] the attribute object
+    def self.build_auto_batch_clusters(opts = {})
+      options = batch_clusters
+
+      static_opts = {
+        options: options
+      }.merge(opts.without(:options).to_h)
+
+      Attributes::AutoBatchClusters.new('auto_batch_clusters', static_opts)
+    end
+
+    def self.batch_clusters
+      Rails.cache.fetch('script_batch_clusters', expires_in: 4.hours) do
+        Configuration.job_clusters.reject do |c|
+          reject_cluster?(c)
+        end.map(&:id).map(&:to_s).sort
+      end
+    end
+
+    def self.reject_cluster?(cluster)
+      cluster.kubernetes? || cluster.linux_host? || cluster.systemd?
+    end
+  end
+
+  module Attributes
+    class AutoBatchClusters < Attribute
+      def widget
+        'select'
+      end
+
+      def label(*)
+        (opts[:label] || 'Cluster').to_s
+      end
+    end
+  end
+end

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -156,7 +156,7 @@ class Script
     job_id = Dir.chdir(project_dir) do
       adapter.submit(job_script)
     end
-    update_job_log(job_id, options[:cluster].to_s)
+    update_job_log(job_id, options[:auto_batch_clusters].to_s)
     write_job_options_to_cache(options)
 
     job_id

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -46,18 +46,6 @@ class Script
         .prepend(0)
         .max + 1
     end
-
-    def batch_clusters
-      Rails.cache.fetch('script_batch_clusters', expires_in: 4.hours) do
-        Configuration.job_clusters.reject do |c|
-          reject_cluster?(c)
-        end.map(&:id).map(&:to_s).sort
-      end
-    end
-
-    def reject_cluster?(cluster)
-      cluster.kubernetes? || cluster.linux_host? || cluster.systemd?
-    end
   end
 
   def initialize(opts = {})
@@ -160,7 +148,7 @@ class Script
   end
 
   def submit(options)
-    adapter = adapter(options[:cluster]).job_adapter
+    adapter = adapter(options[:auto_batch_clusters]).job_adapter
     render_format = adapter.class.name.split('::').last.downcase
 
     job_script = OodCore::Job::Script.new(**submit_opts(options, render_format))
@@ -298,30 +286,8 @@ class Script
   end
 
   def add_cluster_to_form(form: [], attributes: {})
-    return if form.include?('cluster')
+    return if form.include?('auto_batch_clusters')
 
-    clusters = Script.batch_clusters
-    form.prepend('cluster')
-
-    attributes[:cluster] = if clusters.size > 1
-                             select_clusters(clusters)
-                           else
-                             fixed_cluster(clusters)
-                           end
-  end
-
-  def select_clusters(clusters)
-    {
-      widget:  'select',
-      label:   'Cluster',
-      options: clusters
-    }
-  end
-
-  def fixed_cluster(clusters)
-    {
-      value: clusters.first.id.to_s,
-      fixed: true
-    }
+    form << 'auto_batch_clusters'
   end
 end

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -40,14 +40,13 @@ class ProjectsTest < ApplicationSystemTestCase
       ---
       title: the script title
       form:
-      - cluster
+      - auto_batch_clusters
       - auto_scripts
       - auto_accounts
       attributes:
         auto_scripts:
           directory: #{project_dir}
-        cluster:
-          widget: select
+        auto_batch_clusters:
           options:
           - oakley
           - owens
@@ -173,15 +172,14 @@ class ProjectsTest < ApplicationSystemTestCase
         ---
         title: the script title
         form:
-        - cluster
+        - auto_batch_clusters
         - auto_scripts
         attributes:
-          cluster:
-            widget: select
-            label: Cluster
+          auto_batch_clusters:
             options:
             - oakley
             - owens
+            label: Cluster
             help: ''
             required: false
           auto_scripts:
@@ -222,7 +220,7 @@ class ProjectsTest < ApplicationSystemTestCase
                    page.all('#script_auto_scripts option').map(&:value).to_set)
 
       # clusters are automatically added
-      assert_equal(['owens', 'oakley'].to_set, page.all('#script_cluster option').map(&:value).to_set)
+      assert_equal(['owens', 'oakley'].to_set, page.all('#script_auto_batch_clusters option').map(&:value).to_set)
     end
   end
 
@@ -238,12 +236,12 @@ class ProjectsTest < ApplicationSystemTestCase
       assert_selector('h1', text: 'the script title', count: 1)
 
       # assert defaults
-      assert_equal 'oakley', find('#script_cluster').value
+      assert_equal 'oakley', find('#script_auto_batch_clusters').value
       assert_equal 'pzs0715', find('#script_auto_accounts').value
       assert_equal "#{project_dir}/my_cool_script.sh", find('#script_auto_scripts').value
       assert_nil YAML.safe_load(File.read("#{script_dir}/1_job_log"))
 
-      select('owens', from: 'script_cluster')
+      select('owens', from: 'script_auto_batch_clusters')
       select('pas2051', from: 'script_auto_accounts')
       select('my_cooler_script.bash', from: 'script_auto_scripts')
 
@@ -281,12 +279,12 @@ class ProjectsTest < ApplicationSystemTestCase
       assert_selector('h1', text: 'the script title', count: 1)
 
       # assert defaults
-      assert_equal 'oakley', find('#script_cluster').value
+      assert_equal 'oakley', find('#script_auto_batch_clusters').value
       assert_equal 'pzs0715', find('#script_auto_accounts').value
       assert_equal "#{project_dir}/my_cool_script.sh", find('#script_auto_scripts').value
       assert_nil YAML.safe_load(File.read("#{script_dir}/1_job_log"))
 
-      select('owens', from: 'script_cluster')
+      select('owens', from: 'script_auto_batch_clusters')
       select('pas2051', from: 'script_auto_accounts')
       select('my_cooler_script.bash', from: 'script_auto_scripts')
 
@@ -329,9 +327,9 @@ class ProjectsTest < ApplicationSystemTestCase
 
       # only shows 'cluster' & 'auto_scripts'
       assert_equal 2, page.all('.form-group').size
-      assert_not_nil find('#script_cluster')
+      assert_not_nil find('#script_auto_batch_clusters')
       assert_not_nil find('#script_auto_scripts')
-      select('oakley', from: 'script_cluster')
+      select('oakley', from: 'script_auto_batch_clusters')
       assert_raises(Capybara::ElementNotFound) do
         find('#script_bc_num_hours')
       end
@@ -341,7 +339,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
       # now shows 'cluster', 'auto_scripts' & the newly added'bc_num_hours'
       assert_equal 3, page.all('.form-group').size
-      assert_not_nil find('#script_cluster')
+      assert_not_nil find('#script_auto_batch_clusters')
       assert_not_nil find('#script_auto_scripts')
       assert_not_nil find('#script_bc_num_hours')
 
@@ -362,15 +360,10 @@ class ProjectsTest < ApplicationSystemTestCase
         ---
         title: the script title
         form:
-        - cluster
         - auto_scripts
+        - auto_batch_clusters
         - bc_num_hours
         attributes:
-          cluster:
-            value: oakley
-            label: Cluster
-            help: ''
-            required: false
           auto_scripts:
             options:
             - - my_cool_script.sh
@@ -380,6 +373,14 @@ class ProjectsTest < ApplicationSystemTestCase
             directory: "#{dir}/projects/1"
             value: "#{dir}/projects/1/my_cool_script.sh"
             label: Script
+            help: ''
+            required: false
+          auto_batch_clusters:
+            options:
+            - oakley
+            - owens
+            value: oakley
+            label: Cluster
             help: ''
             required: false
           bc_num_hours:


### PR DESCRIPTION
This adds `auto_batch_clusters` to deal with the odd way we deal with clusters currently by creating them directly in the script model.

So instead of this logic being held in the script model itself, it's better to have a smart attribute that can handle this functionality and the script can just deal with it as a required field on initialization.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204564742125102) by [Unito](https://www.unito.io)
