### PR TITLE
k8s-bootstrap/ondemand.yaml creates Secret ondemand-token for ondemand ServiceAccount

### DIFF
--- a/hooks/k8s-bootstrap/ondemand.yaml
+++ b/hooks/k8s-bootstrap/ondemand.yaml
@@ -57,6 +57,15 @@ metadata:
   name: ondemand
   namespace: ondemand
 ---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: ondemand-token
+  namespace: ondemand
+  annotations:
+    kubernetes.io/service-account.name: ondemand
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Hi,

ServiceAccount token autogeneration is disabled since kubernetes 1.24. So it is necessary to create token during ServiceAccount creation explicit.

According the the kubernetes documentation
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes

Please merge.

Thanks,
Jan
