### PR TITLE
Fix an error at /apps/show/:name?path=x

### DIFF
--- a/apps/dashboard/app/controllers/apps_controller.rb
+++ b/apps/dashboard/app/controllers/apps_controller.rb
@@ -27,7 +27,7 @@ class AppsController < ApplicationController
 
     if params[:path]
       # if a path in the app is provided, append this to the url
-      app_uri = uri(app_url)
+      app_uri = URI.parse(app_url)
       app_uri.path = Pathname.new(app_uri.path).join(params[:path]).to_s
       app_url = app_uri.to_s
     end


### PR DESCRIPTION
The route 

> app GET  /apps/show/:name(/:type(/:owner))(.:format) apps#show {:type=>"sys"}

 with a 'path' URL parameter causes an application error. 

```
#<NoMethodError: undefined method `uri' for #<AppsController:0x0000000001f5e0>
Did you mean?  URI>
...
```


Example using 'myjobs':

https://ondemand-test.osc.edu/pun/sys/dashboard/apps/show/myjobs 
redirects to
https://ondemand-test.osc.edu/pun/sys/myjobs without issues.

https://ondemand-test.osc.edu/pun/sys/dashboard/apps/show/myjobs?path=x
causes the above error.



I verified after the change dashboard/apps/show/myjobs?path=x redirects to /myjobs/x and displays the below instead of an error. 

> The page you were looking for doesn't exist.
> You may have mistyped the address or the page may have moved.
> 
> If you are the application owner check the logs for more information.