### PR TITLE
backport #3375 to 3.1

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -30,7 +30,7 @@ module BatchConnect::SessionContextsHelper
         form.collection_radio_buttons(attrib.id, attrib.select_choices, :second, :first, **opts)
       end
     when 'path_selector'
-      form.form_group attrib.id, help: field_options[:help] do
+      form.form_group(attrib.id) do
         render(partial: 'path_selector', locals: { form: form, attrib: attrib, field_options: field_options })
       end
     when 'file_attachments'

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -9,9 +9,10 @@
   button_id = "#{path_selector_id}_button"
   table_id = "#{path_selector_id}_table"
   breadcrumb_id = "#{path_selector_id}_breadcrumb"
+  options =  { data: { 'path-selector': true }}.merge(field_options)
 %>
 
-<%= form.text_field(attrib.id, class: 'form-control', data: { 'path-selector': true }) %>
+<%= form.text_field(attrib.id, class: 'form-control', **options) %>
 
 <button type="button" class="btn btn-primary mt-2" data-toggle="modal" data-target="#<%= path_selector_id %>">
   Select Path


### PR DESCRIPTION
Backport #3375 to 3.1 to allow the path_selector to redefine html options like label and help message.