### PR TITLE
upgrade this action for GH deprecations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: bundle exec rake lint:random
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
           commit-message: lint a random file


### PR DESCRIPTION
Upgrade this action for GH deprecations.

Currently we're getting all of these warnings.

![image](https://github.com/OSC/ondemand/assets/4874123/d938965b-ce26-4866-86e4-d0658136f1a6)
