### PR TITLE
Disabled deleting auto_batch_clusters from edit script forms

### DIFF
--- a/apps/dashboard/app/helpers/scripts_helper.rb
+++ b/apps/dashboard/app/helpers/scripts_helper.rb
@@ -62,6 +62,6 @@ module ScriptsHelper
   end
 
   def script_removable_field?(id)
-    !['script_auto_scripts'].include?(id.to_s)
+    !['script_auto_scripts', 'script_auto_batch_clusters'].include?(id.to_s)
   end
 end

--- a/apps/dashboard/app/helpers/scripts_helper.rb
+++ b/apps/dashboard/app/helpers/scripts_helper.rb
@@ -62,6 +62,6 @@ module ScriptsHelper
   end
 
   def script_removable_field?(id)
-    !['script_auto_scripts', 'script_auto_batch_clusters'].include?(id.to_s)
+    ['script_auto_scripts', 'script_auto_batch_clusters'].exclude?(id.to_s)
   end
 end

--- a/apps/dashboard/test/helpers/scripts_helper_test.rb
+++ b/apps/dashboard/test/helpers/scripts_helper_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ScriptsHelperTest < ActionView::TestCase
+  include ScriptsHelper
+
+  test 'script_removable_field? should return false for expected fields' do
+    assert_equal true, script_removable_field?('any_field')
+
+    non_removable_fields = ['script_auto_scripts', 'script_auto_batch_clusters']
+    non_removable_fields.each do |field|
+      assert_equal false, script_removable_field?(field)
+    end
+  end
+end


### PR DESCRIPTION
Removing the "Remove" button from the `auto_batch_clusters` field in the edit script page