### PR TITLE
fix mocha deprecation warnings

### DIFF
--- a/apps/dashboard/test/apps/support_ticket_email_service_test.rb
+++ b/apps/dashboard/test/apps/support_ticket_email_service_test.rb
@@ -77,7 +77,7 @@ class SupportTicketEmailServiceTest < ActiveSupport::TestCase
   test "deliver_support_ticket should delegate to SupportTicketMailer class and return success message" do
     SupportTicketMailer.expects(:support_email).returns(stub(:deliver_now => nil))
     I18n.stubs(:t).returns("validation message for all support ticket fields")
-    I18n.expects(:t).with('dashboard.support_ticket.creation_success', {to: "to_address@support.ticket.com"}).returns("success message")
+    I18n.expects(:t).with('dashboard.support_ticket.creation_success', to: "to_address@support.ticket.com").returns("success message")
     result = @target.deliver_support_ticket(SupportTicket.new)
 
     assert_equal "success message", result

--- a/apps/dashboard/test/controllers/support_ticket_controller_test.rb
+++ b/apps/dashboard/test/controllers/support_ticket_controller_test.rb
@@ -71,7 +71,7 @@ class SupportTicketControllerTest < ActiveSupport::TestCase
     # We expect the service to deliver the support ticket
     SupportTicketEmailService.any_instance.stubs(:deliver_support_ticket).returns("support ticket message")
 
-    @controller.expects(:redirect_to).with("/home", {:flash => {:notice => "support ticket message"}})
+    @controller.expects(:redirect_to).with("/home", flash: { notice: "support ticket message" })
 
     @controller.create
   end

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -11,7 +11,7 @@ class BatchConnectTest < ApplicationSystemTestCase
 
   def stub_git(dir)
     Open3.stubs(:capture3)
-      .with('git', 'describe', '--always', '--tags', { chdir: dir })
+      .with('git', 'describe', '--always', '--tags', chdir: dir)
       .returns(['1.2.3', '', exit_success])
   end
 

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -237,7 +237,7 @@ class ProjectsTest < ApplicationSystemTestCase
       Open3
         .stubs(:capture3)
         .with({}, 'sbatch', '-A', 'pas2051', '--export', 'NONE', '--parsable', '-M', 'owens',
-              { stdin_data: "hostname\n" })
+              stdin_data: "hostname\n")
         .returns(['job-id-123', '', exit_success])
 
       OodCore::Job::Adapters::Slurm.any_instance
@@ -280,7 +280,7 @@ class ProjectsTest < ApplicationSystemTestCase
       Open3
         .stubs(:capture3)
         .with({}, 'sbatch', '-A', 'pas2051', '--export', 'NONE', '--parsable', '-M', 'owens',
-              { stdin_data: "hostname\n" })
+              stdin_data: "hostname\n")
         .returns(['', 'some error message', exit_failure])
 
       click_on 'Launch'

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -88,14 +88,14 @@ module ActiveSupport
       ['owens', 'oakley'].each do |cluster|
         Open3
           .stubs(:capture3)
-          .with({}, 'scontrol', 'show', 'part', '-o', '-M', cluster.to_s, { stdin_data: '' })
+          .with({}, 'scontrol', 'show', 'part', '-o', '-M', cluster.to_s, stdin_data: '')
           .returns([File.read("test/fixtures/cmd_output/scontrol_show_partitions_#{cluster}.txt"), '', exit_success])
       end
     end
 
     def stub_sacctmgr
       Open3.stubs(:capture3)
-           .with({}, 'sacctmgr', '-nP', 'show', 'users', 'withassoc', 'format=account,cluster,partition,qos', 'where', 'user=me', { stdin_data: '' })
+           .with({}, 'sacctmgr', '-nP', 'show', 'users', 'withassoc', 'format=account,cluster,partition,qos', 'where', 'user=me', stdin_data: '')
            .returns([File.read('test/fixtures/cmd_output/sacctmgr_show_accts.txt'), '', exit_success])
     end
   end


### PR DESCRIPTION
fix mocha deprecation warnings. 

Here's an example of such a warning:

....................Mocha deprecation warning at /home/jeff/ondemand/src/apps/dashboard/app/controllers/support_ticket_controller.rb:34:in `create': Expectation defined at /home/jeff/ondemand/src/apps/dashboard/test/controllers/support_ticket_controller_test.rb:74:in `block in <class:SupportTicketControllerTest>' expected positional hash ({:flash => {:notice => "support ticket message"}}), but received keyword arguments (:flash => {:notice => "support ticket message"}). These will stop matching when strict keyword argument matching is enabled. See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.
