### PR TITLE
Added implementation for overriding project location path

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -25,7 +25,7 @@ class ProjectsController < ApplicationController
     if name_or_icon_nil?
       @project = Project.new
     else
-      returned_params = { name: new_project_params[:name], icon: new_project_params[:icon] }
+      returned_params = { name: new_project_params[:name], icon: new_project_params[:icon], directory: new_project_params[:directory] }
       @project = Project.new(returned_params)
     end
   end
@@ -65,7 +65,7 @@ class ProjectsController < ApplicationController
     else
       # TODO: loop through all errors and show them instead of this
       flash[:alert] = @project.errors[:name].last || @project.errors[:icon].last
-      redirect_to new_project_path(name: project_params[:name], icon: project_params[:icon])
+      redirect_to new_project_path(name: project_params[:name], directory: project_params[:directory], icon: project_params[:icon])
     end
   end
 
@@ -102,7 +102,7 @@ class ProjectsController < ApplicationController
   def project_params
     params
       .require(:project)
-      .permit(:name, :description, :icon, :id)
+      .permit(:name, :directory, :description, :icon, :id)
   end
 
   def show_project_params
@@ -110,6 +110,6 @@ class ProjectsController < ApplicationController
   end
 
   def new_project_params
-    params.permit(:template, :icon, :name)
+    params.permit(:template, :icon, :name, :directory)
   end
 end

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -78,7 +78,8 @@ class Project
       @manifest = Manifest.new({})
     else
       @id = attributes.delete(:id)
-      @directory = attributes.delete(:directory) || Project.dataroot.join(id.to_s)
+      @directory = attributes.delete(:directory)
+      @directory = Project.dataroot.join(id.to_s).to_s if @directory.blank?
 
       @manifest = Manifest.new(attributes).merge(Manifest.load(manifest_path))
     end

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -11,6 +11,10 @@
                     help: I18n.t('dashboard.jobs_project_name_validation') %>
           </div>
           <div class="field">
+            <%= form.text_field :directory, readonly: action_name == "edit",
+                    help: I18n.t('dashboard.jobs_project_directory_help') %>
+          </div>
+          <div class="field">
             <%= form.text_area :description, placeholder: "Project description" %>
           </div>
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
     jobs_project_delete_project_confirmation: "Delete all contents of project directory?"
     jobs_project_manifest_updated: "Project manifest updated!"
     jobs_project_name_validation: "Project name may only contain letters, digits, dashes, underscores, and spaces"
+    jobs_project_directory_help: "Override the default location for this project"
     jobs_create_blank_project: "Create a new project"
     jobs_create_template_project: "Create a new project from a template"
 

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -51,6 +51,28 @@ class ProjectsTest < ActiveSupport::TestCase
     end
   end
 
+  test 'creates project with directory override' do
+    Dir.mktmpdir do |project_path|
+      OodAppkit.stubs(:dataroot).returns(Pathname.new('/tmp'))
+      attrs = { name: 'directory override', directory: project_path, icon: 'fas://arrow-right', id: 1 }
+      project = Project.new(attrs)
+
+      assert_equal "#{project_path}", project.directory
+      assert project.save(attrs), project.errors.inspect
+      assert File.directory?(Pathname.new(project_path))
+      assert File.file?(Pathname.new("#{project_path}/.ondemand/manifest.yml"))
+    end
+  end
+
+  test 'creates with empty directory defaults to projects dataroot' do
+    project_path = Pathname.new('/tmp')
+    OodAppkit.stubs(:dataroot).returns(project_path)
+    attrs = { name: 'test-project', directory: ' ', id: 1 }
+
+    project = Project.new(attrs)
+    assert_equal "#{project_path}/projects/1", project.directory
+  end
+
   test 'deletes project' do
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -83,6 +83,11 @@ class ProjectsTest < ApplicationSystemTestCase
       setup_project(dir, true)
 
       assert File.directory? File.join("#{dir}", '.ondemand')
+
+      #Cleanup to avoid side effects
+      accept_confirm do
+        click_on 'Delete'
+      end
     end
   end
 

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -12,8 +12,8 @@ class ProjectsTest < ApplicationSystemTestCase
   end
 
   def setup_project(dir, override_location = false)
-    data_root = override_location ? '/tmp' : dir
-    OodAppkit.stubs(:dataroot).returns(Pathname.new(data_root))
+    OodAppkit.stubs(:dataroot).returns(Pathname.new(dir)) unless override_location
+
     proj = 'test-project'
     desc = 'test-description'
     icon = 'fas://arrow-right'

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -11,18 +11,23 @@ class ProjectsTest < ApplicationSystemTestCase
     stub_scontrol
   end
 
-  def setup_project(dir)
-    OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
+  def setup_project(dir, override_location = false)
+    data_root = override_location ? '/tmp' : dir
+    OodAppkit.stubs(:dataroot).returns(Pathname.new(data_root))
     proj = 'test-project'
+    desc = 'test-description'
     icon = 'fas://arrow-right'
     visit projects_path
     click_on I18n.t('dashboard.jobs_create_blank_project')
     find('#project_name').set(proj)
+    find('#project_directory').set(dir) if override_location
+    find('#project_description').set(desc)
     find('#product_icon_select').set(icon)
     click_on 'Save'
 
-    `echo 'some_other_command' > #{dir}/projects/1/my_cool_script.sh`
-    `echo 'hostname' > #{dir}/projects/1/my_cooler_script.bash`
+    project_dir = override_location ? dir : "#{dir}/projects/1"
+    `echo 'some_other_command' > #{project_dir}/my_cool_script.sh`
+    `echo 'hostname' > #{project_dir}/my_cooler_script.bash`
   end
 
   def setup_script(project_id)
@@ -73,6 +78,14 @@ class ProjectsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'creates project overriding default project location' do
+    Dir.mktmpdir do |dir|
+      setup_project(dir, true)
+
+      assert File.directory? File.join("#{dir}", '.ondemand')
+    end
+  end
+
   test 'delete a project from the fs and ensure no table entry' do
     Dir.mktmpdir do |dir|
       setup_project(dir)
@@ -107,6 +120,10 @@ class ProjectsTest < ApplicationSystemTestCase
       assert_selector '[href="/projects/1"]', text: 'My Test Project'
       click_on 'Edit'
       assert_selector 'h1', text: 'Editing: My Test Project'
+      assert_equal 'my-test-project', find('#project_name').value
+      assert_equal "#{dir}/projects/1", find('#project_directory').value
+      assert_equal 'test-description', find('#project_description').value
+      assert_equal 'fas://arrow-right', find('#product_icon_select').value
       assert_selector '.btn.btn-default', text: 'Back'
     end
   end


### PR DESCRIPTION
Fixes: #2558 

DRAFT PR => still needs work, but the structure is there.

Implementation to allow overriding the project path when creating a project.

As the `directory` field is a `attr_reader`, I have disable updating the value on edit.

The implementation uses the `path_selector` widget.