### PR TITLE
Fixed interactive apps and sessions left hand menu icon margin

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/apps.scss
@@ -39,7 +39,7 @@ tr.app {
    font-size: 14px;
 }
 
-.app-icon.fa-fw {
+i.app-icon.fa-fw {
   width: 1.25em;
 }
 


### PR DESCRIPTION
Applying margin fixes from PR #3075 to the left hand side navigation in Interactive Apps and Interactive Sessions.

The fix is not working in these pages because there is another CSS margin rule in `batch_connect/sessions.scss` that has the higher precedence, because is loaded after the CSS rule in the fix.

`# batch_connect/sessions.scss`
```css
.list-group .app-icon{
  width: 14px;
  height: 14px;
  font-size: 14px;
}
```

This change makes the CSS rule from #3075 more specific and will take precedence over the other rule.