### PR TITLE
Added external lib folder to autoload path

### DIFF
--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -43,6 +43,7 @@ module Dashboard
       # Ensuring OOD initializers run last so that user's cannot override what we 
       # specify unless we allow the override as well in our own initializers.
       config.paths["config/initializers"] << ::Configuration.config_root.join("initializers").to_s
+      config.autoload_paths << ::Configuration.config_root.join("lib").to_s
       config.paths["app/views"].unshift ::Configuration.config_root.join("views").to_s
     end
   end


### PR DESCRIPTION
In IQSS, we have 2 custom BatchConnect templates that require 2 ruby classes in an specific lib folder.
We are currently adding these 2 ruby files into the installed OnDemand lib folder: `/var/www/ood/apps/sys/dashboard/lib ` under the expected path:` /ood_core/batch_connect/templates/`

We would like support to load these classes from the external config root to keep all customizations and overrides together as well as not modify the dashboard file structure.

We might develop as well custom SmartAttributes and this will help to deploy them