### PR TITLE
Show current filesystem in file browser breadcrumb

### DIFF
--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -1,10 +1,13 @@
 # Helper for /files pages.
 module FilesHelper
-  def path_segment_with_slash(segment, counter, total)
-    # TODO: ucomment if we decide to omit trailing slash on current directory
-    # if counter == 0 || counter == total - 1
+  def path_segment_with_slash(filesystem, segment, counter, total)
+    # TODO: add check for counter == total - 1 if we decide to omit trailing slash on current directory
     if counter == 0
-      segment
+      if filesystem == 'fs'
+        segment
+      else
+        "#{filesystem}: #{segment}"
+      end
     else
       segment + " /"
     end

--- a/apps/dashboard/app/views/files/_breadcrumb.html.erb
+++ b/apps/dashboard/app/views/files/_breadcrumb.html.erb
@@ -7,7 +7,7 @@
 
 <% if file_counter == (file_count - 1) %>
   <li class="breadcrumb-item">
-    <%= path_segment_with_slash(file.basename.to_s, file_counter, file_count) %>
+    <%= path_segment_with_slash(@filesystem, file.basename.to_s, file_counter, file_count) %>
   </li>
   <li class="breadcrumb-item ml-3">
     <button id="goto-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-edit" aria-hidden="true"></i> Change directory</button>
@@ -17,6 +17,6 @@
   </li>
 <% else %>
   <li class="breadcrumb-item">
-    <%= link_to path_segment_with_slash(file.basename.to_s, file_counter, file_count), files_path(@filesystem, file), class: (file_counter == (file_count - 1) ? 'd active' : 'd')  %>
+    <%= link_to path_segment_with_slash(@filesystem, file.basename.to_s, file_counter, file_count), files_path(@filesystem, file), class: (file_counter == (file_count - 1) ? 'd active' : 'd')  %>
   </li>
 <% end %>

--- a/apps/dashboard/app/views/files/_path_selector_breadcrumb.html.erb
+++ b/apps/dashboard/app/views/files/_path_selector_breadcrumb.html.erb
@@ -9,10 +9,10 @@
 
 <% if file_counter == (file_count - 1) %>
   <li class="breadcrumb-item">
-    <%= path_segment_with_slash(file.basename.to_s, file_counter, file_count) %>
+    <%= path_segment_with_slash(@filesystem, file.basename.to_s, file_counter, file_count) %>
   </li>
 <% else %>
   <li class="breadcrumb-item">
-      <span id="<%= files_path(@filesystem, file) %>" class="clickable"><%= path_segment_with_slash(file.basename.to_s, file_counter, file_count) %></span>
+      <span id="<%= files_path(@filesystem, file) %>" class="clickable"><%= path_segment_with_slash(@filesystem, file.basename.to_s, file_counter, file_count) %></span>
   </li>
 <% end %>


### PR DESCRIPTION
This PR makes the current filesystem/remote in the file browser visible in the breadcrumb. Behaviour for local filesystem is same as before.

![image](https://github.com/OSC/ondemand/assets/61623634/1d8e734d-954d-4795-bf3a-9a8bb729c189)
