### PR TITLE
stop using node-pty's deprecated APIs

### DIFF
--- a/apps/shell/app.js
+++ b/apps/shell/app.js
@@ -178,17 +178,13 @@ wss.on('connection', function connection (ws, req) {
 
     console.log('Opened terminal: ' + term.pid);
 
-    term.on('data', function (data) {
+    term.onData(function (data) {
       ws.send(data, function (error) {
         if (error) console.log('Send error: ' + error.message);
       });
     });
 
-    term.on('error', function (error) {
-      ws.close();
-    });
-
-    term.on('close', function () {
+    term.onExit(function (_exitData) {
       ws.close();
     });
 


### PR DESCRIPTION
Fixes #3137  by stop using node-pty's deprecated APIs.  Note that there was never an 'error' or 'close' event as far as I could tell.

There was an 'exit' event, but we didn't listen for it. (maybe that called triggered `close`?)

https://github.com/microsoft/node-pty/blob/6a385f94c1c15bc9c7688eda4c3666f6fbceede6/typings/node-pty.d.ts#L65