### PR TITLE
Removed edit session button in Session card for preset applications

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
@@ -20,9 +20,11 @@
       <span class="card-text"> | </span>
       <%- end -%>
       <%= status(session) %>
-      <%- if session.completed? -%>
+      <%- if session.completed? && !session.app.preset? -%>
         <span class="card-text"> | </span>
         <%= edit(session) %>
+      <%- end -%>
+      <%- if session.completed? -%>
         <span class="card-text"> | </span>
         <%= relaunch(session) %>
       <%- end -%>


### PR DESCRIPTION
Small improvements => Removed edit session button from Session cards for preset applications.

The edit session button makes no sense for preset applications as the form will have no fields.