### PR TITLE
Add delete script functionality for new job composer (#2820)

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -4,7 +4,7 @@
 class ScriptsController < ApplicationController
 
   before_action :find_project
-  before_action :find_script, only: [:show, :edit, :submit, :save]
+  before_action :find_script, only: [:show, :edit, :destroy, :submit, :save]
 
   SAVE_SCRIPT_KEYS = [
     :cluster, :auto_accounts, :auto_accounts_exclude, :auto_scripts, :auto_scripts_exclude,
@@ -23,7 +23,7 @@ class ScriptsController < ApplicationController
     @script = Script.new(opts)
 
     if @script.save
-      redirect_to project_path(params[:project_id]), notice: 'sucess!'
+      redirect_to project_path(params[:project_id]), notice: I18n.t('dashboard.jobs_scripts_created')
     else
       redirect_to project_path(params[:project_id]), alert: @script.errors[:save].last
     end
@@ -34,13 +34,22 @@ class ScriptsController < ApplicationController
   def edit
   end
 
+  # DELETE /projects/:project_id/scripts/:id
+  def destroy
+    if @script.destroy
+      redirect_to project_path(params[:project_id]), notice: I18n.t('dashboard.jobs_scripts_deleted')
+    else
+      redirect_to project_path(params[:project_id]), alert: @script.errors[:destroy].last
+    end
+  end
+
   # POST   /projects/:project_id/scripts/:id/save
   # save the script after editing
   def save
     @script.update(save_script_params[:script])
 
     if @script.save
-      redirect_to project_path(params[:project_id]), notice: 'sucess!'
+      redirect_to project_path(params[:project_id]), notice: I18n.t('dashboard.jobs_scripts_updated')
     else
       redirect_to project_path(params[:project_id]), alert: @script.errors[:save].last
     end
@@ -52,7 +61,7 @@ class ScriptsController < ApplicationController
     opts = submit_script_params[:script].to_h.symbolize_keys
 
     if (job_id = @script.submit(opts))
-      redirect_to(project_path(params[:project_id]), notice: "Successfully submited job #{job_id}.")
+      redirect_to(project_path(params[:project_id]), notice: I18n.t('dashboard.jobs_scripts_submitted', job_id: job_id))
     else
       redirect_to(project_path(params[:project_id]), alert: @script.errors[:submit].last)
     end

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -128,12 +128,23 @@ class Script
 
   def save
     @id = Script.next_id(project_dir) if @id.nil?
-    File.write("#{Script.scripts_dir(project_dir)}/#{id}.yml", to_yaml)
+    File.write(script_file, to_yaml)
 
     true
   rescue StandardError => e
     errors.add(:save, e.message)
     Rails.logger.warn("Cannot save script due to error: #{e.class}:#{e.message}")
+    false
+  end
+
+  def destroy
+    FileUtils.remove_file(script_file)
+    FileUtils.remove_file(job_log_file)
+    FileUtils.remove_file(cache_file_path) if cache_file_exists?
+    true
+  rescue StandardError => e
+    errors.add(:destroy, e.message)
+    Rails.logger.warn("Cannot delete script #{id} due to error: #{e.class}:#{e.message}")
     false
   end
 
@@ -175,6 +186,10 @@ class Script
   end
 
   private
+
+  def script_file
+    File.join(Script.scripts_dir(project_dir), "#{id}.yml")
+  end
 
   # parameters you got from the controller that affect the attributes, not form.
   # i.e., mins & maxes you set in the form but get serialized to the 'attributes' section.

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -49,6 +49,15 @@
             )
             %>
 
+            <%= link_to(
+              t('dashboard.delete'),
+              project_script_path(@project.id, script.id),
+              class: 'btn btn-danger mx-1',
+              method: 'delete',
+              data: { confirm: I18n.t('dashboard.jobs_scripts_delete_script_confirmation') },
+              )
+            %>
+
             <%-
               params = script.smart_attributes.map { |attr| ["script[#{attr.id}]", attr.value] }.to_h
             -%>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -214,6 +214,13 @@ en:
     jobs_create_blank_project: "Create a new project"
     jobs_create_template_project: "Create a new project from a template"
 
+    jobs_scripts_created: "Script successfully created!"
+    jobs_scripts_updated: "Script manifest updated!"
+    jobs_scripts_not_found: "Cannot find script %{script_id}"
+    jobs_scripts_deleted: "Script successfully deleted!"
+    jobs_scripts_submitted: "Successfully submited job %{job_id}."
+    jobs_scripts_delete_script_confirmation: "Delete all contents of script?"
+
     settings_updated: "Settings updated"
 
     breadcrumbs_support_ticket: "Support Ticket"
@@ -245,5 +252,6 @@ en:
     save: "Save"
     add: "Add"
     remove: "Remove"
+    delete: "Delete"
     edit: "Edit"
     show: "Show"

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -183,10 +183,11 @@ class ProjectsTest < ApplicationSystemTestCase
             required: false
       HEREDOC
 
-      assert_selector('.alert-success', text: "×\nClose\nsucess!")
+      success_message = I18n.t('dashboard.jobs_scripts_created')
+      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
       assert_equal(expected_yml, File.read("#{dir}/projects/1/.ondemand/scripts/1.yml"))
 
-      find('[href="/projects/1/scripts/1"]').click
+      find('[href="/projects/1/scripts/1"].btn-success').click
       assert_selector('h1', text: 'the script title', count: 1)
     end
   end
@@ -198,7 +199,7 @@ class ProjectsTest < ApplicationSystemTestCase
       project_dir = "#{dir}/projects/1"
       add_account(1)
 
-      find('[href="/projects/1/scripts/1"]').click
+      find('[href="/projects/1/scripts/1"].btn-success').click
       assert_selector('h1', text: 'the script title', count: 1)
 
       expected_accounts = ['pas1604', 'pas1754', 'pas1871', 'pas2051', 'pde0006', 'pzs0714', 'pzs0715', 'pzs1010',
@@ -213,6 +214,30 @@ class ProjectsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'deleting a script that succeeds' do
+    Dir.mktmpdir do |dir|
+      setup_project(dir)
+      setup_script(1)
+      project_dir = "#{dir}/projects/1"
+      script_dir = "#{project_dir}/.ondemand/scripts"
+      expected_script_files = ["#{script_dir}/1.yml", "#{script_dir}/1_job_log"]
+      # ASSERT EXPECTED SCRIPT FILES
+      expected_script_files.each do |file_path|
+        assert_equal true, File.exist?(file_path)
+      end
+
+      accept_confirm do
+        click_on 'Delete'
+      end
+
+      assert_selector '.alert-success', text: 'Script successfully deleted!'
+      # EXPECTED FILES SHOULD BE DELETED
+      expected_script_files.each do |file_path|
+        assert_not File.exist? file_path
+      end
+    end
+  end
+
   test 'submitting a script with auto attributes that succeeds' do
     Dir.mktmpdir do |dir|
       setup_project(dir)
@@ -221,7 +246,7 @@ class ProjectsTest < ApplicationSystemTestCase
       script_dir = "#{project_dir}/.ondemand/scripts"
       add_account(1)
 
-      find('[href="/projects/1/scripts/1"]').click
+      find('[href="/projects/1/scripts/1"].btn-success').click
       assert_selector('h1', text: 'the script title', count: 1)
 
       # assert defaults
@@ -264,7 +289,7 @@ class ProjectsTest < ApplicationSystemTestCase
       script_dir = "#{project_dir}/.ondemand/scripts"
       add_account(1)
 
-      find('[href="/projects/1/scripts/1"]').click
+      find('[href="/projects/1/scripts/1"].btn-success').click
       assert_selector('h1', text: 'the script title', count: 1)
 
       # assert defaults
@@ -342,7 +367,8 @@ class ProjectsTest < ApplicationSystemTestCase
 
       # correctly saves
       click_on(I18n.t('dashboard.save'))
-      assert_selector('.alert-success', text: "×\nClose\nsucess!")
+      success_message = I18n.t('dashboard.jobs_scripts_updated')
+      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
       assert_current_path '/projects/1'
 
       # note that bc_num_hours has default, min & max
@@ -419,7 +445,8 @@ class ProjectsTest < ApplicationSystemTestCase
 
       # correctly saves
       click_on(I18n.t('dashboard.save'))
-      assert_selector('.alert-success', text: "×\nClose\nsucess!")
+      success_message = I18n.t('dashboard.jobs_scripts_updated')
+      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
       assert_current_path '/projects/1'
 
       expected_yml = <<~HEREDOC
@@ -552,7 +579,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
       find("#save_script_edit").click
       assert_current_path('/projects/1')
-      find('[href="/projects/1/scripts/1"]').click
+      find('[href="/projects/1/scripts/1"].btn-success').click
 
       # now let's check scripts#show to see if they've actually been excluded.
       show_account_options = page.all("#script_auto_accounts option").map(&:value)
@@ -579,7 +606,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
       find("#save_script_edit").click
       assert_current_path('/projects/1')
-      find('[href="/projects/1/scripts/1"]').click
+      find('[href="/projects/1/scripts/1"].btn-success').click
 
       # now let's check scripts#show and they should be back.
       show_account_options = page.all("#script_auto_accounts option").map(&:value)


### PR DESCRIPTION
Added new controller and model functions to delete a script.

Moved the individual script outputs for a script into its own folder to facilitate deleting them.

This is a draft to get early feedback