### PR TITLE
Underline .clickable on hover

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/common.scss
+++ b/apps/dashboard/app/assets/stylesheets/common.scss
@@ -3,6 +3,10 @@
   cursor: pointer;
 }
 
+.clickable:hover {
+  text-decoration: underline;
+}
+
 .gold {
   color: gold;
 }


### PR DESCRIPTION
Fixes issue https://github.com/OSC/ondemand/issues/3136

Would there be anywhere `.clickable` is used where we WOULDN'T want it to indicate with an underline on hover? Also, do we want to bother with active/inactive colors as well?

<img width="492" alt="Screenshot 2023-10-26 at 1 47 46 PM" src="https://github.com/OSC/ondemand/assets/6969170/53ba8037-39ad-4d17-ba94-820085f4e77b">
