### PR TITLE
logo fixup

### DIFF
--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -11,9 +11,9 @@ module DashboardHelper
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      tag.img(src: uri, alt: "logo", height: @user_configuration.dashboard_logo_height, class: 'py-2')
+      tag.img(src: uri, alt: "logo", height: @user_configuration.dashboard_logo_height, class: 'py-2 w-100')
     else # default logo image
-      image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", class: 'py-2')
+      image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", class: 'py-2 w-100')
     end
   end
 


### PR DESCRIPTION
While working on the navigation bar, I noticed this logo is throwing off the rest of the page by extending beyond the page.


You can even see this in production 3.0 right now: Notice how the image extends over the navigation bar.

![image](https://github.com/OSC/ondemand/assets/4874123/38f180c1-b641-4b06-8e43-470878a9cc88)
