### PR TITLE
Add cloud icons for remote favorite paths

### DIFF
--- a/apps/dashboard/app/apps/favorite_path.rb
+++ b/apps/dashboard/app/apps/favorite_path.rb
@@ -16,6 +16,11 @@ class FavoritePath
     filesystem != "fs"
   end
 
+  # FontAwesome icon to use for links
+  def icon
+    remote? ? 'cloud' : 'folder'
+  end
+
   def to_s
     path.to_s
   end

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -99,7 +99,7 @@ class OodApp
             subtitle: favorite_path.title ? favorite_path.path.to_s : nil,
             description: manifest.description,
             url: OodAppkit::Urls::Files.new(base_url: url).url(path: favorite_path.path.to_s, fs: favorite_path.filesystem),
-            icon_uri: favorite_path.remote? ? "fas://cloud" : "fas://folder",
+            icon_uri: "fas://#{favorite_path.icon}",
             caption: caption,
             new_tab: open_in_new_window?,
             tile: tile

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -99,7 +99,7 @@ class OodApp
             subtitle: favorite_path.title ? favorite_path.path.to_s : nil,
             description: manifest.description,
             url: OodAppkit::Urls::Files.new(base_url: url).url(path: favorite_path.path.to_s, fs: favorite_path.filesystem),
-            icon_uri: "fas://folder",
+            icon_uri: favorite_path.remote? ? "fas://cloud" : "fas://folder",
             caption: caption,
             new_tab: open_in_new_window?,
             tile: tile

--- a/apps/dashboard/app/views/files/_favorites.html.erb
+++ b/apps/dashboard/app/views/files/_favorites.html.erb
@@ -5,7 +5,12 @@
     <ul id="favorites" class="nav nav-pills flex-column">
       <li role="presentation" class="nav-item"><%= link_to 'Home Directory', files_path(Dir.home), class: "nav-link d bg-light" %></li>
       <% OodFilesApp.new.favorite_paths.each do |p| %>
-        <li class="nav-item"><%= link_to p.title || p.path.to_s, files_path(p.filesystem, p.path.to_s), class: "nav-link d bg-light" %>
+        <li class="nav-item">
+          <%= link_to files_path(p.filesystem, p.path.to_s), class: "nav-link d bg-light" do %>
+          <%= fa_icon "cloud", classes: '' if p.remote? %>
+          <%= p.title || p.path.to_s  %>
+          <% end %>
+        </li>
       <% end %>
     </ul>
   </nav>

--- a/apps/dashboard/app/views/files/_favorites.html.erb
+++ b/apps/dashboard/app/views/files/_favorites.html.erb
@@ -7,7 +7,7 @@
       <% OodFilesApp.new.favorite_paths.each do |p| %>
         <li class="nav-item">
           <%= link_to files_path(p.filesystem, p.path.to_s), class: "nav-link d bg-light" do %>
-          <%= fa_icon "cloud", classes: '' if p.remote? %>
+          <%= fa_icon p.icon, classes: '' %>
           <%= p.title || p.path.to_s  %>
           <% end %>
         </li>

--- a/apps/dashboard/app/views/files/_favorites.html.erb
+++ b/apps/dashboard/app/views/files/_favorites.html.erb
@@ -3,7 +3,12 @@
 
   <nav>
     <ul id="favorites" class="nav nav-pills flex-column">
-      <li role="presentation" class="nav-item"><%= link_to 'Home Directory', files_path(Dir.home), class: "nav-link d bg-light" %></li>
+      <li role="presentation" class="nav-item">
+        <%= link_to files_path(Dir.home), class: "nav-link d bg-light" do %>
+          <%= fa_icon "home", classes: '' %>
+          Home Directory
+        <% end %>
+      </li>
       <% OodFilesApp.new.favorite_paths.each do |p| %>
         <li class="nav-item">
           <%= link_to files_path(p.filesystem, p.path.to_s), class: "nav-link d bg-light" do %>


### PR DESCRIPTION
This PR adds cloud icons for favorite paths for remote storages both in the navbar and in the file browser.

![remote-storage-icons](https://github.com/OSC/ondemand/assets/61623634/94d675e0-82f1-4f9f-aa52-b4a627685b8e)
The navbar items are currently somewhat ugly due to the spacing, but that is fixed in my other open PR (#3075).