### PR TITLE
disregard brp-python-bytecompile errors

### DIFF
--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -13,6 +13,9 @@
 %global gem_home %{scl_ondemand_core_gem_home}/%{version}-%{package_release}
 %global gems_name ondemand-gems-%{version}-%{package_release}
 
+# disregard brp-python-bytecompile errors
+%global _python_bytecompile_errors_terminate_build 0
+
 %define __brp_mangle_shebangs /bin/true
 %if 0%{?amzn}
 # RPATH is always broken with things like nokogiri


### PR DESCRIPTION
disregard brp-python-bytecompile errors so el7 can continue to build.