### PR TITLE
use local storage for db files

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -110,7 +110,12 @@ module BatchConnect
       # Root directory for file system database
       # @return [Pathname] root directory of file system database
       def db_root
-        dataroot.join("db").tap { |p| p.mkpath unless p.exist? }
+        if Rails.env.production?
+          # directory created in config/initializers/upgrade_to_3.1.rb
+          Configuration.local_dataroot.join('dashboard/batch_connect/db')
+        else
+          dataroot.join("db").tap { |p| p.mkpath unless p.exist? }
+        end
       end
 
       # Root directory for file system database

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -264,6 +264,12 @@ class ConfigurationSingleton
     Pathname.new(root).expand_path
   end
 
+  # The dataroot on the local filesystem, whereas dataroot is likely
+  # on an NFS storage.
+  def local_dataroot
+    Pathname.new("/var/lib/ondemand/#{CurrentUser.name}")
+  end
+
   def locale
     (ENV['OOD_LOCALE'] || 'en').to_sym
   end

--- a/apps/dashboard/config/initializers/upgrade_to_3.1.rb
+++ b/apps/dashboard/config/initializers/upgrade_to_3.1.rb
@@ -1,0 +1,19 @@
+
+Rails.application.config.after_initialize do
+  if Rails.env.production?
+    old_db_dir = BatchConnect::Session.dataroot.join("db")
+    new_db_dir = BatchConnect::Session.db_root
+
+    # have to prep these directories here. Package should have installed
+    # Configuration.local_dataroot's parent directory.
+    local_dr = Configuration.local_dataroot
+    Dir.mkdir(local_dr, 0o0700) unless Dir.exist?(local_dr)
+    FileUtils.mkdir_p(new_db_dir) unless Dir.exist?(new_db_dir)
+
+    next if !old_db_dir.exist? || old_db_dir.empty?
+
+    Dir.children(old_db_dir.to_s) do |db_file|
+      FileUtils.copy("#{old_db_dir}/#{db_file}", "#{new_db_dir}/#{db_file}")
+    end
+  end
+end

--- a/apps/dashboard/config/initializers/upgrade_to_3.1.rb
+++ b/apps/dashboard/config/initializers/upgrade_to_3.1.rb
@@ -4,6 +4,9 @@ Rails.application.config.after_initialize do
     old_db_dir = BatchConnect::Session.dataroot.join("db")
     new_db_dir = BatchConnect::Session.db_root
 
+    # could be running this while building assets. if so, just kick out.
+    next if !new_db_dir.parent.exist?
+
     # have to prep these directories here. Package should have installed
     # Configuration.local_dataroot's parent directory.
     local_dr = Configuration.local_dataroot

--- a/apps/dashboard/config/initializers/upgrade_to_3.1.rb
+++ b/apps/dashboard/config/initializers/upgrade_to_3.1.rb
@@ -4,12 +4,14 @@ Rails.application.config.after_initialize do
     old_db_dir = BatchConnect::Session.dataroot.join("db")
     new_db_dir = BatchConnect::Session.db_root
 
-    # could be running this while building assets. if so, just kick out.
-    next if !new_db_dir.parent.exist?
-
     # have to prep these directories here. Package should have installed
     # Configuration.local_dataroot's parent directory.
     local_dr = Configuration.local_dataroot
+
+    # could be running this while building assets during packaging.
+    # if so, just kick out.
+    next unless local_dr.parent.exist?
+
     Dir.mkdir(local_dr, 0o0700) unless Dir.exist?(local_dr)
     FileUtils.mkdir_p(new_db_dir) unless Dir.exist?(new_db_dir)
 

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -82,6 +82,7 @@ override_dh_auto_install:
 
 	mkdir -p $(DESTDIR)/var/tmp/ondemand-nginx
 	mkdir -p $(DESTDIR)/var/run/ondemand-nginx
+	mkdir -p $(DESTDIR)/var/lib/ondemand
 	mkdir -p $(DESTDIR)/var/lib/ondemand-nginx/config/puns
 	mkdir -p $(DESTDIR)/var/lib/ondemand-nginx/config/apps/sys
 	mkdir -p $(DESTDIR)/var/lib/ondemand-nginx/config/apps/usr
@@ -96,3 +97,4 @@ override_dh_builddeb:
 override_dh_fixperms:
 	dh_fixperms
 	chmod 700 $(APACHE_DIR)/apps/sys/projects
+	chmod 777 $(DESTDIR)/var/lib/ondemand

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -187,6 +187,7 @@ echo "%{git_tag}" > %{buildroot}/opt/ood/VERSION
 %__mkdir_p %{buildroot}%{_sharedstatedir}/ondemand-nginx/config/apps/sys
 %__mkdir_p %{buildroot}%{_sharedstatedir}/ondemand-nginx/config/apps/usr
 %__mkdir_p %{buildroot}%{_sharedstatedir}/ondemand-nginx/config/apps/dev
+%__mkdir_p %{buildroot}%{_sharedstatedir}/ondemand
 %__mkdir_p %{buildroot}%{_tmppath}/ondemand-nginx
 %__mkdir_p %{buildroot}%{_rundir}/ondemand-nginx
 
@@ -321,6 +322,7 @@ touch %{_localstatedir}/www/ood/apps/sys/myjobs/tmp/restart.txt
 %config(noreplace,missingok) %{_sysconfdir}/ood/config/hook.env
 %config(noreplace) %{_sysconfdir}/ood/config/ood_portal.sha256sum
 
+%dir %attr(777, root, root) %{_sharedstatedir}/ondemand
 %dir %{_sharedstatedir}/ondemand-nginx/config
 %dir %{_sharedstatedir}/ondemand-nginx/config/puns
 %dir %{_sharedstatedir}/ondemand-nginx/config/apps

--- a/spec/e2e/00_package_spec.rb
+++ b/spec/e2e/00_package_spec.rb
@@ -107,4 +107,11 @@ describe 'OnDemand installed with packages' do
     it { is_expected.to be_owned_by('root') }
     it { is_expected.to be_grouped_into('root') }
   end
+
+  describe file('/var/lib/ondemand') do
+    it { is_expected.to be_directory }
+    it { is_expected.to be_mode(777) }
+    it { is_expected.to be_owned_by('root') }
+    it { is_expected.to be_grouped_into('root') }
+  end
 end

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -77,7 +77,6 @@ describe 'OnDemand browser test' do
 
   # personal lib directories are 700 and owned by the user.
   describe file('/var/lib/ondemand/ood') do
-    browser.goto ctr_base_url
     it { is_expected.to be_directory }
     it { is_expected.to be_mode(700) }
     it { is_expected.to be_owned_by('ood') }

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -74,4 +74,13 @@ describe 'OnDemand browser test' do
     expect(browser.title).to eq('Dashboard - Open OnDemand')
     expect(browser.table(id: 'directory-contents').present?).to be true
   end
+
+  # personal lib directories are 700 and owned by the user.
+  describe file('/var/lib/ondemand/ood') do
+    browser.goto ctr_base_url
+    it { is_expected.to be_directory }
+    it { is_expected.to be_mode(700) }
+    it { is_expected.to be_owned_by('ood') }
+    it { is_expected.to be_grouped_into('ood') }
+  end
 end


### PR DESCRIPTION
This moves db files to local storage instead of NFS storage. I'm not entirely sure it's bug free as it deals with creating directories through packaging. So we'll likely have to see in a nightly if this works.

In draft for a moment while I write some e2e tests.