### PR TITLE
enhance this helper for building test assets

### DIFF
--- a/apps/dashboard/bin/recompile_js
+++ b/apps/dashboard/bin/recompile_js
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-export RAILS_ENV='development'
-export RAILS_RELATIVE_URL_ROOT='/pun/dev/dashboard'
+if [[ -n "$1" ]]; then
+  export RAILS_ENV='test'
+  export RAILS_RELATIVE_URL_ROOT='/'
+else
+  export RAILS_ENV='development'
+  export RAILS_RELATIVE_URL_ROOT='/pun/dev/dashboard'
+fi
 
 bin/rails assets:clobber
 bin/rails assets:precompile


### PR DESCRIPTION
Let's enhance this helper for building test assets.

So in dev you can just run `bin/recompile_js` but if you want to buiild test assets you'd run `bin/recompile_js test` (or pass any `$1` really so  `bin/recompile_js sdlngsafsdff` works just the same).