### PR TITLE
Adds onpopstate listener to capture back/forward button changes

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -14,13 +14,17 @@ const CONTENTID = '#directory-contents';
 let table = null;
 
 jQuery(function () {
-    table = new DataTable();
 
+    table = new DataTable();
 
     /* END BUTTON ACTIONS */
 
     /* TABLE ACTIONS */
     
+    window.onpopstate = function(event) {
+      table.reloadTable(location.href)
+    };
+
     $(CONTENTID).on(EVENTNAME.reloadTable, function (e, options) {
         let url = $.isEmptyObject(options) ? '' : options.url;
         table.reloadTable(url);

--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -21,7 +21,7 @@ jQuery(function () {
     /* TABLE ACTIONS */
     
     window.onpopstate = function(event) {
-      table.reloadTable(location.href)
+      table.goto(location.href)
     };
 
     $(CONTENTID).on(EVENTNAME.reloadTable, function (e, options) {

--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -14,7 +14,6 @@ const CONTENTID = '#directory-contents';
 let table = null;
 
 jQuery(function () {
-
     table = new DataTable();
 
     /* END BUTTON ACTIONS */


### PR DESCRIPTION
Fixes #2818


https://github.com/OSC/ondemand/assets/6969170/1e407c7c-a281-4a21-870c-4c9d957927d8

I found an even listener on window that detects back/forward button presses. I read into the `Vary` header and could not understand how it would help solve this problem. From my understanding, the `reloadTable()` function changes the URL without a request, and so the back/forward buttons go back to/forward to URLs without any request changes. So a header change doesn't really effect whether or not `reloadTable()` is called.

Tested in Firefox, Chrome, and Safari. 