### PR TITLE
Hide develop custom menu template based on Configuration object

### DIFF
--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
 
         <ul class="navbar-nav">
           <% if @help_bar.empty? %>
-            <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
+            <%= render partial: 'layouts/nav/develop_dropdown' %>
             <%= render partial: 'layouts/nav/help_dropdown' %>
             <%= render partial: 'layouts/nav/user' %>
             <%= render partial: 'layouts/nav/log_out' %>

--- a/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -1,14 +1,16 @@
-<li class="nav-item dropdown" title="<%= t('dashboard.nav_develop_title') %>">
-  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <i class="fas fa-code" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_develop_title') %></span><span class="caret"></span>
-  </a>
+<% if Configuration.app_development_enabled? %>
+  <li class="nav-item dropdown" title="<%= t('dashboard.nav_develop_title') %>">
+    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+      <i class="fas fa-code" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_develop_title') %></span><span class="caret"></span>
+    </a>
 
-  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, 'dropdown-menu-right') %>" role="menu">
-    <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
-    <%= nav_link(t('dashboard.nav_develop_docs'), "book", Configuration.developer_docs_url, new_tab: true) %>
-    <%= nav_link(products_title(:dev), "cog", products_path(type: "dev")) %>
-    <% if Configuration.app_sharing_enabled? %>
-      <%= nav_link(products_title(:usr), "share-alt", products_path(type: "usr")) %>
-    <% end %>
-  </ul>
-</li>
+    <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, 'dropdown-menu-right') %>" role="menu">
+      <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
+      <%= nav_link(t('dashboard.nav_develop_docs'), "book", Configuration.developer_docs_url, new_tab: true) %>
+      <%= nav_link(products_title(:dev), "cog", products_path(type: "dev")) %>
+      <% if Configuration.app_sharing_enabled? %>
+        <%= nav_link(products_title(:usr), "share-alt", products_path(type: "usr")) %>
+      <% end %>
+    </ul>
+  </li>
+<% end %>

--- a/apps/dashboard/test/integration/custom_help_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_help_navigation_test.rb
@@ -96,6 +96,28 @@ class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'develop template should not render when Configuration.app_development_enabled? is false' do
+    stub_user_configuration(
+      {
+        nav_bar:  [{ url: '/test' }],
+        help_bar: ['develop']
+      }
+    )
+
+    Configuration.stubs(:app_development_enabled?).returns(true)
+    get root_path
+    assert_response :success
+    assert_select '#navbar li.dropdown[title]', 1
+    assert_select nav_menu(1) do |menu|
+      assert_select menu.first, 'a', text: 'Develop'
+    end
+
+    Configuration.stubs(:app_development_enabled?).returns(false)
+    get root_path
+    assert_response :success
+    assert_select '#navbar li.dropdown[title]', 0
+  end
+
   def nav_menu(order)
     "#navbar .navbar-nav li.dropdown:nth-of-type(#{order})"
   end


### PR DESCRIPTION
Hides the custom help navigation menu based on the Configuration object

Fixes #2847 