### PR TITLE
Added support for multiple domains for  Apache config in portal generator

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -67,6 +67,7 @@ Listen 8080
   CustomLog "/path/to/my/logs/test.server.name_access_ssl.log" combined
 
   RewriteEngine On
+  RewriteCond %{HTTP_HOST} !^(foo.example.com(:8080)?)?$ [NC]
   RewriteCond %{HTTP_HOST} !^(test.proxy.name(:8080)?)?$ [NC]
   RewriteRule ^(.*) https://test.proxy.name:8080$1 [R=301,NE,L]
 

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -87,7 +87,9 @@ Listen <%= addr_port %>
 
   <%- if @servername && @use_rewrites -%>
   RewriteEngine On
-  RewriteCond %{HTTP_HOST} !^(<%= @proxy_server %>(:<%= @port %>)?)?$ [NC]
+  <%- (@server_aliases + [@proxy_server]).each do |server| -%>
+  RewriteCond %{HTTP_HOST} !^(<%= server %>(:<%= @port %>)?)?$ [NC]
+  <%- end -%>
   RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @proxy_server %>:<%= @port %>$1 [R=301,NE,L]
   <%- end -%>
 


### PR DESCRIPTION
Added support to remove the automatic redirect to the servername/proxy_server domains without having to remove the `servername` property or disabling rewrites.

We would like to access the OnDemand instance through multiple domains, but want to keep the rewrite rules and the `servername` config in place and use `server_aliases` for the alternative domains.

I was thinking of adding a check based on server_aliases being empty, but then I realized that this change will affect existing configurations. That is why the new property `multiple_hosts` was added.