### PR TITLE
use ruby libraries to copy files instead of issuing cp

### DIFF
--- a/apps/dashboard/app/models/transfer.rb
+++ b/apps/dashboard/app/models/transfer.rb
@@ -20,6 +20,7 @@ class Transfer
   attr_accessor :action, :files
 
   REMOVE_ACTION = 'rm'.freeze
+  COPY_ACTION   = 'cp'.freeze
 
   class << self
     def transfers
@@ -120,6 +121,10 @@ class Transfer
 
   def remove?
     action == Transfer::REMOVE_ACTION
+  end
+
+  def copy?
+    action == Transfer::COPY_ACTION
   end
 
   def complete!


### PR DESCRIPTION
Continuing the work of #2668 - this refactors the copy command to use FileUtils instead of the `cp` command.