### PR TITLE
Refactor globus inline js

### DIFF
--- a/apps/dashboard/app/javascript/packs/files/globus.js
+++ b/apps/dashboard/app/javascript/packs/files/globus.js
@@ -1,3 +1,9 @@
+var globus_endpoints;
+
+$(document).ready(function() {
+    globus_endpoints = $("#globus_endpoints").data("globusEndpoints");
+});
+
 /**
  * Given a directory name, return the associated Globus endpoint and path
  * @params {string} directory Directory name

--- a/apps/dashboard/app/views/files/_globus.html.erb
+++ b/apps/dashboard/app/views/files/_globus.html.erb
@@ -2,6 +2,4 @@
   <a href="#" id="globus-link" class="btn btn-primary btn-sm" target="_blank">Globus</a>
 </span>
 
-<%= javascript_tag(nonce: true) do -%>
-  const globus_endpoints = <%= Configuration.globus_endpoints.to_json.html_safe %>;
-<%- end -%>
+<div hidden id="globus_endpoints" data-globus-endpoints="<%= JSON.dump(Configuration.globus_endpoints) %>"></div>


### PR DESCRIPTION
Remove inline javascript related to globus configuration. The json data is now serialized and stored as a data attribute. Resolves OSC/ondemand#2890