### PR TITLE
Added cluster validation to projects.show page to disable script actions

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -10,6 +10,8 @@ class ProjectsController < ApplicationController
       redirect_to(projects_path, alert: I18n.t('dashboard.jobs_project_not_found', project_id: project_id))
     else
       @scripts = Script.all(@project.directory)
+      @valid_project = Script.clusters?
+      flash.now[:alert] = I18n.t("dashboard.jobs_project_invalid_configuration_clusters") unless @valid_project
     end
   end
 

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -45,6 +45,11 @@ class Script
     def next_id
       SecureRandom.alphanumeric(8).downcase
     end
+
+    def clusters?
+      cluster_attribute = SmartAttributes::AttributeFactory.build('auto_batch_clusters', {})
+      !cluster_attribute.select_choices(hide_excludable: false).empty?
+    end
   end
 
   def initialize(opts = {})

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -48,7 +48,7 @@ class Script
 
     def clusters?
       cluster_attribute = SmartAttributes::AttributeFactory.build('auto_batch_clusters', {})
-      !cluster_attribute.select_choices(hide_excludable: false).empty?
+      cluster_attribute.select_choices(hide_excludable: false).any?
     end
   end
 

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -1,4 +1,8 @@
 <%= javascript_include_tag 'projects', nonce: true %>
+<%-
+  disabled = !@valid_project
+  disabled_class = disabled ? 'disabled' : ''
+-%>
 
 <div class='page-header text-center'>
   <h1 class="my-2"><%= @project.title %></h1>
@@ -48,21 +52,21 @@
             <%= link_to(
                 t('dashboard.show'),
                   project_script_path(@project.id, script.id),
-                  class: 'btn btn-success mx-1'
+                  class: "btn btn-success mx-1 #{disabled_class}"
                 )
             %>
 
             <%= link_to(
               t('dashboard.edit'),
               edit_project_script_path(@project.id, script.id),
-              class: 'btn btn-primary mx-1',
+              class: "btn btn-primary mx-1 #{disabled_class}",
             )
             %>
 
             <%= link_to(
               t('dashboard.delete'),
               project_script_path(@project.id, script.id),
-              class: 'btn btn-danger mx-1',
+              class: "btn btn-danger mx-1 #{disabled_class}",
               method: 'delete',
               data: { confirm: I18n.t('dashboard.jobs_scripts_delete_script_confirmation') },
               )
@@ -75,9 +79,10 @@
             <%= button_to(
               t('dashboard.batch_connect_form_launch'),
               submit_project_script_path(@project.id, script.id),
-              class: 'btn btn-secondary mx-1',
+              class: "btn btn-secondary mx-1",
               title: 'Launch script with cached values',
               data: {:method => "post"},
+              disabled: disabled,
               params: params
             )
             %>
@@ -88,9 +93,9 @@
       </tbody>
     </table>
 
-    <%= link_to('New Script', 
+    <%= link_to('New Script',
           new_project_script_path(@project.id),
-          class: 'btn btn-info',  
+          class: "btn btn-info #{disabled_class}",
           title: I18n.t('dashboard.jobs_project_create_new_project_directory'))
     %>
   </div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -235,6 +235,7 @@ en:
     jobs_project_validation_error: "Invalid Request. Please review the errors below"
     jobs_project_save_error: "Cannot save manifest to %{path}"
     jobs_project_generic_error: "There was an error processing your request: %{error}"
+    jobs_project_invalid_configuration_clusters: "An HPC cluster is required. Contact your administrator to add one to the system."
 
     jobs_scripts_created: "Script successfully created!"
     jobs_scripts_updated: "Script manifest updated!"

--- a/apps/dashboard/test/models/script_test.rb
+++ b/apps/dashboard/test/models/script_test.rb
@@ -13,6 +13,19 @@ class ScriptTest < ActiveSupport::TestCase
     assert target.send('attribute_parameter?', 'account_exclude')
     assert target.send('attribute_parameter?', 'account_fixed')
   end
+
+  test 'clusters? return false when auto_batch_clusters returns no clusters' do
+    Configuration.stubs(:job_clusters).returns([])
+
+    assert_equal false, Script.clusters?
+  end
+
+  test 'clusters? return true when auto_batch_clusters returns clusters' do
+    Configuration.stubs(:job_clusters).returns(OodCore::Clusters.load_file('test/fixtures/config/clusters.d'))
+
+    assert_equal true, Script.clusters?
+  end
+
   test 'creates script' do
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)


### PR DESCRIPTION
Added clusters validation to `projects.show` page.
If there are no options defined for the` auto_batch_clusters` Smart Attribute, the system will show a flash message and disable all the script actions in the `projects.show` page.

Fixes #2690 