### PR TITLE
Adding custom completed.{md, html}.erb

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -49,6 +49,7 @@ module BatchConnect::SessionsHelper
           concat support_ticket(session) unless @user_configuration.support_ticket.empty?
           concat display_choices(session)
           safe_concat custom_info_view(session) if session.app.session_info_view
+          safe_concat completed_view(session) if session.app.session_completed_view && session.completed?          
         end
       )
       concat content_tag(:div) { yield }
@@ -63,6 +64,19 @@ module BatchConnect::SessionsHelper
       if session.render_info_view_error_message
         content_tag(:div, class: "alert alert-danger", role: "alert") do
           concat tag.p session.render_info_view_error_message
+        end
+      end
+    end
+  end
+ 
+  def completed_view(session)
+    concat tag.hr
+    content_tag(:div) do
+      concat session.render_completed_view
+
+      if session.render_completed_view_error_message
+        content_tag(:div, class: "alert alert-danger", role: "alert") do
+          concat tag.p session.render_completed_view_error_message
         end
       end
     end

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -300,6 +300,14 @@ module BatchConnect
       nil
     end
 
+    # Completed view used for session info if it exists
+    # @return [String, nil] session info
+    def session_completed_view
+      @session_completed_view ||= Pathname.new(root).glob("completed.{md,html}.erb").find(&:file?).try(:read)
+    rescue
+      nil
+    end
+
     # Paths to custom javascript files
     # @return [Pathname] paths to custom javascript files that exist
     def custom_javascript_files

--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -53,6 +53,10 @@ module BatchConnect
     # Error message about failing to parse info view ERB template.
     # @return [String] error message
     attr_reader :render_info_view_error_message
+    
+    # Error message about failing to parse completed view ERB template.
+    # @return [String] error message
+    attr_reader :render_completed_view_error_message
 
     # Return parsed markdown from info.{md, html}.erb
     # @return [String, nil] return HTML if no error while parsing, else return nil
@@ -64,6 +68,16 @@ module BatchConnect
       nil
     end
 
+    # Return parsed markdown from completed.{md, html}.erb
+    # @return [String, nil] return HTML if no error while parsing, else return nil
+    def render_completed_view
+      @render_completed_view ||= OodAppkit.markdown.render(ERB.new(self.app.session_completed_view, nil, "-").result(binding)).html_safe if self.app.session_completed_view
+    rescue => e
+      @render_completed_view_error_message = "Error when rendering completed view: #{e.class} - #{e.message}"
+      Rails.logger.error(@render_completed_view_error_message)
+      nil
+    end
+    
     # Return the Batch Connect app from the session token
     # @return [BatchConnect::App]
     def app

--- a/apps/dashboard/test/integration/sessions_controller_test.rb
+++ b/apps/dashboard/test/integration/sessions_controller_test.rb
@@ -101,7 +101,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     value = '{"id":"1234","job_id":"1","created_at":1669139262,"token":"sys/token","title":"session title","cache_completed":true}'
     session = BatchConnect::Session.new.from_json(value)
     session.stubs(:status).returns(OodCore::Job::Status.new(state: :completed))
-    session.stubs(:app).returns(stub(valid?: true, token: 'sys/token', attributes: [], session_info_view: nil, ssh_allow?: true))
+    session.stubs(:app).returns(stub(valid?: true, token: 'sys/token', attributes: [], session_info_view: nil, session_completed_view: nil, ssh_allow?: true))
     BatchConnect::Session.stubs(:all).returns([session])
 
     get batch_connect_sessions_path


### PR DESCRIPTION
Adding the option to have a custom completed.{md, html}.erb to show up only when the job is completed (e.g. to show a download link with an output file from the job)