### PR TITLE
Path selector config hide

### DIFF
--- a/apps/dashboard/app/javascript/packs/path_selector/path_selector.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/path_selector.js
@@ -29,6 +29,8 @@ function getPathSelectorOptions(element) {
   options.breadcrumbId      = element.dataset['breadcrumbId'];
   options.selectButtonId    = element.dataset['selectButtonId'];
   options.inputFieldId      = element.dataset['inputFieldId'];
+  options.showFiles         = element.dataset['showFiles'];
+  options.showHidden        = element.dataset['showHidden'];
   options.modalId           = element.id;
 
   return options;

--- a/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
@@ -169,7 +169,9 @@ export class PathSelectorTable {
       const isHidden = file.name.startsWith('.');
       const isFile = file.type == "f";
 
-      if(isHidden) {
+      if(isHidden && isFile) {
+        return this.showHidden && this.showFiles;
+      } else if(isHidden) {
         return this.showHidden;
       } else if(isFile) {
         return this.showFiles;

--- a/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/packs/path_selector/path_selector_data_table.js
@@ -10,6 +10,8 @@ export class PathSelectorTable {
   selectButtonId    = undefined;
   inputFieldId      = undefined;
   modalId           = undefined;
+  showHidden        = undefined;
+  showFiles         = undefined;
 
   constructor(options) {
       this.tableId            = options.tableId;
@@ -19,6 +21,8 @@ export class PathSelectorTable {
       this.selectButtonId     = options.selectButtonId;
       this.inputFieldId       = options.inputFieldId;
       this.modalId            = options.modalId;
+      this.showHidden         = options.showHidden === 'true';
+      this.showFiles          = options.showFiles === 'true';
 
       this.initDataTable();
       this.reloadTable(this.initialUrl());
@@ -162,7 +166,16 @@ export class PathSelectorTable {
   // filter the response from the files API to remove things like hidden files/directories
   filterFileResponse(data) {
     const filteredFiles = data.files.filter((file) => {
-      return !file.name.startsWith('.');
+      const isHidden = file.name.startsWith('.');
+      const isFile = file.type == "f";
+
+      if(isHidden) {
+        return this.showHidden;
+      } else if(isFile) {
+        return this.showFiles;
+      } else {
+        return true;
+      }
     });
 
     data.files = filteredFiles;

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -1,7 +1,7 @@
 <%
-  show_hidden = field_options[:show_hidden] || false
-  show_files = field_options[:show_files] || true
-  inital_directory = field_options[:directory] || CurrentUser.home
+  show_hidden = field_options.fetch(:show_hidden, false)
+  show_files = field_options.fetch(:show_files, true)
+  inital_directory = field_options.fetch(:directory, CurrentUser.home)
 
   input_field_id = "#{form.object_name}_#{attrib.id}"
   path_selector_id = "#{input_field_id}_path_selector"

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -1,13 +1,7 @@
 <%
-  show_hidden = false
-  show_files = false
-
-  inital_directory = attrib.opts[:directory] || CurrentUser.home
-
-  if attrib.opts[:options].is_a?(Array)
-    show_hidden = attrib.opts[:options].include? 'hidden'
-    show_files = attrib.opts[:options].include? 'files'
-  end
+  show_hidden = field_options[:show_hidden] || false
+  show_files = field_options[:show_files] || true
+  inital_directory = field_options[:directory] || CurrentUser.home
 
   input_field_id = "#{form.object_name}_#{attrib.id}"
   path_selector_id = "#{input_field_id}_path_selector"
@@ -27,8 +21,8 @@
     class="modal fade h-75"
     id="<%= path_selector_id %>" tabindex="-1" role="dialog"
     aria-labelledby="modal-path-selector" aria-hidden="true"
-    data-path-selector-show-files="<%= show_files %>"
-    data-path-selector-show-hidden="<%= show_hidden %>"
+    data-show-files="<%= show_files %>"
+    data-show-hidden="<%= show_hidden %>"
     data-initial-directory="<%= inital_directory %>"
     data-files-path="<%= files_path %>"
     data-table-id="<%= table_id %>"


### PR DESCRIPTION
This updates the path selector to actually use configurations to hide hidden things and files.

Here's an example configuration with defaults.
```yaml
---
cluster:
  - owens
form:
  - path
attributes:
  path:
    widget: 'path_selector'
    show_hidden: false
    show_files: true
```