### PR TITLE
Update node pty

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,6 @@ jobs:
           bundle install
           gem install rake
 
-      - name: Setup Node.js
-        run: |
-          npm install -g node-gyp
-
       - name: Setup rclone
         run: sudo apt-get update && sudo apt-get install rclone
 

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -22,7 +22,7 @@
     "js-yaml": "^3.14.0",
     "minimist": "^1.2.6",
     "node-notifier": "^8.0.1",
-    "node-pty": "^0.9.0",
+    "node-pty": "^1.0.0",
     "ws": ">=7.4.6"
   },
   "private": true,

--- a/apps/shell/yarn.lock
+++ b/apps/shell/yarn.lock
@@ -410,7 +410,7 @@ ms@2.0.0, ms@2.1.1, ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-nan@^2.14.0:
+nan@^2.17.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
   integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
@@ -437,12 +437,12 @@ node-notifier@^8.0.1:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-pty@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
-  integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==
+node-pty@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.0.0.tgz#7daafc0aca1c4ca3de15c61330373af4af5861fd"
+  integrity sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==
   dependencies:
-    nan "^2.14.0"
+    nan "^2.17.0"
 
 object-inspect@^1.9.0:
   version "1.12.3"


### PR DESCRIPTION
Update `node-pty` so that builds can continue. Right now there's an(other) issue with `node-gyp` in the packaging repository. So this update is to fix the transient dependency on `node-gyp` along with any other bugfixes this version may have.