### PR TITLE
fix this expression

### DIFF
--- a/apps/dashboard/app/javascript/products_show.js
+++ b/apps/dashboard/app/javascript/products_show.js
@@ -19,7 +19,7 @@ jQuery(function(){
 
 function updateModal(event){
   const button = $(`#${event.target['id']}`);
-  if(button === undefined || button.data() === {}) { return; }
+  if(button === undefined || button.data() == {}) { return; }
 
   const title = button.data('title');
   const cmd = button.data('cmd');


### PR DESCRIPTION
We've been seeing this warning is esbuild for some time, so let's fix this expression here just to get rid of the warning.

```
$ node esbuild.config.js
▲ [WARNING] Comparison using the "===" operator here is always false [equals-new-object]

    app/javascript/products_show.js:22:43:
      22 │   if(button === undefined || button.data() === {}) { return; }
         ╵                                            ~~~

  Equality with a new object is always false in JavaScript because the equality operator tests
  object identity. You need to write code to compare the contents of the object instead. For
  example, use "Array.isArray(x) && x.length === 0" instead of "x === []" to test for an empty
  array.
```