### PR TITLE
Fixes to the nav_bar group selection subcategory order

### DIFF
--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -134,7 +134,7 @@ class NavBar
       group = OodAppGroup.groups_for(apps: SysRouter.apps).select { |g| g.title.downcase == token.downcase }.first
       return nil if group.nil?
       group.apps = extract_links(group.apps)
-      extend_group(group)
+      extend_group(group, sort: true)
     end
   end
 

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -73,7 +73,8 @@ class NavBarTest < ActiveSupport::TestCase
     result = NavBar.items([nav_item])
     assert_equal 1,  result.size
     assert_equal "layouts/nav/group",  result[0].partial_path
-    assert_equal false,  result[0].sort
+    # sort should be true to order subcategories
+    assert_equal true,  result[0].sort
     assert_equal "Interactive Apps",  result[0].title
     assert_equal 4,  result[0].apps.size
   end


### PR DESCRIPTION
Adding sorting to the NavBar group selection subcategories.

fixes #3343 