### PR TITLE
start to redesign the projects#show page

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -102,6 +102,10 @@ class Launcher
   end
   alias inspect to_h
 
+  def quick_launch_params
+    smart_attributes.map { |attr| ["launcher[#{attr.id}]", attr.value] }.to_h
+  end
+
   # Delegate methods to smart_attributes' getter
   #
   # @param method_name the method name called

--- a/apps/dashboard/app/views/layouts/projects.html.erb
+++ b/apps/dashboard/app/views/layouts/projects.html.erb
@@ -1,0 +1,2 @@
+
+<%= render template: "layouts/application", locals: { layout_container_class: 'container-fluid' } %>

--- a/apps/dashboard/app/views/projects/_launcher_details.html.erb
+++ b/apps/dashboard/app/views/projects/_launcher_details.html.erb
@@ -1,0 +1,34 @@
+
+<div class='card'>
+  <div class='card-header'>
+    <div class="row">
+      <!-- this is just a placeholder for when we actually implement it -->
+      <div class="col-2 d-flex align-items-center justify-content-center">
+        <button class="btn btn-primary">
+          <i class="fa fa-pencil"></i>
+        </button>
+      </div>
+
+      <div class="col-8">
+        <h2 class='text-center h4'><%= launcher.title %></h2>
+      </div>
+
+      <div class="col-2 d-flex align-items-center justify-content-center">
+        <%= button_to(
+          project_launcher_path(@project.id, launcher.id),
+          id: "delete_#{launcher.id}",
+          class: "btn btn-danger float-right",
+          title: 'delete something',
+          data: { confirm: I18n.t('dashboard.jobs_scripts_delete_script_confirmation') },
+          method: :delete) do %>
+          <i class="fa fa-trash"></i>
+        <%- end -%>
+      </div>
+    </div>
+  </div>
+
+  <div class="card-body">
+    placeholder for launcher details.
+  </div>
+</div>
+

--- a/apps/dashboard/app/views/projects/_launcher_details.html.erb
+++ b/apps/dashboard/app/views/projects/_launcher_details.html.erb
@@ -1,12 +1,24 @@
 
+<%-
+  disabled = !@valid_project
+  disabled_class = disabled ? 'disabled' : ''
+  edit_title = "#{t('dashboard.edit')} launcher #{launcher.title}"
+  delete_title = "#{t('dashboard.delete')} launcher #{launcher.title}"
+-%>
+
 <div class='card'>
   <div class='card-header'>
     <div class="row">
       <!-- this is just a placeholder for when we actually implement it -->
       <div class="col-2 d-flex align-items-center justify-content-center">
-        <button class="btn btn-primary">
+        <%= link_to(
+          edit_project_launcher_path(@project.id, launcher.id),
+          class: "btn btn-primary #{disabled_class}",
+          id: "edit_#{launcher.id}",
+          title: edit_title) do
+        %>
           <i class="fa fa-pencil"></i>
-        </button>
+        <%- end %>
       </div>
 
       <div class="col-8">
@@ -18,9 +30,10 @@
           project_launcher_path(@project.id, launcher.id),
           id: "delete_#{launcher.id}",
           class: "btn btn-danger float-right",
-          title: 'delete something',
+          title: delete_title,
           data: { confirm: I18n.t('dashboard.jobs_scripts_delete_script_confirmation') },
-          method: :delete) do %>
+          method: :delete) do
+        %>
           <i class="fa fa-trash"></i>
         <%- end -%>
       </div>

--- a/apps/dashboard/app/views/projects/_launcher_details.html.erb
+++ b/apps/dashboard/app/views/projects/_launcher_details.html.erb
@@ -9,7 +9,6 @@
 <div class='card'>
   <div class='card-header'>
     <div class="row">
-      <!-- this is just a placeholder for when we actually implement it -->
       <div class="col-2 d-flex align-items-center justify-content-center">
         <%= link_to(
           edit_project_launcher_path(@project.id, launcher.id),
@@ -41,7 +40,31 @@
   </div>
 
   <div class="card-body">
-    placeholder for launcher details.
+    <div class="row justify-content-between">
+      <div class="col-4">
+        <%= button_to(
+          t('dashboard.batch_connect_form_launch'),
+          submit_project_launcher_path(@project.id, launcher.id),
+          class: 'btn btn-secondary',
+          title: 'Launch script with cached or default values',
+          disabled: disabled,
+          params: launcher.quick_launch_params
+        )
+        %>
+      </div>
+
+      <div class="col-4">
+        <%= link_to(
+            t('dashboard.show'),
+            project_launcher_path(@project.id, launcher.id),
+            class: "btn btn-success float-right #{disabled_class}")
+        %>
+      </div>
+    </div>
+
+    <div class="row">
+      <%= launcher.most_recent_job_id %>
+    </div>
   </div>
 </div>
 

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -83,13 +83,6 @@
                 )
             %>
 
-            <%= link_to(
-              t('dashboard.edit'),
-              edit_project_launcher_path(@project.id, script.id),
-              class: "btn btn-primary mx-1 #{disabled_class}",
-            )
-            %>
-
             <%-
               params = script.smart_attributes.map { |attr| ["launcher[#{attr.id}]", attr.value] }.to_h
             -%>

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -43,7 +43,7 @@
       <%- @scripts.each_with_index do |script, index| -%>
       <%- active_class = index.positive? ? '' : 'show active' -%>
       <div class="tab-pane fade <%= active_class %>" id="view_<%= script.id %>" role="tabpanel" >
-        <p>This would show data on the <strong><%= script.title %></strong> launcher.</p>
+        <%= render(partial: 'launcher_details', locals: { launcher: script }) %>
       </div>
       <%- end -%>
 
@@ -88,15 +88,6 @@
               edit_project_launcher_path(@project.id, script.id),
               class: "btn btn-primary mx-1 #{disabled_class}",
             )
-            %>
-
-            <%= link_to(
-              t('dashboard.delete'),
-              project_launcher_path(@project.id, script.id),
-              class: "btn btn-danger mx-1 #{disabled_class}",
-              method: 'delete',
-              data: { confirm: I18n.t('dashboard.jobs_scripts_delete_script_confirmation') },
-              )
             %>
 
             <%-

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -4,17 +4,17 @@
   disabled_class = disabled ? 'disabled' : ''
 -%>
 
-<div class='page-header text-center'>
-  <h1 class="my-2"><%= @project.title %></h1>
+<div class='row'>
+  <div class="col-2 align-self-center justify-content-center d-flex">
+    <%= link_to 'Back', projects_path, class: 'btn btn-default align-self-start', title: 'Return to projects page' %>
+  </div>
 
-  <small class="text-muted">This is a preview of the new 'Project Manager'</small>
-</div>
 
+  <div class='page-header text-center col-8'>
+    <h1 class="my-2 h3"><%= @project.title %></h1>
 
-<div class='row row-cols-1 row-cols-md-2'>
-  <p>
-    <%= link_to 'Back', projects_path, class: 'btn btn-default', title: 'Return to projects page' %>
-  </p>
+    <small class="text-muted">This is a preview of the new 'Project Manager'</small>
+  </div>
 </div>
 
 <div class="row my-2">
@@ -22,6 +22,33 @@
     <i class="fas fa-folder-open" aria-hidden="true"></i>
     <%= t('dashboard.project') %> <%= t('dashboard.directory') %> <span data-toggle="project" data-url="<%= project_path(@project.id) %>"></span>
   </a>
+</div>
+
+<div class="row mb-3">
+  <div class="col-4">
+    <div class="list-group" id="launcher-list" role="tablist">
+
+      <%- @scripts.each_with_index do |script, index| -%>
+      <%- active_class = index.positive? ? '' : 'active' -%>
+      <a class="list-group-item list-group-item list-group-item-action <%= active_class %>" id="show_<%= script.id %>" data-toggle="list" href="#view_<%= script.id %>" role="tab">
+        <%= script.title %>
+      </a>
+      <%- end -%>
+
+    </div>
+  </div>
+  <div class="col-8">
+    <div class="tab-content" id="some id">
+
+      <%- @scripts.each_with_index do |script, index| -%>
+      <%- active_class = index.positive? ? '' : 'show active' -%>
+      <div class="tab-pane fade <%= active_class %>" id="view_<%= script.id %>" role="tabpanel" >
+        <p>This would show data on the <strong><%= script.title %></strong> launcher.</p>
+      </div>
+      <%- end -%>
+
+    </div>
+  </div>
 </div>
 
 <div class='card'>

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -26,11 +26,12 @@
 
 <div class="row mb-3">
   <div class="col-4">
-    <div class="list-group" id="launcher-list" role="tablist">
+    <div class="list-group" id="launcher_list" role="tablist">
 
       <%- @scripts.each_with_index do |script, index| -%>
       <%- active_class = index.positive? ? '' : 'active' -%>
-      <a class="list-group-item list-group-item list-group-item-action <%= active_class %>" id="show_<%= script.id %>" data-toggle="list" href="#view_<%= script.id %>" role="tab">
+      <a class="list-group-item list-group-item list-group-item-action <%= active_class %>"
+         id="show_<%= script.id %>" data-toggle="list" href="#view_<%= script.id %>" role="tab">
         <%= script.title %>
       </a>
       <%- end -%>
@@ -51,63 +52,8 @@
   </div>
 </div>
 
-<div class='card'>
-  <h3 class='card-header'>Launchers</h3>
-  <div class='card-body'>
-    <table class='table table-bordered table-hover'>
-      <thead>
-        <tr>
-          <th scope='col' class='text-center'>Job Info</th>
-          <th scope='col' class='text-center'>Launcher Name</th>
-          <th scope='col' class='text-center'>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-      <% @scripts.each do |script| %>
-        <tr class="script-card" id="<%= script.id %>">
-          <td
-            class='text-center col-md-4'
-            data-job-id="<%= script.most_recent_job_id %>"
-            data-job-cluster="<%= script.most_recent_job_cluster %>"
-            data-job-poller='true'
-          >
-            <div class="spinner-border"></div>
-          </td>
-          <td class='text-center col-md-4'><%= script.title %></td>
-          <td class='col-md-12 text-center'>
-          <div class="d-inline-flex">
-            <%= link_to(
-                t('dashboard.show'),
-                  project_launcher_path(@project.id, script.id),
-                  class: "btn btn-success mx-1 #{disabled_class}"
-                )
-            %>
-
-            <%-
-              params = script.smart_attributes.map { |attr| ["launcher[#{attr.id}]", attr.value] }.to_h
-            -%>
-
-            <%= button_to(
-              t('dashboard.batch_connect_form_launch'),
-              submit_project_launcher_path(@project.id, script.id),
-              class: "btn btn-secondary mx-1",
-              title: 'Launch script with cached values',
-              data: {:method => "post"},
-              disabled: disabled,
-              params: params
-            )
-            %>
-            </div>
-          </td>
-        <tr>
-      <% end %>
-      </tbody>
-    </table>
-
-    <%= link_to('New Launcher',
-          new_project_launcher_path(@project.id),
-          class: "btn btn-info #{disabled_class}",
-          title: I18n.t('dashboard.jobs_project_create_new_project_directory'))
-    %>
-  </div>
-</div>
+<%= link_to('New Launcher',
+  new_project_launcher_path(@project.id),
+  class: "btn btn-info #{disabled_class}",
+  title: I18n.t('dashboard.jobs_project_create_new_project_directory'))
+%>

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -46,8 +46,8 @@ class ProjectManagerTest < ApplicationSystemTestCase
     find('#launcher_title').set('the script title')
     click_on 'Save'
 
-    script_element = find('.script-card')
-    script_element[:id]
+    script_element = all('#launcher_list a').first
+    script_element[:id].gsub('show_', '')
   end
 
   def add_account(project_id, script_id, save: true)

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -295,7 +295,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       end
 
       accept_confirm do
-        click_on 'Delete'
+        find("#delete_#{script_id}").click
       end
 
       assert_selector '.alert-success', text: 'Script successfully deleted!'


### PR DESCRIPTION
This starts to redesign the projects#show page. It's only additive right now so that tests can pass and I can get a feel for what it should look like. 

The basic idea is that instead of having the table for all the launchers, we'd have this list that can toggle them. In that view (which only has text right now) is where you'd not only RUD launchers but also interact with the jobs that the launchers have created.

![image](https://github.com/OSC/ondemand/assets/4874123/476b0267-dbd5-4d0c-9f94-43519d417f0e)

This is work for ticket #3109.