### PR TITLE
Include completed_at in serialized batch connect card attributes

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -31,6 +31,10 @@ module BatchConnect
     # @return [Integer] created at
     attr_accessor :created_at
 
+    # When this session finished, as a unix timestamp
+    # @return [Integer] completed at
+    attr_accessor :completed_at
+
     # Token describing app and sub app
     # @return [String] app token
     attr_accessor :token
@@ -87,7 +91,7 @@ module BatchConnect
     # Attributes used for serialization
     # @return [Hash] attributes to be serialized
     def attributes
-      %w(id cluster_id job_id created_at token title script_type cache_completed).map do |attribute|
+      %w(id cluster_id job_id created_at token title script_type cache_completed completed_at).map do |attribute|
         [ attribute, nil ]
       end.to_h
     end
@@ -421,6 +425,7 @@ module BatchConnect
     def update_cache_completed!
       if (! cache_completed) && completed?
         self.cache_completed = true
+        self.completed_at = Time.now.to_i
         db_file.write(to_json)
       end
     end

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -551,7 +551,8 @@ module BatchConnect
           'token'           => 'bc_jupyter',
           'title'           => 'Jupyter Notebook',
           'script_type'     => 'basic',
-          'cache_completed' => nil
+          'cache_completed' => nil,
+          'completed_at'    => nil
         }
         Timecop.freeze(now) do
           assert session.save(app: bc_jupyter_app, context: ctx), session.errors.each(&:to_s).to_s


### PR DESCRIPTION
We are using the `modified_at` session attribute in our Connection View session cards, and we'd like to roll the change up into the official distribution.

The `modified_at` value is used to construct a link to our Grafana resource utilization dashboard (see below).

I have prepared a corresponding change for the `ood-documentation` repo, but I thought I should see how this pull request goes before submitting a pull request there.

Here's the info.html.erb we are using with this change:

```
<%
  grafana_url_prefix = 'YOUR-URL-PREFIX-HERE'
  start_time = created_at.to_i * 1000

  if cache_completed
    end_time = modified_at.to_i * 1000
  else
    end_time = 'now'
  end
%>
<a href="<%= grafana_url_prefix %>&from=<%= start_time %>&to=<%= end_time %>&var-jobid=<%= job_id %>&refresh=5m" target="_blank">View this job's resource utilization</a>
```
