### PR TITLE
Created default executable script on new Script and added validation

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -11,7 +11,12 @@ class ProjectsController < ApplicationController
     else
       @scripts = Script.all(@project.directory)
       @valid_project = Script.clusters?
-      flash.now[:alert] = I18n.t("dashboard.jobs_project_invalid_configuration_clusters") unless @valid_project
+      @valid_scripts = Script.scripts?(@project.directory)
+
+      alert_messages = []
+      alert_messages << I18n.t('dashboard.jobs_project_invalid_configuration_clusters') unless @valid_project
+      alert_messages << I18n.t('dashboard.jobs_project_invalid_configuration_scripts') if @scripts.any? && !@valid_scripts
+      flash.now[:alert] = alert_messages.join(' ') if alert_messages.any?
     end
   end
 

--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -17,6 +17,7 @@ class ScriptsController < ApplicationController
 
   def new
     @script = Script.new(project_dir: @project.directory)
+    @script.create_default_script
   end
 
   # POST  /dashboard/projects/:project_id/scripts

--- a/apps/dashboard/app/controllers/scripts_controller.rb
+++ b/apps/dashboard/app/controllers/scripts_controller.rb
@@ -17,16 +17,18 @@ class ScriptsController < ApplicationController
 
   def new
     @script = Script.new(project_dir: @project.directory)
-    @script.create_default_script
   end
 
   # POST  /dashboard/projects/:project_id/scripts
   def create
     opts = { project_dir: @project.directory }.merge(create_script_params[:script])
     @script = Script.new(opts)
+    default_script_created = @script.create_default_script
 
     if @script.save
-      redirect_to project_path(params[:project_id]), notice: I18n.t('dashboard.jobs_scripts_created')
+      notice_messages = [I18n.t('dashboard.jobs_scripts_created')]
+      notice_messages << I18n.t('dashboard.jobs_scripts_default_created') if default_script_created
+      redirect_to project_path(params[:project_id]), notice: notice_messages.join(' ')
     else
       redirect_to project_path(params[:project_id]), alert: @script.errors[:save].last
     end

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -199,15 +199,15 @@ class Script
   end
 
   def create_default_script
-    return if Script.scripts?(project_dir)
-    return if default_script_path.exist?
+    return false if Script.scripts?(project_dir) || default_script_path.exist?
 
-    script_content = <<~EOF
+    script_content = <<~DEFAULT_SCRIPT
       #!/bin/bash
-      # Sample script to configure project defaults. Delete when other scrips available.
+      # Sample script to configure project defaults. Delete when other scripts are available.
       echo "Hello World"
-    EOF
+    DEFAULT_SCRIPT
     File.open(default_script_path, 'w+') { |file| file.write(script_content) }
+    true
   end
 
   private

--- a/apps/dashboard/app/models/script.rb
+++ b/apps/dashboard/app/models/script.rb
@@ -50,6 +50,11 @@ class Script
       cluster_attribute = SmartAttributes::AttributeFactory.build('auto_batch_clusters', {})
       cluster_attribute.select_choices(hide_excludable: false).any?
     end
+
+    def scripts?(project_dir)
+      script_attribute = SmartAttributes::AttributeFactory.build('auto_scripts', { directory: project_dir })
+      script_attribute.select_choices(hide_excludable: false).any?
+    end
   end
 
   def initialize(opts = {})
@@ -193,10 +198,26 @@ class Script
     most_recent_job['cluster']
   end
 
+  def create_default_script
+    return if Script.scripts?(project_dir)
+    return if default_script_path.exist?
+
+    script_content = <<~EOF
+      #!/bin/bash
+      # Sample script to configure project defaults. Delete when other scrips available.
+      echo "Hello World"
+    EOF
+    File.open(default_script_path, 'w+') { |file| file.write(script_content) }
+  end
+
   private
 
   def self.script_path(root_dir, script_id)
     Pathname.new(File.join(Script.scripts_dir(root_dir), script_id.to_s))
+  end
+
+  def default_script_path
+    Pathname(File.join(project_dir, 'hello_world.sh'))
   end
 
   def self.script_form_file(script_path)

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -239,6 +239,7 @@ en:
     jobs_project_invalid_configuration_scripts: "An executable script is required for your project. Upload a script using the file application."
 
     jobs_scripts_created: "Script successfully created!"
+    jobs_scripts_default_created: "A 'hello_world.sh' was also added to this project."
     jobs_scripts_updated: "Script manifest updated!"
     jobs_scripts_not_found: "Cannot find script %{script_id}"
     jobs_scripts_deleted: "Script successfully deleted!"

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -236,12 +236,13 @@ en:
     jobs_project_save_error: "Cannot save manifest to %{path}"
     jobs_project_generic_error: "There was an error processing your request: %{error}"
     jobs_project_invalid_configuration_clusters: "An HPC cluster is required. Contact your administrator to add one to the system."
+    jobs_project_invalid_configuration_scripts: "An executable script is required for your project. Upload a script using the file application."
 
     jobs_scripts_created: "Script successfully created!"
     jobs_scripts_updated: "Script manifest updated!"
     jobs_scripts_not_found: "Cannot find script %{script_id}"
     jobs_scripts_deleted: "Script successfully deleted!"
-    jobs_scripts_submitted: "Successfully submited job %{job_id}."
+    jobs_scripts_submitted: "Successfully submitted job %{job_id}."
     jobs_scripts_delete_script_confirmation: "Delete all contents of script?"
     jobs_scripts_fixed_field: "Fixed Value"
 

--- a/apps/dashboard/test/models/script_test.rb
+++ b/apps/dashboard/test/models/script_test.rb
@@ -97,8 +97,9 @@ class ScriptTest < ActiveSupport::TestCase
       OodAppkit.stubs(:dataroot).returns(projects_path)
 
       target = Script.new({ project_dir: projects_path.to_s, id: 1234, title: 'Default Script' })
-      target.create_default_script
+      created_script = target.create_default_script
 
+      assert_equal true, created_script
       assert_equal true, Pathname(File.join(projects_path, 'hello_world.sh')).exist?
     end
   end
@@ -114,8 +115,9 @@ class ScriptTest < ActiveSupport::TestCase
       File.open(File.join(projects_path, 'test_script.sh'), 'w+') { |file| file.write(script_content) }
 
       target = Script.new({ project_dir: projects_path.to_s, id: 1234, title: 'With Script' })
-      target.create_default_script
+      created_script = target.create_default_script
 
+      assert_equal false, created_script
       assert_equal false, Pathname(File.join(projects_path, 'hello_world.sh')).exist?
     end
   end


### PR DESCRIPTION
Creates a default executable script in the project's directory when a new Script is created.
As well, it adds a validation message when there are no executable scripts in the project.

Fixes #3255 