### PR TITLE
rm recursive permissions on project manager

### DIFF
--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -66,8 +66,6 @@ override_dh_auto_install:
 	# Avoid x86 compiled fixtures on non-x86
 	rm -rf $(APACHE_DIR)/apps/sys/dashboard/test
 
-	chmod 700 $(APACHE_DIR)/apps/sys/projects
-
 	# ood config files
 	rake package:version > $(DESTDIR)/opt/ood/VERSION
 	install -m 644 nginx_stage/share/nginx_stage_example.yml $(CONFIG_DIR)/nginx_stage.yml
@@ -94,3 +92,7 @@ override_dh_strip:
 
 override_dh_builddeb:
 	dh_builddeb -- -Zgzip
+
+override_dh_fixperms:
+	dh_fixperms
+	chmod 700 $(APACHE_DIR)/apps/sys/projects

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -295,7 +295,8 @@ touch %{_localstatedir}/www/ood/apps/sys/myjobs/tmp/restart.txt
 %{_localstatedir}/www/ood/apps/sys/activejobs
 %{_localstatedir}/www/ood/apps/sys/myjobs
 %{_localstatedir}/www/ood/apps/sys/projects
-%attr(700, root, root) %{_localstatedir}/www/ood/apps/sys/projects
+%dir %attr(700, root, root) %{_localstatedir}/www/ood/apps/sys/projects
+%{_localstatedir}/www/ood/apps/sys/projects/manifest.yml
 %{_localstatedir}/www/ood/apps/sys/bc_desktop
 %exclude %{_localstatedir}/www/ood/apps/sys/*/tmp/*
 

--- a/spec/e2e/00_package_spec.rb
+++ b/spec/e2e/00_package_spec.rb
@@ -92,4 +92,19 @@ describe 'OnDemand installed with packages' do
     it { is_expected.to be_owned_by('ondemand-nginx') }
     it { is_expected.to be_grouped_into('ondemand-nginx') }
   end
+
+  # tests for beta project manager. remove when it's no longer in beta.
+  describe file('/var/www/ood/apps/sys/projects') do
+    it { is_expected.to be_directory }
+    it { is_expected.to be_mode(700) }
+    it { is_expected.to be_owned_by('root') }
+    it { is_expected.to be_grouped_into('root') }
+  end
+
+  describe file('/var/www/ood/apps/sys/projects/manifest.yml') do
+    it { is_expected.to be_directory }
+    it { is_expected.to be_mode(644) }
+    it { is_expected.to be_owned_by('root') }
+    it { is_expected.to be_grouped_into('root') }
+  end
 end

--- a/spec/e2e/00_package_spec.rb
+++ b/spec/e2e/00_package_spec.rb
@@ -102,7 +102,7 @@ describe 'OnDemand installed with packages' do
   end
 
   describe file('/var/www/ood/apps/sys/projects/manifest.yml') do
-    it { is_expected.to be_directory }
+    it { is_expected.to be_file }
     it { is_expected.to be_mode(644) }
     it { is_expected.to be_owned_by('root') }
     it { is_expected.to be_grouped_into('root') }


### PR DESCRIPTION
rm recursive permissions on project manager because after setting the directory to 750 in puppet - the manifest.yml file is still 700 - which is unreadable by us.