### PR TITLE
Container images upgrade to NodeJS 18 and Ruby 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf -y install https://yum.osc.edu/ondemand/latest/ondemand-release-web-late
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled powertools && \
-    dnf -y module enable nodejs:14 ruby:3.0 && \
+    dnf -y module enable nodejs:18 ruby:3.1 && \
     dnf install -y \
         file \
         lsof \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN cp /etc/yum.repos.d/ondemand-web.repo /etc/yum.repos.d/ondemand-nightly-web.
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled powertools && \
-    dnf -y module enable nodejs:14 ruby:3.0 && \
+    dnf -y module enable nodejs:18 ruby:3.1 && \
     dnf install -y epel-release && \
     dnf install -y ondemand ondemand-dex && \
     dnf clean all && rm -rf /var/cache/dnf/*


### PR DESCRIPTION
As of #2885, we should also upgrade related container image versions. Currently, image build will fail:

![WX20230809-125825@2x](https://github.com/OSC/ondemand/assets/43995067/a850d3ce-98cc-4770-9b4c-5bc7fe290636)
