### PR TITLE
correctly handle options that start with numbers

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -709,6 +709,11 @@ function optionForFromToken(str) {
       }
 
       let optionForValue = mountainCaseWords(document.getElementById(optionForId).value);
+      // handle special case where the very first token here is a number.
+      // browsers expect a prefix of hyphens as if it's the next token.
+      if (optionForValue.match(/^\d/)) {
+        optionForValue = `-${optionForValue}`;
+      }
 
       hide = option.dataset[`optionFor${optionFor}${optionForValue}`] === 'false';
       if (hide) {

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -164,6 +164,8 @@ attributes:
           data-min-bc-num-hours-for-cluster-oakley: 111,
         ]
       - [ 'Economics 8846', 'astronomy-with/other-characters/8846.31.4' ]
+      - [ '123ABC', '123ABC' ]
+      - [ '456def', '456def' ]
   classroom_size:
     widget: select
     options:
@@ -179,6 +181,8 @@ attributes:
           data-option-for-classroom-astronomy-5678: false,
           data-option-for-classroom-astronomy-with/other-characters/8846.31.4: false,
           data-set-checkbox-test: 1,
+          data-option-for-classroom-123ABC: false,
+          data-option-for-classroom-456def: false,
         ]
   gpus:
     widget: number_field

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -658,7 +658,6 @@ class BatchConnectTest < ApplicationSystemTestCase
     # now change the classroom size and see options that start with
     # numbers disappear
     select('large', from: bc_ele_id('classroom_size'))
-    assert_equal('display: none;', find_option_style('classroom_size', 'large'))
     assert_equal('display: none;', find_option_style('classroom', '123ABC'))
     assert_equal('display: none;', find_option_style('classroom', '456def'))
 

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -637,34 +637,12 @@ class BatchConnectTest < ApplicationSystemTestCase
     assert_equal('display: none;', find_option_style('classroom_size', 'large'))
 
     # select the default, and it's back.
-    select('physics_1234', from: bc_ele_id('classroom'))
+    select('Physics 1234', from: bc_ele_id('classroom'))
     assert_equal('', find_option_style('classroom_size', 'large'))
 
     # now change the lowercase classroom and see large dissappear again.
     select('456def', from: bc_ele_id('classroom'))
     assert_equal('display: none;', find_option_style('classroom_size', 'large'))
-  end
-
-  # similar to the test above, only the inverse.
-  test 'options can disable other options that start with numbers' do
-    visit new_batch_connect_session_context_url('sys/bc_jupyter')
-
-    # defaults
-    assert_equal('physics_1234', find_value('classroom'))
-    assert_equal('small', find_value('classroom_size'))
-    assert_equal('', find_option_style('classroom', '123ABC'))
-    assert_equal('', find_option_style('classroom', '456def'))
-
-    # now change the classroom size and see options that start with
-    # numbers disappear
-    select('large', from: bc_ele_id('classroom_size'))
-    assert_equal('display: none;', find_option_style('classroom', '123ABC'))
-    assert_equal('display: none;', find_option_style('classroom', '456def'))
-
-    # select the default, and they are back.
-    select('small', from: bc_ele_id('classroom_size'))
-    assert_equal('', find_option_style('classroom', '123ABC'))
-    assert_equal('', find_option_style('classroom', '456def'))
   end
 
   test 'options with numbers and slashes' do

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -624,6 +624,50 @@ class BatchConnectTest < ApplicationSystemTestCase
     find("##{bc_ele_id('bc_email_on_started')}", visible: false)
   end
 
+  test 'options that start with numbers hide other options' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # defaults
+    assert_equal('physics_1234', find_value('classroom'))
+    assert_equal('small', find_value('classroom_size'))
+    assert_equal('', find_option_style('classroom_size', 'large'))
+
+    # now change the classroom and see large dissappear
+    select('123ABC', from: bc_ele_id('classroom'))
+    assert_equal('display: none;', find_option_style('classroom_size', 'large'))
+
+    # select the default, and it's back.
+    select('physics_1234', from: bc_ele_id('classroom'))
+    assert_equal('', find_option_style('classroom_size', 'large'))
+
+    # now change the lowercase classroom and see large dissappear again.
+    select('456def', from: bc_ele_id('classroom'))
+    assert_equal('display: none;', find_option_style('classroom_size', 'large'))
+  end
+
+  # similar to the test above, only the inverse.
+  test 'options can disable other options that start with numbers' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # defaults
+    assert_equal('physics_1234', find_value('classroom'))
+    assert_equal('small', find_value('classroom_size'))
+    assert_equal('', find_option_style('classroom', '123ABC'))
+    assert_equal('', find_option_style('classroom', '456def'))
+
+    # now change the classroom size and see options that start with
+    # numbers disappear
+    select('large', from: bc_ele_id('classroom_size'))
+    assert_equal('display: none;', find_option_style('classroom_size', 'large'))
+    assert_equal('display: none;', find_option_style('classroom', '123ABC'))
+    assert_equal('display: none;', find_option_style('classroom', '456def'))
+
+    # select the default, and they are back.
+    select('small', from: bc_ele_id('classroom_size'))
+    assert_equal('', find_option_style('classroom', '123ABC'))
+    assert_equal('', find_option_style('classroom', '456def'))
+  end
+
   test 'options with numbers and slashes' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 


### PR DESCRIPTION
correctly handle options that start with numbers. This fixes the bug that was filed on discourse - https://discourse.openondemand.org/t/data-option-for-option-does-not-work/3139