### PR TITLE
Fix spelling error in need_auth.html from ood-portal-generator 

### DIFF
--- a/ood-portal-generator/share/need_auth.html
+++ b/ood-portal-generator/share/need_auth.html
@@ -13,7 +13,7 @@
         <div class="col-md-6">
           <div class="card-text">
             You have successfully installed Open OnDemand. <br><br>
-            However, you now have to configurure authentication for this apache instance.
+            However, you now have to configure authentication for this apache instance.
             See <a href="https://osc.github.io/ood-documentation/latest/authentication.html">the authentication documentation</a> 
             for all the options available.
           </div>


### PR DESCRIPTION
Fixed a small spelling error in _need_auth.html_ when I was plugging around the code base for the `ood-portal-generator` utility. The spelling error is presented when you first deploy Open Ondemand, but have not yet configured an OpenIDC provider for Apache.