### PR TITLE
Refactor transfer rm

### DIFF
--- a/apps/dashboard/app/models/transfer.rb
+++ b/apps/dashboard/app/models/transfer.rb
@@ -19,6 +19,8 @@ class Transfer
   # files could either be an array of strings or an array of hashes (string=>string)
   attr_accessor :action, :files
 
+  REMOVE_ACTION = 'rm'.freeze
+
   class << self
     def transfers
       @transfers ||= []
@@ -114,5 +116,14 @@ class Transfer
   def perform_later
     save
     TransferLocalJob.perform_later(self)
+  end
+
+  def remove?
+    action == Transfer::REMOVE_ACTION
+  end
+
+  def complete!
+    self.exit_status = errors.any? ? 1 : 0
+    self.completed_at = Time.now.to_i
   end
 end

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -136,7 +136,6 @@ class FilesTest < ApplicationSystemTestCase
       # select dir to move
       visit files_url(dir)
       find('tbody a', exact_text: 'app').ancestor('tr').check
-      # assert false
       find('tbody a', exact_text: 'single_file').ancestor('tr').check
       find('#delete-btn').click
       find('button.swal2-confirm').click

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -126,19 +126,28 @@ class FilesTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       # copy to dest/app
       src = File.join(dir, 'app')
-      `cp -r #{Rails.root.join('app').to_s} #{src}`
+      single_file = File.join(dir, 'single_file')
+      `cp -r #{Rails.root.join('app')} #{src}`
+      `touch #{single_file}`
+
+      assert File.directory?(src)
+      assert File.file?(single_file)
 
       # select dir to move
       visit files_url(dir)
-      find('tbody a', exact_text: 'app').ancestor('tr').click
+      find('tbody a', exact_text: 'app').ancestor('tr').check
+      # assert false
+      find('tbody a', exact_text: 'single_file').ancestor('tr').check
       find('#delete-btn').click
       find('button.swal2-confirm').click
 
       # verify app dir deleted according to UI
       assert_no_selector 'tbody a', exact_text: 'app', wait: 10
+      assert_no_selector 'tbody a', exact_text: 'single_file', wait: 10
 
-      # verify app dir actually deleted
-      refute File.exist?(src)
+      # verify app dir & single_file were actually deleted
+      refute(File.exist?(src), Dir.children(dir))
+      refute(File.exist?(single_file), Dir.children(dir))
     end
   end
 


### PR DESCRIPTION
Work on #2668 to refactor the removal of files to use ruby APIs instead of issuing the `rm` command.