### PR TITLE
re-enable ActionController::Live

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -53,7 +53,7 @@ gem 'mocha', '~> 2.1', group: :test
 gem 'autoprefixer-rails', '~> 10.2.5'
 gem 'dotiw'
 gem 'local_time', '~> 1.0.3'
-gem 'zip_tricks', '~> 5.5'
+gem 'zip_kit', '~> 6.2'
 gem 'rss', '~> 0.2'
 
 gem 'jsbundling-rails', '~> 1.0'

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.13)
-    zip_tricks (5.6.0)
+    zip_kit (6.2.0)
 
 PLATFORMS
   ruby
@@ -315,7 +315,7 @@ DEPENDENCIES
   sprockets-rails (>= 2.0.0)
   timecop (~> 0.9)
   webrick
-  zip_tricks (~> 5.5)
+  zip_kit (~> 6.2)
 
 BUNDLED WITH
    2.3.6

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -1,6 +1,6 @@
 # The controller for all the files pages /dashboard/files
 class FilesController < ApplicationController
-  include ZipTricks::RailsStreaming
+  include ActionController::Live
 
   before_action :strip_sendfile_headers, only: [:fs]
 
@@ -58,22 +58,25 @@ class FilesController < ApplicationController
             response.sending_file = true
             response.cache_control[:public] ||= false
 
-            # FIXME: strategy 1: is below, use zip_tricks
-            # strategy 2: use actual zip command (likely much faster) and ActionController::Live
-            zip_tricks_stream do |zip|
-              @path.files_to_zip.each do |file|
-                begin
-                  next unless File.readable?(file.realpath)
+            zip_headers = ZipKit::OutputEnumerator.new.streaming_http_headers
+            response.headers.merge!(zip_headers)
 
-                  if File.file?(file.realpath)
-                    zip.write_deflated_file(file.relative_path.to_s) do |zip_file|
-                      IO.copy_stream(file.realpath, zip_file)
+            send_stream(filename: zipname) do |stream|
+              ZipKit::Streamer.open(stream) do |zip|
+                @path.files_to_zip.each do |file|
+                  begin
+                    next unless File.readable?(file.realpath)
+
+                    if File.file?(file.realpath)
+                      zip.write_deflated_file(file.relative_path.to_s) do |zip_file|
+                        IO.copy_stream(file.realpath, zip_file)
+                      end
+                    else
+                      zip.add_empty_directory(dirname: file.relative_path.to_s)
                     end
-                  else
-                    zip.add_empty_directory(dirname: file.relative_path.to_s)
+                  rescue => e
+                    logger.warn("error writing file #{file.path} to zip: #{e.message}")
                   end
-                rescue => e
-                  logger.warn("error writing file #{file.path} to zip: #{e.message}")
                 end
               end
             end


### PR DESCRIPTION
This works to re-enable ActionController::Live. It replaces zip_tricks which is now deprecated with zip_kit which is the replacement.

It also fixes the issue with streaming zip files so ActionController::Live can be used in the downloading of zip files.