### PR TITLE
Added check to avoid errors when empty options array

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_scripts.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_scripts.rb
@@ -36,6 +36,8 @@ module SmartAttributes
       # Defaults to first script path in the project
       # @return [String] attribute value
       def value
+        return nil if !opts[:value] && opts[:options].empty?
+        
         (opts[:value] || opts[:options].first.last).to_s
       end
       


### PR DESCRIPTION
When there are no scripts: `AUTO_SCRIPT_EXTENSIONS = ['sh', 'csh', 'bash', 'slurm', 'sbatch', 'qsub']` in the project directory, adding a script into a project fails as the options array is empty.

Fix to avoid these errors.