### PR TITLE
Add a Globus button to make transfers easier

### DIFF
--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -1,7 +1,6 @@
 import Handlebars from 'handlebars';
 import {EVENTNAME as SWAL_EVENTNAME} from './sweet_alert.js';
-import { getGlobusLink, updateGlobusButton } from './globus.js';
-
+import { getGlobusLink, updateGlobusLink } from './globus.js';
 export { CONTENTID, EVENTNAME };
 
 const EVENTNAME = {
@@ -296,9 +295,9 @@ class DataTable {
     }
 
     updateGlobus() {
-      if ($('#globus-btn').length) {
-        $('#globus-btn-link').attr('href', getGlobusLink(history.state.currentDirectory));
-        updateGlobusButton(history.state.currentDirectory, $('#globus-btn'));
+      if ($('#globus-link').length) {
+        $('#globus-link').attr('href', getGlobusLink(history.state.currentDirectory));
+        updateGlobusLink(history.state.currentDirectory, $('#globus-link'), $('#globus-wrapper'));
       }
     }
 
@@ -373,7 +372,7 @@ class DataTable {
                         currentFilesystem: data.filesystem,
                         currentFilenames: Array.from(data.files, x => x.name)
                     }, data.name, data.url);
-                }      
+                }
                 this.updateGlobus();
             }
           })

--- a/apps/dashboard/app/javascript/packs/files/data_table.js
+++ b/apps/dashboard/app/javascript/packs/files/data_table.js
@@ -1,5 +1,6 @@
 import Handlebars from 'handlebars';
 import {EVENTNAME as SWAL_EVENTNAME} from './sweet_alert.js';
+import { getGlobusLink, updateGlobusButton } from './globus.js';
 
 export { CONTENTID, EVENTNAME };
 
@@ -243,6 +244,7 @@ class DataTable {
         $('#directory-contents_filter').prepend(`<label style="margin-right: 20px" for="show-dotfiles"><input type="checkbox" id="show-dotfiles" ${this.getShowDotFiles() ? 'checked' : ''}> Show Dotfiles</label>`)
         $('#directory-contents_filter').prepend(`<label style="margin-right: 14px" for="show-owner-mode"><input type="checkbox" id="show-owner-mode" ${this.getShowOwnerMode() ? 'checked' : ''}> Show Owner/Mode</label>`)
 
+        this.updateGlobus();
     }
 
     async reloadTable(url) {
@@ -291,6 +293,13 @@ class DataTable {
 
     updateDotFileVisibility() {
         this.reloadTable();
+    }
+
+    updateGlobus() {
+      if ($('#globus-btn').length) {
+        $('#globus-btn-link').attr('href', getGlobusLink(history.state.currentDirectory));
+        updateGlobusButton(history.state.currentDirectory, $('#globus-btn'));
+      }
     }
 
     updateShowOwnerModeVisibility() {
@@ -365,6 +374,7 @@ class DataTable {
                         currentFilenames: Array.from(data.files, x => x.name)
                     }, data.name, data.url);
                 }      
+                this.updateGlobus();
             }
           })
           .finally(() => {

--- a/apps/dashboard/app/javascript/packs/files/globus.js
+++ b/apps/dashboard/app/javascript/packs/files/globus.js
@@ -1,0 +1,46 @@
+/**
+ * Given a directory name, find the associated Globus endpoint
+ * @params {string} directory Directory name
+ * @return {string|undefined} Globus endpoint ID
+ */
+function getEndpoint(directory) {
+  for (const [prefix, endpoint] of Object.entries(globus_endpoints)) {
+    if(directory.startsWith(prefix)) {
+      return endpoint
+    }
+  }
+}
+
+/**
+ * Generate a link to the Globus transfer app
+ * @params {string} directory Directory name
+ * @return {string|null} Globus transfer app URL with directory and endpoint populated
+ */
+export function getGlobusLink(directory) {
+  let endpoint = getEndpoint(directory);
+  let url = null;
+
+  if (endpoint) {
+    url = "https://app.globus.org/file-manager?origin_id=" + endpoint + "&origin_path=" + directory;
+  }
+
+  return url;
+}
+
+/**
+ * Enable or disable the Globus button and update the tooltip based on current directory
+ * @params {string} directory Directory name
+ * @params {object} JQuery object
+ * @return undefined
+ */
+export function updateGlobusButton(directory, button) {
+  endpoint = getEndpoint(directory);
+  if (endpoint) {
+    button.prop("disabled", false);
+    button.prop("title", "Open the current directory with Globus");
+  } 
+  else {
+    button.prop("disabled", true);
+    button.prop("title", "No Globus endpoint associated with this directory");
+  }
+}

--- a/apps/dashboard/app/javascript/packs/files/globus.js
+++ b/apps/dashboard/app/javascript/packs/files/globus.js
@@ -1,12 +1,12 @@
 /**
- * Given a directory name, find the associated Globus endpoint
+ * Given a directory name, return the associated Globus endpoint and path
  * @params {string} directory Directory name
  * @return {string|undefined} Globus endpoint ID
  */
-function getEndpoint(directory) {
-  for (const [prefix, endpoint] of Object.entries(globus_endpoints)) {
-    if(directory.startsWith(prefix)) {
-      return endpoint
+function getEndpointInfo(directory) {
+  for (const endpoint of globus_endpoints) {
+    if (directory.startsWith(endpoint["path"])) {
+      return endpoint;
     }
   }
 }
@@ -17,30 +17,30 @@ function getEndpoint(directory) {
  * @return {string|null} Globus transfer app URL with directory and endpoint populated
  */
 export function getGlobusLink(directory) {
-  let endpoint = getEndpoint(directory);
-  let url = null;
-
-  if (endpoint) {
-    url = "https://app.globus.org/file-manager?origin_id=" + endpoint + "&origin_path=" + directory;
+  let info = getEndpointInfo(directory);
+  if (info) {
+    let origin_path = directory.replace(info.path, info.endpoint_path);
+    origin_path = origin_path.replace("//", "/");
+    url = "https://app.globus.org/file-manager?origin_id=" + info.endpoint + "&origin_path=" + origin_path;
+    return url
   }
-
-  return url;
 }
 
 /**
  * Enable or disable the Globus button and update the tooltip based on current directory
- * @params {string} directory Directory name
- * @params {object} JQuery object
+ * @params {string} directory Filesystem directory name
+ * @params {object} link The link object whose href value will change
+ * @params {object} wrapper The wrapper containing the link whose tooltip title will change
  * @return undefined
  */
-export function updateGlobusButton(directory, button) {
-  endpoint = getEndpoint(directory);
-  if (endpoint) {
-    button.prop("disabled", false);
-    button.prop("title", "Open the current directory with Globus");
+export function updateGlobusLink(directory, link, wrapper) {
+  let info = getEndpointInfo(directory);
+  if (info) {
+    link.removeClass("disabled");
+    wrapper.prop("title", "Open the current directory with Globus");
   } 
   else {
-    button.prop("disabled", true);
-    button.prop("title", "No Globus endpoint associated with this directory");
+    link.addClass("disabled");
+    wrapper.prop("title", "No Globus endpoint associated with this directory");
   }
 }

--- a/apps/dashboard/app/javascript/stylesheets/navbar.scss
+++ b/apps/dashboard/app/javascript/stylesheets/navbar.scss
@@ -97,10 +97,6 @@
     margin-bottom: 0px;
   }
 
-  #globus-btn-link {
-    color: white;
-  }
-
   .ood-app.navbar ul.navbar-breadcrumbs > li > a, .ood-app.navbar ul.navbar-breadcrumbs > li + li:before {
     padding-top: 0px;
     padding-bottom: 0px;

--- a/apps/dashboard/app/javascript/stylesheets/navbar.scss
+++ b/apps/dashboard/app/javascript/stylesheets/navbar.scss
@@ -97,6 +97,10 @@
     margin-bottom: 0px;
   }
 
+  #globus-btn-link {
+    color: white;
+  }
+
   .ood-app.navbar ul.navbar-breadcrumbs > li > a, .ood-app.navbar ul.navbar-breadcrumbs > li + li:before {
     padding-top: 0px;
     padding-bottom: 0px;

--- a/apps/dashboard/app/views/files/_globus.html.erb
+++ b/apps/dashboard/app/views/files/_globus.html.erb
@@ -1,0 +1,10 @@
+<button id="globus-btn" type="button" class="btn btn-primary btn-sm">
+  <a href="#" id="globus-btn-link" target="_blank">Globus</a>
+</button>
+<script>
+const globus_endpoints = {
+  <% Configuration.globus_endpoints.each do |key, value| %>
+    "<%= key %>": "<%= value %>",
+  <% end %>
+};
+</script>

--- a/apps/dashboard/app/views/files/_globus.html.erb
+++ b/apps/dashboard/app/views/files/_globus.html.erb
@@ -1,10 +1,7 @@
-<button id="globus-btn" type="button" class="btn btn-primary btn-sm">
-  <a href="#" id="globus-btn-link" target="_blank">Globus</a>
-</button>
+<span id="globus-wrapper">
+  <a href="#" id="globus-link" class="btn btn-primary btn-sm" target="_blank">Globus</a>
+</span>
+
 <script>
-const globus_endpoints = {
-  <% Configuration.globus_endpoints.each do |key, value| %>
-    "<%= key %>": "<%= value %>",
-  <% end %>
-};
+  const globus_endpoints = <%= Configuration.globus_endpoints.to_json.html_safe %>;
 </script>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -11,6 +11,9 @@
     <button id="new-dir-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-folder-plus" aria-hidden="true"></i> New Directory</button>
     <button id="upload-btn" type="button" class="btn btn-primary btn-sm"><i class="fas fa-upload" aria-hidden="true"></i> Upload</button>
     <button id="download-btn" type="button" class="btn btn-primary btn-sm"><i class="fas fa-download" aria-hidden="true"></i> Download</button>
+    <% if Configuration.globus_endpoints %>
+      <%= render partial: 'globus' %>
+    <% end %>
     <button id="copy-move-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-copy" aria-hidden="true"></i> Copy/Move</button>
     <button id="delete-btn" type="button" class="btn btn-danger btn-sm"><i class="fas fa-trash" aria-hidden="true"></i> Delete</button>
 </div>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -196,6 +196,11 @@ class ConfigurationSingleton
     config.has_key?(:support_ticket) || config.fetch(:profiles, {}).any? { |_, profile| profile.has_key?(:support_ticket) }
   end
 
+  # Globus configuration
+  def globus_endpoints
+    config.fetch(:globus_endpoints, nil)
+  end
+
   # Load the dotenv local files first, then the /etc dotenv files and
   # the .env and .env.production or .env.development files.
   #

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -63,7 +63,6 @@ class ConfigurationSingleton
       :facl_domain              => nil,
       :auto_groups_filter       => nil,
       :bc_clean_old_dirs_days   => '30',
-      :globus_endpoints         => nil,
       :google_analytics_tag_id  => nil,
       :project_template_dir     => "#{config_root}/projects"
     }.freeze

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -63,6 +63,7 @@ class ConfigurationSingleton
       :facl_domain              => nil,
       :auto_groups_filter       => nil,
       :bc_clean_old_dirs_days   => '30',
+      :globus_endpoints         => nil,
       :google_analytics_tag_id  => nil,
       :project_template_dir     => "#{config_root}/projects"
     }.freeze


### PR DESCRIPTION
Preliminary integration between Open OnDemand and Globus Transfer. When an OOD admin defines 'globus_endpoints' in their config, a Globus button will appear in the user interface. When clicked, this button will open a link to the Globus transfer web app using the correct transfer endpoint and directory info.

I will be submitting the documentation shortly, but briefly the easiest way to configure this is to add a globus_endpoints parameter to ondemand.d that looks like this:

# For a single Globus endpoint
      globus_endpoints:
        "/": "716de4ac-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

# For multiple endpoints at different locations
      globus_endpoints:
        "/home": "716de4ac-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
        "/project": "8c33758b-xxxx-xxxx-xxxx-xxxxxxxxxxxx"