### PR TITLE
Added saved settings menu and details view

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -158,6 +158,7 @@ small.form-text {
 @import "products";
 @import "batch_connect/sessions";
 @import "batch_connect/session_contexts";
+@import "batch_connect/saved_settings";
 @import "insufficient_quota";
 @import "insufficient_balance";
 @import "fa_shims";

--- a/apps/dashboard/app/assets/stylesheets/batch_connect/saved_settings.scss
+++ b/apps/dashboard/app/assets/stylesheets/batch_connect/saved_settings.scss
@@ -1,0 +1,5 @@
+#saved-settings-menu {
+  .saved-settings-list .app-icon {
+    color: rgba(0, 0, 0, 0.25);
+  }
+}

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -1,7 +1,6 @@
 # The controller for creating batch connect sessions.
 class BatchConnect::SessionContextsController < ApplicationController
   include BatchConnectConcern
-  include UserSettingStore
 
   # GET /batch_connect/<app_token>/session_contexts/new
   def new
@@ -88,13 +87,13 @@ class BatchConnect::SessionContextsController < ApplicationController
 
     # Set the rendering format for displaying attributes
     def set_prefill_templates
-      @prefill_templates ||= bc_templates(@app.token)
+      @prefill_templates ||=  BatchConnect::Settings.app_settings(@app.token)
     end
 
     def save_template
       return unless params[:save_template].present? && params[:save_template] == "on" && params[:template_name].present?
 
-      save_bc_template(@app.token, params[:template_name], @session_context.to_h)
+      BatchConnect::Settings.new(@app.token, params[:template_name], @session_context.to_h).save
     end
 
     # Only permit certian parameters

--- a/apps/dashboard/app/controllers/batch_connect/sessions_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/sessions_controller.rb
@@ -1,6 +1,7 @@
 # The controller for active batch connect sessions.
 class BatchConnect::SessionsController < ApplicationController
   include BatchConnectConcern
+  include UserSettingStore
 
   # GET /batch_connect/sessions
   # GET /batch_connect/sessions.json
@@ -9,6 +10,7 @@ class BatchConnect::SessionsController < ApplicationController
     @sessions.each(&:update_cache_completed!)
 
     set_app_groups
+    set_saved_settings
     set_my_quotas
   end
 
@@ -60,6 +62,11 @@ class BatchConnect::SessionsController < ApplicationController
       @usr_app_groups = bc_usr_app_groups
       @dev_app_groups = bc_dev_app_groups
       @apps_menu_group = bc_custom_apps_group
+    end
+
+    # Set the all the saved settings to render the navigation
+    def set_saved_settings
+      @bc_saved_settings = all_bc_templates
     end
 
     def delete_session_panel?

--- a/apps/dashboard/app/controllers/batch_connect/settings_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/settings_controller.rb
@@ -1,14 +1,17 @@
 # The controller to manage BatchConnect saved settings
 class BatchConnect::SettingsController < ApplicationController
   include BatchConnectConcern
+  include UserSettingStore
 
   # GET /batch_connect/<app_token>/settings/<settings_name>
   def show
     set_app_groups
+    set_saved_settings
 
     app_token = params[:token]
     settings_name = params[:id]
-    @settings = BatchConnect::Settings.find(app_token, settings_name)
+    settings_values = bc_templates(app_token).fetch(settings_name.to_sym, {})
+    @settings = BatchConnect::Settings.new(app_token, settings_name, settings_values)
     if @settings.outdated?
       flash.now[:alert] = t('dashboard.bc_saved_settings.outdated_message', app_title: @settings.app.title)
     end
@@ -18,13 +21,18 @@ class BatchConnect::SettingsController < ApplicationController
   def destroy
     app_token = params[:token]
     settings_name = params[:id]
-    settings = BatchConnect::Settings.find(app_token, settings_name)
-    settings.delete
+    delete_bc_template(app_token, settings_name)
     redirect_to new_batch_connect_session_context_path(token: app_token),
-                notice: t('dashboard.bc_saved_settings.deleted_message', settings_name: settings.name)
+                notice: t('dashboard.bc_saved_settings.deleted_message', settings_name: settings_name)
   end
 
   private
+
+  # Set the all the saved settings to render the navigation
+  def set_saved_settings
+    @bc_saved_settings = all_bc_templates
+  end
+
   # Set list of app lists for navigation
   def set_app_groups
     @sys_app_groups = bc_sys_app_groups

--- a/apps/dashboard/app/controllers/batch_connect/settings_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/settings_controller.rb
@@ -1,0 +1,35 @@
+# The controller to manage BatchConnect saved settings
+class BatchConnect::SettingsController < ApplicationController
+  include BatchConnectConcern
+
+  # GET /batch_connect/<app_token>/settings/<settings_name>
+  def show
+    set_app_groups
+
+    app_token = params[:token]
+    settings_name = params[:id]
+    @settings = BatchConnect::Settings.find(app_token, settings_name)
+    if @settings.outdated?
+      flash.now[:alert] = t('dashboard.bc_saved_settings.outdated_message', app_title: @settings.app.title)
+    end
+  end
+
+  # DELETE /batch_connect/<app_token>/settings/<settings_name>
+  def destroy
+    app_token = params[:token]
+    settings_name = params[:id]
+    settings = BatchConnect::Settings.find(app_token, settings_name)
+    settings.delete
+    redirect_to new_batch_connect_session_context_path(token: app_token),
+                notice: t('dashboard.bc_saved_settings.deleted_message', settings_name: settings.name)
+  end
+
+  private
+  # Set list of app lists for navigation
+  def set_app_groups
+    @sys_app_groups = bc_sys_app_groups
+    @usr_app_groups = bc_usr_app_groups
+    @dev_app_groups = bc_dev_app_groups
+    @apps_menu_group = bc_custom_apps_group
+  end
+end

--- a/apps/dashboard/app/controllers/batch_connect/settings_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/settings_controller.rb
@@ -8,8 +8,9 @@ class BatchConnect::SettingsController < ApplicationController
     set_app_groups
     set_saved_settings
 
-    app_token = params[:token]
-    settings_name = params[:id]
+    settings_params = settings_request_params
+    app_token = settings_params[:token]
+    settings_name = settings_params[:id]
     settings_values = bc_templates(app_token).fetch(settings_name.to_sym, {})
     @settings = BatchConnect::Settings.new(app_token, settings_name, settings_values)
     if @settings.outdated?
@@ -19,14 +20,19 @@ class BatchConnect::SettingsController < ApplicationController
 
   # DELETE /batch_connect/<app_token>/settings/<settings_name>
   def destroy
-    app_token = params[:token]
-    settings_name = params[:id]
+    settings_params = settings_request_params
+    app_token = settings_params[:token]
+    settings_name = settings_params[:id]
     delete_bc_template(app_token, settings_name)
     redirect_to new_batch_connect_session_context_path(token: app_token),
                 notice: t('dashboard.bc_saved_settings.deleted_message', settings_name: settings_name)
   end
 
   private
+
+  def settings_request_params
+    params.permit(:token, :id)
+  end
 
   # Set the all the saved settings to render the navigation
   def set_saved_settings

--- a/apps/dashboard/app/javascript/full_page_spinner.js
+++ b/apps/dashboard/app/javascript/full_page_spinner.js
@@ -1,0 +1,10 @@
+jQuery(function (){
+    function showSpinner() {
+        $('body').addClass('modal-open');
+        $('#full-page-spinner').removeClass('d-none');
+    }
+
+    $('.full-page-spinner').each((index, element) => {
+        $(element).closest('form').on('submit', showSpinner);
+    });
+});

--- a/apps/dashboard/app/models/batch_connect/settings.rb
+++ b/apps/dashboard/app/models/batch_connect/settings.rb
@@ -1,0 +1,108 @@
+module BatchConnect
+  # An Interactive Application saved parameters from the form.
+  class Settings
+    include ActiveModel::Model
+
+    class << self
+      def find(token, name)
+        settings_values = BatchConnectSettingsReader.new.app_templates(token).fetch(name.to_sym, {})
+        BatchConnect::Settings.new(token, name, settings_values)
+      end
+
+      def app_settings(app_token)
+        BatchConnectSettingsReader.new.all.fetch(app_token.to_sym, {})
+      end
+
+      def all_by_app_title
+        all.group_by { |settings| settings.app.title }.sort
+      end
+
+      def all
+        BatchConnectSettingsReader.new.all.flat_map do |token, settings_by_name|
+          settings_by_name.map do |settings_name, settings_values|
+            BatchConnect::Settings.new(token, settings_name, settings_values)
+          end
+        end
+      end
+    end
+
+    attr_reader :token, :name, :values
+
+    def initialize(token, name, values)
+      @token = token.to_s
+      @name = name.to_s
+      @values = values.to_h
+    end
+
+    def app
+      @app ||= BatchConnect::App.from_token token
+    end
+
+    def to_h
+      values.clone
+    end
+
+    def outdated?
+      outdated = false
+      # CHECK IF THERE ARE NEW ATTRIBUTES NOT IN THE VALUES HASH
+      app.attributes.each do |attribute|
+        outdated = true unless values.key?(attribute.id.to_sym)
+      end
+      # CHECK IF THERE ARE OLD VALUES NO LONGER IN THE APP ATTRIBUTES STILL IN THE VALUES HASH
+      values.each do |attribute_id, _|
+        outdated = true if app.attributes.select { |attribute| attribute.id.to_sym == attribute_id }.empty?
+      end
+
+      outdated
+    end
+
+    def save
+      BatchConnectSettingsReader.new.save_app_template(token, name, to_h)
+    end
+
+    def delete
+      BatchConnectSettingsReader.new.delete_app_template(token, name)
+    end
+
+    private
+
+    class BatchConnectSettingsReader
+      include UserSettingStore
+
+      BC_TEMPLATES = :batch_connect_templates
+
+      def all
+        user_settings[BC_TEMPLATES].to_h
+      end
+
+      def app_templates(app_token)
+        all[app_token.to_sym].to_h
+      end
+
+      def save_app_template(app_token, name, key_values)
+        current_templates = all
+        current_app_templates = current_templates[app_token.to_sym] || {}
+
+        new_template = {}
+        new_template[name.to_sym] = key_values
+
+        new_settings = {}
+        new_settings[BC_TEMPLATES] = {}
+        new_settings[BC_TEMPLATES][app_token.to_sym] = current_app_templates.merge(new_template)
+
+        update_user_settings(new_settings)
+      end
+
+      def delete_app_template(app_token, name)
+        current_templates = all
+        current_templates.fetch(app_token.to_sym, {}).delete(name.to_sym)
+        current_templates.delete(app_token.to_sym) if current_templates.fetch(app_token.to_sym, {}).empty?
+
+        new_settings = {}
+        new_settings[BC_TEMPLATES] = current_templates
+        update_user_settings(new_settings)
+      end
+    end
+
+  end
+end

--- a/apps/dashboard/app/models/batch_connect/settings.rb
+++ b/apps/dashboard/app/models/batch_connect/settings.rb
@@ -3,29 +3,6 @@ module BatchConnect
   class Settings
     include ActiveModel::Model
 
-    class << self
-      def find(token, name)
-        settings_values = BatchConnectSettingsReader.new.app_templates(token).fetch(name.to_sym, {})
-        BatchConnect::Settings.new(token, name, settings_values)
-      end
-
-      def app_settings(app_token)
-        BatchConnectSettingsReader.new.all.fetch(app_token.to_sym, {})
-      end
-
-      def all_by_app_title
-        all.group_by { |settings| settings.app.title }.sort
-      end
-
-      def all
-        BatchConnectSettingsReader.new.all.flat_map do |token, settings_by_name|
-          settings_by_name.map do |settings_name, settings_values|
-            BatchConnect::Settings.new(token, settings_name, settings_values)
-          end
-        end
-      end
-    end
-
     attr_reader :token, :name, :values
 
     def initialize(token, name, values)
@@ -54,54 +31,6 @@ module BatchConnect
       end
 
       outdated
-    end
-
-    def save
-      BatchConnectSettingsReader.new.save_app_template(token, name, to_h)
-    end
-
-    def delete
-      BatchConnectSettingsReader.new.delete_app_template(token, name)
-    end
-
-    private
-
-    class BatchConnectSettingsReader
-      include UserSettingStore
-
-      BC_TEMPLATES = :batch_connect_templates
-
-      def all
-        user_settings[BC_TEMPLATES].to_h
-      end
-
-      def app_templates(app_token)
-        all[app_token.to_sym].to_h
-      end
-
-      def save_app_template(app_token, name, key_values)
-        current_templates = all
-        current_app_templates = current_templates[app_token.to_sym] || {}
-
-        new_template = {}
-        new_template[name.to_sym] = key_values
-
-        new_settings = {}
-        new_settings[BC_TEMPLATES] = {}
-        new_settings[BC_TEMPLATES][app_token.to_sym] = current_app_templates.merge(new_template)
-
-        update_user_settings(new_settings)
-      end
-
-      def delete_app_template(app_token, name)
-        current_templates = all
-        current_templates.fetch(app_token.to_sym, {}).delete(name.to_sym)
-        current_templates.delete(app_token.to_sym) if current_templates.fetch(app_token.to_sym, {}).empty?
-
-        new_settings = {}
-        new_settings[BC_TEMPLATES] = current_templates
-        update_user_settings(new_settings)
-      end
     end
 
   end

--- a/apps/dashboard/app/models/batch_connect/settings.rb
+++ b/apps/dashboard/app/models/batch_connect/settings.rb
@@ -15,10 +15,6 @@ module BatchConnect
       @app ||= BatchConnect::App.from_token token
     end
 
-    def to_h
-      values.clone
-    end
-
     def outdated?
       outdated = false
       # CHECK IF THERE ARE NEW ATTRIBUTES NOT IN THE VALUES HASH

--- a/apps/dashboard/app/models/concerns/user_setting_store.rb
+++ b/apps/dashboard/app/models/concerns/user_setting_store.rb
@@ -39,4 +39,40 @@ module UserSettingStore
   def user_settings_path
     Pathname.new(::Configuration.user_settings_file)
   end
+
+  def all_bc_templates
+    user_settings[BC_TEMPLATES].to_h
+  end
+
+  def bc_templates(app_token)
+    templates = all_bc_templates
+    return {} if templates.empty?
+
+    user_settings[BC_TEMPLATES][app_token.to_sym].to_h
+  end
+
+  def save_bc_template(app_token, name, key_values)
+    current_templates = user_settings[BC_TEMPLATES] || {}
+    current_app_templates = current_templates[app_token.to_sym] || {}
+
+    new_template = {}
+    new_template[name.to_sym] = key_values
+
+    new_settings = {}
+    new_settings[BC_TEMPLATES] = {}
+    new_settings[BC_TEMPLATES][app_token.to_sym] = current_app_templates.merge(new_template)
+
+    update_user_settings(new_settings)
+  end
+
+  def delete_bc_template(app_token, name)
+    current_templates = all_bc_templates
+    current_templates.fetch(app_token.to_sym, {}).delete(name.to_sym)
+    # Delete app_token group when empty
+    current_templates.delete(app_token.to_sym) if current_templates.fetch(app_token.to_sym, {}).empty?
+
+    new_settings = {}
+    new_settings[BC_TEMPLATES] = current_templates
+    update_user_settings(new_settings)
+  end
 end

--- a/apps/dashboard/app/models/concerns/user_setting_store.rb
+++ b/apps/dashboard/app/models/concerns/user_setting_store.rb
@@ -39,25 +39,4 @@ module UserSettingStore
   def user_settings_path
     Pathname.new(::Configuration.user_settings_file)
   end
-
-  def bc_templates(app_token)
-    templates = user_settings[BC_TEMPLATES]
-    return {} if templates.nil? || templates.empty?
-
-    user_settings[BC_TEMPLATES][app_token.to_sym].to_h
-  end
-
-  def save_bc_template(app_token, name, key_values)
-    current_templates = user_settings[BC_TEMPLATES] || {}
-    current_app_templates = current_templates[app_token.to_sym] || {}
-
-    new_template = {}
-    new_template[name.to_sym] = key_values
-
-    new_settings = {}
-    new_settings[BC_TEMPLATES] = {}
-    new_settings[BC_TEMPLATES][app_token.to_sym] = current_app_templates.merge(new_template)
-
-    update_user_settings(new_settings)
-  end
 end

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -58,6 +58,7 @@ locals: {
 
 <div class="row">
   <div class="col-md-3">
+    <%= render partial: 'batch_connect/shared/saved_settings_menu' %>
     <%=
       render(
         partial: "batch_connect/shared/app_menu",

--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -21,6 +21,7 @@ locals: {
 <div class="row">
   <%- if any_apps -%>
     <div class="col-md-3">
+      <%= render partial: 'batch_connect/shared/saved_settings_menu' %>
       <%=
         render(
           partial: "batch_connect/shared/app_menu",

--- a/apps/dashboard/app/views/batch_connect/settings/show.html.erb
+++ b/apps/dashboard/app/views/batch_connect/settings/show.html.erb
@@ -1,0 +1,97 @@
+<% content_for :title, t('dashboard.bc_saved_settings.title') %>
+
+<%= render partial: 'batch_connect/shared/breadcrumb',
+locals: {
+  links: [
+  {
+    text: t('dashboard.breadcrumbs_home'),
+    href: root_path
+  },
+  {
+    text: "#{@settings.app.title}",
+    href: new_batch_connect_session_context_path(token: @settings.token)
+  },
+  {
+    text: @settings.name
+  }]
+}
+%>
+
+<div class="row">
+  <div class="col-md-3">
+    <%= render partial: 'batch_connect/shared/saved_settings_menu' %>
+    <%=
+      render(
+        partial: "batch_connect/shared/app_menu",
+        locals: {
+          sys_app_groups: @sys_app_groups,
+          usr_app_groups: @usr_app_groups,
+          dev_app_groups: @dev_app_groups,
+          apps_menu_group: @apps_menu_group
+        }
+      )
+    %>
+  </div>
+  <div id="bc-saved-settings" class="col-md-9">
+    <div id="settings-card" class="card mb-4">
+      <div class="card-heading">
+        <div class="h5 card-header overflow-auto">
+          <div class="float-right">
+              <%
+                if @settings.app.valid?
+                  params = @settings.values.map{|name, value| ["batch_connect_session_context[#{name}]", value]}.to_h
+                  title = t('dashboard.bc_saved_settings.launch_title', app_title: @settings.app.title, settings_name: @settings.name)
+              %>
+              <%=
+                button_to(
+                  batch_connect_session_contexts_path(token: @settings.token),
+                  method: :post,
+                  class: %w[btn btn-warning full-page-spinner],
+                  form_class: %w[d-inline],
+                  title: title,
+                  'aria-label': title,
+                  data: { toggle: "tooltip", placement: "left" },
+                  params: params
+                ) do
+                  "#{fa_icon('play', classes: nil)} <span aria-hidden='true'>#{t('dashboard.bc_saved_settings.launch_label')}</span>".html_safe
+                end
+              %>
+              <span class="card-text"> | </span>
+            <% end %>
+            <%
+              title = t('dashboard.bc_saved_settings.delete_title', settings_name: @settings.name)
+            %>
+            <%=
+              button_to(
+                batch_connect_setting_path(token: @settings.token, id: @settings.name),
+                method: :delete,
+                class: %w[btn btn-danger full-page-spinner],
+                form_class: %w[d-inline],
+                title: title,
+                'aria-label': title,
+                data: { confirm: t('dashboard.bc_saved_settings.delete_confirm'), toggle: "tooltip", placement: "left"}
+              ) do
+                "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.bc_saved_settings.delete_label')}</span>".html_safe
+              end
+            %>
+          </div>
+
+          <span class="d-block card-text"><%= @settings.name %></span>
+          <span class="small"><%= @settings.app.title %></span>
+        </div>
+      </div>
+
+      <p class="list-group-item header"><%= t('dashboard.bc_saved_settings.settings_values_label') %></p>
+      <div class="card-body">
+        <% @settings.app.attributes.each do |attribute| %>
+          <p>
+            <strong><%= attribute.label %>:</strong>
+            <%= @settings.values[attribute.id.to_sym] %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+</div>
+<%= render partial: 'batch_connect/shared/full_page_spinner' %>

--- a/apps/dashboard/app/views/batch_connect/shared/_full_page_spinner.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_full_page_spinner.html.erb
@@ -1,15 +1,6 @@
-<script nonce="<%= content_security_policy_nonce %>">
-jQuery(function (){
-    function showSpinner() {
-        $('body').addClass('modal-open');
-        $('#full-page-spinner').removeClass('d-none');
-    }
-
-    $('.full-page-spinner').each((index, element) => {
-        $(element).closest('form').on('submit', showSpinner);
-    });
-});
-</script>
+<%- content_for :head do -%>
+  <%= javascript_include_tag('full_page_spinner', nonce: true) %>
+<%- end -%>
 <div id="full-page-spinner" class="d-none">
   <div class="spinner-border" role="status"></div>
 </div>

--- a/apps/dashboard/app/views/batch_connect/shared/_full_page_spinner.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_full_page_spinner.html.erb
@@ -1,0 +1,15 @@
+<script nonce="<%= content_security_policy_nonce %>">
+jQuery(function (){
+    function showSpinner() {
+        $('body').addClass('modal-open');
+        $('#full-page-spinner').removeClass('d-none');
+    }
+
+    $('.full-page-spinner').each((index, element) => {
+        $(element).closest('form').on('submit', showSpinner);
+    });
+});
+</script>
+<div id="full-page-spinner" class="d-none">
+  <div class="spinner-border" role="status"></div>
+</div>

--- a/apps/dashboard/app/views/batch_connect/shared/_saved_settings_menu.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_saved_settings_menu.html.erb
@@ -1,0 +1,34 @@
+<%- if Configuration.bc_saved_settings? -%>
+  <% all_settings = BatchConnect::Settings.all_by_app_title %>
+  <div id="saved-settings-menu" class="card system-and-shared-apps-header">
+    <div class="card-header"><%= t('dashboard.bc_saved_settings.title') %></div>
+    <div class="list-group list-group-flush">
+      <% if all_settings.empty? %>
+        <span class="list-group-item list-group-item-action">
+          <%= t('dashboard.bc_saved_settings.no_settings_title') %>
+        </span>
+      <% end %>
+      <% all_settings.each_with_index do | (_, saved_settings_list), index|
+        app = saved_settings_list.first.app
+        link = app.link
+      %>
+        <p class="list-group-item mb-0 header">
+          <a href="#" class="" data-toggle="collapse" data-target="<%= "#saved-settings-#{index}" %>" aria-expanded="true" aria-controls="<%= "saved-settings-#{index}" %>">
+            <%= icon_tag(link.icon_uri) unless link.icon_uri.to_s.blank? %>
+            <%= app.title %>
+          </a>
+        </p>
+        <div id="<%= "saved-settings-#{index}" %>" class="show saved-settings-list">
+          <% saved_settings_list.sort_by(&:name).each do |settings| %>
+            <a class="list-group-item list-group-item-action"
+               href="<%= batch_connect_setting_path(token: settings.app.token, id: settings.name) %>"
+               title="">
+              <i id="" class="fa fa-file fa-fw app-icon" aria-hidden="true"></i>
+              <%= settings.name %>
+            </a>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/apps/dashboard/app/views/batch_connect/shared/_saved_settings_menu.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_saved_settings_menu.html.erb
@@ -1,5 +1,5 @@
 <%- if Configuration.bc_saved_settings? -%>
-  <% all_settings = BatchConnect::Settings.all_by_app_title %>
+  <% all_settings = @bc_saved_settings %>
   <div id="saved-settings-menu" class="card system-and-shared-apps-header">
     <div class="card-header"><%= t('dashboard.bc_saved_settings.title') %></div>
     <div class="list-group list-group-flush">
@@ -8,8 +8,8 @@
           <%= t('dashboard.bc_saved_settings.no_settings_title') %>
         </span>
       <% end %>
-      <% all_settings.each_with_index do | (_, saved_settings_list), index|
-        app = saved_settings_list.first.app
+      <% all_settings.sort.each_with_index do | (app_token, app_saved_settings), index|
+        app = BatchConnect::App.from_token(app_token.to_s)
         link = app.link
       %>
         <p class="list-group-item mb-0 header">
@@ -19,12 +19,12 @@
           </a>
         </p>
         <div id="<%= "saved-settings-#{index}" %>" class="show saved-settings-list">
-          <% saved_settings_list.sort_by(&:name).each do |settings| %>
+          <% app_saved_settings.sort.each do |setting_name, _| %>
             <a class="list-group-item list-group-item-action"
-               href="<%= batch_connect_setting_path(token: settings.app.token, id: settings.name) %>"
+               href="<%= batch_connect_setting_path(token: app.token, id: setting_name) %>"
                title="">
               <i id="" class="fa fa-file fa-fw app-icon" aria-hidden="true"></i>
-              <%= settings.name %>
+              <%= setting_name %>
             </a>
           <% end %>
         </div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -255,6 +255,18 @@ en:
 
     settings_updated: "Settings updated"
 
+    bc_saved_settings:
+      title: "Saved Settings"
+      no_settings_title: "You have no saved settings."
+      launch_label: "Launch"
+      launch_title: "Launch %{app_title} with %{settings_name} parameters"
+      delete_label: "Delete"
+      delete_title: "Delete %{settings_name} saved settings"
+      delete_confirm: "Are you sure?"
+      deleted_message: "Saved settings %{settings_name} deleted."
+      settings_values_label: "Values"
+      outdated_message: "%{app_title} parameters have changed since these settings were created."
+
     user_configuration:
       support_ticket_error: "support_ticket is misconfigured. \"email\" or \"rt_api\" sections are required in the configuration YAML."
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
     bc_saved_settings:
       title: "Saved Settings"
       no_settings_title: "You have no saved settings."
+      missing_settings: "Selected saved settings not found."
       launch_label: "Launch"
       launch_title: "Launch %{app_title} with %{settings_name} parameters"
       delete_label: "Delete"

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     resources :sessions, only: [:index, :destroy]
     post 'sessions/:id/cancel', to: 'sessions#cancel', as: 'cancel_session'
     scope '*token', constraints: { token: %r{((usr/[^/]+)|dev|sys)/[^/]+(/[^/]+)?} } do
+      resources :settings, only: [:show, :destroy]
       resources :session_contexts, only: [:new, :create]
       root 'session_contexts#new'
     end

--- a/apps/dashboard/test/models/batch_connect/settings_test.rb
+++ b/apps/dashboard/test/models/batch_connect/settings_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module BatchConnect
+  class SettingsTest < ActionView::TestCase
+
+    test 'can set values' do
+      target = BatchConnect::Settings.new('app/token', 'settings name', { name: 'value' })
+
+      assert_equal('app/token', target.token)
+      assert_equal('settings name', target.name)
+      assert_equal({ name: 'value' }, target.values)
+    end
+
+    test 'app returns BatchConnect::App based on token' do
+      target = BatchConnect::Settings.new('sys/token', 'settings name', { name: 'value' })
+
+      assert_instance_of(BatchConnect::App, target.app)
+      assert_equal('sys/token', target.app.token)
+    end
+
+    test 'outdated? returns true when settings keys do not match app attribute ids' do
+      app_token = 'sys/token'
+      setting_values = { bc_account: 'engineering', bc_cluster: 'test', bc_hours: 4 }
+      target = BatchConnect::Settings.new(app_token, 'settings name', setting_values)
+      create_app(app_token, ['bc_account', 'bc_cluster'])
+      assert_equal(true, target.outdated?)
+
+      setting_values = { bc_account: 'engineering' }
+      target = BatchConnect::Settings.new(app_token, 'settings name', setting_values)
+      create_app(app_token, ['bc_account', 'bc_cluster'])
+      assert_equal(true, target.outdated?)
+    end
+
+    test 'outdated? returns false when settings keys match app attribute ids' do
+      app_token = 'sys/token'
+      setting_values = { bc_account: 'engineering', bc_cluster: 'test' }
+      target = BatchConnect::Settings.new(app_token, 'settings name', setting_values)
+      create_app(app_token, ['bc_account', 'bc_cluster'])
+
+      assert_equal(false, target.outdated?)
+    end
+
+    private
+
+    def create_app(token, attributes)
+      router = Router.router_from_token(token)
+      app = BatchConnect::App.new(router: router)
+      app.stubs(:attributes).returns(attributes.map { |id| SmartAttributes::AttributeFactory.build(id, {}) })
+      BatchConnect::App.stubs(:from_token).with(app.token).returns(app)
+    end
+  end
+end


### PR DESCRIPTION
First slice for the Saved Settings Management feature.

It adds a left hand side menu to display the current saved settings. It provides a detail view of the saved settings when click through from the menu.

Only the delete and launch actions are currently implemented in this first iteration.

PS: we think that "App Configurations" might be more fitting for this feature than "Saved Settings"

### Technical Notes
I still need to add tests, but I wanted to show you the implementation details.

