### PR TITLE
Added saved settings widget

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/batch_connect/saved_settings.scss
+++ b/apps/dashboard/app/assets/stylesheets/batch_connect/saved_settings.scss
@@ -3,3 +3,35 @@
     color: rgba(0, 0, 0, 0.25);
   }
 }
+
+div.settings-widget {
+  .small {
+    font-size: 0.8rem;
+  }
+
+  img.app-icon {
+    width: 30px;
+    height: 30px;
+    font-size: 18px;
+  }
+
+  i.app-icon {
+    height: unset;
+    font-size: 18px;
+    margin-top: 2px;
+    margin-right: 5px;
+  }
+
+  .header {
+    height: 38px;
+  }
+
+  .saved-settings-toggle {
+    font-size: 0.75rem;
+  }
+
+  .saved-settings-toggle:focus {
+    box-shadow: none;
+  }
+}
+

--- a/apps/dashboard/app/helpers/batch_connect/settings_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/settings_helper.rb
@@ -1,0 +1,13 @@
+# Utility methods related to saved_settings
+module BatchConnect::SettingsHelper
+  include UserSettingStore
+
+  def all_saved_settings
+    all_bc_templates.sort.flat_map do |app_token, app_saved_settings|
+      app_saved_settings.sort.map do |settings_name, settings_values|
+        BatchConnect::Settings.new(app_token, settings_name, settings_values)
+      end
+    end
+  end
+
+end

--- a/apps/dashboard/app/models/batch_connect/settings.rb
+++ b/apps/dashboard/app/models/batch_connect/settings.rb
@@ -22,7 +22,7 @@ module BatchConnect
         outdated = true unless values.key?(attribute.id.to_sym)
       end
       # CHECK IF THERE ARE OLD VALUES NO LONGER IN THE APP ATTRIBUTES STILL IN THE VALUES HASH
-      values.each do |attribute_id, _|
+      values.each_key do |attribute_id|
         outdated = true if app.attributes.select { |attribute| attribute.id.to_sym == attribute_id }.empty?
       end
 

--- a/apps/dashboard/app/views/batch_connect/settings/_action_buttons.html.erb
+++ b/apps/dashboard/app/views/batch_connect/settings/_action_buttons.html.erb
@@ -1,0 +1,33 @@
+  <%=
+    title = t('dashboard.bc_saved_settings.edit_title', settings_name: settings.name)
+    link_to(
+      batch_connect_edit_settings_path(token: settings.token, id: settings.name),
+      class: %w[btn px-1 py-0 btn-outline-dark edit-saved-settings-button full-page-spinner],
+      title: title,
+      'aria-label': title,
+      data: { toggle: "tooltip", placement: "left" }
+    ) do
+      fa_icon('pen', classes: nil)
+    end
+  %>
+  <span class="card-text"> | </span>
+  <%
+    if settings.app.valid?
+      params = settings.values.map{|name, value| ["batch_connect_session_context[#{name}]", value]}.to_h
+      title = t('dashboard.bc_saved_settings.launch_title', app_title: settings.app.title, settings_name: settings.name)
+  %>
+    <%=
+      button_to(
+        batch_connect_session_contexts_path(token: settings.token),
+        method: :post,
+        class: %w[btn px-1 py-0 btn-outline-dark launch-saved-settings-button full-page-spinner],
+        form_class: %w[d-inline],
+        title: title,
+        'aria-label': title,
+        data: { toggle: "tooltip", placement: "left" },
+        params: params
+      ) do
+        fa_icon('play', classes: nil)
+      end
+    %>
+  <% end %>

--- a/apps/dashboard/app/views/batch_connect/settings/show.html.erb
+++ b/apps/dashboard/app/views/batch_connect/settings/show.html.erb
@@ -33,7 +33,7 @@ locals: {
     %>
   </div>
   <div id="bc-saved-settings" class="col-md-9">
-    <div id="settings-card" class="card mb-4">
+    <div id="settings-card" class="list-group card mb-4">
       <div class="card-heading">
         <div class="h5 card-header overflow-auto">
           <div class="float-end">

--- a/apps/dashboard/app/views/batch_connect/settings/show.html.erb
+++ b/apps/dashboard/app/views/batch_connect/settings/show.html.erb
@@ -37,41 +37,7 @@ locals: {
       <div class="card-heading">
         <div class="h5 card-header overflow-auto">
           <div class="float-end">
-              <%=
-                title = t('dashboard.bc_saved_settings.edit_title', settings_name: @settings.name)
-                link_to(
-                  batch_connect_edit_settings_path(token: @settings.token, id: @settings.name),
-                  id: 'edit-saved-settings-button',
-                  class: %w[btn px-1 py-0 btn-outline-dark full-page-spinner],
-                  title: title,
-                  'aria-label': title,
-                  data: { toggle: "tooltip", placement: "left" }
-                ) do
-                  fa_icon('pen', classes: nil)
-                end
-              %>
-              <span class="card-text"> | </span>
-              <%
-                if @settings.app.valid?
-                  params = @settings.values.map{|name, value| ["batch_connect_session_context[#{name}]", value]}.to_h
-                  title = t('dashboard.bc_saved_settings.launch_title', app_title: @settings.app.title, settings_name: @settings.name)
-              %>
-              <%=
-                button_to(
-                  batch_connect_session_contexts_path(token: @settings.token),
-                  id: 'launch-saved-settings-button',
-                  method: :post,
-                  class: %w[btn px-1 py-0 btn-outline-dark full-page-spinner],
-                  form_class: %w[d-inline],
-                  title: title,
-                  'aria-label': title,
-                  data: { toggle: "tooltip", placement: "left" },
-                  params: params
-                ) do
-                  fa_icon('play', classes: nil)
-                end
-              %>
-            <% end %>
+            <%= render partial: 'batch_connect/settings/action_buttons', locals:{ settings: @settings } %>
           </div>
 
           <span id="settings-name" class="d-block card-text"><%= @settings.name %></span>

--- a/apps/dashboard/app/views/widgets/_saved_settings.html.erb
+++ b/apps/dashboard/app/views/widgets/_saved_settings.html.erb
@@ -1,0 +1,45 @@
+<%- saved_settings = all_saved_settings -%>
+<%- unless saved_settings.empty? -%>
+<div class="settings-widget">
+  <h3><%= t('dashboard.saved_settings_title') %></h3>
+  <div class="row">
+  <% saved_settings.each_with_index do |settings, index| %>
+    <%- batch_connect_app = settings.app -%>
+    <%- link = batch_connect_app.link -%>
+    <%- tile_data = link.tile -%>
+    <%- icon_uri = URI(tile_data.fetch(:icon, link.icon_uri).to_s) -%>
+    <%- toggle_id = "saved-settings-#{index}" -%>
+    <div class="col-md-6">
+      <div class="card mb-4">
+        <div class="card-heading">
+          <div class="h5 card-header overflow-auto">
+            <div class="float-right">
+              <%= render partial: 'batch_connect/settings/action_buttons', locals:{ settings: settings } %>
+            </div>
+            <a class="saved-settings-show" href="<%= batch_connect_setting_path(token: settings.token, id: settings.name) %>">
+              <span class="card-text"><%= settings.name %></span>
+            </a>
+          </div>
+          <span class="list-group-item header d-flex align-items-center pl-0">
+            <a href="#" class="btn px-1 py-0 saved-settings-toggle" data-toggle="collapse" data-target="#<%= toggle_id %>"><%= fa_icon('plus', classes: nil) %></a>
+            <%= icon_tag(icon_uri) unless icon_uri.to_s.blank? %>
+            <%= settings.app.title %>
+          </span>
+        </div>
+
+        <div id="<%= toggle_id %>" class="card-body collapse">
+          <% settings.app.attributes.each do |attribute| %>
+            <p>
+              <strong><%= attribute.label %>:</strong>
+              <span><%= settings.values[attribute.id.to_sym] %></span>
+            </p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  </div>
+</div>
+
+<%= render partial: 'batch_connect/shared/full_page_spinner' %>
+<% end %>

--- a/apps/dashboard/app/views/widgets/_saved_settings.html.erb
+++ b/apps/dashboard/app/views/widgets/_saved_settings.html.erb
@@ -13,7 +13,7 @@
       <div class="card mb-4">
         <div class="card-heading">
           <div class="h5 card-header overflow-auto">
-            <div class="float-right">
+            <div class="float-end">
               <%= render partial: 'batch_connect/settings/action_buttons', locals:{ settings: settings } %>
             </div>
             <a class="saved-settings-show" href="<%= batch_connect_setting_path(token: settings.token, id: settings.name) %>">
@@ -21,7 +21,7 @@
             </a>
           </div>
           <span class="list-group-item header d-flex align-items-center pl-0">
-            <a href="#" class="btn px-1 py-0 saved-settings-toggle" data-toggle="collapse" data-target="#<%= toggle_id %>"><%= fa_icon('plus', classes: nil) %></a>
+            <a href="#" class="btn px-1 py-0 saved-settings-toggle" data-bs-toggle="collapse" data-bs-target="#<%= toggle_id %>"><%= fa_icon('plus', classes: nil) %></a>
             <%= icon_tag(icon_uri) unless icon_uri.to_s.blank? %>
             <%= settings.app.title %>
           </span>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -212,6 +212,8 @@ en:
 
     recently_used_apps_title: 'Recently Used Apps'
 
+    saved_settings_title: 'Saved Settings'
+
     files_download_not_enabled: "Downloading files is not enabled on this server."
     files_directory_download_error_modal_title: "Directory too large to download"
     files_directory_download_unauthorized: "You can only download a directory as zip that you have read and execute access to"

--- a/apps/dashboard/test/fixtures/file_output/user_settings/saved_settings_widget.yml
+++ b/apps/dashboard/test/fixtures/file_output/user_settings/saved_settings_widget.yml
@@ -1,0 +1,8 @@
+---
+batch_connect_templates:
+  sys/bc_paraview:
+    widget_name:
+      cluster: quick
+      bc_num_hours: '8'
+      bc_account: widget
+      bc_vnc_resolution: 500x600

--- a/apps/dashboard/test/fixtures/file_output/user_settings/settings_helper.yml
+++ b/apps/dashboard/test/fixtures/file_output/user_settings/settings_helper.yml
@@ -1,0 +1,13 @@
+---
+batch_connect_templates:
+  sys/bc_paraview:
+    account memory:
+      cluster: memory
+      bc_num_hours: '10'
+      bc_account: helper_memory
+      bc_vnc_resolution: 800x600
+    account cpu:
+      cluster: cpu
+      bc_num_hours: '1'
+      bc_account: helper_cpu
+      bc_vnc_resolution: 1080x800

--- a/apps/dashboard/test/helpers/batch_connect/settings_helper_test.rb
+++ b/apps/dashboard/test/helpers/batch_connect/settings_helper_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class BatchConnect::SettingsHelperTest < ActionView::TestCase
+
+  include BatchConnect::SettingsHelper
+
+  test 'all_saved_settings should return stored saved settings' do
+    file = "#{Rails.root}/test/fixtures/file_output/user_settings/settings_helper.yml"
+    Configuration.stubs(:user_settings_file).returns(file)
+    result = all_saved_settings
+    assert_equal 2, result.size
+
+    assert_equal 'sys/bc_paraview', result[0].token
+    assert_equal 'account cpu', result[0].name
+    assert_equal 'cpu', result[0].values[:cluster]
+    assert_equal '1', result[0].values[:bc_num_hours]
+    assert_equal 'helper_cpu', result[0].values[:bc_account]
+    assert_equal '1080x800', result[0].values[:bc_vnc_resolution]
+
+    assert_equal 'sys/bc_paraview', result[1].token
+    assert_equal 'account memory', result[1].name
+    assert_equal 'memory', result[1].values[:cluster]
+    assert_equal '10', result[1].values[:bc_num_hours]
+    assert_equal 'helper_memory', result[1].values[:bc_account]
+    assert_equal '800x600', result[1].values[:bc_vnc_resolution]
+  end
+end

--- a/apps/dashboard/test/integration/saved_settings_controller_test.rb
+++ b/apps/dashboard/test/integration/saved_settings_controller_test.rb
@@ -24,8 +24,8 @@ class SavedSettingsControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'Paraview', css_select('div#settings-card p#settings-app').text.strip
 
       # display the saved settings actions buttons
-      assert_select 'div.card-header #edit-saved-settings-button', 1
-      assert_select 'div.card-header #launch-saved-settings-button', 1
+      assert_select 'div.card-header .edit-saved-settings-button', 1
+      assert_select 'div.card-header .launch-saved-settings-button', 1
       assert_select 'div.card-body #delete-saved-settings-button', 1
 
       # display the saved settings values

--- a/apps/dashboard/test/integration/saved_settings_widget_test.rb
+++ b/apps/dashboard/test/integration/saved_settings_widget_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'html_helper'
+require 'test_helper'
+
+class SavedSettingsWidgetTest < ActionDispatch::IntegrationTest
+  def setup
+    stub_sys_apps
+
+    stub_user_configuration(
+      {
+        dashboard_layout: {
+          rows: [{ columns: [{ width: 12, widgets: ['saved_settings'] }] }]
+        }
+      }
+    )
+  end
+
+  test 'should not render saved settings widget when no saved settings' do
+    get '/'
+
+    assert_select 'div.settings-widget h3', 0
+  end
+
+  test 'should render saved settings widget' do
+    stub_user_settings
+
+    get '/'
+
+    assert_select 'div.settings-widget h3' do |widget_header|
+      assert_equal 1, widget_header.size
+      assert_equal true, widget_header.first.text.include?(I18n.t('dashboard.saved_settings_title')),
+                   'Should display the widget title'
+
+      saved_setting_link = css_select('div.settings-widget div.h5.card-header a.saved-settings-show')
+      assert_equal 1, saved_setting_link.size
+      assert_equal 'widget_name', saved_setting_link.first.text.strip
+      assert_equal batch_connect_setting_path(token: 'sys/bc_paraview', id: 'widget_name'), saved_setting_link.first['href']
+
+      assert_equal 'Paraview', css_select('div.settings-widget span.list-group-item.header').text.strip
+    end
+  end
+
+  def stub_user_settings
+    file = "#{Rails.root}/test/fixtures/file_output/user_settings/saved_settings_widget.yml"
+    Configuration.stubs(:user_settings_file).returns(file)
+  end
+end


### PR DESCRIPTION
Created a saved settings widget to display the saved settings in the homepage.

Sample configuration:
```yaml
    dashboard_layout:
      rows:
        - columns:
            - width: 12
              widgets:
                - "saved_settings"
                - "pinned_apps"
```