### PR TITLE
path_selector to support initial directory w/ tests

### DIFF
--- a/apps/dashboard/app/javascript/packs/path_selector/path_selector.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/path_selector.js
@@ -23,13 +23,13 @@ function makeTable(element) {
 function getPathSelectorOptions(element) {
   options = {};
 
-  options.filesPath       = element.dataset['filesPath'];
-  options.homeDirectory   = element.dataset['homeDirectory'];
-  options.tableId         = element.dataset['tableId'];
-  options.breadcrumbId    = element.dataset['breadcrumbId'];
-  options.selectButtonId  = element.dataset['selectButtonId'];
-  options.inputFieldId    = element.dataset['inputFieldId'];
-  options.modalId         = element.id;
+  options.filesPath         = element.dataset['filesPath'];
+  options.initialDirectory  = element.dataset['initialDirectory'];
+  options.tableId           = element.dataset['tableId'];
+  options.breadcrumbId      = element.dataset['breadcrumbId'];
+  options.selectButtonId    = element.dataset['selectButtonId'];
+  options.inputFieldId      = element.dataset['inputFieldId'];
+  options.modalId           = element.id;
 
   return options;
 }

--- a/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
@@ -3,22 +3,22 @@ export class PathSelectorTable {
   _table = null;
 
   // input data that should be passed into the constructor
-  tableId         = undefined;
-  filesPath       = undefined;
-  breadcrumbId    = undefined;
-  homeDirectory   = undefined;
-  selectButtonId  = undefined;
-  inputFieldId    = undefined;
-  modalId         = undefined;
+  tableId           = undefined;
+  filesPath         = undefined;
+  breadcrumbId      = undefined;
+  initialDirectory  = undefined;
+  selectButtonId    = undefined;
+  inputFieldId      = undefined;
+  modalId           = undefined;
 
   constructor(options) {
-      this.tableId        = options.tableId;
-      this.filesPath      = options.filesPath;
-      this.breadcrumbId   = options.breadcrumbId;
-      this.homeDirectory  = options.homeDirectory;
-      this.selectButtonId = options.selectButtonId;
-      this.inputFieldId   = options.inputFieldId;
-      this.modalId        = options.modalId;
+      this.tableId            = options.tableId;
+      this.filesPath          = options.filesPath;
+      this.breadcrumbId       = options.breadcrumbId;
+      this.initialDirectory   = options.initialDirectory;
+      this.selectButtonId     = options.selectButtonId;
+      this.inputFieldId       = options.inputFieldId;
+      this.modalId            = options.modalId;
 
       this.initDataTable();
       this.reloadTable(this.initialUrl());
@@ -139,7 +139,7 @@ export class PathSelectorTable {
   getLastVisited() {
     const lastVisited = localStorage.getItem(this.storageKey());
     if(lastVisited === null) {
-      return this.homeDirectory;
+      return this.initialDirectory;
     } else {
       return lastVisited;
     }

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -1,6 +1,9 @@
 <%
   show_hidden = false
   show_files = false
+
+  inital_directory = attrib.opts[:directory] || CurrentUser.home
+
   if attrib.opts[:options].is_a?(Array)
     show_hidden = attrib.opts[:options].include? 'hidden'
     show_files = attrib.opts[:options].include? 'files'
@@ -26,7 +29,7 @@
     aria-labelledby="modal-path-selector" aria-hidden="true"
     data-path-selector-show-files="<%= show_files %>"
     data-path-selector-show-hidden="<%= show_hidden %>"
-    data-home-directory="<%= Dir.home %>"
+    data-initial-directory="<%= inital_directory %>"
     data-files-path="<%= files_path %>"
     data-table-id="<%= table_id %>"
     data-breadcrumb-id="<%= breadcrumb_id %>"
@@ -34,7 +37,7 @@
     data-input-field-id="<%= input_field_id %>"
     >
 
-  <div class="modal-dialog modal-dialog-centered" role="document">
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="modal-path-selector-title">Select Your Working Directory</h5>


### PR DESCRIPTION
Looks like the initial directory was hard coded to the user's home. This addition allows users to set the `directory`.

To enable a different initial directory just add the `directory` attribute like so:

```yaml
form:
  - path
attributes:
  path:
    widget: 'path_selector'
    directory: /some/other/directory
```