### PR TITLE
add a link to project directory in projects#show

### DIFF
--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -10,6 +10,13 @@
   </p>
 </div>
 
+<div class="row my-2">
+  <a id="new-dir-btn" class="btn btn-outline-dark" href="<%= files_path(fs: 'fs', filepath: @project.directory ) %>">
+    <i class="fas fa-folder-open" aria-hidden="true"></i>
+    <%= t('dashboard.project') %> <%= t('dashboard.directory') %>
+  </a>
+</div>
+
 <div class='card'>
   <h3 class='card-header'>Scripts</h3>
   <div class='card-body'>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -281,3 +281,5 @@ en:
     delete: "Delete"
     edit: "Edit"
     show: "Show"
+    project: "Project"
+    directory: "Directory"


### PR DESCRIPTION
This adds a link to project directory in `projects#show` as seen below.

This whole page's view is subject to change, but we would need some sort of file management in this view - this is just the lowest hanging fruit.


![image](https://github.com/OSC/ondemand/assets/4874123/caa4db7d-09a3-4ebd-8e2a-9bd8a3a0369c)
