### PR TITLE
Functional prototype for static values in Scripts

### DIFF
--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -7,8 +7,10 @@ class ScriptsController < ApplicationController
   before_action :find_script, only: [:show, :edit, :destroy, :submit, :save]
 
   SAVE_SCRIPT_KEYS = [
-    :cluster, :auto_accounts, :auto_accounts_exclude, :auto_accounts_fixed, :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
-    :auto_queues, :auto_queues_exclude, :auto_queues_fixed, :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
+    :cluster, :auto_accounts, :auto_accounts_exclude, :auto_accounts_fixed,
+    :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
+    :auto_queues, :auto_queues_exclude, :auto_queues_fixed,
+    :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
     :bc_num_slots, :bc_num_slots_fixed, :bc_num_slots_min, :bc_num_slots_max,
     :bc_num_hours, :bc_num_hours_fixed, :bc_num_hours_min, :bc_num_hours_max
   ].freeze

--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -7,10 +7,10 @@ class ScriptsController < ApplicationController
   before_action :find_script, only: [:show, :edit, :destroy, :submit, :save]
 
   SAVE_SCRIPT_KEYS = [
-    :cluster, :auto_accounts, :auto_accounts_exclude, :auto_scripts, :auto_scripts_exclude,
-    :auto_queues, :auto_queues_exclude, :auto_batch_clusters, :auto_batch_clusters_exclude,
-    :bc_num_slots, :bc_num_slots_min, :bc_num_slots_max,
-    :bc_num_hours, :bc_num_hours_min, :bc_num_hours_max
+    :cluster, :auto_accounts, :auto_accounts_exclude, :auto_accounts_fixed, :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
+    :auto_queues, :auto_queues_exclude, :auto_queues_fixed, :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
+    :bc_num_slots, :bc_num_slots_fixed, :bc_num_slots_min, :bc_num_slots_max,
+    :bc_num_hours, :bc_num_hours_fixed, :bc_num_hours_min, :bc_num_hours_max
   ].freeze
 
   def new

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -1,12 +1,16 @@
 # Helper for creating new batch connect sessions.
 module BatchConnect::SessionContextsHelper
-  def create_widget(form, attrib, format: nil, hide_excludable: true)
-    return '' if attrib.fixed?
+  def create_widget(form, attrib, format: nil, hide_excludable: true, hide_fixed: true)
+    return '' if hide_fixed && attrib.fixed?
     return '' if attrib.hide_when_empty? && attrib.value.blank?
 
     widget = attrib.widget
     field_options = attrib.field_options(fmt: format)
     all_options = attrib.all_options(fmt: format)
+
+    if attrib.fixed?
+      return render :partial => "batch_connect/session_contexts/fixed", :locals => { form: form, attrib: attrib, field_options: field_options, format: format }
+    end
 
     case widget
     when 'select'

--- a/apps/dashboard/app/helpers/scripts_helper.rb
+++ b/apps/dashboard/app/helpers/scripts_helper.rb
@@ -5,7 +5,11 @@ module ScriptsHelper
   def create_editable_widget(form, attrib, format: nil)
     widget = attrib.widget
     attrib.html_options = { class: 'real-field', autocomplete: 'off' }
-    locals = { form: form, attrib: attrib, format: format }
+    # For editable script elements, we want the standard render form even when they are fixed.
+    # We need to reset the fixed attribute to avoid being render as a read only text field.
+    fixed_attribute = attrib.fixed?
+    attrib.opts[:fixed] = false
+    locals = { form: form, attrib: attrib, format: format, fixed: fixed_attribute }
 
     case widget
     when 'number_field'

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -121,6 +121,9 @@ function addInProgressField(event) {
   justAdded.find('[data-select-toggler]')
            .on('click', (event) => { enableOrDisableSelectOption(event) });
 
+  justAdded.find('[data-fixed-toggler]')
+           .on('click', (event) => { toggleFixed(event) });
+
   const entireDiv = event.target.parentElement.parentElement.parentElement;
   entireDiv.remove();
 }
@@ -132,25 +135,23 @@ function fixedFieldEnabled(checkbox, dataElement) {
 }
 
 function toggleFixed(event) {
-  const dataElement = document.getElementById(event.target.dataset.selectId);
+  event.target.disabled = true;
+  const elementId = event.target.dataset.fixedToggler;
+  const dataElement = document.getElementById(elementId);
   if (event.target.checked) {
     fixedFieldEnabled(event.target, dataElement)
   } else {
     dataElement.disabled = false;
     $(`input[type=hidden][name="${dataElement.name}"]`).remove();
   }
+
+  event.target.disabled = false;
 }
 
 function enableOrDisableSelectOption(event) {
   const toggleAction = event.target.dataset.selectToggler;
   const li = event.target.parentElement;
   event.target.disabled = true;
-
-  if(toggleAction == 'fixed') {
-    toggleFixed(event)
-    event.target.disabled = false;
-    return
-  }
 
   const inputId = event.target.dataset.target;
   const choice = $(li).find('[data-select-value]')[0].textContent;
@@ -219,13 +220,18 @@ function initSelectFields(){
     optionToToggle.disabled = true;
     optionToToggle.selected = false;
   });
+}
+
+
+function initFixedFields(){
+  const fixedCheckboxes = Array.from($('[data-fixed-toggler]'));
 
   // find all the enabled 'fixed' checkboxes
-  allButtons.filter((fixedFieldCheckbox) => {
+  fixedCheckboxes.filter((fixedFieldCheckbox) => {
     return fixedFieldCheckbox.checked;
     // now disable the select field
   }).map((fixedFieldCheckbox) => {
-    const dataElement = document.getElementById(fixedFieldCheckbox.dataset.selectId);
+    const dataElement = document.getElementById(fixedFieldCheckbox.dataset.fixedToggler);
     fixedFieldEnabled(fixedFieldCheckbox, dataElement)
   });
 }
@@ -246,5 +252,9 @@ jQuery(() => {
   $('[data-select-toggler]')
     .on('click', (event) => { enableOrDisableSelectOption(event) });
 
+  $('[data-fixed-toggler]')
+      .on('click', (event) => { toggleFixed(event) });
+
   initSelectFields();
+  initFixedFields();
 });

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -125,10 +125,32 @@ function addInProgressField(event) {
   entireDiv.remove();
 }
 
+function fixedFieldEnabled(checkbox, dataElement) {
+  dataElement.disabled = true;
+  const input = $('<input>').attr('type','hidden').attr('name', dataElement.name).attr('value', dataElement.value);
+  $(checkbox).after(input);
+}
+
+function toggleFixed(event) {
+  const dataElement = document.getElementById(event.target.dataset.selectId);
+  if (event.target.checked) {
+    fixedFieldEnabled(event.target, dataElement)
+  } else {
+    dataElement.disabled = false;
+    $(`input[type=hidden][name="${dataElement.name}"]`).remove();
+  }
+}
+
 function enableOrDisableSelectOption(event) {
   const toggleAction = event.target.dataset.selectToggler;
   const li = event.target.parentElement;
   event.target.disabled = true;
+
+  if(toggleAction == 'fixed') {
+    toggleFixed(event)
+    event.target.disabled = false;
+    return
+  }
 
   const inputId = event.target.dataset.target;
   const choice = $(li).find('[data-select-value]')[0].textContent;
@@ -196,6 +218,15 @@ function initSelectFields(){
     const optionToToggle = selectOptions.filter(opt => opt.text == optionText)[0];
     optionToToggle.disabled = true;
     optionToToggle.selected = false;
+  });
+
+  // find all the enabled 'fixed' checkboxes
+  allButtons.filter((fixedFieldCheckbox) => {
+    return fixedFieldCheckbox.checked;
+    // now disable the select field
+  }).map((fixedFieldCheckbox) => {
+    const dataElement = document.getElementById(fixedFieldCheckbox.dataset.selectId);
+    fixedFieldEnabled(fixedFieldCheckbox, dataElement)
   });
 }
 

--- a/apps/dashboard/app/javascript/packs/script_edit.js
+++ b/apps/dashboard/app/javascript/packs/script_edit.js
@@ -44,8 +44,8 @@ function addNewField(_event) {
 }
 
 function updateNewFieldOptions(selectMenu) {
-  for(var newField in newFieldData) {
-    field = document.getElementById(`script_${newField}`);
+  for(let newField in newFieldData) {
+    const field = document.getElementById(`script_${newField}`);
 
     // if the field doesn't already exist, it's an option for a new field.
     if(field === null) {
@@ -122,19 +122,21 @@ function addInProgressField(event) {
            .on('click', (event) => { enableOrDisableSelectOption(event) });
 
   justAdded.find('[data-fixed-toggler]')
-           .on('click', (event) => { toggleFixed(event) });
+           .on('click', (event) => { toggleFixedField(event) });
 
   const entireDiv = event.target.parentElement.parentElement.parentElement;
   entireDiv.remove();
 }
 
 function fixedFieldEnabled(checkbox, dataElement) {
+  // Disable the element to avoid updates from the user
   dataElement.disabled = true;
+  // As it is disabled, need to add a hidden field with the same name to send the fixed field value to the backend.
   const input = $('<input>').attr('type','hidden').attr('name', dataElement.name).attr('value', dataElement.value);
   $(checkbox).after(input);
 }
 
-function toggleFixed(event) {
+function toggleFixedField(event) {
   event.target.disabled = true;
   const elementId = event.target.dataset.fixedToggler;
   const dataElement = document.getElementById(elementId);
@@ -142,6 +144,7 @@ function toggleFixed(event) {
     fixedFieldEnabled(event.target, dataElement)
   } else {
     dataElement.disabled = false;
+    // Field enabled, remove the hidden field with the same name needed when disabled.
     $(`input[type=hidden][name="${dataElement.name}"]`).remove();
   }
 
@@ -229,7 +232,7 @@ function initFixedFields(){
   // find all the enabled 'fixed' checkboxes
   fixedCheckboxes.filter((fixedFieldCheckbox) => {
     return fixedFieldCheckbox.checked;
-    // now disable the select field
+    // now fix the value of the related field
   }).map((fixedFieldCheckbox) => {
     const dataElement = document.getElementById(fixedFieldCheckbox.dataset.fixedToggler);
     fixedFieldEnabled(fixedFieldCheckbox, dataElement)
@@ -253,7 +256,7 @@ jQuery(() => {
     .on('click', (event) => { enableOrDisableSelectOption(event) });
 
   $('[data-fixed-toggler]')
-      .on('click', (event) => { toggleFixed(event) });
+      .on('click', (event) => { toggleFixedField(event) });
 
   initSelectFields();
   initFixedFields();

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -201,7 +201,7 @@ class Script
   # parameters you got from the controller that affect the attributes, not form.
   # i.e., mins & maxes you set in the form but get serialized to the 'attributes' section.
   def attribute_parameter?(name)
-    name.end_with?('_min') || name.end_with?('_max') || name.end_with?('_exclude') || name.end_with?('_fixed')
+    ['min', 'max', 'exclude', 'fixed'].any? { |postfix| name && name.end_with?("_#{postfix}") }
   end
 
   # update the 'form' portion of the yaml file given 'params' from the controller.

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -111,7 +111,7 @@ class Script
   end
 
   def original_parameter(string)
-    match = /([\w_]+)_(?:min|max|exclude)/.match(string)
+    match = /([\w_]+)_(?:min|max|exclude|fixed)/.match(string)
     match[1]
   end
 
@@ -201,7 +201,7 @@ class Script
   # parameters you got from the controller that affect the attributes, not form.
   # i.e., mins & maxes you set in the form but get serialized to the 'attributes' section.
   def attribute_parameter?(name)
-    name.end_with?('_min') || name.end_with?('_max') || name.end_with?('_exclude')
+    name.end_with?('_min') || name.end_with?('_max') || name.end_with?('_exclude') || name.end_with?('_fixed')
   end
 
   # update the 'form' portion of the yaml file given 'params' from the controller.
@@ -222,6 +222,7 @@ class Script
       orig_param = original_parameter(key).to_sym
       self[orig_param].min = value if key.end_with?('_min') && !value.to_s.empty?
       self[orig_param].max = value if key.end_with?('_max') && !value.to_s.empty?
+      self[orig_param].opts[:fixed] = true if key.end_with?('_fixed')
 
       if key.end_with?('_exclude')
         exclude_list = value.split(',').to_a

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_fixed.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_fixed.html.erb
@@ -1,0 +1,6 @@
+<%-
+  all_options = attrib.all_options(fmt: format)
+  all_options[:readonly] = true
+%>
+
+<%= form.text_field(attrib.id, all_options) %>

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_edit_fixed_field.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_edit_fixed_field.html.erb
@@ -6,7 +6,7 @@
 -%>
 <div class="list-group col-md-4">
   <div class="list-group-item mb-3">
-    <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%= fixed ? 'checked' : '' %>  data-select-toggler="fixed" data-select-id="<%= field_id %>">
-    <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_static_field') %></label>
+    <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%= fixed ? 'checked' : '' %> data-fixed-toggler="<%= field_id %>">
+    <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_fixed_field') %></label>
   </div>
 </div>

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_edit_fixed_field.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_edit_fixed_field.html.erb
@@ -1,0 +1,12 @@
+<%-
+  field_id = "#{form.object_name}_#{attrib.id}"
+
+  fixed_id = "#{field_id}_fixed"
+  fixed_name = "#{form.object_name}[#{attrib.id}_fixed]"
+-%>
+<div class="list-group col-md-4">
+  <div class="list-group-item mb-3">
+    <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%= fixed ? 'checked' : '' %>  data-select-toggler="fixed" data-select-id="<%= field_id %>">
+    <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_static_field') %></label>
+  </div>
+</div>

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_number.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_number.html.erb
@@ -18,13 +18,7 @@
 
   <div class="d-none edit-group mb-3">
 
-    <div class="list-group col-md-4">
-      <div class="list-group-item mb-3">
-        <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%=  fixed ? 'checked' : '' %>>
-        <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_static_field') %></label>
-      </div>
-    </div>
-
+    <%= render(partial: 'scripts/editable_form_fields/edit_fixed_field',  locals: { form: form, attrib: attrib, fixed: fixed }) %>
 
     <label for="<%= min_edit_id %>">Minimum</label>
     <input  min="1" step="1"

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_number.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_number.html.erb
@@ -1,4 +1,4 @@
-<%- 
+<%-
   field_id = "#{form.object_name}_#{attrib.id}"
   min_edit_id = "#{field_id}_min"
   min_edit_name = "#{form.object_name}[#{attrib.id}_min]"
@@ -8,12 +8,23 @@
 
   current_min = attrib.field_options[:min]
   current_max = attrib.field_options[:max]
+
+  fixed_id = "#{field_id}_fixed"
+  fixed_name = "#{form.object_name}[#{attrib.id}_fixed]"
 -%>
 
 <div class="editable-form-field">
-  <%=  create_widget(form, attrib, format: format) %>
+  <%=  create_widget(form, attrib, format: format, hide_fixed: false) %>
 
   <div class="d-none edit-group mb-3">
+
+    <div class="list-group col-md-4">
+      <div class="list-group-item mb-3">
+        <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%=  fixed ? 'checked' : '' %>>
+        <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_static_field') %></label>
+      </div>
+    </div>
+
 
     <label for="<%= min_edit_id %>">Minimum</label>
     <input  min="1" step="1"

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
@@ -2,9 +2,6 @@
   field_id = "#{form.object_name}_#{attrib.id}"
   exclude_id = "#{field_id}_exclude"
   exclude_name = "#{form.object_name}[#{attrib.id}_exclude]"
-
-  fixed_id = "#{field_id}_fixed"
-  fixed_name = "#{form.object_name}[#{attrib.id}_fixed]"
 -%>
 
 <div class="editable-form-field">
@@ -12,12 +9,7 @@
 
   <div class="d-none edit-group">
 
-    <div class="list-group col-md-4">
-      <div class="list-group-item mb-3">
-        <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%= fixed ? 'checked' : '' %>>
-        <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_static_field') %></label>
-      </div>
-    </div>
+    <%= render(partial: 'scripts/editable_form_fields/edit_fixed_field',  locals: { form: form, attrib: attrib, fixed: fixed }) %>
 
     <ol class="list-group text-center col-md-4 mb-3">
       <%- attrib.select_choices(hide_excludable: false).each do |select_data| %>
@@ -55,5 +47,5 @@
     value="<%= attrib.exclude_select_choices.join(',') %>">
   </input>
 
-  <%= render(partial: 'scripts/editable_form_fields/edit_field_buttons',  locals: { field_id: field_id, fixed_name: fixed_name }) %>
+  <%= render(partial: 'scripts/editable_form_fields/edit_field_buttons',  locals: { field_id: field_id }) %>
 </div>

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_editable_select.html.erb
@@ -2,13 +2,23 @@
   field_id = "#{form.object_name}_#{attrib.id}"
   exclude_id = "#{field_id}_exclude"
   exclude_name = "#{form.object_name}[#{attrib.id}_exclude]"
+
+  fixed_id = "#{field_id}_fixed"
+  fixed_name = "#{form.object_name}[#{attrib.id}_fixed]"
 -%>
 
 <div class="editable-form-field">
-  <%=  create_widget(form, attrib, format: format, hide_excludable: false) %>
+  <%=  create_widget(form, attrib, format: format, hide_excludable: false, hide_fixed: false) %>
 
   <div class="d-none edit-group">
-    
+
+    <div class="list-group col-md-4">
+      <div class="list-group-item mb-3">
+        <input type="checkbox" id="<%= fixed_id %>" name="<%= fixed_name %>" value="true" <%= fixed ? 'checked' : '' %>>
+        <label class="form-check-label" for="<%= fixed_id %>"><%= t('dashboard.jobs_scripts_static_field') %></label>
+      </div>
+    </div>
+
     <ol class="list-group text-center col-md-4 mb-3">
       <%- attrib.select_choices(hide_excludable: false).each do |select_data| %>
       <%- 
@@ -45,5 +55,5 @@
     value="<%= attrib.exclude_select_choices.join(',') %>">
   </input>
 
-  <%= render(partial: 'scripts/editable_form_fields/edit_field_buttons',  locals: { field_id: field_id }) %>
+  <%= render(partial: 'scripts/editable_form_fields/edit_field_buttons',  locals: { field_id: field_id, fixed_name: fixed_name }) %>
 </div>

--- a/apps/dashboard/app/views/scripts/editable_form_fields/_generic.html.erb
+++ b/apps/dashboard/app/views/scripts/editable_form_fields/_generic.html.erb
@@ -3,7 +3,7 @@
 -%>
 
 <div class="editable-form-field">
-  <%=  create_widget(form, attrib, format: format) %>
+  <%=  create_widget(form, attrib, format: format, hide_fixed: false) %>
 
   <div class="d-none edit-group">
   </div>

--- a/apps/dashboard/app/views/scripts/show.html.erb
+++ b/apps/dashboard/app/views/scripts/show.html.erb
@@ -7,7 +7,7 @@
 <%= bootstrap_form_for(@script, url: submit_project_script_path) do |f| %>
   <% @script.smart_attributes.each do |attrib| %>
     <%# TODO generate render_format %>
-    <%= create_widget(f, attrib, format: nil) %>
+    <%= create_widget(f, attrib, format: nil, hide_fixed: false) %>
   <% end %>
 
   <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -241,7 +241,7 @@ en:
     jobs_scripts_deleted: "Script successfully deleted!"
     jobs_scripts_submitted: "Successfully submited job %{job_id}."
     jobs_scripts_delete_script_confirmation: "Delete all contents of script?"
-    jobs_scripts_static_field: "Static Value"
+    jobs_scripts_fixed_field: "Fixed Value"
 
     settings_updated: "Settings updated"
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -241,6 +241,7 @@ en:
     jobs_scripts_deleted: "Script successfully deleted!"
     jobs_scripts_submitted: "Successfully submited job %{job_id}."
     jobs_scripts_delete_script_confirmation: "Delete all contents of script?"
+    jobs_scripts_static_field: "Static Value"
 
     settings_updated: "Settings updated"
 

--- a/apps/dashboard/test/models/script_test.rb
+++ b/apps/dashboard/test/models/script_test.rb
@@ -3,6 +3,16 @@
 require 'test_helper'
 
 class ScriptTest < ActiveSupport::TestCase
+  test 'supported field postfix' do
+    target = Script.new({ project_dir: '/path/project', id: 1234, title: 'Test Script' })
+    refute target.send('attribute_parameter?', nil)
+    refute target.send('attribute_parameter?', '')
+    refute target.send('attribute_parameter?', 'account_notsupported')
+    assert target.send('attribute_parameter?', 'account_min')
+    assert target.send('attribute_parameter?', 'account_max')
+    assert target.send('attribute_parameter?', 'account_exclude')
+    assert target.send('attribute_parameter?', 'account_fixed')
+  end
   test 'creates script' do
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)

--- a/apps/dashboard/test/system/jobs_app_test.rb
+++ b/apps/dashboard/test/system/jobs_app_test.rb
@@ -398,6 +398,7 @@ class ProjectsTest < ApplicationSystemTestCase
       fill_in('script_bc_num_hours', with: 42)
       fill_in('script_bc_num_hours_min', with: 20)
       fill_in('script_bc_num_hours_max', with: 101)
+      find('#script_bc_num_hours_fixed').click
       find('#save_script_bc_num_hours').click
 
       # correctly saves
@@ -439,6 +440,7 @@ class ProjectsTest < ApplicationSystemTestCase
             min: 20
             step: 1
             value: '42'
+            fixed: true
             max: 101
             label: Number of hours
             help: ''


### PR DESCRIPTION
Fixes #2948

Prototype to implement fixes values within new Job Composer scripts.

I am not sure about the UI as the combination of the dropdown + Add/Remove actions + Set as static are all linked.
I am not sure either of using the SmartAttributes `fixed` property to implement this feature, but seems like the right approach.

This PR shows what I had to do to make it work with SmartAttributes and the `fixed` property, but it is more a hack than a PR.

@johrstrom what is your idea for the UI?
And for the backend? Should the fixed property be use for this feature?