### PR TITLE
Update to NodeJS 18 and Ruby 3.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,10 @@ jobs:
           - os: ubuntu-latest
             ruby: "3.0.2"
             bundler: "2.3.5"
+          # Test versions from RHEL8 & RHEL9
+          - os: ubuntu-latest
+            ruby: "3.1.2"
+            bundler: "2.3.7"
           # Test versions from Amazon Linux 2023
           - os: ubuntu-latest
             ruby: "3.2.2"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rake'
 gem 'dotenv', '~> 2.1'
 
 group :package do
-  gem 'ood_packaging', '~> 0.10.0'
+  gem 'ood_packaging', '~> 0.11.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     oga (3.3)
       ast
       ruby-ll (~> 2.1)
-    ood_packaging (0.10.0)
+    ood_packaging (0.11.0)
       rake (~> 13.0.1)
     open_uri_redirections (0.2.1)
     parallel (1.21.0)
@@ -177,7 +177,7 @@ DEPENDENCIES
   beaker-docker (~> 1.4.0)
   beaker-rspec
   dotenv (~> 2.1)
-  ood_packaging (~> 0.10.0)
+  ood_packaging (~> 0.11.0)
   rake
   rspec
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   watir
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   watir
 
 BUNDLED WITH
-   2.3.7
+   2.3.6

--- a/apps/dashboard/.yarnrc
+++ b/apps/dashboard/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -308,4 +308,4 @@ DEPENDENCIES
   zip_tricks (~> 5.5)
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -308,4 +308,4 @@ DEPENDENCIES
   zip_tricks (~> 5.5)
 
 BUNDLED WITH
-   2.3.7
+   2.3.6

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -275,4 +275,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -275,4 +275,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   2.3.7
+   2.3.6

--- a/apps/shell/.yarnrc
+++ b/apps/shell/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000

--- a/ood-portal-generator/Gemfile.lock
+++ b/ood-portal-generator/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.3.7
+   2.3.6

--- a/ood-portal-generator/Gemfile.lock
+++ b/ood-portal-generator/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -5,7 +5,7 @@ Maintainer: Ohio Supercomputer Center <oschelp@osc.edu>
 Build-Depends: debhelper (>=11~), curl, build-essential,
   tzdata, libxml2-dev, libxslt-dev, pkg-config, zlib1g-dev, liblzma-dev,
   ruby, ruby-dev,
-  nodejs (>= 14.0), nodejs (<< 15.0),
+  nodejs (>= 18.0), nodejs (<< 19.0),
   sqlite, libsqlite3-dev, python3
 Standards-Version: 4.1.4
 Homepage: https://openondemand.org
@@ -15,7 +15,7 @@ Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends},
   ruby, apache2, sudo, lsof, lua-posix, tzdata, file,
-  nodejs (>= 14.0), nodejs (<< 15.0),
+  nodejs (>= 18.0), nodejs (<< 19.0),
   ondemand-nginx (= 1.22.1.p6.0.17.ood3.1), ondemand-passenger (= 6.0.17.ood3.1)
 Recommends: rclone
 Description: Open OnDemand is an open source release of the Ohio SuperComputer Center's

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -33,7 +33,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 ifeq ($(ARCH),ppc64le)
-	bundle config set force_ruby_platform true
+	bundle config set --global force_ruby_platform true
 	bundle config build.nokogiri --use-system-libraries
 endif
 	BUNDLE_WITHOUT='test package' bundle install

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -138,16 +138,6 @@ set -x
 set -e
 export GEM_HOME=$(pwd)/gems-build
 export GEM_PATH=$(pwd)/gems-build:$GEM_PATH
-# Force downgrade of bundler to avoid bugs with 2.3.7
-# TODO: Remove if/when using dedicated ondemand-bundler RPM
-%if 0%{?rhel} && 0%{?rhel} > 7
-pushd apps/dashboard
-bundle update --bundler=2.3.6
-popd
-pushd apps/myjobs
-bundle update --bundler=2.3.6
-popd
-%endif
 %ifarch aarch64
 %if 0%{?rhel} && 0%{?rhel} < 9
 # Nokogiri and possibly other gems will fail to build on older aarch64 and glibc

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -5,7 +5,7 @@
 %define git_tag_minus_v %(echo %{git_tag} | sed -r 's/^v//')
 %define major_version %(echo %{git_tag_minus_v} | cut -d. -f1)
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
-%define runtime_version %{major_version}.%{minor_version}.2
+%define runtime_version %{major_version}.%{minor_version}.3
 %define runtime_release 1
 %define runtime_version_full %{runtime_version}-%{runtime_release}%{?dist}
 %define selinux_policy_ver %(rpm --qf "%%{version}" -q selinux-policy)

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -68,6 +68,7 @@ BuildRequires:   rsync
 BuildRequires:   git
 BuildRequires:   python3
 BuildRequires:   libffi-devel
+BuildRequires:   libyaml-devel
 
 Requires:        git
 Requires:        sudo, lsof, cronie, wget, curl, make, rsync, file, libxml2, libxslt, zlib, lua-posix, diffutils
@@ -137,14 +138,24 @@ set -x
 set -e
 export GEM_HOME=$(pwd)/gems-build
 export GEM_PATH=$(pwd)/gems-build:$GEM_PATH
+# Force downgrade of bundler to avoid bugs with 2.3.7
+# TODO: Remove if/when using dedicated ondemand-bundler RPM
+%if 0%{?rhel} && 0%{?rhel} > 7
+pushd apps/dashboard
+bundle update --bundler=2.3.6
+popd
+pushd apps/myjobs
+bundle update --bundler=2.3.6
+popd
+%endif
 %ifarch aarch64
 %if 0%{?rhel} && 0%{?rhel} < 9
 # Nokogiri and possibly other gems will fail to build on older aarch64 and glibc
-bundle config set force_ruby_platform true
+bundle config set --global force_ruby_platform true
 %endif
 %endif
 %ifarch ppc64le
-bundle config set force_ruby_platform true
+bundle config set --global force_ruby_platform true
 %endif
 BUNDLE_WITHOUT='test package' bundle install
 rake --trace -mj%{ncpus} build

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -132,9 +132,9 @@ def bootstrap_repos
     case host_inventory['platform_version']
     when /^7/
       repos << 'centos-release-scl yum-plugin-priorities'
-    when /^8/
-      on hosts, 'dnf -y module enable ruby:3.0'
-      on hosts, 'dnf -y module enable nodejs:14'
+    when /^(8|9)/
+      on hosts, 'dnf -y module enable ruby:3.1'
+      on hosts, 'dnf -y module enable nodejs:18'
     end
   when 'ubuntu'
     on hosts, 'apt-get update'


### PR DESCRIPTION
NodeJS update affects all OSes except EL7 and Amazon 2023
Ruby 3.1 update only affects EL8 and EL9
Fixes #2884