### PR TITLE
Updated projects to serliaze id into projects manifest

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -65,9 +65,7 @@ class Project
     end
   end
 
-  attr_reader :directory, :id, :template
-
-  delegate :icon, :name, :description, to: :manifest
+  attr_reader :id, :name, :description, :icon, :directory, :template
 
   validates :name, presence: { message: :required }, on: [:create, :update]
   validates :id, :directory, :icon, presence: { message: :required }, on: [:update]
@@ -80,13 +78,25 @@ class Project
   attr_accessor :template
 
   def initialize(attributes = {})
-    @id = attributes.delete(:id)
-    @directory = attributes.delete(:directory)
+    set_data(attributes)
+    @directory = attributes[:directory]
     @directory = File.expand_path(@directory) unless @directory.blank?
-    @template = attributes.delete(:template)
+    @template = attributes[:template]
 
-    @manifest = Manifest.new(attributes)
-    @manifest = @manifest.merge(Manifest.load(manifest_path)) unless new_record?
+    return if new_record?
+
+    contents = File.read(manifest_path)
+    raw_opts = YAML.safe_load(contents)
+    set_data(raw_opts.symbolize_keys)
+  end
+
+  def to_h
+    {
+      :id => id,
+      :name => name,
+      :description => description,
+      :icon => icon,
+    }
   end
 
   def new_record?
@@ -96,24 +106,21 @@ class Project
     id && directory && !File.exist?(manifest_path)
   end
 
-  def save(attributes={})
-    @id = attributes.delete(:id) if attributes.key?(:id)
-    @directory = attributes.delete(:directory) if attributes.key?(:directory)
-    @directory = File.expand_path(@directory) unless @directory.blank?
-    @manifest = manifest.merge(attributes)
-
+  def save
     return false unless valid?(:create)
 
     # SET DEFAULTS
     @id = Project.next_id if id.blank?
     @directory = Project.dataroot.join(id.to_s).to_s if directory.blank?
-    @manifest = manifest.merge({ icon: 'fas://cog' }) if icon.blank?
+    @icon = 'fas://cog' if icon.blank?
 
     make_dir && sync_template && store_manifest(:save)
   end
 
   def update(attributes)
-    @manifest = manifest.merge(attributes)
+    # ensure id is not updated
+    attributes.delete(:id)
+    set_data(attributes)
 
     return false unless valid?(:update)
 
@@ -121,20 +128,25 @@ class Project
   end
 
   def store_manifest(operation)
-    if manifest.valid? && manifest.save(manifest_path) && add_to_lookup
-      true
-    else
-      errors.add(operation, I18n.t('dashboard.jobs_project_save_error', path: manifest_path))
-      false
-    end
+    save_manifest(operation) && add_to_lookup(operation)
   end
 
-  def add_to_lookup
+  def save_manifest(operation)
+    Pathname(manifest_path).write(to_h.deep_stringify_keys.compact.to_yaml)
+
+    true
+  rescue StandardError => e
+    errors.add(operation, I18n.t('dashboard.jobs_project_save_error', path: manifest_path))
+    Rails.logger.warn "Cannot save project manifest: #{manifest_path} with error #{e.class}:#{e.message}"
+    false
+  end
+
+  def add_to_lookup(operation)
     new_table = Project.lookup_table.merge(Hash[id, directory.to_s])
     File.write(Project.lookup_file, new_table.to_yaml)
     true
   rescue StandardError => e
-    errors.add(:update, "Cannot update lookup file lookup file with error #{e.class}:#{e.message}")
+    errors.add(operation, "Cannot update lookup file lookup file with error #{e.class}:#{e.message}")
     false
   end
 
@@ -149,7 +161,7 @@ class Project
 
   def icon_class
     # rails will prepopulate the tag with fa- so just the name is needed
-    manifest.icon.sub('fas://', '')
+    icon.sub('fas://', '')
   end
 
   def destroy!
@@ -178,8 +190,13 @@ class Project
   end
 
   private
-
-  attr_reader :manifest
+  
+  def set_data(attributes)
+    @id = attributes[:id] if attributes.key?(:id)
+    @name = attributes.fetch(:name, '')
+    @description = attributes.fetch(:description, '')
+    @icon = attributes.fetch(:icon, '')
+  end
 
   def make_dir
     project_dataroot.mkpath         unless project_dataroot.exist?

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -101,9 +101,10 @@ class ProjectsTest < ActiveSupport::TestCase
 
       expected_manifest_yml = <<~HEREDOC
         ---
+        id: #{project.id}
         name: test-project
-        icon: fas://arrow-right
         description: description
+        icon: fas://arrow-right
       HEREDOC
 
       assert_equal expected_manifest_yml, File.read(manifest_path)
@@ -137,9 +138,10 @@ class ProjectsTest < ActiveSupport::TestCase
 
       expected_manifest_yml = <<~HEREDOC
         ---
+        id: #{project.id}
         name: test-project-2
-        icon: fas://arrow-left
         description: my test project
+        icon: fas://arrow-left
       HEREDOC
 
       assert project.update(test_attributes)

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -6,7 +6,7 @@ class ProjectsTest < ActiveSupport::TestCase
   test 'create empty project' do
     project = Project.new
 
-    assert_nil project.id
+    assert_not_empty project.id
     assert_nil project.directory
     assert_equal '', project.name
     assert_equal '', project.description


### PR DESCRIPTION
Added id into manifest data serialization.
As id is not supported by the current `Manifest` implementation and it is likely that other project metadata items will need to be stored in the manifest, I have removed the dependency with the `Manifest` class and store the data directly in the `Project` class.

Fixes #3120 