### PR TITLE
Fixes to SettingsController after CurrentUser settings refactoring

### DIFF
--- a/apps/dashboard/app/controllers/settings_controller.rb
+++ b/apps/dashboard/app/controllers/settings_controller.rb
@@ -2,11 +2,12 @@
 
 # The Controller for user level settings /dashboard/settings.
 class SettingsController < ApplicationController
+  include UserSettingStore
   ALLOWED_SETTINGS = [:profile].freeze
 
   def update
     new_settings = read_settings(settings_param)
-    CurrentUser.update_user_settings(new_settings) unless new_settings.empty?
+    update_user_settings(new_settings) unless new_settings.empty?
 
     logger.info "settings: updated user settings to: #{new_settings}"
     respond_to do |format|


### PR DESCRIPTION
Fixes to the SettingsController after the CurrentUser settings refactoring.

I didn't see this was needed when the refactoring was done. And the tests available were not sufficient to catch this.
I have fixed both.