### PR TITLE
also upload logs when system tests fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,10 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: system-test-failures
-          path: apps/dashboard/tmp/screenshots/*.png
+          name: system-test-failures-{{ matrix.ruby }}
+          path: |
+            apps/dashboard/tmp/screenshots/*.png
+            apps/dashboard/log/test.log
 
   k8s-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With #3003 failing for unknown reasons - let's add test.log to the artifact(s) we upload.