### PR TITLE
rm unused config flag for new projects app

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -43,7 +43,6 @@ class ConfigurationSingleton
       :bc_simple_auto_accounts      => false,
       :bc_clean_old_dirs            => false,
       :per_cluster_dataroot         => false,
-      :jobs_app_alpha               => false,
       :remote_files_enabled         => false,
       :host_based_profiles          => false,
       :disable_bc_shell             => false,

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -2,7 +2,7 @@ require "authz/app_developer_constraint"
 
 Rails.application.routes.draw do
 
-  if Configuration.jobs_app_alpha?
+  if Configuration.can_access_projects?
     resources :projects do
       root 'projects#index'
       resources :scripts do

--- a/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
+++ b/apps/dashboard/test/fixtures/config/ondemand.d/booleans.yml
@@ -4,7 +4,6 @@ bc_dynamic_js: true
 bc_simple_auto_accounts: true
 per_cluster_dataroot: true
 file_navigator: true
-jobs_app_alpha: true
 remote_files_enabled: true
 host_based_profiles: true
 disable_bc_shell: true

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -7,8 +7,6 @@ class ProjectsTest < ApplicationSystemTestCase
   def setup
     stub_clusters
     stub_user
-    Configuration.stubs(:jobs_app_alpha).returns(true)
-    Rails.application.reload_routes!
     stub_sacctmgr
     stub_scontrol
   end


### PR DESCRIPTION
Now that we have #2839 - we don't need this flag anymore. 