### PR TITLE
redirect to HTTP_HOST to support aliases

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -54,7 +54,7 @@ Listen 8080
   ServerAlias foo.example.com
 
   RewriteEngine On
-  RewriteRule ^(.*) https://test.proxy.name:8080$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:8080$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -47,7 +47,7 @@
   ServerName example.com
 
   RewriteEngine On
-  RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -47,7 +47,7 @@
   ServerName example.com
 
   RewriteEngine On
-  RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
@@ -47,7 +47,7 @@
   ServerName example.com
 
   RewriteEngine On
-  RewriteRule ^(.*) https://example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -47,7 +47,7 @@
   ServerName ondemand.example.com
 
   RewriteEngine On
-  RewriteRule ^(.*) https://ondemand.example.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -47,7 +47,7 @@
   ServerName example.com
 
   RewriteEngine On
-  RewriteRule ^(.*) https://example-proxy.com:443$1 [R=301,NE,L]
+  RewriteRule ^(.*) https://%{HTTP_HOST}:443$1 [R=301,NE,L]
 </VirtualHost>
 
 # The Open OnDemand portal VirtualHost

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -63,7 +63,7 @@ Listen <%= addr_port %>
   <%- end -%>
 
   RewriteEngine On
-  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @proxy_server %>:<%= @port %>$1 [R=301,NE,L]
+  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://%{HTTP_HOST}:<%= @port %>$1 [R=301,NE,L]
 </VirtualHost>
 <% end -%>
 


### PR DESCRIPTION
redirect to HTTP_HOST to support aliases. Tests will fail for a bit while I update the fixtures, but I want to get a spot check on it before I proceed.

This should fix #3442 - or at least I'm hoping to.