### PR TITLE
Fix file browser error on copy/move

### DIFF
--- a/apps/dashboard/app/javascript/files/clip_board.js
+++ b/apps/dashboard/app/javascript/files/clip_board.js
@@ -53,7 +53,7 @@ jQuery(function () {
       };
 
       $(CONTENTID).trigger(SWAL_EVENTNAME.showError, eventData);
-      $(CONTENTID).trigger(EVENTNAME.clearClipbaord, eventData);
+      $(CONTENTID).trigger(EVENTNAME.clearClipboard, eventData);
 
     } else {
       clipBoard.updateClipboardFromSelection(options.selection);


### PR DESCRIPTION
I noticed some errors using the file browser in one of our instances, when clicking the Copy/Move button. Turns out there was a small typo in the code.
This PR fixes the error.

![image](https://github.com/OSC/ondemand/assets/61623634/44e53c49-a2d5-4d14-88db-1c27d56e768e)
