### PR TITLE
Fix paths for some partials

### DIFF
--- a/apps/dashboard/app/views/active_jobs/_ganglia_graphs_table.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_ganglia_graphs_table.html.erb
@@ -8,7 +8,7 @@
 	
 	<% if !d.nodes.nil? %>
 		<% d.nodes.each do |node| %>
-			<%= render partial: 'active_jobs/job_details_node_view.html.erb', :locals => {:data => d, :node => node } %>
+			<%= render partial: 'active_jobs/job_details_node_view', :locals => {:data => d, :node => node } %>
 		<% end %>
 	<% end %>
 	

--- a/apps/dashboard/app/views/active_jobs/extended_data.json.jbuilder
+++ b/apps/dashboard/app/views/active_jobs/extended_data.json.jbuilder
@@ -1,3 +1,3 @@
-  json.html_extended_panel render partial: 'active_jobs/extended_panel.html.erb', :locals => {:data => jobstatusdata}
+  json.html_extended_panel render partial: 'active_jobs/extended_panel', :locals => {:data => jobstatusdata}
   json.status jobstatusdata.status
-  json.html_ganglia_graphs_table render partial: 'active_jobs/ganglia_graphs_table.html.erb', :locals => {:d => jobstatusdata}
+  json.html_ganglia_graphs_table render partial: 'active_jobs/ganglia_graphs_table', :locals => {:d => jobstatusdata}

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
@@ -3,15 +3,15 @@
 
 <% if browser.platform == :windows %>
 
-  <%= render partial: 'batch_connect/sessions/connections/native_vnc_windows.html.erb', :locals => { :connect => connect, :localport => localport } %>
+  <%= render partial: 'batch_connect/sessions/connections/native_vnc_windows', :locals => { :connect => connect, :localport => localport } %>
 
 <% elsif browser.platform == :mac %>
 
-  <%= render partial: 'batch_connect/sessions/connections/native_vnc_mac.html.erb', :locals => { :connect => connect, :localport => localport } %>
+  <%= render partial: 'batch_connect/sessions/connections/native_vnc_mac', :locals => { :connect => connect, :localport => localport } %>
 
 <% elsif browser.platform == :linux %>
 
-  <%= render partial: 'batch_connect/sessions/connections/native_vnc_linux.html.erb', :locals => { :connect => connect, :localport => localport } %>
+  <%= render partial: 'batch_connect/sessions/connections/native_vnc_linux', :locals => { :connect => connect, :localport => localport } %>
 
 <% else %>
   We do not currently support documentation for connecting to a VNC session


### PR DESCRIPTION
I was testing some things in the nightly version of OOD, and I noticed there was an internal server error after starting the VNC.
I assume Rails 7 no longer accepts the `.html.erb` ending on the partial paths since this used to work previously.
```
#<ActionView::MissingTemplate: Missing partial batch_connect/sessions/connections/_native_vnc_linux.html.erb with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :md, :markdown, :jbuilder]}.

Searched in:
  * "/etc/ood/config/apps/dashboard/views"
  * "/var/www/ood/apps/sys/dashboard/app/views"
  * "/opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/3.1.20240324-169099.23584b9.nightly/gems/ood_appkit-2.1.4/app/views"

Did you mean?  batch_connect/sessions/connections/native_vnc_linux
               batch_connect/sessions/connections/native_vnc
```

This PR fixes the partial paths in the places where the `.html.erb` extension is used.