### PR TITLE
Added template files sync when creating a project from a template

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -64,6 +64,7 @@ class ProjectsController < ApplicationController
     else
       message = @project.errors[:save].empty? ? I18n.t('dashboard.jobs_project_validation_error') : I18n.t('dashboard.jobs_project_generic_error', error: @project.collect_errors)
       flash.now[:alert] = message
+      @templates = templates if project_params.key?(:template)
       render :new
     end
   end

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -3,7 +3,17 @@
 require 'test_helper'
 
 class ProjectsTest < ActiveSupport::TestCase
-  test 'crate project validation' do
+  test 'create empty project' do
+    project = Project.new
+
+    assert_nil project.id
+    assert_nil project.directory
+    assert_equal '', project.name
+    assert_equal '', project.description
+    assert_equal '', project.icon
+  end
+
+  test 'create project validation' do
     Dir.mktmpdir do |tmp|
       OodAppkit.stubs(:dataroot).returns(Pathname.new(tmp))
 
@@ -13,12 +23,13 @@ class ProjectsTest < ActiveSupport::TestCase
       assert_not project.errors[:name].empty?
 
       invalid_directory = Project.dataroot
-      project = Project.new({ name: 'test', icon: 'invalid_format', directory: invalid_directory.to_s })
+      project = Project.new({ name: 'test', icon: 'invalid_format', directory: invalid_directory.to_s, template: '/invalid/template' })
 
       assert_not project.save
-      assert_equal 2, project.errors.size
+      assert_equal 3, project.errors.size
       assert_not project.errors[:icon].empty?
       assert_not project.errors[:directory].empty?
+      assert_not project.errors[:template].empty?
     end
   end
 
@@ -29,6 +40,41 @@ class ProjectsTest < ActiveSupport::TestCase
 
       assert project.errors.inspect
       assert Dir.entries("#{projects_path}/projects").include?(project.id)
+    end
+  end
+
+  test 'creates project with directory override' do
+    Dir.mktmpdir do |tmp|
+      projects_root = Pathname.new(tmp)
+      project_dir = File.join(tmp, 'dir_override')
+      project = create_project(projects_root, directory: project_dir)
+
+      assert_equal project_dir, project.directory
+      assert File.directory?(Pathname.new(project_dir))
+      assert File.file?(Pathname.new("#{project_dir}/.ondemand/manifest.yml"))
+    end
+  end
+
+  test 'creates project with template copies template files' do
+    Dir.mktmpdir do |tmp|
+      template_dir = File.join(tmp, 'template')
+      file_content = <<~HEREDOC
+        some multiline content
+        echo 'multiline content'
+        description: multiline content
+      HEREDOC
+      Pathname.new(template_dir).mkpath
+      File.open("#{template_dir}/script.sh", 'w') { |file| file.write(file_content) }
+      File.open("#{template_dir}/info.txt", 'w') { |file| file.write(file_content) }
+      File.open("#{template_dir}/config.yml", 'w') { |file| file.write(file_content) }
+
+      Configuration.stubs(:project_template_dir).returns(tmp)
+      projects_path = Pathname.new(tmp)
+      project = create_project(projects_path, template: template_dir)
+
+      assert Dir.entries(project.directory).include?('script.sh')
+      assert Dir.entries(project.directory).include?('info.txt')
+      assert Dir.entries(project.directory).include?('config.yml')
     end
   end
 
@@ -96,11 +142,7 @@ class ProjectsTest < ActiveSupport::TestCase
         description: my test project
       HEREDOC
 
-      puts "project: #{project.inspect}"
-
       assert project.update(test_attributes)
-
-      puts "project: #{project.inspect}"
 
       assert File.exist?(project.manifest_path.to_s)
 
@@ -115,13 +157,14 @@ class ProjectsTest < ActiveSupport::TestCase
       old_id = project.id
       old_directory = project.directory
 
-      assert project.update({ id: 'updated', name: 'updated', icon: 'fas://updated', directory: '/updated', description: 'updated' })
+      assert project.update({ id: 'updated', name: 'updated', icon: 'fas://updated', directory: '/updated', description: 'updated', template: '/some/path' })
       assert_equal 'updated', project.name
       assert_equal 'fas://updated', project.icon
       assert_equal 'updated', project.description
 
       assert_equal old_id, project.id
       assert_equal old_directory, project.directory
+      assert_nil project.template
     end
   end
 
@@ -137,13 +180,12 @@ class ProjectsTest < ActiveSupport::TestCase
     end
   end
 
-  def create_project(projects_path, name: 'test-project', icon: 'fas://arrow-right', description: 'description', directory: nil)
+  def create_project(projects_path, name: 'test-project', icon: 'fas://arrow-right', description: 'description', directory: nil, template: nil)
     OodAppkit.stubs(:dataroot).returns(projects_path)
     id = Project.next_id
-    directory = Project.dataroot.join(id.to_s).to_s if directory.blank?
-    attrs = { name: name, icon: icon, id: id, description: description, directory: directory }
+    attrs = { name: name, icon: icon, id: id, description: description, directory: directory, template: template }
     project = Project.new(attrs)
-    assert project.save
+    assert project.save, project.collect_errors
 
     project
   end


### PR DESCRIPTION
Fixes: #2954 

First implementation to sync the files from a template into a new project.
All files from the template will be copied in this implementation.

It is based on the batch connect session stage method.

Regarding the template interface, I have removed the link to add a project from a template and always added the templates if any available. Let me know if I should revert this part.