### PR TITLE
add net-tools to amazon 2023

### DIFF
--- a/spec/e2e/nodesets/amzn2023.yml
+++ b/spec/e2e/nodesets/amzn2023.yml
@@ -9,7 +9,7 @@ HOSTS:
     docker_cmd:
       - '/usr/sbin/init'
     docker_image_commands:
-      - 'dnf install -y dnf-utils wget which cronie iproute initscripts langpacks-en glibc-all-langpacks'
+      - 'dnf install -y net-tools dnf-utils wget which cronie iproute initscripts langpacks-en glibc-all-langpacks'
     docker_env:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8


### PR DESCRIPTION
add net-tools to amazon 2023 because e2e tests are failing because they're unable to find the command `nestat`.