### PR TITLE
only query the fs api if you navigate select a directory

### DIFF
--- a/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
@@ -72,6 +72,7 @@ export class PathSelectorTable {
       createdRow: function (row, data, _dataIndex) {
         row.classList.add('clickable');
         row.dataset['apiUrl'] = data.url;
+        row.dataset['pathType'] = data.type;
       },
     });
   }
@@ -104,7 +105,17 @@ export class PathSelectorTable {
   clickRow(event) {
     const row = $(event.target).closest('tr').get(0);
     const url = row.dataset['apiUrl'];
-    this.reloadTable(url);
+    const pathType = row.dataset['pathType'];
+
+    // only reload table for directories. and correct last visited
+    // if it's a file.
+    if(pathType == 'f') {
+      const currentDir = this.getLastVisited();
+      const fileName = url.split('/').slice(-1)[0];
+      this.setLastVisited(`${currentDir}/${fileName}`);
+    } else {
+      this.reloadTable(url);
+    }
   }
 
   clickBreadcrumb(event) {


### PR DESCRIPTION
Fixes #2673 by only reloading the file table when a directory is chosen. This has the added benefit of working for file selection.