### PR TITLE
Profile automatic selection improvements

### DIFF
--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -83,6 +83,7 @@ class UserConfiguration
   def initialize(request_hostname: nil)
     @config = ::Configuration.config
     @request_hostname = request_hostname.to_sym if request_hostname
+    @defined_profiles = config.fetch(:profiles, {}).keys
     add_property_methods
   end
 
@@ -142,13 +143,13 @@ class UserConfiguration
 
   # The current user profile. Used to select the configuration properties.
   def profile
-    return user_settings[:profile_override].to_sym if user_settings[:profile_override]
-
     if Configuration.host_based_profiles
       request_hostname
-    elsif user_settings[:profile]
+    elsif user_settings[:profile] && defined_profiles.include?(user_settings[:profile].to_sym)
       user_settings[:profile].to_sym
-    elsif Configuration.default_profile
+    elsif defined_profiles.include?(request_hostname)
+      request_hostname
+    elsif Configuration.default_profile && defined_profiles.include?(Configuration.default_profile.to_sym)
       Configuration.default_profile.to_sym
     end
   end
@@ -183,5 +184,5 @@ class UserConfiguration
     end
   end
 
-  attr_reader :config, :request_hostname
+  attr_reader :config, :defined_profiles, :request_hostname
 end


### PR DESCRIPTION
While configuring the FASRC and Sid profiles for our IQSS OOD installation and after discussions with the IQSS team, we have a proposal to improve how the current profile is selected in OOD.

The new approach will only select a profile if there is a definition of it in the configuration and manually selected profiles will take precedence over automatically selected ones.

We think this new approach will improve the configuration and user experience of working with profiles.

The new logic is:
If `Configuration.host_based_profiles` is true, use current request host as the profile.
If there is a profile selected in the UserSettingStore and this profiles is defined, use it.
If there is a profile defined that matches the current request host, use it.
If there is a default profile configured and this profiles is defined, use it.
if none match, no profile is selected and the default configuration is used.