### PR TITLE
use relative OIDCRedirectURI where applicable

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -189,14 +189,6 @@ module OodPortalGenerator
       "#{client_protocol}#{client_id}#{client_port}"
     end
 
-    def apache_redirect_uri
-      if @view.proxy_server.to_s != @view.servername.to_s
-        "#{client_protocol}#{@view.proxy_server}/oidc"
-      else
-        '/oidc'
-      end
-    end
-
     def client_redirect_uri
       "#{client_url}/oidc"
     end
@@ -305,7 +297,6 @@ module OodPortalGenerator
       attrs = {
         dex_http_port:              http_port,
         oidc_uri:                   '/oidc',
-        oidc_redirect_uri:          apache_redirect_uri,
         oidc_provider_metadata_url: "#{issuer}/.well-known/openid-configuration",
         oidc_client_id:             client_id,
         oidc_client_secret:         client_secret

--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -189,6 +189,14 @@ module OodPortalGenerator
       "#{client_protocol}#{client_id}#{client_port}"
     end
 
+    def apache_redirect_uri
+      if @view.proxy_server.to_s != @view.servername.to_s
+        "#{client_protocol}#{@view.proxy_server}/oidc"
+      else
+        '/oidc'
+      end
+    end
+
     def client_redirect_uri
       "#{client_url}/oidc"
     end
@@ -297,7 +305,7 @@ module OodPortalGenerator
       attrs = {
         dex_http_port:              http_port,
         oidc_uri:                   '/oidc',
-        oidc_redirect_uri:          client_redirect_uri,
+        oidc_redirect_uri:          apache_redirect_uri,
         oidc_provider_metadata_url: "#{issuer}/.well-known/openid-configuration",
         oidc_client_id:             client_id,
         oidc_client_secret:         client_secret

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -107,7 +107,11 @@ module OodPortalGenerator
       @oidc_provider_metadata_url       = opts.fetch(:oidc_provider_metadata_url, nil)
       @oidc_client_id                   = opts.fetch(:oidc_client_id, nil)
       @oidc_client_secret               = opts.fetch(:oidc_client_secret, nil)
-      @oidc_redirect_uri                = "#{protocol}#{servername}#{@oidc_uri}"
+      @oidc_redirect_uri                = if opts.key?(:proxy_server)
+                                            "#{protocol}#{@proxy_server}#{@oidc_uri}"
+                                          else
+                                            @oidc_uri.to_s
+                                          end
       @oidc_remote_user_claim           = opts.fetch(:oidc_remote_user_claim, 'preferred_username')
       @oidc_scope                       = opts.fetch(:oidc_scope, "openid profile email")
       @oidc_crypto_passphrase           = opts.fetch(:oidc_crypto_passphrase, Digest::SHA1.hexdigest(servername))

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -7,7 +7,7 @@ module OodPortalGenerator
   class View
     attr_reader :ssl, :protocol, :proxy_server, :port, :dex_uri
     attr_accessor :user_map_match, :user_map_cmd, :logout_redirect, :dex_http_port, :dex_enabled
-    attr_accessor :oidc_uri, :oidc_client_secret, :oidc_remote_user_claim, :oidc_client_id, :oidc_provider_metadata_url, :oidc_redirect_uri
+    attr_accessor :oidc_uri, :oidc_client_secret, :oidc_remote_user_claim, :oidc_client_id, :oidc_provider_metadata_url
 
     # let the application set the auth if it needs to
     attr_writer :auth
@@ -107,11 +107,6 @@ module OodPortalGenerator
       @oidc_provider_metadata_url       = opts.fetch(:oidc_provider_metadata_url, nil)
       @oidc_client_id                   = opts.fetch(:oidc_client_id, nil)
       @oidc_client_secret               = opts.fetch(:oidc_client_secret, nil)
-      @oidc_redirect_uri                = if opts.key?(:proxy_server)
-                                            "#{protocol}#{@proxy_server}#{@oidc_uri}"
-                                          else
-                                            @oidc_uri.to_s
-                                          end
       @oidc_remote_user_claim           = opts.fetch(:oidc_remote_user_claim, 'preferred_username')
       @oidc_scope                       = opts.fetch(:oidc_scope, "openid profile email")
       @oidc_crypto_passphrase           = opts.fetch(:oidc_crypto_passphrase, Digest::SHA1.hexdigest(servername))

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -64,7 +64,7 @@
   OIDCProviderMetadataURL http://example.com/dex/.well-known/openid-configuration
   OIDCClientID example.com
   OIDCClientSecret 83bc78b7-6f5e-4010-9d80-22f328aa6550
-  OIDCRedirectURI http://example.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim email
   OIDCScope "openid profile email"
   OIDCCryptoPassphrase 0caaf24ab1a0c33440c06afe99df986365b0781f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -84,7 +84,7 @@
   OIDCProviderMetadataURL https://example.com/dex/.well-known/openid-configuration
   OIDCClientID example.com
   OIDCClientSecret 83bc78b7-6f5e-4010-9d80-22f328aa6550
-  OIDCRedirectURI https://example.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim email
   OIDCScope "openid profile email"
   OIDCCryptoPassphrase 0caaf24ab1a0c33440c06afe99df986365b0781f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -84,7 +84,7 @@
   OIDCProviderMetadataURL https://example.com/dex/.well-known/openid-configuration
   OIDCClientID example.com
   OIDCClientSecret 83bc78b7-6f5e-4010-9d80-22f328aa6550
-  OIDCRedirectURI https://example.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim preferred_username
   OIDCScope "openid profile email"
   OIDCCryptoPassphrase 0caaf24ab1a0c33440c06afe99df986365b0781f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
@@ -84,7 +84,7 @@
   OIDCProviderMetadataURL https://example.com:5554/.well-known/openid-configuration
   OIDCClientID example.com
   OIDCClientSecret 83bc78b7-6f5e-4010-9d80-22f328aa6550
-  OIDCRedirectURI https://example.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim email
   OIDCScope "openid profile email"
   OIDCCryptoPassphrase 0caaf24ab1a0c33440c06afe99df986365b0781f

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -68,7 +68,7 @@
   OIDCProviderMetadataURL https://idp.example.com/auth/realms/osc/.well-known/openid-configuration
   OIDCClientID ondemand.example.com
   OIDCClientSecret secret
-  OIDCRedirectURI http://ondemand.example.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim preferred_username
   OIDCScope "openid profile email groups"
   OIDCCryptoPassphrase e2c5ee12c92a019f19b5e532641ac0da2f9acdac

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -84,7 +84,7 @@
   OIDCProviderMetadataURL https://idp.example.com/auth/realms/osc/.well-known/openid-configuration
   OIDCClientID ondemand.example.com
   OIDCClientSecret secret
-  OIDCRedirectURI https://ondemand.example.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim preferred_username
   OIDCScope "openid profile email groups"
   OIDCCryptoPassphrase e2c5ee12c92a019f19b5e532641ac0da2f9acdac

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -84,7 +84,7 @@
   OIDCProviderMetadataURL https://example-proxy.com/dex/.well-known/openid-configuration
   OIDCClientID example.com
   OIDCClientSecret 83bc78b7-6f5e-4010-9d80-22f328aa6550
-  OIDCRedirectURI https://example.com/oidc
+  OIDCRedirectURI https://example-proxy.com/oidc
   OIDCRemoteUserClaim email
   OIDCScope "openid profile email"
   OIDCCryptoPassphrase 0caaf24ab1a0c33440c06afe99df986365b0781f

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -84,7 +84,7 @@
   OIDCProviderMetadataURL https://example-proxy.com/dex/.well-known/openid-configuration
   OIDCClientID example.com
   OIDCClientSecret 83bc78b7-6f5e-4010-9d80-22f328aa6550
-  OIDCRedirectURI https://example-proxy.com/oidc
+  OIDCRedirectURI /oidc
   OIDCRemoteUserClaim email
   OIDCScope "openid profile email"
   OIDCCryptoPassphrase 0caaf24ab1a0c33440c06afe99df986365b0781f

--- a/ood-portal-generator/spec/ood_portal_generator_view_spec.rb
+++ b/ood-portal-generator/spec/ood_portal_generator_view_spec.rb
@@ -15,7 +15,7 @@ describe OodPortalGenerator::View do
       example_config_opts -= %w(dex) 
       
       # delete inst vars that are not actual options in the example file
-      config_opts -= %w(protocol allowed_hosts oidc_redirect_uri dex_http_port)
+      config_opts -= %w(protocol allowed_hosts dex_http_port)
 
       expect(config_opts + example_config_opts - (config_opts & example_config_opts)).to be_empty
     end

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -131,7 +131,7 @@ Listen <%= addr_port %>
   <%- if @oidc_client_secret -%>
   OIDCClientSecret <%= @oidc_client_secret %>
   <%- end -%>
-  OIDCRedirectURI <%= @oidc_redirect_uri %>
+  OIDCRedirectURI <%= @oidc_uri %>
   OIDCRemoteUserClaim <%= @oidc_remote_user_claim %>
   OIDCScope "<%= @oidc_scope %>"
   OIDCCryptoPassphrase <%= @oidc_crypto_passphrase %>


### PR DESCRIPTION
Use relative `OIDCRedirectURI` where applicable, i.e., when not using a proxy server.

This is for partial support for #3442 - at least the OIDC bit.