### PR TITLE
add a rake task to determine file format

### DIFF
--- a/lib/tasks/test.rb
+++ b/lib/tasks/test.rb
@@ -88,5 +88,21 @@ namespace :test do
     end
   end
 
+  task :unix do
+    dos_files = Dir.glob('*/**/*.{rb,js,scss,html,erb}').reject do |file|
+      file.include?('vendor/') || file.include?('node_modules/')
+    end.map do |file|
+      dos_encoded = `file #{file} | grep -q CRLF; echo $?`.chomp.to_i
+      dos_encoded.positive? ? nil : file
+    end.compact
+
+    if dos_files.empty?
+      puts 'There are no DOS encoded files in this project.'
+    else
+      dos_files.each { |f| warn f }
+      abort('"text:unix" failed! These files are dos encoded.')
+    end
+  end
+
   task :all => [:unit, :shellcheck]
 end


### PR DESCRIPTION
This adds a top level `test:unix` rake task so we can start enforcing Unix file encoding.

I can't add this to the CI yet, because it would fail. There are several files in this project that are DOS encoded that I'd like to (a) fix and (b) make sure we don't get any more.