### PR TITLE
change sorting css styles to be more accessible

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/data_tables.scss
+++ b/apps/dashboard/app/assets/stylesheets/data_tables.scss
@@ -1,8 +1,30 @@
 
+// get rid of jquery's default sorting icons.
+// so we can put them in a span below.
 th.sorting::before {
-  bottom: 52% !important;
+  content: "" !important;
 }
 
 th.sorting::after {
-  top: 52% !important;
+  content: "" !important;
+}
+
+table.dataTable th:hover {
+  background-color: darkgrey;
+}
+
+table.dataTable th[aria-sort="descending"] span::after {
+  content: "▼";
+  margin-left: 1.5rem !important;
+  color: currentcolor;
+  font-size: 100%;
+  top: 0;
+}
+
+table.dataTable th[aria-sort="ascending"] span::after {
+  content: "▲";
+  margin-left: 1.5rem !important;
+  color: currentcolor;
+  font-size: 100%;
+  top: 0;
 }

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -70,10 +70,11 @@
                 </div>
               </div>
               <table class="table table-hover table-condensed d-table w-100" id="<%= table_id %>">
+                <caption>Choose a file or directory to use in the form.</caption>
                 <thead>
                   <tr>
-                    <th>Type</th>
-                    <th>Name</th>
+                    <th>Type<span aria-hidden="true"></span></th>
+                    <th>Name<span aria-hidden="true"></span></th>
                   </tr>
                 </thead>
                 <tbody>

--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -12,13 +12,13 @@
           <th>
              <input type="checkbox" id="select_all" title="Select All"></input>
           </th>
-          <th>Type</th>
-          <th>Name</th>
+          <th>Type<span aria-hidden="true"></span></th>
+          <th>Name<span aria-hidden="true"></span></th>
           <th><span class="sr-only">Actions</span></th>
-          <th>Size</th>
-          <th>Modified at</th>
-          <th>Owner</th>
-          <th>Mode</th>
+          <th>Size<span aria-hidden="true"></span></th>
+          <th>Modified at<span aria-hidden="true"></span></th>
+          <th>Owner<span aria-hidden="true"></span></th>
+          <th>Mode<span aria-hidden="true"></span></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -19,9 +19,9 @@ class FilesTest < ApplicationSystemTestCase
 
   test "visiting files app directory" do
     visit files_url(Rails.root.to_s)
-    find('tbody a', exact_text: 'app').ancestor('tr').click
+    find('tbody a', exact_text: 'app').ancestor('tr').find('input[type="checkbox"]').click
     assert_selector '.selected', count: 1
-    find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
+    find('tbody a', exact_text: 'config').ancestor('tr').find('input[type="checkbox"]').click
     assert_selector '.selected', count: 2
   end
 
@@ -50,7 +50,7 @@ class FilesTest < ApplicationSystemTestCase
   test "copying files" do
     visit files_url(Rails.root.to_s)
     %w(app config manifest.yml).each do |f|
-      find('a', exact_text: f).ancestor('tr').click(:meta)
+      find('a', exact_text: f).ancestor('tr').find('input[type="checkbox"]').click
     end
     assert_selector '.selected', count: 3
 

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -16,15 +16,15 @@ class RemoteFilesTest < ApplicationSystemTestCase
   test 'visiting files app directory' do
     with_rclone_conf(Rails.root.to_s) do
       visit files_url('alias_remote', '/')
-      find('tbody a', exact_text: 'app').ancestor('tr').click
+      find('tbody a', exact_text: 'app').ancestor('tr').find('input[type="checkbox"]').click
       assert_selector '.selected', count: 1
-      find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
+      find('tbody a', exact_text: 'config').ancestor('tr').find('input[type="checkbox"]').click
       assert_selector '.selected', count: 2
 
       visit files_url('local_remote', Rails.root.to_s)
-      find('tbody a', exact_text: 'app').ancestor('tr').click
+      find('tbody a', exact_text: 'app').ancestor('tr').find('input[type="checkbox"]').click
       assert_selector '.selected', count: 1
-      find('tbody a', exact_text: 'config').ancestor('tr').click(:meta)
+      find('tbody a', exact_text: 'config').ancestor('tr').find('input[type="checkbox"]').click
       assert_selector '.selected', count: 2
     end
   end
@@ -61,7 +61,7 @@ class RemoteFilesTest < ApplicationSystemTestCase
   test 'copying files' do
     visit files_url(Rails.root.to_s)
     %w(app config manifest.yml).each do |f|
-      find('a', exact_text: f).ancestor('tr').click(:meta)
+      find('a', exact_text: f).ancestor('tr').find('input[type="checkbox"]').click
     end
     assert_selector '.selected', count: 3
 

--- a/apps/dashboard/test/system/remote_files_test.rb
+++ b/apps/dashboard/test/system/remote_files_test.rb
@@ -188,7 +188,7 @@ class RemoteFilesTest < ApplicationSystemTestCase
         # select dir to move
         visit files_url('alias_remote', '/bucket')
         %w(app config manifest.yml).each do |f|
-          find('a', exact_text: f).ancestor('tr').click(:meta)
+          find('a', exact_text: f).ancestor('tr').find('input[type="checkbox"]').click
         end
         assert_selector '.selected', count: 3
 
@@ -231,7 +231,7 @@ class RemoteFilesTest < ApplicationSystemTestCase
         # select dir to move
         visit files_url('extra_remote', dir)
         %w(app config manifest.yml).each do |f|
-          find('a', exact_text: f).ancestor('tr').click(:meta)
+          find('a', exact_text: f).ancestor('tr').find('input[type="checkbox"]').click
         end
         assert_selector '.selected', count: 3
 
@@ -271,8 +271,8 @@ class RemoteFilesTest < ApplicationSystemTestCase
 
         # select dir to move
         visit files_url('alias_remote', '/bucket')
-        find('a', exact_text: 'app').ancestor('tr').click(:meta)
-        find('a', exact_text: 'foo.txt').ancestor('tr').click(:meta)
+        find('a', exact_text: 'app').ancestor('tr').find('input[type="checkbox"]').click
+        find('a', exact_text: 'foo.txt').ancestor('tr').find('input[type="checkbox"]').click
         find('#delete-btn').click
         find('button.swal2-confirm').click
 


### PR DESCRIPTION
change sorting css styles to be more accessible

This changes the sorting chevrons on the files app and path selector data tables to be more accessible. Specifically, so screen-readers don't read the sorting chevrons fixing #3153.

This does also change the visual style to have 1 chevron, and it's only applied to the column that's currently being used to sort the table.

Before:
![image](https://github.com/OSC/ondemand/assets/4874123/b7b9f82d-b78a-4457-95f4-0c4e3df05516)

After:
![image](https://github.com/OSC/ondemand/assets/4874123/281609db-9a46-4eb5-ba24-2efbaed0d76b)


