### PR TITLE
Degrade gracefully when scheduler is not Slurm

### DIFF
--- a/apps/dashboard/app/helpers/system_status_helper.rb
+++ b/apps/dashboard/app/helpers/system_status_helper.rb
@@ -39,7 +39,7 @@ module SystemStatusHelper
     "#{(value.to_f / total * 100).round 2}%"
   end
 
-  def valid_percent(percent)
+  def valid_percent?(percent)
     percent.to_f >= 0
   end
 

--- a/apps/dashboard/app/helpers/system_status_helper.rb
+++ b/apps/dashboard/app/helpers/system_status_helper.rb
@@ -13,8 +13,21 @@ module SystemStatusHelper
     }
   end
 
+  def not_slurm_hash(job_adapter)
+    scheduler = job_adapter.class.name.demodulize
+    {
+      message: "Cluster information is not available with #{scheduler}. Currently, only Slurm clusters are supported.",
+      percent: -1
+    }
+  end
+
   def components_status(job_adapter)
-    cluster_info = job_adapter.cluster_info
+    begin
+      cluster_info = job_adapter.cluster_info
+    rescue NotImplementedError
+      return [not_slurm_hash(job_adapter)]
+    end
+
     [
       status_hash('Nodes', cluster_info.active_nodes, cluster_info.total_nodes),
       status_hash('Processors', cluster_info.active_processors, cluster_info.total_processors),
@@ -24,6 +37,10 @@ module SystemStatusHelper
 
   def percent(value, total)
     "#{(value.to_f / total * 100).round 2}%"
+  end
+
+  def valid_percent(percent)
+    percent.to_f >= 0
   end
 
   def active_jobs(job_adapter)

--- a/apps/dashboard/app/views/system_status/index.turbo_stream.erb
+++ b/apps/dashboard/app/views/system_status/index.turbo_stream.erb
@@ -11,9 +11,11 @@
             <div class="container py-2">
               <div><%= current_status[:message] %></div>
 
-              <div class="progress">
-                <div class="progress-bar" role="progressbar" style="width: <%= current_status[:percent] %>"><%= current_status[:percent] %> in use</div>
-              </div>
+              <% if valid_percent(current_status[:percent]) %>
+                <div class="progress">
+                  <div class="progress-bar" role="progressbar" style="width: <%= current_status[:percent] %>"><%= current_status[:percent] %> in use</div>
+                </div>
+              <% end %>
             </div>
           <% end %>
 

--- a/apps/dashboard/app/views/system_status/index.turbo_stream.erb
+++ b/apps/dashboard/app/views/system_status/index.turbo_stream.erb
@@ -11,7 +11,7 @@
             <div class="container py-2">
               <div><%= current_status[:message] %></div>
 
-              <% if valid_percent(current_status[:percent]) %>
+              <% if valid_percent?(current_status[:percent]) %>
                 <div class="progress">
                   <div class="progress-bar" role="progressbar" style="width: <%= current_status[:percent] %>"><%= current_status[:percent] %> in use</div>
                 </div>


### PR DESCRIPTION
fixes #3569 

Cluster information is currently only available on Slurm. To ensure that the system status page works on other clusters, the following message is displayed when cluster information is not available ([Scheduler] being the scheduler used by the cluster).
![image](https://github.com/OSC/ondemand/assets/149011429/0e961c31-2195-45b4-8fd2-34dffc16d62e)