### PR TITLE
use pr-labler version 4.3.0

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add labels to PR
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4.3.0
       with:
         repo-token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
         configuration-path: .github/labeler.yml


### PR DESCRIPTION
Version 5 (the current version of this workflow) has some breaking changes. So let's lock on version 4 as it works and works well (enough).