### PR TITLE
Update Passenger and NGINX dependencies

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -16,7 +16,7 @@ Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends},
   ruby, apache2, sudo, lsof, lua-posix, tzdata, file,
   nodejs (>= 18.0), nodejs (<< 19.0),
-  ondemand-nginx (= 1.22.1.p6.0.17.ood3.1), ondemand-passenger (= 6.0.17.ood3.1)
+  ondemand-nginx (= 1.24.0.p6.0.20.ood3.1), ondemand-passenger (= 6.0.20.ood3.1)
 Recommends: rclone
 Description: Open OnDemand is an open source release of the Ohio SuperComputer Center's
   OnDemand platform to provide HPC access via a web browser, supporting web based file

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -74,8 +74,8 @@ Requires:        python3
 Requires:        rclone
 %endif
 Requires:        ondemand-apache = %{runtime_version_full}
-Requires:        ondemand-nginx = 1.22.1-1.p6.0.17.ood%{runtime_version}%{?dist}
-Requires:        ondemand-passenger = 6.0.17-1.ood%{runtime_version}%{?dist}
+Requires:        ondemand-nginx = 1.24.0-1.p6.0.20.ood%{runtime_version}%{?dist}
+Requires:        ondemand-passenger = 6.0.20-1.ood%{runtime_version}%{?dist}
 Requires:        ondemand-ruby = %{runtime_version_full}
 Requires:        ondemand-nodejs = %{runtime_version_full}
 Requires:        ondemand-runtime = %{runtime_version_full}


### PR DESCRIPTION
This may be good to pull into 3.1 backport