### PR TITLE
Fix FontAwesome icon width in navbar app icons

### DIFF
--- a/apps/dashboard/app/javascript/stylesheets/apps.scss
+++ b/apps/dashboard/app/javascript/stylesheets/apps.scss
@@ -39,6 +39,14 @@ tr.app {
    font-size: 14px;
 }
 
+.app-icon.fa-fw {
+  width: 1.25em;
+}
+
+.app-icon:not(.fa-fw) {
+  margin-right: 0.25em;
+}
+
 .navbar img.menu-icon {
   width: 14px;
   height: 14px;


### PR DESCRIPTION
Currently some of the FontAwesome icons flow over the fixed width that is set for the icons. Visible in the screenshot here:
![iconissue](https://github.com/OSC/ondemand/assets/61623634/0238e20b-6d63-435a-97fa-706751b76845)

This PR sets the proper width for FA icons, while keeping the size the same:
![iconissue_fixed](https://github.com/OSC/ondemand/assets/61623634/ff76a9cd-a763-4fb6-98f1-dafd983911a4)

This happens since [FA sets the width](https://github.com/FortAwesome/Font-Awesome/blob/afecf2af5d897b763e5e8e28d46aad2f710ccad6/css/fontawesome.css#L62) of `.fa-fw` to `1.25em`. I added `margin-right` to non-FA icons to align app names properly, although another option would be to set width (and height) to `1.25em` for those, but that would affect the size or aspect ratio of them.
