### PR TITLE
add gcc to dev container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,6 +18,7 @@ RUN dnf -y update && \
     dnf -y module enable nodejs:14 ruby:3.0 && \
     dnf install -y epel-release && \
     dnf install -y ondemand ondemand-dex && \
+    dnf install -y gcc && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
 RUN sed -i 's#^CREATE_MAIL_SPOOL=yes#CREATE_MAIL_SPOOL=no#' /etc/default/useradd; \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,7 +18,7 @@ RUN dnf -y update && \
     dnf -y module enable nodejs:14 ruby:3.0 && \
     dnf install -y epel-release && \
     dnf install -y ondemand ondemand-dex && \
-    dnf install -y gcc && \
+    dnf install -y gcc gcc-c++ libyaml-devel && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
 RUN sed -i 's#^CREATE_MAIL_SPOOL=yes#CREATE_MAIL_SPOOL=no#' /etc/default/useradd; \


### PR DESCRIPTION
add `gcc` to dev container to build dependent gems in the dev dashboard.