### PR TITLE
Add possibility of using syslog for nginx logs

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -142,7 +142,7 @@ module NginxStage
     # @param user [String] the user of the nginx process
     # @return [String] the path to the nginx access log
     def pun_access_log_path(user:)
-      File.expand_path @pun_access_log_path % {user: user}
+      expand_nginx_log_path @pun_access_log_path % {user: user}
     end
 
     attr_writer :pun_access_log_path
@@ -154,7 +154,7 @@ module NginxStage
     # @param user [String] the user of the nginx process
     # @return [String] the path to the nginx error log
     def pun_error_log_path(user:)
-      File.expand_path @pun_error_log_path % {user: user}
+      expand_nginx_log_path @pun_error_log_path % {user: user}
     end
 
     attr_writer :pun_error_log_path
@@ -528,5 +528,13 @@ module NginxStage
         return obj
       end
 
+      # Expand paths only if they are not special
+      def expand_nginx_log_path(path)
+        if path == "stderr" || path.start_with?("syslog:") || path.start_with?("memory:")
+          path
+        else
+          File.expand_path path
+        end
+      end
   end
 end


### PR DESCRIPTION
We would like to use syslog for the nginx access and error logs, but we noticed that this is currently not possible as the paths are always expanded, for example `syslog:server=unix:/some/path` is expanded to `/root/syslog:server=unix:/some/path`, which is invalid. This PR excludes the [special cases](https://nginx.org/en/docs/ngx_core_module.html#error_log) `stderr`, `syslog:` and `memory:` from being expanded.

Note that syslog does not work completely due to issues with Passenger, but I'll be submitting a separate PR regarding that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204620175481781) by [Unito](https://www.unito.io)
