### PR TITLE
mv the user settings file off the dataroot

### DIFF
--- a/apps/dashboard/app/models/concerns/user_setting_store.rb
+++ b/apps/dashboard/app/models/concerns/user_setting_store.rb
@@ -37,7 +37,9 @@ module UserSettingStore
   end
 
   def user_settings_path
-    Pathname.new(::Configuration.dataroot).join(::Configuration.user_settings_file)
+    Pathname.new(::Configuration.user_settings_file).tap do |path|
+      FileUtils.mkdir_p(path.to_s) unless File.exist?(path.parent.to_s)
+    end
   end
 
   def bc_templates(app_token)

--- a/apps/dashboard/app/models/concerns/user_setting_store.rb
+++ b/apps/dashboard/app/models/concerns/user_setting_store.rb
@@ -37,9 +37,7 @@ module UserSettingStore
   end
 
   def user_settings_path
-    Pathname.new(::Configuration.user_settings_file).tap do |path|
-      FileUtils.mkdir_p(path.to_s) unless File.exist?(path.parent.to_s)
-    end
+    Pathname.new(::Configuration.user_settings_file)
   end
 
   def bc_templates(app_token)

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -62,7 +62,7 @@ class ConfigurationSingleton
   def string_configs
     {
       :module_file_dir          => nil,
-      :user_settings_file       => '.ood',
+      :user_settings_file       => Pathname.new("~/.config/ondemand/settings.yml").expand_path.to_s,
       :facl_domain              => nil,
       :auto_groups_filter       => nil,
       :bc_clean_old_dirs_days   => '30',

--- a/apps/dashboard/config/initializers/upgrade_to_3.1.rb
+++ b/apps/dashboard/config/initializers/upgrade_to_3.1.rb
@@ -3,8 +3,10 @@
 Rails.application.config.after_initialize do
   old_default = "#{Configuration.dataroot}/.ood"
   new_file_location = Configuration.user_settings_file
+  new_file_dir = Pathname.new(new_file_location).parent
 
   next if File.exist?(new_file_location)
 
-  FileUtils.mv(old_default, new_file_location) if File.exist?(old_default)
+  FileUtils.mkdir_p(new_file_dir) unless File.exist?(new_file_dir.to_s)
+  FileUtils.mv(old_default, new_file_location.to_s) if File.exist?(old_default)
 end

--- a/apps/dashboard/config/initializers/upgrade_to_3.1.rb
+++ b/apps/dashboard/config/initializers/upgrade_to_3.1.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  old_default = "#{Configuration.dataroot}/.ood"
+  new_file_location = Configuration.user_settings_file
+
+  next if File.exist?(new_file_location)
+
+  FileUtils.mv(old_default, new_file_location) if File.exist?(old_default)
+end

--- a/apps/dashboard/test/integration/settings_controller_test.rb
+++ b/apps/dashboard/test/integration/settings_controller_test.rb
@@ -19,7 +19,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
       }
     }
     Dir.mktmpdir {|temp_data_dir|
-      Configuration.stubs(:dataroot).returns(temp_data_dir)
+      Configuration.stubs(:user_settings_file).returns("#{temp_data_dir}/settings.yml")
 
       post settings_path, params: data, headers: @headers
       assert_response :redirect
@@ -31,18 +31,18 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     data = { settings: {} }
 
     Dir.mktmpdir {|temp_data_dir|
-      Configuration.stubs(:dataroot).returns(temp_data_dir)
+      Configuration.stubs(:user_settings_file).returns("#{temp_data_dir}/settings.yml")
       post settings_path, params: data, headers: @headers
       assert_response :redirect
       assert_nil TestUserSettings.new.user_settings[:profile]
     }
   end
 
-  test "should not save user_settings whne parameters are outside the settings namespace" do
+  test "should not save user_settings when parameters are outside the settings namespace" do
     data = { profile: "root_value" }
 
     Dir.mktmpdir {|temp_data_dir|
-      Configuration.stubs(:dataroot).returns(temp_data_dir)
+      Configuration.stubs(:user_settings_file).returns("#{temp_data_dir}/settings.yml")
       post settings_path, params: data, headers: @headers
       assert_response :redirect
       assert_nil TestUserSettings.new.user_settings[:profile]

--- a/apps/dashboard/test/models/concerns/user_setting_store_test.rb
+++ b/apps/dashboard/test/models/concerns/user_setting_store_test.rb
@@ -18,22 +18,18 @@ class UserSettingStoreTest < ActionView::TestCase
   end
 
   test 'read_user_settings should read data from user settings file' do
-    with_modified_env(OOD_DATAROOT:           "#{Rails.root}/test/fixtures/config/user_settings",
-                      OOD_USER_SETTINGS_FILE: '.valid') do
-      expected_user_settings = { :profile=>'file_value' }
+    Configuration.stubs(:user_settings_file).returns("#{Rails.root}/test/fixtures/config/user_settings/.valid")
+    expected_user_settings = { :profile=>'file_value' }
 
-      assert_equal expected_user_settings, read_user_settings
-    end
+    assert_equal expected_user_settings, read_user_settings
   end
 
   test 'read_user_settings should log errors when reading settings from file' do
-    with_modified_env(OOD_DATAROOT:           "#{Rails.root}/test/fixtures/config/user_settings",
-                      OOD_USER_SETTINGS_FILE: '.invalid') do
-      Rails.logger.expects(:error).with(regexp_matches(/Can't read or parse settings file/)).at_least_once
-      expected_user_settings = {}
+    Configuration.stubs(:user_settings_file).returns("#{Rails.root}/test/fixtures/config/user_settings/.invalid")
+    Rails.logger.expects(:error).with(regexp_matches(/Can't read or parse settings file/)).at_least_once
+    expected_user_settings = {}
 
-      assert_equal expected_user_settings, read_user_settings
-    end
+    assert_equal expected_user_settings, read_user_settings
   end
 
   test 'update_user_settings should create data directory when is not available' do
@@ -41,7 +37,7 @@ class UserSettingStoreTest < ActionView::TestCase
       data_root = Pathname.new(temp_data_dir).join('update_test')
       assert_equal false, data_root.exist?
 
-      Configuration.stubs(:dataroot).returns(data_root.to_s)
+      Configuration.stubs(:user_settings_file).returns("#{data_root.to_s}/settings.yml")
 
       update_user_settings({})
 
@@ -51,7 +47,7 @@ class UserSettingStoreTest < ActionView::TestCase
 
   test 'update_user_settings should update internal data and user settings file' do
     Dir.mktmpdir do |temp_data_dir|
-      Configuration.stubs(:dataroot).returns(temp_data_dir)
+      Configuration.stubs(:user_settings_file).returns("#{temp_data_dir}/settings.yml")
 
       settings = user_settings
       settings[:profile] = 'profile_value'

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -41,8 +41,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
 
   def setup()
     @test_temp_dir = Dir.mktmpdir
-    Configuration.stubs(:dataroot).returns(@test_temp_dir)
-    Configuration.stubs(:user_settings_file).returns('.user_configuration_test_settings')
+    Configuration.stubs(:user_settings_file).returns("#{@test_temp_dir}/settings.yml")
   end
 
   def teardown

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1298,7 +1298,7 @@ class BatchConnectTest < ApplicationSystemTestCase
   test 'saves settings as a template' do
     with_modified_env({ ENABLE_NATIVE_VNC: 'true' }) do
       Dir.mktmpdir do |dir|
-        Configuration.stubs(:dataroot).returns(Pathname.new(dir))
+        Configuration.stubs(:user_settings_file).returns(Pathname.new("#{dir}/settings.yml"))
         BatchConnect::Session.any_instance.stubs(:save).returns(true)
         BatchConnect::Session.any_instance.stubs(:job_id).returns('job-id-123')
         OodCore::Job::Adapters::Slurm.any_instance
@@ -1319,7 +1319,7 @@ class BatchConnectTest < ApplicationSystemTestCase
 
         click_on('Launch', wait: 30)
         expected = output_fixture('user_settings/simple_bc_test.yml')
-        actual = File.read("#{dir}/.ood")
+        actual = File.read("#{dir}/settings.yml")
 
         assert_equal(expected, actual)
       end


### PR DESCRIPTION
mv the user settings file off the dataroot.

Fixes #3302 

@abujeda PTAL and see if this is going to be problematic for you. I don't know how to handle the case when folks have redefined the old config path/filename.