### PR TITLE
backport Filter hidden modules (#2997) to 3.0.

### DIFF
--- a/apps/dashboard/app/models/hpc_module.rb
+++ b/apps/dashboard/app/models/hpc_module.rb
@@ -10,9 +10,9 @@ class HpcModule
           begin
             JSON.parse(File.read(file)).map do |name, spider_output|
               spider_output.map do |_, mod|
-                HpcModule.new(name, version: mod['Version'])
+                HpcModule.new(name, version: mod['Version'], hidden: mod['hidden'])
               end
-            end.flatten.uniq
+            end.flatten.uniq.reject(&:hidden?)
           rescue StandardError => e
             Rails.logger.warn("Did not read #{file} correctly because #{e.class}:#{e.message}")
             []
@@ -31,11 +31,13 @@ class HpcModule
     end
   end
 
-  attr_reader :name, :version
+  attr_reader :name, :version, :hidden
+  alias hidden? hidden
 
-  def initialize(name, version: nil)
+  def initialize(name, version: nil, hidden: false)
     @name = name
     @version = version.to_s if version
+    @hidden = hidden
   end
 
   def to_s

--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -14,7 +14,11 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def find_all_options(ele, opt)
-    all("##{bc_ele_id(ele)} option[value='#{opt}']")
+    if opt.nil?
+      all("##{bc_ele_id(ele)} option")
+    else
+      all("##{bc_ele_id(ele)} option[value='#{opt}']")
+    end
   end
 
   def find_max(ele)

--- a/apps/dashboard/test/models/hpc_module_test.rb
+++ b/apps/dashboard/test/models/hpc_module_test.rb
@@ -25,12 +25,13 @@ class HpcModuleTest < ActiveSupport::TestCase
     end
   end
 
-  test 'all versions is corrrect, sorted and unique' do
+  test 'all_versions is corrrect, sorted and unique' do
     stub_sys_apps
     with_modified_env({ OOD_MODULE_FILE_DIR: fixture_dir }) do
+      # "app_jupyter/1.2.21" in oakley.json is hidden
       expected = [
         'app_jupyter/3.1.18', 'app_jupyter/3.0.17', 'app_jupyter/2.3.2', 'app_jupyter/2.2.10',
-        'app_jupyter/1.2.21', 'app_jupyter/1.2.16', 'app_jupyter/0.35.6'
+        'app_jupyter/1.2.21', 'app_jupyter/0.35.6'
       ]
       assert_equal(expected, HpcModule.all_versions('app_jupyter').map(&:to_s))
     end
@@ -62,5 +63,17 @@ class HpcModuleTest < ActiveSupport::TestCase
     m = HpcModule.new('test', version: 9001)
     assert !m.default?
     assert_equal m.version, '9001' # we gave an int, got back a string
+  end
+
+  test 'hidden modules are filtered' do
+    stub_sys_apps
+    with_modified_env({ OOD_MODULE_FILE_DIR: fixture_dir }) do
+      # "mkl/.2019.0.5" in oakley.json is hidden
+      expected = [
+        'mkl/2019.0.5', 'mkl/2019.0.3', 'mkl/2018.0.3', 'mkl/2017.0.7',
+        'mkl/2017.0.4', 'mkl/2017.0.2', 'mkl/11.3.3'
+      ]
+      assert_equal(expected, HpcModule.all_versions('mkl').map(&:to_s))
+    end
   end
 end

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -614,7 +614,6 @@ class BatchConnectTest < ApplicationSystemTestCase
       assert_equal 'owens', find_value('cluster')
       # versions not available on owens
       assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', 'app_jupyter/3.1.18')
-      assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', 'app_jupyter/1.2.16')
       assert_equal 'display: none;', find_option_style('auto_modules_app_jupyter', 'app_jupyter/0.35.6')
       assert_equal 'display: none;', find_option_style('auto_modules_intel', 'intel/18.0.4')
 
@@ -622,7 +621,6 @@ class BatchConnectTest < ApplicationSystemTestCase
       select('oakley', from: bc_ele_id('cluster'))
       assert_equal 'app_jupyter', find_value('auto_modules_app_jupyter')
       assert_equal '', find_option_style('auto_modules_app_jupyter', 'app_jupyter/3.1.18')
-      assert_equal '', find_option_style('auto_modules_app_jupyter', 'app_jupyter/1.2.16')
       assert_equal '', find_option_style('auto_modules_app_jupyter', 'app_jupyter/0.35.6')
 
       # and lots of intel versions aren't
@@ -650,6 +648,29 @@ class BatchConnectTest < ApplicationSystemTestCase
       # which should be 'netcdf-serial/4.3.3.1'
       click_on('Launch')
       verify_bc_alert('sys/bc_jupyter',  I18n.t('dashboard.batch_connect_sessions_errors_staging'), module_value)
+    end
+  end
+
+  test 'auto generated modules hide hidden modules' do
+    with_modified_env({ OOD_MODULE_FILE_DIR: 'test/fixtures/modules' }) do
+      visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+      # defaults, note that intel doesn't show the default version
+      assert_equal 'app_jupyter', find_value('auto_modules_app_jupyter')
+      assert_equal 'intel/2021.3.0', find_value('auto_modules_intel')
+      assert_equal 'owens', find_value('cluster')
+
+      # oakley has the hidden intel module 'intel/2021.4.0'
+      select('oakley', from: bc_ele_id('cluster'))
+
+      actual_options = find_all_options('auto_modules_intel', nil).map(&:text)
+
+      # '2021.4.0' is not listed here.
+      expected_options = [
+        '2021.3.0', '19.1.3', '19.0.5', '19.0.3', '18.0.4', '18.0.3', '18.0.2',
+        '18.0.0', '17.0.7', '17.0.5', '17.0.2', '16.0.8', '16.0.3'
+      ]
+      assert_equal(expected_options, actual_options)
     end
   end
 


### PR DESCRIPTION
auto_modules needs to filter hidden modules so they don't show up in the UI.