### PR TITLE
ensure build dir is clean when building assets

### DIFF
--- a/apps/dashboard/esbuild.config.js
+++ b/apps/dashboard/esbuild.config.js
@@ -27,7 +27,7 @@ const prepPlugin = {
 
       // FIXME probably a better way to do this? build below already recognizes the filetypes.
       fs.readdir(faDir, (err, files) => {
-        if(err) throw `${faDir} has to exist for to compile. Did you run 'bin/setup'?`;
+        if(err) throw `${faDir} has to exist for assets to compile. Did you run 'bin/setup'?`;
 
         files.forEach(file => {
           fs.copyFileSync(`${faDir}/${file}`, `${buildDir}/${file}`);

--- a/apps/dashboard/esbuild.config.js
+++ b/apps/dashboard/esbuild.config.js
@@ -1,18 +1,11 @@
 const esbuild = require('esbuild');
 const fs = require('fs');
 
-// FIXME probably a better way to do this? build below already recognizes the filetypes.
 const faDir = 'node_modules/@fortawesome/fontawesome-free/webfonts/';
-fs.readdir(faDir, (err, files) => {
-  if(err) throw `${faDir} has to exist for to compile. Did you run 'bin/setup'?`;
-
-  files.forEach(file => {
-    fs.copyFile(`${faDir}/${file}`, `app/assets/builds/${file}`, () => {});
-  });
-});
 
 // could just glob and pass this in the cli, but glob support is shell dependant
-entryPoints = filesFromDir('app/javascript');
+const entryPoints = filesFromDir('app/javascript');
+const buildDir = 'app/assets/builds';
 
 function filesFromDir(dir) {
   return fs.readdirSync(dir).map((file) => {
@@ -24,13 +17,34 @@ function filesFromDir(dir) {
   }).flat(); // only works for 1 subdirectory
 }
 
+const prepPlugin = {
+  name: 'prep-build-dir',
+  setup(build) {
+    build.onStart(() => {
+      fs.rmSync(buildDir, { recursive: true, force: true });
+      fs.mkdirSync(buildDir);
+      fs.copyFileSync('tmp/.keep', `${buildDir}/.keep`);
+
+      // FIXME probably a better way to do this? build below already recognizes the filetypes.
+      fs.readdir(faDir, (err, files) => {
+        if(err) throw `${faDir} has to exist for to compile. Did you run 'bin/setup'?`;
+
+        files.forEach(file => {
+          fs.copyFileSync(`${faDir}/${file}`, `${buildDir}/${file}`);
+        });
+      });
+    })
+  },
+}
+
 esbuild.build({
   entryPoints: entryPoints,
   bundle: true,
   sourcemap: true,
   format: 'esm',
-  outdir: 'app/assets/builds',
+  outdir: buildDir,
   external: ['fs'],
+  plugins: [prepPlugin],
   minify: process.env.RAILS_ENV == 'production' ? true : false,
 }).catch((e) => console.error(e.message));
 


### PR DESCRIPTION
ensure build dir is clean when building assets. I found that this directory isn't always clean and it can leak stuff when you're building assets over and over again like we do in dev environments.