### PR TITLE
Show app card host only for running sessions

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_host.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_host.html.erb
@@ -1,17 +1,19 @@
-<% if session.ssh_to_compute_node? %>
-  <p>
-    <strong><%= t('dashboard.batch_connect_sessions_stats_host') %></strong>  
-    <% if session.running? && session.connect.host %>
-      <a href="<%= OodAppkit.shell.url(host: session.connect.host).to_s %>" target="_blank" class="btn btn-primary btn-sm fas fa-terminal"> 
-        <%= session.connect.host %> 
-      </a>
-    <% else %> 
-      <%= t('dashboard.batch_connect_sessions_stats_undetermined_host') %>
-    <% end %>
-  </p>
-<% else %>  
+<% if session.running? %>
+  <% if session.ssh_to_compute_node? %>
+    <p>
+      <strong><%= t('dashboard.batch_connect_sessions_stats_host') %></strong>
+      <% if session.connect.host %>
+        <a href="<%= OodAppkit.shell.url(host: session.connect.host).to_s %>" target="_blank" class="btn btn-primary btn-sm fas fa-terminal">
+          <%= session.connect.host %>
+        </a>
+      <% else %>
+        <%= t('dashboard.batch_connect_sessions_stats_undetermined_host') %>
+      <% end %>
+    </p>
+  <% else %>
     <p>
       <strong><%= t('dashboard.batch_connect_sessions_stats_host') %></strong>
       <%= session.connect.host || t('dashboard.batch_connect_sessions_stats_undetermined_host') %>
-    </p>  
+    </p>
+  <% end %>
 <% end %>


### PR DESCRIPTION
We're testing OOD 3.1 and I noticed the behaviour for host on app cards changed in #3211.

Upon closer inspection it turns out that if you have SSH to compute nodes disabled the users will see an internal server error on the My interactive sessions page while the job is starting (before `connection.yml` exists, so `session.connect` is not safe to call).
![image](https://github.com/OSC/ondemand/assets/61623634/a1b67f62-e1b5-4a54-a724-d76efa43cb6a)

```
#<Errno::ENOENT: No such file or directory @ rb_sysopen - /users/robkarls/ondemand/data/sys/dashboard/batch_connect/dev/ood-base-jupyter/output/737014d2-07c4-47ac-b601-f157ba9bf322/connection.yml>

/var/www/ood/apps/sys/dashboard/app/models/batch_connect/session.rb:560:in `read'
/var/www/ood/apps/sys/dashboard/app/models/batch_connect/session.rb:560:in `read'
/var/www/ood/apps/sys/dashboard/app/models/batch_connect/session.rb:560:in `connect'
/var/www/ood/apps/sys/dashboard/app/views/batch_connect/sessions/card/_host.html.erb:15:in `_app_views_batch_connect_sessions_card__host_html_erb__2025030219551494985_15040'
```


Previously the host was only visible for running sessions, but now for everything except running sessions it shows "Undetermined"
Left is 3.0, right is 3.1, compute node shell enabled (i.e. no internal server error here):
![host_undetermined](https://github.com/OSC/ondemand/assets/61623634/1b5e9d7d-d058-440c-8f83-b6cd987e8231)

This PR changes that so it behaves as it did previously, i.e. it is only visible for running sessions. There might be some better place to place `if session.running?`, so the whole template would not be wrapped. Let me know if you'd like me to change that.
