### PR TITLE
correctly set auto_modules' label

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
@@ -27,7 +27,7 @@ module SmartAttributes
       end
 
       def label(*)
-        @opts[:label] || @hpc_module.nil? ? 'Auto modules (none given)' : "#{@hpc_module.titleize} version"
+        @opts[:label] || (@hpc_module.nil? ? 'Auto modules (none given)' : "#{@hpc_module.titleize} version")
       end
 
       def select_choices(*)

--- a/apps/dashboard/test/lib/smart_attributes/auto_modules_test.rb
+++ b/apps/dashboard/test/lib/smart_attributes/auto_modules_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SmartAttributes::AutoModulesTest < ActiveSupport::TestCase
+
+  def fixture_dir
+    "#{Rails.root}/test/fixtures/modules/"
+  end
+
+  test 'can correctly set the label' do
+    with_modified_env({ OOD_MODULE_FILE_DIR: fixture_dir }) do
+      label = 'my cool label'
+      attribute = SmartAttributes::AttributeFactory.build('auto_modules_R', { label: label })
+
+      assert_equal(label, attribute.label)
+    end
+  end
+end


### PR DESCRIPTION
A bug from discourse - https://discourse.openondemand.org/t/auto-modules-module-name-label/3054 - where you're unable to correctly set the label on the `auto_modules` smart attribute.

To replicate you could:
* enable auto modules with the environment variable `OOD_MODULE_FILE_DIR`. 
  * check production config for files - https://github.com/search?q=repo%3AOSC%2Fosc-ood-config%20OOD_MODULE_FILE_DIR&type=code  - or use/copy the test fixtures

* Use a simple form like this that attempts to set the label on `auto_modules_R`
```yaml
cluster:
  - pitzer
  - owens

form:
  - auto_modules_R

attributes:
  auto_modules_R:
    label: "my cool R Version"
```

Or - since I provided  a test, you could checkout the current master version of the auto_modules file and run that test.