### PR TITLE
serialize more job info

### DIFF
--- a/apps/dashboard/app/models/hpc_job.rb
+++ b/apps/dashboard/app/models/hpc_job.rb
@@ -25,8 +25,4 @@ class HpcJob < OodCore::Job::Info
                        status:          status.to_s,
                        allocated_nodes: [] }).deep_stringify_keys
   end
-
-  def cache_key
-    "#{cluster}_#{id}"
-  end
 end

--- a/apps/dashboard/app/models/hpc_job.rb
+++ b/apps/dashboard/app/models/hpc_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class HpcJob < OodCore::Job::Info
+  attr_reader :cluster
+
+  COMPLETED = 'completed'
+
+  class << self
+    def from_core_info(info: nil, cluster: nil)
+      new(cluster: cluster, **info.to_h)
+    end
+  end
+
+  def initialize(cluster: nil, **args)
+    @cluster = cluster
+    super(**args)
+  end
+
+  def completed?
+    status.to_s == COMPLETED
+  end
+
+  def to_h
+    super.to_h.merge({ cluster:         cluster,
+                       status:          status.to_s,
+                       allocated_nodes: [] }).deep_stringify_keys
+  end
+
+  def cache_key
+    "#{cluster}_#{id}"
+  end
+end

--- a/apps/dashboard/app/models/hpc_job.rb
+++ b/apps/dashboard/app/models/hpc_job.rb
@@ -13,7 +13,7 @@ class HpcJob < OodCore::Job::Info
 
   def initialize(cluster: nil, **args)
     @cluster = cluster
-    super(**args)
+    super(**args.deep_symbolize_keys)
   end
 
   def completed?

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -203,12 +203,7 @@ class Launcher
   end
 
   def active_jobs
-    @active_jobs ||= jobs.map do |job|
-      adapter = adapter(job['cluster'].to_sym).job_adapter
-      adapter.info(job['id'])
-    end.reject do |job|
-      job.status == :completed
-    end
+    @active_jobs ||= jobs.reject { |job| job.completed? }
   end
 
   def job_cluster(id)
@@ -219,7 +214,12 @@ class Launcher
   end
 
   def jobs
-    @jobs ||= YAML.safe_load(File.read(job_log_file.to_s), permitted_classes: [Time]).to_a
+    @jobs ||= begin
+      data = YAML.safe_load(File.read(job_log_file.to_s), permitted_classes: [Time]).to_a
+      data.map do |job_data|
+        HpcJob.new(**job_data)
+      end
+    end
   end
 
   def create_default_script
@@ -324,7 +324,7 @@ class Launcher
     adapter = adapter(cluster).job_adapter
     info = adapter.info(job_id)
     job = HpcJob.from_core_info(info: info, cluster: cluster)
-    new_jobs = jobs + [job.to_h]
+    new_jobs = (jobs + [job.to_h]).map(&:to_h)
 
     File.write(job_log_file.to_s, new_jobs.to_yaml)
   end

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -219,7 +219,7 @@ class Launcher
   end
 
   def jobs
-    @jobs ||= YAML.safe_load(File.read(job_log_file.to_s)).to_a
+    @jobs ||= YAML.safe_load(File.read(job_log_file.to_s), permitted_classes: [Time]).to_a
   end
 
   def create_default_script
@@ -321,11 +321,10 @@ class Launcher
   end
 
   def update_job_log(job_id, cluster)
-    new_jobs = jobs + [{
-      'id'          => job_id,
-      'submit_time' => Time.now.to_i,
-      'cluster'     => cluster.to_s
-    }]
+    adapter = adapter(cluster).job_adapter
+    info = adapter.info(job_id)
+    job = HpcJob.from_core_info(info: info, cluster: cluster)
+    new_jobs = jobs + [job.to_h]
 
     File.write(job_log_file.to_s, new_jobs.to_yaml)
   end

--- a/apps/dashboard/app/views/projects/_launcher_details.html.erb
+++ b/apps/dashboard/app/views/projects/_launcher_details.html.erb
@@ -75,11 +75,7 @@
 
           <div id="<%= active_job_list_id %>" >
           <%- launcher.active_jobs.each do |job| -%>
-            <a class="list-group-item list-group-item list-group-item-action justify-content-center"
-              data-job-poller="true"
-              data-job-cluster="<%= launcher.job_cluster(job.id) %>"
-              data-job-id="<%= job.id %>"
-            >
+            <a class="list-group-item list-group-item list-group-item-action justify-content-center">
               <%= job.id %>
             </a>
             <%- end -%>

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -344,10 +344,10 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       click_on 'Launch'
       assert_selector('.alert-success', text: 'job-id-123')
-      assert_equal [{ 'id'          => 'job-id-123',
-                      'submit_time' => @expected_now,
-                      'cluster'     => 'owens' }],
-                   YAML.safe_load(File.read("#{script_dir}/job_history.log"))
+      jobs = YAML.safe_load(File.read("#{script_dir}/job_history.log"), permitted_classes: [Time])
+
+      assert_equal(1, jobs.size)
+      assert_equal('job-id-123', jobs[0]['id'])
     end
   end
 
@@ -392,10 +392,10 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       click_on 'Launch'
       assert_selector('.alert-success', text: 'job-id-123')
-      assert_equal [{ 'id'          => 'job-id-123',
-                      'submit_time' => @expected_now,
-                      'cluster'     => 'owens' }],
-                   YAML.safe_load(File.read("#{script_dir}/job_history.log"))
+      jobs = YAML.safe_load(File.read("#{script_dir}/job_history.log"), permitted_classes: [Time])
+
+      assert_equal(1, jobs.size)
+      assert_equal('job-id-123', jobs[0]['id'])
     end
   end
 


### PR DESCRIPTION
Fixes #3474. I did try Rails caching for a minute - but I don't think we'd want it because we will need a way to find `all` jobs, which caches really don't accommodate for - they're more about immediate access to key value pairs rather than searching across all values.

So, this PR just serializes more information in the current job history log.