### PR TITLE
(release 3.0) Allow oidc_crypto_passphrase to be set for ood-portal-generator

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -104,7 +104,7 @@ module OodPortalGenerator
       @oidc_redirect_uri                = "#{protocol}#{servername}#{@oidc_uri}"
       @oidc_remote_user_claim           = opts.fetch(:oidc_remote_user_claim, 'preferred_username')
       @oidc_scope                       = opts.fetch(:oidc_scope, "openid profile email")
-      @oidc_crypto_passphrase           = Digest::SHA1.hexdigest(servername)
+      @oidc_crypto_passphrase           = opts.fetch(:oidc_crypto_passphrase, Digest::SHA1.hexdigest(servername))
       @oidc_session_inactivity_timeout  = opts.fetch(:oidc_session_inactivity_timeout, 28800)
       @oidc_session_max_duration        = opts.fetch(:oidc_session_max_duration, 28800)
       @oidc_state_max_number_of_cookies = opts.fetch(:oidc_state_max_number_of_cookies, '10 true')

--- a/ood-portal-generator/share/ood_portal_example.yml
+++ b/ood-portal-generator/share/ood_portal_example.yml
@@ -351,6 +351,12 @@
 # Default: "openid profile email"
 #oidc_scope: "openid profile email"
 
+# OIDC crypto passphrase
+# Example:
+#   oidc_crypto_passphrase: "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"
+# Default: SHA1 sum of servername
+#oidc_crypto_passphrase: ~
+
 # OIDC session inactivity timeout
 # Example:
 #     oidc_session_inactivity_timeout: 28800

--- a/ood-portal-generator/spec/ood_portal_generator_view_spec.rb
+++ b/ood-portal-generator/spec/ood_portal_generator_view_spec.rb
@@ -15,7 +15,7 @@ describe OodPortalGenerator::View do
       example_config_opts -= %w(dex) 
       
       # delete inst vars that are not actual options in the example file
-      config_opts -= %w(protocol allowed_hosts oidc_redirect_uri oidc_crypto_passphrase dex_http_port)
+      config_opts -= %w(protocol allowed_hosts oidc_redirect_uri dex_http_port)
 
       expect(config_opts + example_config_opts - (config_opts & example_config_opts)).to be_empty
     end


### PR DESCRIPTION

Cherry pick #2807

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204592202958190) by [Unito](https://www.unito.io)
