### PR TITLE
Send excludeable options

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -7,7 +7,8 @@ class ScriptsController < ApplicationController
   before_action :find_script, only: [:show, :edit, :submit, :save]
 
   SAVE_SCRIPT_KEYS = [
-    :cluster, :auto_accounts, :auto_scripts, :auto_queues, :auto_batch_clusters,
+    :cluster, :auto_accounts, :auto_accounts_exclude, :auto_scripts, :auto_scripts_exclude,
+    :auto_queues, :auto_queues_exclude, :auto_batch_clusters, :auto_batch_clusters_exclude,
     :bc_num_slots, :bc_num_slots_min, :bc_num_slots_max,
     :bc_num_hours, :bc_num_hours_min, :bc_num_hours_max
   ].freeze

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -127,15 +127,36 @@ function enableOrDisableSelectOption(event) {
   const li = event.target.parentElement;
   event.target.disabled = true;
 
+  const inputId = event.target.dataset.target;
+  const choice = $(li).find('[data-select-value]')[0].textContent;
+
   if(toggleAction == 'add') {
     li.classList.remove('list-group-item-danger', 'text-strike');
     const removeButton = $(li).find('[data-select-toggler="remove"]')[0];
     removeButton.disabled = false;
+    removeFromExcludeInput(inputId, choice);
   } else {
     li.classList.add('list-group-item-danger', 'text-strike');
     const addButton = $(li).find('[data-select-toggler="add"]')[0];
     addButton.disabled = false;
+    addToExcludeInput(inputId, choice);
   }
+}
+
+function addToExcludeInput(id, item) {
+  const input = document.getElementById(id);
+  const list = input.value.split(',');
+  list.push(item);
+
+  input.value = list.join(',');
+}
+
+function removeFromExcludeInput(id, item) {
+  const input = document.getElementById(id);
+  const currentList = input.value.split(',').filter(word => word != "");
+  const newList = currentList.filter(word => word != item);
+
+  input.value = newList.join(',');
 }
 
 jQuery(() => {

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -130,16 +130,22 @@ function enableOrDisableSelectOption(event) {
   const inputId = event.target.dataset.target;
   const choice = $(li).find('[data-select-value]')[0].textContent;
 
+  const select = document.getElementById(event.target.dataset.selectId);
+  const selectOptions = Array.from(select.options);
+  const optionToToggle = selectOptions.filter(opt => opt.value == choice)[0];
+
   if(toggleAction == 'add') {
     li.classList.remove('list-group-item-danger', 'text-strike');
     const removeButton = $(li).find('[data-select-toggler="remove"]')[0];
     removeButton.disabled = false;
     removeFromExcludeInput(inputId, choice);
+    optionToToggle.disabled = false;
   } else {
     li.classList.add('list-group-item-danger', 'text-strike');
     const addButton = $(li).find('[data-select-toggler="add"]')[0];
     addButton.disabled = false;
     addToExcludeInput(inputId, choice);
+    optionToToggle.disabled = true;
   }
 }
 

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -151,7 +151,7 @@ function enableOrDisableSelectOption(event) {
 
 function addToExcludeInput(id, item) {
   const input = document.getElementById(id);
-  const list = input.value.split(',');
+  const list = input.value.split(',').filter(word => word != '');
   list.push(item);
 
   input.value = list.join(',');

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
@@ -1,5 +1,7 @@
 <%-
   field_id = "#{form.object_name}_#{attrib.id}"
+  exclude_id = "#{field_id}_exclude"
+  exclude_name = "#{form.object_name}[#{attrib.id}_exclude]"
 -%>
 
 <div class="editable-form-field">
@@ -15,13 +17,15 @@
 
       <li class="list-group-item">
 
-        <button class="btn btn-info float-left" data-select-toggler="add" type="button" disabled>
+        <button class="btn btn-info float-left" type="button"
+          data-select-toggler="add" data-target="<%= exclude_id %>" disabled>
           <%= t('dashboard.add') %>
         </button>
 
-        <%= choice %>
+        <span data-select-value><%= choice %></span>
 
-        <button class="btn btn-warning float-right" data-select-toggler="remove" type="button">
+        <button class="btn btn-warning float-right" type="button"
+          data-select-toggler="remove" data-target="<%= exclude_id %>">
           <%= t('dashboard.remove') %>
         </button>
 
@@ -30,6 +34,9 @@
     </ol>
     
   </div>
+
+  <input type="hidden" value="" id='<%= exclude_id %>' name='<%= exclude_name %>'>
+  </input>
 
   <%= render(partial: 'scripts/editable_form_fields/edit_field_buttons',  locals: { field_id: field_id }) %>
 </div>

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
@@ -18,14 +18,14 @@
       <li class="list-group-item">
 
         <button class="btn btn-info float-left" type="button"
-          data-select-toggler="add" data-target="<%= exclude_id %>" disabled>
+          data-select-toggler="add" data-target="<%= exclude_id %>" data-select-id="<%= field_id %>" disabled>
           <%= t('dashboard.add') %>
         </button>
 
         <span data-select-value><%= choice %></span>
 
         <button class="btn btn-warning float-right" type="button"
-          data-select-toggler="remove" data-target="<%= exclude_id %>">
+          data-select-toggler="remove" data-target="<%= exclude_id %>" data-select-id="<%= field_id %>">
           <%= t('dashboard.remove') %>
         </button>
 


### PR DESCRIPTION
Following #2903 - when you click in the UI to add or remove an option from a select list, the system will start to populate an `input` field with the list of things you want to exclude. Since it's an `input` it'll directly send the exclude list with all the other parameters.