### PR TITLE
refactor navbar to be menubar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a rake task to determine ensure unix file formats in [3227](https://github.com/OSC/ondemand/pull/3227).
 - Batch Connect apps can now provide a completed.{md, html}.erb in [3269](https://github.com/OSC/ondemand/pull/3269).
 - Sites can now disable uploads and downloads in [3236](https://github.com/OSC/ondemand/pull/3236).
+- Sites can now use disable_logs in ood_portal.yml to disable logs in apache in [3290](https://github.com/OSC/ondemand/pull/3290).
 
 ### Fixed
 - Develop menu now correctly shows/hides when given a configuration in [2848](https://github.com/OSC/ondemand/pull/2848).
@@ -56,6 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - BatchConnect apps now use rsync with safer arguments in [3239](https://github.com/OSC/ondemand/pull/3239).
 - Dynamic forms correctly handle options that start with numbers in [3241](https://github.com/OSC/ondemand/pull/3241).
 - Multiple domains corrrectly redirect in [3264](https://github.com/OSC/ondemand/pull/3264).
+- MATE desktop will only patch the autostart .desktop files if they exist in [3291](https://github.com/OSC/ondemand/pull/3291).
+
 
 ### Changed
 - Open OnDemand now requires NodeJS 18 and Ruby 3.1 on applicable platforms in [2885](https://github.com/OSC/ondemand/pull/2885).

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -23,11 +23,11 @@ module ApplicationHelper
   # @param role [String] app role i.e. "vdi", "shell", etc.
   # @param data [Hash] data parameter for the link_to helper.
   # @return nil if url not set or the HTML string for the bootstrap nav link
-  def nav_link(title, icon, url, new_tab: false, role: nil, data: nil)
+  def nav_link(title, icon, url, new_tab: false, data: nil)
     if url
       icon_uri = URI("fa://#{icon}")
       render partial: 'layouts/nav/link',
-             locals:  { title: title, class: 'dropdown-item', icon_uri: icon_uri, url: url.to_s, new_tab: new_tab, role: role, data: data }
+             locals:  { title: title, class: 'dropdown-item', icon_uri: icon_uri, url: url.to_s, new_tab: new_tab, data: data }
     end
   end
 

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -28,18 +28,14 @@
 <body>
   <header>
     <nav class="navbar navbar-expand-md shadow-sm navbar-color navbar-<%= @user_configuration.navbar_type %>">
-    <% if @user_configuration.dashboard_header_img_logo %>
-      <a class="navbar-brand navbar-brand-logo" href="<%= root_path %>"><img class="img-fluid" src="<%= @user_configuration.dashboard_header_img_logo %>" alt="<%= @user_configuration.dashboard_title %>"></a>
-    <% else %>
-      <a class="navbar-brand" href="<%= root_path %>"><%= @user_configuration.dashboard_title %></a>
-    <% end %>
+      <ul class="navbar-nav w-100" role="menubar">
+        <%= render partial: 'layouts/nav/logo' %>
       
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
 
-      <div class="collapse navbar-collapse" id="navbar">
-        <ul class="navbar-nav mr-auto">
+        <div class="collapse navbar-collapse" id="navbar">
           <% if @nav_bar.empty? %>
             <%= render partial: 'layouts/nav/featured_apps' %>
             <%= render partial: 'layouts/nav/group', collection: @nav_groups %>
@@ -48,19 +44,19 @@
           <% else %>
             <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @nav_bar }%>
           <% end %>
-        </ul>
 
-        <ul class="navbar-nav">
-          <% if @help_bar.empty? %>
-            <%= render partial: 'layouts/nav/develop_dropdown' %>
-            <%= render partial: 'layouts/nav/help_dropdown' %>
-            <%= render partial: 'layouts/nav/user' %>
-            <%= render partial: 'layouts/nav/log_out' %>
-          <% else %>
-            <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @help_bar, menu_alignment: 'dropdown-menu-right' }%>
-          <% end %>
-        </ul>
-      </div>
+          <div class="ml-auto d-flex">
+            <% if @help_bar.empty? %>
+              <%= render partial: 'layouts/nav/develop_dropdown' %>
+              <%= render partial: 'layouts/nav/help_dropdown' %>
+              <%= render partial: 'layouts/nav/user' %>
+              <%= render partial: 'layouts/nav/log_out' %>
+            <% else %>
+              <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @help_bar, menu_alignment: 'dropdown-menu-right' }%>
+            <% end %>
+          </div>
+        </div>
+      </ul>
     </nav>
   </header>
 

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
 <body>
   <header>
     <nav class="navbar navbar-expand-md shadow-sm navbar-color navbar-<%= @user_configuration.navbar_type %>">
-      <ul class="navbar-nav w-100" role="menubar">
+      <ul class="navbar-nav w-100 align-items-center" role="menubar">
         <%= render partial: 'layouts/nav/logo' %>
       
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -45,16 +45,17 @@
             <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @nav_bar }%>
           <% end %>
 
-          <div class="ml-auto d-flex">
-            <% if @help_bar.empty? %>
-              <%= render partial: 'layouts/nav/develop_dropdown' %>
-              <%= render partial: 'layouts/nav/help_dropdown' %>
-              <%= render partial: 'layouts/nav/user' %>
-              <%= render partial: 'layouts/nav/log_out' %>
-            <% else %>
-              <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @help_bar, menu_alignment: 'dropdown-menu-right' }%>
-            <% end %>
-          </div>
+          <!-- add some space between nav_bar and help_menu -->
+          <div class="ml-auto"></div>
+
+          <% if @help_bar.empty? %>
+            <%= render partial: 'layouts/nav/develop_dropdown' %>
+            <%= render partial: 'layouts/nav/help_dropdown' %>
+            <%= render partial: 'layouts/nav/user' %>
+            <%= render partial: 'layouts/nav/log_out' %>
+          <% else %>
+            <%= render partial: 'layouts/nav/custom_navigation', locals: { navigation: @help_bar, menu_alignment: 'dropdown-menu-right' }%>
+          <% end %>
         </div>
       </ul>
     </nav>

--- a/apps/dashboard/app/views/layouts/nav/_all_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_all_apps.html.erb
@@ -1,5 +1,17 @@
-<li class="nav-item" title="<%= t('dashboard.nav_all_apps') %>">
-  <%= tag.a class: 'nav-link', href: apps_index_path, aria: ({ current: ('page' if (current_page?(controller: '/apps', action: 'index' ))) }) do %>
-    <i class="fas fa-th" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_all_apps') %></span>
-  <% end %>
+<%-
+  aria =  if current_page?(controller: '/apps', action: 'index')
+            "aria-current=page"
+          else
+            ""
+          end
+-%>
+
+<li class="nav-item" role="none">
+  <a title="<%= t('dashboard.nav_all_apps') %>" class="nav-link"
+     role="menuitem" href="<%= apps_index_path %>"
+     <%= aria %>
+    >
+    <i class="fas fa-th" aria-hidden="true"></i>
+    <span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_all_apps') %></span>
+  </a>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -1,6 +1,6 @@
 <% if Configuration.app_development_enabled? %>
-  <li class="nav-item dropdown" title="<%= t('dashboard.nav_develop_title') %>">
-    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <li class="nav-item dropdown" role="none">
+    <a role='menuitem' title="<%= t('dashboard.nav_develop_title') %>" href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <i class="fas fa-code" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_develop_title') %></span><span class="caret"></span>
     </a>
 

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -1,20 +1,21 @@
 <% if @featured_group.present? %>
   <% group = @featured_group %>
-  <li class="nav-item dropdown" title="<%= group.title %>" >
-    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
+  <li class="nav-item dropdown" role="none">
+    <a role="menuitem" href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
 
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu" role="menu" title="<%= group.title %>">
       <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, nav_limit: group.nav_limit).each_with_index do |g, index| %>
         <%= content_tag "li", "", class: "dropdown-divider", role: "separator" if index > 0 %>
         <%= content_tag "li", g.title_with_nav_limit_caption, class: "dropdown-header" unless g.title_with_nav_limit_caption.empty? %>
         <% g.apps.take(g.nav_limit).map { |app| app.links.first }.compact.each do |link| %>
-            <li>
+            <li role="none">
               <%=
                 link_to(
                   link.url.to_s,
                   title: link.title,
                   class: "dropdown-item",
                   target: link.new_tab? ? "_blank" : nil,
+                  role: 'menuitem',
                   data: link.data
                 ) do
               %>
@@ -28,8 +29,8 @@
       <% end %>
 
       <%= content_tag "li", "", class: "dropdown-divider", role: "separator" %>
-      <li title="<%= t('dashboard.nav_all_apps') %>">
-        <a href="<%= apps_index_path %>" class="dropdown-item">
+      <li title="<%= t('dashboard.nav_all_apps') %>" role="none">
+        <a href="<%= apps_index_path %>" class="dropdown-item" role="menuitem" tabindex="-1">
           <i class="fas fa-th" aria-hidden="true"></i> <%= t('dashboard.nav_all_apps') %>
         </a>
       </li>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -30,7 +30,7 @@
 
       <%= content_tag "li", "", class: "dropdown-divider", role: "separator" %>
       <li title="<%= t('dashboard.nav_all_apps') %>" role="none">
-        <a href="<%= apps_index_path %>" class="dropdown-item" role="menuitem" tabindex="-1">
+        <a href="<%= apps_index_path %>" class="dropdown-item" role="menuitem">
           <i class="fas fa-th" aria-hidden="true"></i> <%= t('dashboard.nav_all_apps') %>
         </a>
       </li>

--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -1,7 +1,7 @@
 <% if @featured_group.present? %>
   <% group = @featured_group %>
   <li class="nav-item dropdown" role="none">
-    <a role="menuitem" href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= group.title %><span class="caret"></span></a>
+    <a role="menuitem" href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="menuitem" title="<%= group.title %>"><%= group.title %><span class="caret"></span></a>
 
     <ul class="dropdown-menu" role="menu" title="<%= group.title %>">
       <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, nav_limit: group.nav_limit).each_with_index do |g, index| %>

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -1,9 +1,9 @@
-<li class="nav-item dropdown" title="<%= group.title %>">
-  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<li class="nav-item dropdown" role="none">
+  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="menuitem">
     <%= icon_tag(group.icon_uri, classes: 'menu-icon') if group.icon_uri %><span> <%= group.title %></span><span class="caret"></span>
   </a>
 
-  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, '') %>">
+  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, '') %>" title="<%= group.title %>" role="menu">
     <%= render partial: 'layouts/nav/group_items', locals: local_assigns %>
   </ul>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_group.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group.html.erb
@@ -1,5 +1,5 @@
 <li class="nav-item dropdown" role="none">
-  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="menuitem">
+  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="menuitem" title="<%= group.title %>">
     <%= icon_tag(group.icon_uri, classes: 'menu-icon') if group.icon_uri %><span> <%= group.title %></span><span class="caret"></span>
   </a>
 

--- a/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_group_items.html.erb
@@ -3,7 +3,7 @@
   <%= content_tag(:li, g.title, class: ["dropdown-header"]) unless g.title.empty? %>
   <% g.apps.each do |app| %>
     <% app.links.each do |link| %>
-      <li>
+      <li role="none">
         <%=
           link_to(
             link.url.to_s,
@@ -11,6 +11,7 @@
             class: "dropdown-item",
             target: link.new_tab? ? "_blank" : nil,
             aria: ({ current: ('page' if (current_page?(link.url))) }),
+            role: 'menuitem',
             data: link.data
           ) do
         %>

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -1,5 +1,7 @@
-<li class="nav-item dropdown" title="<%= t('dashboard.nav_help_title') %>" >
-  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<li class="nav-item dropdown" role="none">
+  <a href="#" title="<%= t('dashboard.nav_help_title') %>" class="nav-link dropdown-toggle"
+    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+    role="menuitem">
     <i class="fas fa-question-circle" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_help_title') %></span><span class="caret"></span>
   </a>
 

--- a/apps/dashboard/app/views/layouts/nav/_link.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_link.html.erb
@@ -13,13 +13,15 @@ data - optional, data parameter for the link_to helper
   url = local_assigns.fetch(:url)
   icon_uri = local_assigns.fetch(:icon_uri, URI("fas://cog"))
 %>
+<li role="none">
 <%=
   link_to(
     url,
     title: title,
-    class: "#{local_assigns.fetch(:class, 'nav-link')} #{local_assigns.fetch(:role, nil)}",
+    class: "#{local_assigns.fetch(:class, 'nav-link')}",
     target: local_assigns.fetch(:new_tab, false) ? "_blank" : nil,
     aria: ({ current: ('page' if (current_page?(url))) }),
+    role: 'menuitem',
     data: local_assigns.fetch(:data, nil)
   ) do
 %>
@@ -28,3 +30,4 @@ data - optional, data parameter for the link_to helper
     <%= title %>
   <% end %>
 <% end %>
+</li>

--- a/apps/dashboard/app/views/layouts/nav/_log_out.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_log_out.html.erb
@@ -1,3 +1,6 @@
-<li class="nav-item">
-  <a class="nav-link" href="/logout"><i class="fas fa-sign-out-alt" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_logout') %></span></a>
+<li class="nav-item" role="none">
+  <a class="nav-link" href="/logout" title="<%= t('dashboard.nav_logout') %>" role="menuitem">
+    <i class="fas fa-sign-out-alt" aria-hidden="true"></i>
+    <span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_logout') %></span>
+  </a>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_logo.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_logo.html.erb
@@ -1,0 +1,14 @@
+
+<%- 
+  aria = current_page?(root_path) ? "aria-current=page" : ''
+-%>
+
+<li role="none" >
+<% if @user_configuration.dashboard_header_img_logo %>
+  <a class="navbar-brand navbar-brand-logo" href="<%= root_path %>" <%= aria %> role='menuitem'>
+    <img class="img-fluid" src="<%= @user_configuration.dashboard_header_img_logo %>" alt="<%= @user_configuration.dashboard_title %>">
+  </a>
+<% else %>
+  <a class="navbar-brand" <%= aria %> role='menuitem' href="<%= root_path %>"><%= @user_configuration.dashboard_title %></a>
+<% end %>
+</li>

--- a/apps/dashboard/app/views/layouts/nav/_sessions.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_sessions.html.erb
@@ -1,5 +1,17 @@
-<li class="nav-item" title="<%= t('dashboard.breadcrumbs_my_sessions') %>">
-  <%= tag.a class: 'nav-link', href: batch_connect_sessions_path, aria: ({ current: ('page' if (current_page?(controller: 'batch_connect/sessions', action: 'index'))) }) do %>
-    <i class="fas fa-window-restore" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_sessions') %></span>
-  <% end %>
+<%-
+  aria =  if current_page?(controller: 'batch_connect/sessions', action: 'index')
+            "aria-current=page"
+          else
+            ""
+          end
+-%>
+
+<li class="nav-item" role="none">
+  <a title="<%= t('dashboard.breadcrumbs_my_sessions') %>" class="nav-link"
+     role="menuitem" href="<%= batch_connect_sessions_path %>"
+     <%= aria %>
+    >
+    <i class="fas fa-window-restore" aria-hidden="true"></i>
+    <span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_sessions') %></span>
+  </a>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_user.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_user.html.erb
@@ -1,5 +1,7 @@
-<li class="nav-item" data-container="body" data-toggle="popover" data-content="<%= t('dashboard.nav_user', username: @user.name) %>" data-placement="bottom">
-  <a class="nav-link disabled">
-    <i class="fas fa-user" aria-hidden="true" title="<%= t('dashboard.nav_user', username: @user.name) %>" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_user', username: @user.name) %></span>
+<li class="nav-item" data-container="body" data-toggle="popover"
+  data-content="<%= t('dashboard.nav_user', username: @user.name) %>" data-placement="bottom"
+  role="none">
+  <a class="nav-link disabled" role="menuitem" title="<%= t('dashboard.nav_user', username: @user.name) %>" href="#">
+    <i class="fas fa-user" aria-hidden="true" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_user', username: @user.name) %></span>
   </a>
 </li>

--- a/apps/dashboard/test/html_helper.rb
+++ b/apps/dashboard/test/html_helper.rb
@@ -2,12 +2,20 @@
 # integration tests.
 class ActiveSupport::TestCase
 
+  def nav_link(title)
+    css_select("nav a.nav-link[title='#{title}']")
+  end
+
   def dropdown_list(title)
-    css_select("li.dropdown[title='#{title}'] ul")
+    css_select("nav a.nav-link.dropdown-toggle[title='#{title}'] + ul")
+  end
+
+  def dropdown_links
+    'nav a.nav-link.dropdown-toggle[title]'
   end
 
   def dropdown_link(order)
-    ".navbar-expand-md > #navbar li.dropdown:nth-of-type(#{order}) a"
+    "nav #navbar li.dropdown:nth-of-type(#{order}) a[title]"
   end
 
   # given a dropdown list, return the list items as an array of strings

--- a/apps/dashboard/test/integration/custom_help_navigation_test.rb
+++ b/apps/dashboard/test/integration/custom_help_navigation_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'html_helper'
 
 class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
   test 'should render a custom help navigation menu when help_bar is defined in UserConfiguration' do
@@ -19,7 +20,8 @@ class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
                 url:     '/menu/link',
                 new_tab: false },
               { title:   'Profile Link',
-                profile: 'profile1' }
+                profile: 'profile1',
+                icon:    'fa://user'}
             ] },
           { title: 'Docs Menu',
             links: [
@@ -40,60 +42,52 @@ class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Check nav menus
-    assert_select '#navbar li.dropdown[title]', 2
+    assert_select dropdown_links, 2
+    assert_select dropdown_link(1), text: 'Help Menu'
+    assert_select dropdown_link(2), text: 'Docs Menu'
 
-    # Check custom "Help Menu"
-    assert_select nav_menu(1) do |menu|
-      assert_select menu.first, 'a', text: 'Help Menu'
-      assert_select menu.first, 'ul' do |menu_items|
-        menu_items.first['class'].include?('dropdown-menu-right')
-      end
-    end
-    assert_select nav_menu_header('Help Menu'), text: 'Help Menu Dropdown Header'
-    assert_select nav_menu_links('Help Menu') do |elements|
-      assert_equal 2, elements.size
-      assert_match(/Menu Link/, elements[0].text)
-      assert_equal '/menu/link', elements[0]['href']
-      assert_nil elements[0]['target']
-      check_icon(elements[0], 'fa-cog')
-    end
+    # Check custom 'Help Menu'
+    menu_items = dropdown_list('Help Menu')
+    assert_equal true, menu_items.first['class'].include?('dropdown-menu-right')
+    menu_links = css_select(menu_items, 'a')
+    assert_equal 2, menu_links.size
+    # Check first expected link
+    assert_match(/Menu Link/, menu_links[0].text)
+    assert_equal '/menu/link', menu_links[0]['href']
+    assert_nil menu_links[0]['target']
+    check_icon(menu_links[0], 'fa-cog')
+    # Check second expected link
+    assert_match(/Profile Link/, menu_links[1].text)
+    assert_equal settings_path("settings[profile]" => "profile1"), menu_links[1]['href']
+    assert_nil menu_links[1]['target']
+    check_icon(menu_links[1], 'fa-user')
 
     # Check custom 'Docs Menu'
-    assert_select nav_menu(2) do |menu|
-      assert_select menu.first, 'a', text: 'Docs Menu'
-      assert_select menu.first, 'ul' do |menu_items|
-        menu_items.first['class'].include?('dropdown-menu-right')
-      end
-    end
-    assert_select nav_menu_header('Docs Menu'), text: 'Docs Menu Dropdown Header'
-    assert_select nav_menu_links('Docs Menu') do |elements|
-      assert_equal 1, elements.size
-      assert_match(/Jupyter Notebook/, elements[0].text)
-      assert_equal '/batch_connect/sys/bc_jupyter/session_contexts/new', elements[0]['href']
-      assert_nil elements[0]['target']
-      check_icon(elements[0], 'fa-gear')
-    end
+    menu_items = dropdown_list('Docs Menu')
+    assert_equal true, menu_items.first['class'].include?('dropdown-menu-right')
+    menu_links = css_select(menu_items, 'a')
+    assert_equal 1, menu_links.size
+    # Check first expected link
+    assert_match(/Jupyter Notebook/, menu_links[0].text)
+    assert_equal '/batch_connect/sys/bc_jupyter/session_contexts/new', menu_links[0]['href']
+    assert_nil menu_links[0]['target']
+    check_icon(menu_links[0], 'fa-gear')
 
     # Check custom link
-    assert_select nav_link('Custom Help Link'), text: 'Custom Help Link'
-    assert_select nav_link('Custom Help Link') do |link|
-      assert_equal '/custom/link', link.first['href']
-      assert_equal '_blank', link.first['target']
-      check_icon(link.first, 'fa-desktop')
-    end
-
+    link = nav_link('Custom Help Link')[0]
+    assert_match /Custom Help Link/, link.text
+    assert_equal '/custom/link', link['href']
+    assert_equal '_blank', link['target']
+    check_icon(link, 'fa-desktop')
     # User
-    assert_select '#navbar .navbar-nav a.nav-link.disabled' do |link|
-      assert_match(/Logged in as/, link.first.text.strip)
-      check_icon(link.first, 'fa-user')
-    end
+    user = nav_link("Logged in as #{CurrentUser.name}")[0]
+    check_icon(user, 'fa-user')
 
     # Log out link
-    assert_select "#navbar .navbar-nav a.nav-link[href='/logout']" do |link|
-      assert_equal '/logout', link.first['href']
-      assert_equal 'Log Out', link.first.text.strip
-      check_icon(link.first, 'fa-sign-out-alt')
-    end
+    logout = nav_link('Log Out')[0]
+    assert_match /Log Out/, logout.text
+    assert_equal '/logout', logout['href']
+    check_icon(logout, 'fa-sign-out-alt')
   end
 
   test 'develop template should not render when Configuration.app_development_enabled? is false' do
@@ -107,31 +101,13 @@ class CustomHelpNavigationTest < ActionDispatch::IntegrationTest
     Configuration.stubs(:app_development_enabled?).returns(true)
     get root_path
     assert_response :success
-    assert_select '#navbar li.dropdown[title]', 1
-    assert_select nav_menu(1) do |menu|
-      assert_select menu.first, 'a', text: 'Develop'
-    end
+    assert_select dropdown_links, 1
+    assert_select dropdown_link(1), text: 'Develop'
 
     Configuration.stubs(:app_development_enabled?).returns(false)
     get root_path
     assert_response :success
-    assert_select '#navbar li.dropdown[title]', 0
-  end
-
-  def nav_menu(order)
-    "#navbar .navbar-nav li.dropdown:nth-of-type(#{order})"
-  end
-
-  def nav_menu_links(title)
-    "#navbar .navbar-nav li.dropdown[title='#{title}'] ul.dropdown-menu a"
-  end
-
-  def nav_menu_header(title)
-    "#navbar .navbar-nav li.dropdown[title='#{title}'] ul.dropdown-menu li.dropdown-header"
-  end
-
-  def nav_link(title)
-    "#navbar .navbar-nav a.nav-link[title='#{title}']"
+    assert_select dropdown_links, 0
   end
 
   def check_icon(parent_element, icon_class)

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -156,7 +156,8 @@ acls: [{ adapter: :group, groups: ['GROUP'] }] }
 
     get root_path
     assert_response :success
-    assert_select '.navbar-collapse > .nav li.dropdown[title]', 0
+    assert_select dropdown_links, 1 # +1 here is 'Help'
+    assert_select dropdown_link(1), text: 'Help' # ensure is Help
   end
 
   test 'should exclude gateway apps if NavConfig.categories is set to default and whitelist is enabled' do
@@ -167,7 +168,12 @@ acls: [{ adapter: :group, groups: ['GROUP'] }] }
 
     get root_path
     assert_response :success
-    assert_select ".navbar-collapse > .nav li.dropdown[title='Gateway Apps']", 0
+    assert_select  dropdown_links, 5 # +1 here is 'Help'
+    assert_select  dropdown_link(1), text: 'Files'
+    assert_select  dropdown_link(2), text: 'Jobs'
+    assert_select  dropdown_link(3), text: 'Clusters'
+    assert_select  dropdown_link(4), text: 'Interactive Apps'
+    assert_select  dropdown_link(5), text: 'Help'
   end
 
   test 'uses NavConfig.categories as sort order if whitelist is false' do
@@ -178,7 +184,7 @@ acls: [{ adapter: :group, groups: ['GROUP'] }] }
 
     get root_path
     assert_response :success
-    assert_select '.navbar-expand-md > #navbar li.dropdown[title]', 6 # +1 here is 'Help'
+    assert_select  dropdown_links, 6 # +1 here is 'Help'
     assert_select  dropdown_link(1), text: 'Jobs'
     assert_select  dropdown_link(2), text: 'Interactive Apps'
     assert_select  dropdown_link(3), text: 'Files'
@@ -198,7 +204,7 @@ acls: [{ adapter: :group, groups: ['GROUP'] }] }
 
     get root_path
     assert_response :success
-    assert_select '.navbar-expand-md > #navbar li.dropdown[title]', 4 # +1 here is 'Help'
+    assert_select dropdown_links, 4 # +1 here is 'Help'
     assert_select  dropdown_link(1), text: 'Files'
     assert_select  dropdown_link(2), text: 'Interactive Apps'
     assert_select  dropdown_link(3), text: 'Clusters'
@@ -216,7 +222,8 @@ acls: [{ adapter: :group, groups: ['GROUP'] }] }
 
     get root_path
     assert_response :success
-    assert_select '.navbar-collapse > .nav li.dropdown[title]', 0
+    assert_select dropdown_links, 1 # +1 here is 'Help'
+    assert_select dropdown_link(1), text: 'Help' # ensure is Help
   end
 
   test 'verify default values for NavConfig' do
@@ -232,7 +239,7 @@ acls: [{ adapter: :group, groups: ['GROUP'] }] }
 
     get root_path
     assert_response :success
-    assert_select '.navbar-expand-md > #navbar li.dropdown[title]', 6 # +1 here is 'Help'
+    assert_select dropdown_links, 6 # +1 here is 'Help'
 
     assert_select dropdown_link(1), text: 'Clusters'
     assert_select dropdown_link(2), text: 'Files'


### PR DESCRIPTION
This refactors the navigation bar to follow the `menubar` pattern.  I'll try to leave comments here and there for more description on the changes.

The example/documentation I'm following is here:
https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/

@abujeda can you please take a look at how this affects customizing the navigation bar? There could be some areas I missed and/or adversely affected. 