### PR TITLE
add the ability to define default launcher fields

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -357,7 +357,6 @@ class Launcher
 
   def add_default_fields(form: [], **_args)
     Configuration.launcher_default_items.each do |default_item|
-      Rails.logger.debug("adding #{default_item} unless #{form.include?(default_item)}")
       form << default_item unless form.include?(default_item)
     end
   end

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -70,6 +70,8 @@ class Launcher
     }
 
     add_required_fields(**sm_opts)
+    # add defaults if it's a brand new launcher with only title and directory.
+    add_default_fields(**sm_opts) if opts.size <= 2
     @smart_attributes = build_smart_attributes(**sm_opts)
   end
 
@@ -351,6 +353,13 @@ class Launcher
   def add_required_fields(form: [], attributes: {})
     add_cluster_to_form(form: form, attributes: attributes)
     add_script_to_form(form: form, attributes: attributes)
+  end
+
+  def add_default_fields(form: [], **_args)
+    Configuration.launcher_default_items.each do |default_item|
+      Rails.logger.debug("adding #{default_item} unless #{form.include?(default_item)}")
+      form << default_item unless form.include?(default_item)
+    end
   end
 
   def add_script_to_form(form: [], attributes: {})

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -209,6 +209,10 @@ class ConfigurationSingleton
     config.fetch(:globus_endpoints, nil)
   end
 
+  def launcher_default_items
+    config.fetch(:launcher_default_items, []).to_a
+  end
+
   # Load the dotenv local files first, then the /etc dotenv files and
   # the .env and .env.production or .env.development files.
   #

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -262,6 +262,53 @@ class ProjectManagerTest < ApplicationSystemTestCase
     end
   end
 
+  test 'creates new laucher with default items' do
+    Dir.mktmpdir do |dir|
+      Configuration.stubs(:launcher_default_items).returns(['bc_num_hours'])
+      project_id = setup_project(dir)
+      script_id = setup_script(project_id)
+
+      # note that bc_num_hours is in this YAML.
+      expected_yml = <<~HEREDOC
+        ---
+        title: the script title
+        created_at: #{@expected_now}
+        form:
+        - auto_batch_clusters
+        - auto_scripts
+        - bc_num_hours
+        attributes:
+          auto_batch_clusters:
+            options:
+            - oakley
+            - owens
+            label: Cluster
+            help: ''
+            required: false
+          auto_scripts:
+            options:
+            - - my_cool_script.sh
+              - "#{dir}/projects/#{project_id}/my_cool_script.sh"
+            - - my_cooler_script.bash
+              - "#{dir}/projects/#{project_id}/my_cooler_script.bash"
+            directory: "#{dir}/projects/#{project_id}"
+            label: Script
+            help: ''
+            required: false
+          bc_num_hours:
+            min: 1
+            step: 1
+            label: Number of hours
+            help: ''
+            required: true
+      HEREDOC
+
+      success_message = I18n.t('dashboard.jobs_scripts_created')
+      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
+      assert_equal(expected_yml, File.read("#{dir}/projects/#{project_id}/.ondemand/scripts/#{script_id}/form.yml"))
+    end
+  end
+
   test 'showing scripts with auto attributes' do
     Dir.mktmpdir do |dir|
       project_id = setup_project(dir)


### PR DESCRIPTION
Fixes #3099 by allowing centers to define launcher fields that should get created when you create a new launcher.