### PR TITLE
Fixed app-icon margin for Pinned Apps after update in #3075 PR

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
@@ -181,6 +181,10 @@
     margin-bottom: 0.2em;
   }
 
+  .app-icon {
+    margin-right: 0;
+  }
+
   p.app-title {
     margin: 0;
   }


### PR DESCRIPTION
PR #3075 affected the images for pinned apps, adding a right margin that was not needed in this context.

This is a fix to reset the right margin to 0.