### PR TITLE
Only patch the autostart .desktop files that are installed on the system

### DIFF
--- a/apps/bc_desktop/template/desktops/mate.sh
+++ b/apps/bc_desktop/template/desktops/mate.sh
@@ -14,7 +14,9 @@ AUTOSTART="${HOME}/.config/autostart"
 rm -fr "${AUTOSTART}"    # clean up previous autostarts
 mkdir -p "${AUTOSTART}"
 for service in "gnome-keyring-gpg" "gnome-keyring-pkcs11" "gnome-keyring-secrets" "gnome-keyring-ssh" "mate-volume-control-applet" "polkit-mate-authentication-agent-1" "pulseaudio" "rhsm-icon" "spice-vdagent" "xfce4-power-manager"; do
-  cat "/etc/xdg/autostart/${service}.desktop" <(echo "X-MATE-Autostart-enabled=false") > "${AUTOSTART}/${service}.desktop"
+  if [[ -f "/etc/xdg/autostart/${service}.desktop" ]]; then
+    cat "/etc/xdg/autostart/${service}.desktop" <(echo "X-MATE-Autostart-enabled=false") > "${AUTOSTART}/${service}.desktop"
+  fi
 done
 
 # Disable pulseaudio


### PR DESCRIPTION
This prevents invalid 'group-less' files being generated for .desktop files not present on the host.

By not testing for the presence of the listed services' .desktop files the user's .config/autostart folder is polluted with .desktop files for the missing services containing only the line:

X-MATE-Autostart-enabled=false

This is an invalid file as it lacks the '[Desktop Entry]' section group required in all desktop files.