### PR TITLE
add config for prefill templates

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -1,16 +1,18 @@
 
-<%= render "prefill_templates" %>
+<%= render "prefill_templates" if Configuration.bc_saved_settings? %>
 
 <%= bootstrap_form_for(@session_context) do |f| %>
   <% f.object.each do |attrib| %>
     <%= create_widget(f, attrib, format: @render_format) %>
   <% end %>
 
+  <%- if Configuration.bc_saved_settings? -%>
   <div class="form-group form-check d-flex">
       <input class="form-check-input align-self-center" name="save_template" type="checkbox" id="batch_connect_session_save_template">
       <label class="form-check-label align-self-center" for="batch_connect_session_save_template"><%= t('dashboard.batch_connect_form_save') %></label>
       <input class="ml-auto" name="template_name" type="text" id="batch_connect_session_template_name" aria-label="<%= t('dashboard.batch_connect_form_template_name_label') %>" readonly>
   </div>
+  <%- end -%>
 
   <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
 <% end %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -42,6 +42,7 @@ class ConfigurationSingleton
       :bc_dynamic_js                => false,
       :bc_simple_auto_accounts      => false,
       :bc_clean_old_dirs            => false,
+      :bc_saved_settings            => false,
       :per_cluster_dataroot         => false,
       :remote_files_enabled         => false,
       :remote_files_validation      => false,

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -92,17 +92,17 @@ en:
     batch_connect_form_choose_template_name: "Choose a template name"
     batch_connect_form_data_root: "data root directory"
     batch_connect_form_launch: "Launch"
-    batch_connect_form_prefill: "Prefill with template"
+    batch_connect_form_prefill: "Use saved settings"
     batch_connect_form_prefill_error: "Oops... Something is wrong with your template"
     batch_connect_form_reset_resolution: "Reset Resolution"
-    batch_connect_form_save: "Save as template"
-    batch_connect_form_save_new_template: "save as a new template"
-    batch_connect_form_select_template: "select a template"
-    batch_connect_form_template_name_label: "template name"
+    batch_connect_form_save: "Save settings"
+    batch_connect_form_save_new_template: "save new settings"
+    batch_connect_form_select_template: "select saved settings"
+    batch_connect_form_template_name_label: "setting name"
     batch_connect_form_session_data_html: |
       * The %{title} session data for this session can be accessed
         under the %{data_link_tag}.
-    batch_connect_form_type_new_name: "Type your new template name here"
+    batch_connect_form_type_new_name: "App settings name"
     batch_connect_form_type_new_name_error: "Please type a valid name to continue"
     batch_connect_form_invalid: "The form.yml has missing options in the %{id} form field."
     batch_connect_invalid_form_array: "'form' element in form.yml is not an Array"

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1296,7 +1296,7 @@ class BatchConnectTest < ApplicationSystemTestCase
   end
 
   test 'saves settings as a template' do
-    with_modified_env({ ENABLE_NATIVE_VNC: 'true' }) do
+    with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SAVED_SETTINGS: true }) do
       Dir.mktmpdir do |dir|
         Configuration.stubs(:dataroot).returns(Pathname.new(dir))
         BatchConnect::Session.any_instance.stubs(:save).returns(true)

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1296,7 +1296,7 @@ class BatchConnectTest < ApplicationSystemTestCase
   end
 
   test 'saves settings as a template' do
-    with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SAVED_SETTINGS: true }) do
+    with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SAVED_SETTINGS: 'true' }) do
       Dir.mktmpdir do |dir|
         Configuration.stubs(:dataroot).returns(Pathname.new(dir))
         BatchConnect::Session.any_instance.stubs(:save).returns(true)


### PR DESCRIPTION
Fixes #3303 

This also changes the language (through internationalization) from `prefill templates` to `save(d) settings`. I think that just sounds better. `template` seems a bit esoteric to me, where `save` and `settings` seem to fit better - especially for new users.