### PR TITLE
change config to a div and put it in a partial

### DIFF
--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -1,0 +1,7 @@
+<!-- configuration options exposed to javascript -->
+<div hidden id="ood_config"
+  data-max-file-size="<%= Configuration.file_upload_max %>"
+  data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
+  data-jobs-info-path="<%= jobs_info_path('delme', 'delme').gsub(/[\/]*delme[\/]*/,'') %>"
+  data-uppy-locale="<%= I18n.t('dashboard.uppy', :default => {}).to_json %>"
+></div>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -23,15 +23,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="profile" content="<%= @user_configuration.profile %>">
 
-  <!-- configuration options exposed to javascript -->
-  <meta id="ood_config"
-    data-bg-color="<%= @user_configuration.brand_bg_color %>"
-    data-link-bg-color="<%= @user_configuration.brand_link_active_bg_color %>"
-    data-max-file-size="<%= Configuration.file_upload_max %>"
-    data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
-    data-jobs-info-path="<%= jobs_info_path('delme', 'delme').gsub(/[\/]*delme[\/]*/,'') %>"
-    data-uppy-locale="<%= I18n.t('dashboard.uppy', :default => {}).to_json %>"
-  />
+  <%= render partial: 'layouts/config' %>
 </head>
 <body>
   <header>

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -14,11 +14,7 @@
 
   <%= csrf_meta_tags %>
 
-  <!-- configuration options exposed to javascript -->
-  <meta id="ood_config"
-    data-bg-color="<%= @user_configuration.brand_bg_color %>"
-    data-link-bg-color="<%= @user_configuration.brand_link_active_bg_color %>"
-  />
+  <%= render partial: 'layouts/config' %>
 </head>
 <body class="d-flex h-100">
 


### PR DESCRIPTION
This is a simple refactor that does a couple things:

* changes the config tag from `meta` to `div` because, well it isn't really meta.
* puts all this configuration into a partial because, as you can see, the `editor`'s layout is already out of sync.