### PR TITLE
save excludable options

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -1,6 +1,6 @@
 # Helper for creating new batch connect sessions.
 module BatchConnect::SessionContextsHelper
-  def create_widget(form, attrib, format: nil)
+  def create_widget(form, attrib, format: nil, hide_excludable: true)
     return '' if attrib.fixed?
     return '' if attrib.hide_when_empty? && attrib.value.blank?
 
@@ -10,7 +10,7 @@ module BatchConnect::SessionContextsHelper
 
     case widget
     when 'select'
-      form.select attrib.id, attrib.select_choices, field_options, attrib.html_options
+      form.select(attrib.id, attrib.select_choices(hide_excludable: hide_excludable), field_options, attrib.html_options)
     when 'resolution_field'
       resolution_field(form, attrib.id, all_options)
     when 'check_box'

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -165,6 +165,25 @@ function removeFromExcludeInput(id, item) {
   input.value = newList.join(',');
 }
 
+function initSelectFields(){
+  const allButtons = Array.from($('[data-select-toggler]'));
+
+  // find all the disabled 'remove' buttons
+  allButtons.filter((button) => {
+    return button.disabled && button.dataset.selectToggler == 'remove';
+
+  // now map that disabled button to the option it's disabled.
+  }).map((button) => {
+    const li = button.parentElement;
+    const optionText = $(li).find('[data-select-value]')[0].textContent;
+    return optionText;
+
+  // now disable all the options
+  }).forEach((option) => {
+    $(`select [value='${option}']`).attr('disabled', 'true')
+  });
+}
+
 jQuery(() => {
   newFieldTemplate = $('#new_field_template');
   $('#add_new_field_button').on('click', (event) => { addNewField(event) });
@@ -180,4 +199,6 @@ jQuery(() => {
 
   $('[data-select-toggler]')
     .on('click', (event) => { enableOrDisableSelectOption(event) });
+
+  initSelectFields();
 });

--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -166,9 +166,23 @@ module SmartAttributes
 
     # Array of choices for select fields used to build <option> tags
     # @return [Array] choices in form [name, value], [name, value]
-    def select_choices
-      o = opts.fetch(:options, [])
-      o.nil? ? [] : o
+    def select_choices(hide_excludable: true)
+      opts.fetch(:options, []).to_a.reject do |option_data|
+        if hide_excludable
+          option = option_data.is_a?(Array) ? option_data.first : option_data
+          exclude_select_choices.include?(option)
+        else
+          false
+        end
+      end
+    end
+
+    def exclude_select_choices
+      opts.fetch(:exclude_options, []).to_a
+    end
+
+    def exclude_select_choices=(list)
+      opts[:exclude_options] = list
     end
 
     # String value if this attribute is "checked" (relevant for checkboxes)

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -197,9 +197,14 @@ class Script
     params.select do |key, _value|
       attribute_parameter?(key)
     end.each do |key, value|
-      orig_param = original_parameter(key)
-      self[orig_param.to_sym].min = value if key.end_with?('_min') && !value.to_s.empty?
-      self[orig_param.to_sym].max = value if key.end_with?('_max') && !value.to_s.empty?
+      orig_param = original_parameter(key).to_sym
+      self[orig_param].min = value if key.end_with?('_min') && !value.to_s.empty?
+      self[orig_param].max = value if key.end_with?('_max') && !value.to_s.empty?
+
+      if key.end_with?('_exclude')
+        exclude_list = value.split(',').to_a
+        self[orig_param].exclude_select_choices = exclude_list unless exclude_list.empty?
+      end
     end
   end
 

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
@@ -5,27 +5,31 @@
 -%>
 
 <div class="editable-form-field">
-  <%=  create_widget(form, attrib, format: format) %>
+  <%=  create_widget(form, attrib, format: format, hide_excludable: false) %>
 
   <div class="d-none edit-group">
     
     <ol class="list-group text-center col-md-4 mb-3">
-      <%- attrib.select_choices.each do |select_data| %>
+      <%- attrib.select_choices(hide_excludable: false).each do |select_data| %>
       <%- 
         choice = parse_select_data(select_data)
+        disabled = attrib.exclude_select_choices.include?(choice)
+        li_classes = disabled ? 'list-group-item list-group-item-danger text-strike' : 'list-group-item'
       -%>
 
-      <li class="list-group-item">
+      <li class="<%= li_classes %>">
 
         <button class="btn btn-info float-left" type="button"
-          data-select-toggler="add" data-target="<%= exclude_id %>" data-select-id="<%= field_id %>" disabled>
+          data-select-toggler="add" data-target="<%= exclude_id %>" data-select-id="<%= field_id %>"
+          <%= disabled ? nil : 'disabled="true"'.html_safe %> >
           <%= t('dashboard.add') %>
         </button>
 
         <span data-select-value><%= choice %></span>
 
         <button class="btn btn-warning float-right" type="button"
-          data-select-toggler="remove" data-target="<%= exclude_id %>" data-select-id="<%= field_id %>">
+          data-select-toggler="remove" data-target="<%= exclude_id %>" data-select-id="<%= field_id %>"
+          <%= disabled ? 'disabled="true"'.html_safe : nil %> >
           <%= t('dashboard.remove') %>
         </button>
 
@@ -35,7 +39,8 @@
     
   </div>
 
-  <input type="hidden" value="" id='<%= exclude_id %>' name='<%= exclude_name %>'>
+  <input type="hidden" id='<%= exclude_id %>' name='<%= exclude_name %>'
+    value="<%= attrib.exclude_select_choices.join(',') %>">
   </input>
 
   <%= render(partial: 'scripts/editable_form_fields/edit_field_buttons',  locals: { field_id: field_id }) %>


### PR DESCRIPTION
This enhances excludable options so that all options are shown in scripts#edit when you're choosing which to show and which to hide. Then in scripts#show the options you've chosen to exclude are indeed hidden.  This also adds a new field to attribute so that we can save which options to exclude.

Continues the work for #2902.

The easiest thing to test is excluding options from `cluster` in `scripts#edit`.

Here I'm excluding `ascend` from the cluster options.
![image](https://github.com/OSC/ondemand/assets/4874123/e48463b1-eb13-4648-a8a7-feb069019dd3)

It serializes to this:
```yaml
  auto_batch_clusters:
    options:
    - ascend
    - owens
    - pitzer
    value: pitzer
    exclude_options:
    - ascend
```

Now in `scripts#show` you don't see an option for `ascend`.

![image](https://github.com/OSC/ondemand/assets/4874123/8b250ad2-7d22-4a0b-b215-e9475fe4ade9)
