### PR TITLE
Added edit session feature to load BatchConnect form with existing session parameters

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -10,9 +10,13 @@ class BatchConnect::SessionContextsController < ApplicationController
     set_session_context
     set_prefill_templates
 
+    session_id = params[:session_id]
+    valid_session = session_id && BatchConnect::Session.exist?(session_id)
+
     if @app.valid?
       begin
-        @app.update_session_with_cache(@session_context, cache_file)
+        app_parameters_file = valid_session ? BatchConnect::Session.find(session_id).user_defined_context_file : cache_file
+        @app.update_session_with_cache(@session_context, app_parameters_file)
       rescue => e
         flash.now[:alert] = t('dashboard.batch_connect_form_attr_cache_error',error_message: e.message)
       end

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -107,6 +107,22 @@ module BatchConnect::SessionsHelper
     end
   end
 
+  def edit(session)
+    title = t('dashboard.batch_connect_sessions_edit_title', title: session.title)
+    button_to(
+      new_batch_connect_session_context_path(token: session.token),
+      method: :get,
+      class: %w[btn px-1 py-0 btn-outline-dark],
+      form_class: %w[d-inline edit-session],
+      title: title,
+      'aria-label': title,
+      data: { toggle: "tooltip", placement: "left" },
+      params: {session_id: session.id}
+    ) do
+      "#{fa_icon('pen', classes: nil, title: '')}".html_safe
+    end
+  end
+
   def cancel_or_delete(session)
     if Configuration.cancel_session_enabled && !session.completed?
       cancel(session)

--- a/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
@@ -21,8 +21,10 @@
       <%- end -%>
       <%= status(session) %>
       <%- if session.completed? -%>
-      <span class="card-text"> | </span>
-      <%= relaunch(session) %>
+        <span class="card-text"> | </span>
+        <%= edit(session) %>
+        <span class="card-text"> | </span>
+        <%= relaunch(session) %>
       <%- end -%>
     </div>
   </div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
     batch_connect_sessions_cancel_confirm: "Are you sure?"
     batch_connect_sessions_cancel_title: "Cancel"
     batch_connect_sessions_relaunch_title: "Relaunch"
+    batch_connect_sessions_edit_title: "Edit new %{title} with this session parameters"
     batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:"
     batch_connect_sessions_errors_submission: "Failed to submit session with the following error:"
     batch_connect_sessions_novnc_launch: "Launch %{app_title}"


### PR DESCRIPTION
An idea for a new feature:
Add an edit button into the session card to pre-load the Interactive Apps form with the session launch parameters.

This might be useful if users need to adjust few parameters when launching a new session