### PR TITLE
Updated project and script model to use random alphanumeric ids

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -21,10 +21,7 @@ class Project
     end
 
     def next_id
-      lookup_table.map { |id, _directory| id }
-                  .map(&:to_i)
-                  .concat([0]) # could be the first project
-                  .max + 1
+      SecureRandom.alphanumeric(8).downcase
     end
 
     def all
@@ -35,7 +32,7 @@ class Project
 
     def find(id)
       opts = lookup_table.select do |lookup_id, _directory|
-        lookup_id == id.to_i
+        lookup_id == id.to_s
       end.map do |lookup_id, directory|
         { id: lookup_id, directory: directory }
       end.first

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -14,10 +14,6 @@ class Script
       end
     end
 
-    def creation_marker_path(script_dir)
-      File.join(script_dir, ".created.json")
-    end
-
     def find(id, project_dir)
       script_path = Script.script_path(project_dir, id)
       file = script_form_file(script_path)
@@ -46,7 +42,7 @@ class Script
       nil
     end
 
-    def next_id(project_dir)
+    def next_id
       SecureRandom.alphanumeric(8).downcase
     end
   end
@@ -131,12 +127,11 @@ class Script
   end
 
   def save
-    @id = Script.next_id(project_dir) if @id.nil?
+    @id = Script.next_id if @id.nil?
     @created_at = Time.now.to_i if @created_at.nil?
     script_path = Script.script_path(project_dir, id)
     script_path.mkpath unless script_path.exist?
     File.write(Script.script_form_file(script_path), to_yaml)
-    add_creation_marker(script_path)
 
     true
   rescue StandardError => e
@@ -254,11 +249,6 @@ class Script
 
   def cache_file_exists?
     cache_file_path.exist?
-  end
-
-  def add_creation_marker(script_dir)
-    creation_marker = Pathname.new(Script.creation_marker_path(script_dir))
-    File.write(creation_marker, { }.to_json) unless creation_marker.exist?
   end
 
   def cached_values

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -5,13 +5,17 @@ class Script
 
   class ClusterNotFound < StandardError; end
 
-  attr_reader :title, :id, :project_dir, :smart_attributes
+  attr_reader :title, :id, :created_at, :project_dir, :smart_attributes
 
   class << self
     def scripts_dir(project_dir)
       Pathname.new("#{project_dir}/.ondemand/scripts").tap do |path|
         path.mkpath unless path.exist?
       end
+    end
+
+    def creation_marker_path(script_dir)
+      File.join(script_dir, ".created.json")
     end
 
     def find(id, project_dir)
@@ -23,7 +27,9 @@ class Script
     def all(project_dir)
       Dir.glob("#{scripts_dir(project_dir).to_s}/*/form.yml").map do |file|
         Script.from_yaml(file, project_dir)
-      end.compact
+      end.compact.sort_by do |s|
+        s.created_at
+      end
     end
 
     def from_yaml(file, project_dir)
@@ -41,11 +47,7 @@ class Script
     end
 
     def next_id(project_dir)
-      all(project_dir)
-        .map(&:id)
-        .map(&:to_i)
-        .prepend(0)
-        .max + 1
+      SecureRandom.alphanumeric(8).downcase
     end
   end
 
@@ -55,6 +57,7 @@ class Script
     @project_dir = opts[:project_dir] || raise(StandardError, 'You must set the project directory')
     @id = opts[:id]
     @title = opts[:title].to_s
+    @created_at = opts[:created_at]
     sm_opts = {
       form:       opts[:form] || [],
       attributes: opts[:attributes] || {}
@@ -78,7 +81,7 @@ class Script
       hash[sm.id.to_s] = sm.options_to_serialize
     end.deep_stringify_keys
 
-    hsh = { 'title' => title }
+    hsh = { 'title' => title, 'created_at' => created_at }
     hsh.merge!({ 'form' => smart_attributes.map { |sm| sm.id.to_s } })
     hsh.merge!({ 'attributes' => attributes })
     hsh.to_yaml
@@ -129,9 +132,11 @@ class Script
 
   def save
     @id = Script.next_id(project_dir) if @id.nil?
+    @created_at = Time.now.to_i if @created_at.nil?
     script_path = Script.script_path(project_dir, id)
     script_path.mkpath unless script_path.exist?
     File.write(Script.script_form_file(script_path), to_yaml)
+    add_creation_marker(script_path)
 
     true
   rescue StandardError => e
@@ -249,6 +254,11 @@ class Script
 
   def cache_file_exists?
     cache_file_path.exist?
+  end
+
+  def add_creation_marker(script_dir)
+    creation_marker = Pathname.new(Script.creation_marker_path(script_dir))
+    File.write(creation_marker, { }.to_json) unless creation_marker.exist?
   end
 
   def cached_values

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -6,7 +6,7 @@
   <div class="col-md-9">
     <div class="row">
       <% @projects.each do |project| %>
-        <div class="col-md-3 project-icon">
+        <div id="<%= project.id %>" class="col-md-3 project-icon project-card">
           <div class="text-center d-flex justify-content-center">
             <%= link_to(project_path(project.id), class: 'text-dark') do %>
               <%= icon_tag(URI.parse(project.icon)) %>

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -23,7 +23,7 @@
       </thead>
       <tbody>
       <% @scripts.each do |script| %>
-        <tr>
+        <tr class="script-card" id="<%= script.id %>">
           <td
             class='text-center col-md-4'
             data-job-id="<%= script.most_recent_job_id %>"


### PR DESCRIPTION
Fixes #2991 

Updated project and script model to use random alphanumeric strings as ids

Had to add `created_at` field to the script model to order the scripts as they are created.