### PR TITLE
Fixes to the active sessions widget after the introduction of the Turbo Stream libraries

### DIFF
--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -39,7 +39,9 @@ jQuery(function (){
     $('#full-page-spinner').removeClass('d-none');
   }
 
-  pollAndReplace(bcIndexUrl(), bcPollDelay(), "batch_connect_sessions");
+  if ($('#batch_connect_sessions').length) {
+    pollAndReplace(bcIndexUrl(), bcPollDelay(), "batch_connect_sessions");
+  }
 
   $('button.relaunch').each((index, element) => {
     $(element).on('click', showSpinner);

--- a/apps/dashboard/app/views/widgets/_sessions.html.erb
+++ b/apps/dashboard/app/views/widgets/_sessions.html.erb
@@ -1,6 +1,5 @@
 <%-
   max_sessions = 3
-  poll_delay = Configuration.bc_sessions_poll_delay
   active_sessions = BatchConnect::Session.all.reject { |s| s.completed? }
   session_selection = active_sessions.first(max_sessions)
 -%>
@@ -18,10 +17,6 @@
   </div>
 
   <div class="active-sessions-content">
-    <div id="batch_connect_sessions" class="row" data-bs-toggle="poll" data-url="<%= batch_connect_sessions_path(format: :js) %>" data-delay="<%= poll_delay %>">
-      <div class="col-md-12">
-        <%= render partial: "/batch_connect/sessions/panel", collection: session_selection, as: :session %>
-      </div>
-    </div>
+    <%= render partial: "/batch_connect/sessions/panel", collection: session_selection, as: :session %>
   </div>
 <% end %>


### PR DESCRIPTION
The Active Sessions widget is meant to display a subset of the current active interactive sessions.

After the introduction of the Turbo Stream, all the session cards (regardless of the status) are replaced when an update is fetch from the server. This is causing that the active sessions widget goes from showing the first 3 active sessions to display all.

The fix is simply to disable the updates.
Later on, we will implement a solution to refresh the session data in the widget.