### PR TITLE
sort ondemand.d files by name before loading

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -387,7 +387,7 @@ class ConfigurationSingleton
 
   def read_config
     files = Pathname.glob(config_directory.join("*.{yml,yaml,yml.erb,yaml.erb}"))
-    files.each_with_object({}) do |f, conf|
+    files.sort.each_with_object({}) do |f, conf|
       begin
         content = ERB.new(f.read, trim_mode: "-").result(binding)
         yml = YAML.safe_load(content, aliases: true) || {}

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -460,4 +460,22 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'config files are sorted by name' do
+    Dir.mktmpdir do |dir|
+      with_modified_env({ OOD_CONFIG_D_DIRECTORY: dir.to_s }) do
+        a_config = { 'nav_categories' => ['AAA', 'BBB'] }
+        z_config = { 'nav_categories' => ['YYY', 'ZZZ'] }
+
+        File.open("#{dir}/a_config.yml", 'w+') { |f| f.write(a_config.to_yaml) }
+        File.open("#{dir}/z_config.yml", 'w+') { |f| f.write(z_config.to_yaml) }
+
+        config = ConfigurationSingleton.new.config
+        nav = config.fetch(:nav_categories)
+
+        # z_config has overwritten a_config
+        assert_equal(nav, ['YYY', 'ZZZ'])
+      end
+    end
+  end
 end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -474,7 +474,25 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
         nav = config.fetch(:nav_categories)
 
         # z_config has overwritten a_config
-        assert_equal(nav, ['YYY', 'ZZZ'])
+        assert_equal(['YYY', 'ZZZ'], nav)
+      end
+    end
+  end
+
+  test 'config files are sorted by name with numbers' do
+    Dir.mktmpdir do |dir|
+      with_modified_env({ OOD_CONFIG_D_DIRECTORY: dir.to_s }) do
+        zero_config = { 'nav_categories' => ['AAA', 'BBB'] }
+        one_config = { 'nav_categories' => ['YYY', 'ZZZ'] }
+
+        File.open("#{dir}/00_config.yml", 'w+') { |f| f.write(zero_config.to_yaml) }
+        File.open("#{dir}/01_config.yml", 'w+') { |f| f.write(one_config.to_yaml) }
+
+        config = ConfigurationSingleton.new.config
+        nav = config.fetch(:nav_categories)
+
+        # z_config has overwritten a_config
+        assert_equal(['YYY', 'ZZZ'], nav)
       end
     end
   end


### PR DESCRIPTION
Fixes #2894 by sorting ondemand.d files by name before loading them.