### PR TITLE
enable dynamic forms in the scripts#show page

### DIFF
--- a/apps/dashboard/app/javascript/script_show.js
+++ b/apps/dashboard/app/javascript/script_show.js
@@ -1,0 +1,5 @@
+import { makeChangeHandlers } from './dynamic_forms';
+
+jQuery(function() {
+  makeChangeHandlers('script');
+});

--- a/apps/dashboard/app/lib/account_cache.rb
+++ b/apps/dashboard/app/lib/account_cache.rb
@@ -68,8 +68,11 @@ module AccountCache
         end
 
         cluster_data = other_clusters.map do |other_cluster|
-          ["data-option-for-cluster-#{other_cluster}", false]
-        end.to_h
+          [
+            ["data-option-for-cluster-#{other_cluster}", false],
+            ["data-option-for-auto-batch-clusters-#{other_cluster}", false]
+          ]
+        end.flatten(1).to_h
 
         cluster_queues.map do |queue|
           unless blocked_queue?(queue)

--- a/apps/dashboard/app/views/scripts/show.html.erb
+++ b/apps/dashboard/app/views/scripts/show.html.erb
@@ -1,6 +1,7 @@
 
 <h1><%= @script.title %></h1>
 
+<%= javascript_include_tag 'script_show', nonce: true %>
 
 <%= link_to 'Back', project_path(params[:project_id]), class: 'btn btn-default my-3',  title: 'Return to projects page' %>
 


### PR DESCRIPTION
enable dynamic forms in the scripts#show page. This is primarily when scripts add `queues`. This list of select options needs to be dynamic, so this adds the javascript to be dynamic as well as the relevant `data-option-for` directives. 