### PR TITLE
support for dynamic checkboxes

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -294,7 +294,7 @@ function setValue(event, changeId) {
 
   if(changeVal !== undefined) {
     const element = document.getElementById(changeId);
-    if(element.type == 'checkbox') {
+    if(element['type'] == 'checkbox') {
       setCheckboxValue(element, changeVal);
     } else {
       element.value = changeVal;

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -293,8 +293,21 @@ function setValue(event, changeId) {
   const changeVal = table.get(chosenVal, undefined);
 
   if(changeVal !== undefined) {
-    const innerElement = document.getElementById(changeId);
-    innerElement.value = changeVal;
+    const element = document.getElementById(changeId);
+    if(element.type == 'checkbox') {
+      setCheckboxValue(element, changeVal);
+    } else {
+      element.value = changeVal;
+    }
+  }
+}
+
+function setCheckboxValue(checkbox, value) {
+  const affirmitiveValue = checkbox.value;
+  if(value == affirmitiveValue) {
+    checkbox.checked = true;
+  } else {
+    checkbox.checked = false;
   }
 }
 

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -293,9 +293,8 @@ function setValue(event, changeId) {
   const changeVal = table.get(chosenVal, undefined);
 
   if(changeVal !== undefined) {
-    const innerElement = $(`#${changeId}`);
-    innerElement.attr('value', changeVal);
-    innerElement.val(changeVal);
+    const innerElement = document.getElementById(changeId);
+    innerElement.value = changeVal;
   }
 }
 

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -303,8 +303,8 @@ function setValue(event, changeId) {
 }
 
 function setCheckboxValue(checkbox, value) {
-  const affirmitiveValue = checkbox.value;
-  if(value == affirmitiveValue) {
+  const positiveValue = checkbox.value;
+  if(value == positiveValue) {
     checkbox.checked = true;
   } else {
     checkbox.checked = false;

--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -34,6 +34,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     find("##{bc_ele_id(ele)}", visible: visible).value
   end
 
+  def checked?(ele)
+    find("##{bc_ele_id(ele)}").checked?
+  end
+
   def find_css_class(id)
     find("##{id}")['class'].to_s
   end

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -172,11 +172,13 @@ attributes:
           'medium', 'medium',
           data-option-for-classroom-astronomy-5678: false,
           data-option-for-classroom-astronomy-with/other-characters/8846.31.4: false,
+          data-set-checkbox-test: 0,
         ]
       - [
           'large', 'large',
           data-option-for-classroom-astronomy-5678: false,
           data-option-for-classroom-astronomy-with/other-characters/8846.31.4: false,
+          data-set-checkbox-test: 1,
         ]
   gpus:
     widget: number_field
@@ -187,6 +189,8 @@ attributes:
     default: false
   bc_email_on_started:
     help: 'this is a help message should be hidden, sometimes'
+  checkbox_test:
+    widget: check_box
 form:
   - bc_num_hours
   - bc_num_slots
@@ -205,3 +209,4 @@ form:
   - auto_modules_app_jupyter
   - auto_modules_intel
   - auto_modules_netcdf-serial
+  - checkbox_test

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -573,7 +573,8 @@ module BatchConnect
           'advanced_options'            => '',
           'auto_modules_app_jupyter'    => '',
           'auto_modules_intel'          => '',
-          'auto_modules_netcdf_serial'  => ''
+          'auto_modules_netcdf_serial'  => '',
+          'checkbox_test'               => '',
         }
 
         assert session.save(app: bc_jupyter_app, context: ctx), session.errors.each(&:to_s).to_s

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -567,6 +567,26 @@ class BatchConnectTest < ApplicationSystemTestCase
     assert_equal 'display: none;', find_option_style('classroom_size', 'large')
   end
 
+  test 'options can check and uncheck' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # defaults
+    assert_equal('small', find_value('classroom_size'))
+    refute(checked?('checkbox_test'))
+
+    # select large and it's checked
+    select('large', from: bc_ele_id('classroom_size'))
+    assert(checked?('checkbox_test'))
+
+    # back to small and it's unchanged
+    select('small', from: bc_ele_id('classroom_size'))
+    assert(checked?('checkbox_test'))
+
+    # now choose medium and it's un-checked
+    select('medium', from: bc_ele_id('classroom_size'))
+    refute(checked?('checkbox_test'))
+  end
+
   test 'stage errors are shown' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
     err_msg = 'this is a just a test for staging error messages'


### PR DESCRIPTION
Fixes #3182 so that `data-set-` directives on options can check and un-check checkboxes.

Here's a variation of the from I'd been using to test this. Selecting the different options from `option_selector` flips the checkbox from checked to un-checked and back and forth.

```yaml

cluster:
  - pitzer
  - owens

form:
  - checkbox_test
  - option_selector

attributes:
  option_selector:
    widget: select
    options:
      - [
          'check', 'check',
          data-set-checkbox-test: '1'
        ]
      - [
          'un-check', 'un-check',
          data-set-checkbox-test: '0'
        ]
  checkbox_test:
    widget: check_box
```