### PR TITLE
add support for module names with hyphens in them (#2938)

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attribute_factory.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute_factory.rb
@@ -1,7 +1,7 @@
 module SmartAttributes
   class AttributeFactory
 
-    AUTO_MODULES_REX = /\Aauto_modules_([\w]+)\z/.freeze
+    AUTO_MODULES_REX = /\Aauto_modules_([\w-]+)\z/.freeze
 
     class << self
       # Build an attribute object from an id and its options

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
@@ -19,7 +19,7 @@ module SmartAttributes
         super
 
         @hpc_module = @opts[:module]
-        @id = "#{id}_#{@hpc_module}" # reset the id to be unique from other auto_module_*
+        @id = "#{id}_#{normalize_module(@hpc_module)}" # reset the id to be unique from other auto_module_*
       end
 
       def widget
@@ -49,6 +49,12 @@ module SmartAttributes
       def show_default?
         default = @opts[:default]
         default.nil? ? true : default != false
+      end
+
+      # normalize module names so they can be accessed through methods.
+      # see https://github.com/OSC/ondemand/issues/2933
+      def normalize_module(module_name)
+        module_name.to_s.gsub('-', '_')
       end
     end
   end

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -204,3 +204,4 @@ form:
   - advanced_options
   - auto_modules_app_jupyter
   - auto_modules_intel
+  - auto_modules_netcdf-serial

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/template/script.sh.erb
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/template/script.sh.erb
@@ -1,0 +1,4 @@
+
+# note in the form this is auto_modules_netcdf-serial
+# with a hyphen
+<%- raise StandardError, context.auto_modules_netcdf_serial if context.auto_modules_netcdf_serial == 'netcdf-serial/4.3.3.1' -%>

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -557,23 +557,24 @@ module BatchConnect
         ctx.attributes = { 'cluster' => 'owens', 'bc_num_hours' => 100, 'cuda_version' => 'cuda_100' }
 
         expected_user_context = {
-          'cluster'                  => 'owens',
-          'bc_num_hours'             => '100',
-          'bc_num_slots'             => '1',
-          'mode'                     => '1',
-          'node_type'                => '',
-          'gpus'                     => '0',
-          'bc_account'               => '',
-          'bc_account_other'         => '',
-          'bc_email_on_started'      => '',
-          'python_version'           => '',
-          'cuda_version'             => 'cuda_100',
-          'hidden_change_thing'      => 'default',
-          'classroom'                => '',
-          'classroom_size'           => '',
-          'advanced_options'         => '',
-          'auto_modules_app_jupyter' => '',
-          'auto_modules_intel'       => ''
+          'cluster'                     => 'owens',
+          'bc_num_hours'                => '100',
+          'bc_num_slots'                => '1',
+          'mode'                        => '1',
+          'node_type'                   => '',
+          'gpus'                        => '0',
+          'bc_account'                  => '',
+          'bc_account_other'            => '',
+          'bc_email_on_started'         => '',
+          'python_version'              => '',
+          'cuda_version'                => 'cuda_100',
+          'hidden_change_thing'         => 'default',
+          'classroom'                   => '',
+          'classroom_size'              => '',
+          'advanced_options'            => '',
+          'auto_modules_app_jupyter'    => '',
+          'auto_modules_intel'          => '',
+          'auto_modules_netcdf_serial'  => ''
         }
 
         assert session.save(app: bc_jupyter_app, context: ctx), session.errors.each(&:to_s).to_s

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -635,6 +635,24 @@ class BatchConnectTest < ApplicationSystemTestCase
     end
   end
 
+  test 'auto modules allow hyphens' do
+    with_modified_env({ OOD_MODULE_FILE_DIR: 'test/fixtures/modules' }) do
+      visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+      # defaults to the default version
+      assert_equal('netcdf-serial', find_value('auto_modules_netcdf_serial'))
+
+      select('4.3.3.1', from: bc_ele_id('auto_modules_netcdf_serial'))
+      module_value = 'netcdf-serial/4.3.3.1'
+      assert_equal(module_value, find_value('auto_modules_netcdf_serial'))
+
+      # the script.sh.erb raises the message 'context.auto_modules_netcdf_serial' (note the _ in the name)
+      # which should be 'netcdf-serial/4.3.3.1'
+      click_on('Launch')
+      verify_bc_alert('sys/bc_jupyter',  I18n.t('dashboard.batch_connect_sessions_errors_staging'), module_value)
+    end
+  end
+
   test 'auto accounts are cluster aware' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }


### PR DESCRIPTION
Backports #2938 to 3.0.

Add support for module names with hyphens in them. Now you can add a module like `auto_modules_netcdf-serial` and reference them through `context.auto_modules_netcdf_serial` with underscores.