### PR TITLE
Remove Hard-coded Script Location

### DIFF
--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -211,9 +211,7 @@ class Script
   end
 
   def cache_file_path
-    Pathname.new(project_dir).join(".ondemand/scripts/#{id}_opts.json")
-    # TODO: fix bug 
-    #Pathname.new("#{Script.scripts_dir(project_dir)}/#{id}_cache.json")
+    Pathname.new("#{Script.scripts_dir(project_dir)}/#{id}_cache.json")
   end
 
   def cache_file_exists?


### PR DESCRIPTION
This was fixed in PR #2823 but the actual code that was effected wasn't. This just removes the workaround.