### PR TITLE
Stop serializing the connection view.

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -39,10 +39,6 @@ module BatchConnect
     # @return [String] session title
     attr_accessor :title
 
-    # The view used to display the connection information for this session
-    # @return [String, nil] session view
-    attr_accessor :view
-
     # Batch connect script type
     # @return [String] script type
     attr_accessor :script_type
@@ -71,13 +67,13 @@ module BatchConnect
     # Return the Batch Connect app from the session token
     # @return [BatchConnect::App]
     def app
-      BatchConnect::App.from_token(self.token)
+      @app ||= BatchConnect::App.from_token(self.token)
     end
 
     # Attributes used for serialization
     # @return [Hash] attributes to be serialized
     def attributes
-      %w(id cluster_id job_id created_at token title view script_type cache_completed).map do |attribute|
+      %w(id cluster_id job_id created_at token title script_type cache_completed).map do |attribute|
         [ attribute, nil ]
       end.to_h
     end
@@ -97,6 +93,10 @@ module BatchConnect
     rescue => e
       Rails.logger.error("ERROR: Error parsing user_context file: '#{user_defined_context_file}' --- #{e.class} - #{e.message}")
       {}
+    end
+
+    def view
+      app.session_view
     end
 
     class << self
@@ -236,7 +236,6 @@ module BatchConnect
       self.id         = SecureRandom.uuid
       self.token      = app.token
       self.title      = app.title
-      self.view       = app.session_view
       self.created_at = Time.now.to_i
       self.cluster_id = context.try(:cluster).to_s
 

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -526,7 +526,6 @@ module BatchConnect
           'created_at'      => now.to_i,
           'token'           => 'bc_jupyter',
           'title'           => 'Jupyter Notebook',
-          'view'            => nil,
           'script_type'     => 'basic',
           'cache_completed' => nil
         }


### PR DESCRIPTION
Stop serializing the connection view, and instead read it from the app directly.