### PR TITLE
expose bc_dynamic_js to javascript so we can always load these files

### DIFF
--- a/apps/dashboard/app/javascript/packs/batch_connect.js
+++ b/apps/dashboard/app/javascript/packs/batch_connect.js
@@ -3,10 +3,10 @@
 import { attachPathSelectors } from './path_selector/path_selector'
 import { prefillTemplatesHandler } from './prefill_templates/prefill_templates'
 import { prefillSubmitHandler } from './prefill_templates/prefill_submit'
+import { isBCDynamicJSEnabled } from './config';
 
 const bcPrefix = 'batch_connect_session_context';
 const shortNameRex = new RegExp(`${bcPrefix}_([\\w\\-]+)`);
-const tokenRex = /([A-Z][a-z]+){1}([\w\-]+)/;
 
 // @example ['NodeType', 'Cluster']
 const formTokens = [];
@@ -716,21 +716,14 @@ function optionForFromToken(str) {
   document.getElementById(elementId).dispatchEvent((new Event('change', { bubbles: true })));
 };
 
-// simple function to sanitize css query strings
-function sanitizeQuery(item) {
-  return item.replaceAll('.', '\\.');
-}
-
-
-function optionForEvent(target) {
-  let simpleName = shortId(target['id']);
-  return mountainCaseWords(simpleName);
-};
-
 jQuery(function() {
-  makeChangeHandlers();
+  if(isBCDynamicJSEnabled()){
+    makeChangeHandlers();
+  }
+
   attachPathSelectors();
   prefillTemplatesHandler();
   prefillSubmitHandler();
+
   initializing = false;
 });

--- a/apps/dashboard/app/javascript/packs/config.js
+++ b/apps/dashboard/app/javascript/packs/config.js
@@ -43,7 +43,13 @@ function uppyLocale() {
   return JSON.parse(cfgData['uppyLocale']);
 }
 
+function isBCDynamicJSEnabled() {
+  const cfgData = configData();
+  return cfgData['bcDynamicJs'] == 'true'
+}
+
 export {
+  isBCDynamicJSEnabled,
   maxFileSize,
   transfersPath,
   jobsInfoPath,

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -17,7 +17,7 @@
   <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
 <% end %>
 
-<%= javascript_include_tag 'batch_connect', nonce: true if Configuration.bc_dynamic_js? %>
+<%= javascript_include_tag('batch_connect', nonce: true) %>
 
 <% @app.custom_javascript_files.each do |jsfile| %>
   <%= javascript_tag "(function(){\n" + jsfile.read + "\n}());" %>

--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -4,4 +4,5 @@
   data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
   data-jobs-info-path="<%= jobs_info_path('delme', 'delme').gsub(/[\/]*delme[\/]*/,'') %>"
   data-uppy-locale="<%= I18n.t('dashboard.uppy', :default => {}).to_json %>"
+  data-bc-dynamic-js="<%= Configuration.bc_dynamic_js %>"
 ></div>

--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -4,5 +4,5 @@
   data-transfers-path="<%= transfers_path(format: "json") if respond_to?(:transfers_path) %>"
   data-jobs-info-path="<%= jobs_info_path('delme', 'delme').gsub(/[\/]*delme[\/]*/,'') %>"
   data-uppy-locale="<%= I18n.t('dashboard.uppy', :default => {}).to_json %>"
-  data-bc-dynamic-js="<%= Configuration.bc_dynamic_js %>"
+  data-bc-dynamic-js="<%= Configuration.bc_dynamic_js? %>"
 ></div>

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -6,7 +6,8 @@ class BatchConnectTest < ApplicationSystemTestCase
   def setup
     stub_sys_apps
     stub_user
-    Configuration.stubs(:bc_dynamic_js?).returns(true)
+    Configuration.stubs(:bc_dynamic_js).returns(true)
+    Configuration.stubs(:bc_dynamic_js?).returns(true) #stub the alias too
   end
 
   def stub_git(dir)


### PR DESCRIPTION
Fixes #2950 so that the javascript file (with path_selector and other updates) will get loaded all the time. Only when `bc_dynamic_js` is enabled (the config now exposed through javascript) will the javascript file create event handlers for the same.