### PR TITLE
Fix flash button after upgrade to Bootstrap 5

### DIFF
--- a/apps/dashboard/app/javascript/products_show.js
+++ b/apps/dashboard/app/javascript/products_show.js
@@ -43,7 +43,7 @@ function updateModal(event){
 
   xhr.onloadend = function() {
     $(`#${spinnerId}`).replaceWith(`
-      <button class="close float-end" data-dismiss="modal">&times;</button>
+      <button class="close float-end" data-bs-dismiss="modal">&times;</button>
     `);
     if (this.status != 200) {
       $(`#${id} .product-cli-body`).html(`${header}A fatal error has occurred`);

--- a/apps/dashboard/app/javascript/products_show.js
+++ b/apps/dashboard/app/javascript/products_show.js
@@ -4,7 +4,7 @@ const id = 'product_cli_modal';
 const spinnerId = `${id}_spinner`;
 const headerId = `${id}_header`;
 const buttonId = `${id}_button`;
-const closeButton = `<button id="${buttonId}" class="close float-end" data-bs-dismiss="modal">&times;</button>`;
+const closeButton = `<button id="${buttonId}" class="btn-close float-end" data-bs-dismiss="modal"></button>`;
 
 jQuery(function(){
   $('[data-toggle="cli"]').on('click', (event) => updateModal(event));
@@ -43,7 +43,7 @@ function updateModal(event){
 
   xhr.onloadend = function() {
     $(`#${spinnerId}`).replaceWith(`
-      <button class="close float-end" data-bs-dismiss="modal">&times;</button>
+      <button class="btn-close float-end" data-bs-dismiss="modal">&times;</button>
     `);
     if (this.status != 200) {
       $(`#${id} .product-cli-body`).html(`${header}A fatal error has occurred`);

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_prefill_templates.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_prefill_templates.html.erb
@@ -15,9 +15,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title h5" id="formPrefillErrorLabel"><%= t('dashboard.batch_connect_form_prefill_error') %></div>
-        <button type="button" class="close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>"></button>
       </div>
       <div class="modal-body" id="batch_connect_session_template_form_error_modal_body"></div>
     </div>
@@ -29,9 +27,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title h5" id="chooseTemplateNameLabel"><%= t('dashboard.batch_connect_form_choose_template_name') %></div>
-        <button type="button" class="close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>"></button>
       </div>
       <div class="modal-body">
         <select class="form-control selectpicker" id="modal_input_template_name">
@@ -55,9 +51,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title h5"><%= t('dashboard.batch_connect_form_type_new_name_error') %></div>
-        <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
     </div>
   </div>

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_prefill_templates.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_prefill_templates.html.erb
@@ -15,7 +15,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title h5" id="formPrefillErrorLabel"><%= t('dashboard.batch_connect_form_prefill_error') %></div>
-        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('dashboard.close') %>">
+        <button type="button" class="close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
@@ -29,7 +29,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title h5" id="chooseTemplateNameLabel"><%= t('dashboard.batch_connect_form_choose_template_name') %></div>
-        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('dashboard.close') %>">
+        <button type="button" class="close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
@@ -44,7 +44,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="batch_connect_session_template_choose_name_button"><%= t('dashboard.save') %></button>
-        <button type="button" class="btn btn-danger" data-dismiss="modal"><%= t('dashboard.close') %></button>
+        <button type="button" class="btn btn-danger" data-bs-dismiss="modal"><%= t('dashboard.close') %></button>
       </div>
     </div>
   </div>
@@ -55,7 +55,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title h5"><%= t('dashboard.batch_connect_form_type_new_name_error') %></div>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -19,7 +19,7 @@ locals: {
 
 <%- if @session && @session.errors.any? -%>
   <div class="alert alert-danger alert-dismissible" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>
 

--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -19,9 +19,7 @@ locals: {
 
 <%- if @session && @session.errors.any? -%>
   <div class="alert alert-danger alert-dismissible" role="alert">
-    <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 
     <% @session.errors.each do |error| %>
       <% if error.attribute == :submit %>

--- a/apps/dashboard/app/views/files/_copy_move_popup.html.erb
+++ b/apps/dashboard/app/views/files/_copy_move_popup.html.erb
@@ -2,7 +2,7 @@
 {{#if files}}
 <div class="card mb-3">
   <div class="card-body">
-    <button id="clipboard-clear" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <button id="clipboard-clear" type="button" class="close" data-bs-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     <p class="mt-4">Copy or move the files below from <code>{{from}}</code> to the current directory:</p>
   </div>
   <ul class="list-group list-group-flush">

--- a/apps/dashboard/app/views/files/_copy_move_popup.html.erb
+++ b/apps/dashboard/app/views/files/_copy_move_popup.html.erb
@@ -2,7 +2,7 @@
 {{#if files}}
 <div class="card mb-3">
   <div class="card-body">
-    <button id="clipboard-clear" type="button" class="close" data-bs-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <button id="clipboard-clear" type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     <p class="mt-4">Copy or move the files below from <code>{{from}}</code> to the current directory:</p>
   </div>
   <ul class="list-group list-group-flush">

--- a/apps/dashboard/app/views/files/_default_label_error_messages.html.erb
+++ b/apps/dashboard/app/views/files/_default_label_error_messages.html.erb
@@ -13,7 +13,7 @@
           <pre class="card-body">{{error_message}}</pre>
         </div>
       </div>
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     </div>
   {{else}}
     {{> defaultLabel}}

--- a/apps/dashboard/app/views/files/_default_label_error_messages.html.erb
+++ b/apps/dashboard/app/views/files/_default_label_error_messages.html.erb
@@ -13,7 +13,7 @@
           <pre class="card-body">{{error_message}}</pre>
         </div>
       </div>
-      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   {{else}}
     {{> defaultLabel}}

--- a/apps/dashboard/app/views/layouts/_browser_warning.html.erb
+++ b/apps/dashboard/app/views/layouts/_browser_warning.html.erb
@@ -1,7 +1,6 @@
 <% if !browser.modern? %>
     <div class="alert alert-danger alert-dismissible" role="alert">
-      <button type="button" class="close" data-bs-dismiss="alert">
-        <span aria-hidden="true">&times;</span>
+      <button type="button" class="btn-close" data-bs-dismiss="alert">
         <span class="sr-only">Close</span>
       </button>
       OnDemand requires a newer version of the browser you are using.

--- a/apps/dashboard/app/views/layouts/_browser_warning.html.erb
+++ b/apps/dashboard/app/views/layouts/_browser_warning.html.erb
@@ -1,6 +1,6 @@
 <% if !browser.modern? %>
     <div class="alert alert-danger alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert">
+      <button type="button" class="close" data-bs-dismiss="alert">
         <span aria-hidden="true">&times;</span>
         <span class="sr-only">Close</span>
       </button>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -77,7 +77,7 @@
 
     <div id="js-alert-danger-template" class="d-none" aria-hidden="true">
       <div class="alert alert-danger alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert">
+        <button type="button" class="close" data-bs-dismiss="alert">
           <span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>
@@ -87,7 +87,7 @@
 
     <% if alert %>
       <div class="alert alert-danger alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert">
+        <button type="button" class="close" data-bs-dismiss="alert">
           <span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>
@@ -97,7 +97,7 @@
 
     <% if notice %>
       <div class="alert alert-success" role="alert">
-        <button type="button" class="close" data-dismiss="alert">
+        <button type="button" class="close" data-bs-dismiss="alert">
           <span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -77,8 +77,7 @@
 
     <div id="js-alert-danger-template" class="d-none" aria-hidden="true">
       <div class="alert alert-danger alert-dismissible" role="alert">
-        <button type="button" class="close" data-bs-dismiss="alert">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>
         ALERT_MSG
@@ -87,8 +86,7 @@
 
     <% if alert %>
       <div class="alert alert-danger alert-dismissible" role="alert">
-        <button type="button" class="close" data-bs-dismiss="alert">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>
         <%= alert %>
@@ -97,8 +95,7 @@
 
     <% if notice %>
       <div class="alert alert-success" role="alert">
-        <button type="button" class="close" data-bs-dismiss="alert">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>
         <%= notice %>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -94,7 +94,7 @@
     <% end %>
 
     <% if notice %>
-      <div class="alert alert-success" role="alert">
+      <div class="alert alert-success alert-dismissible" role="alert">
         <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -268,7 +268,7 @@
   <% end %>
 
   <% if notice %>
-      <div class="alert alert-success" role="alert">
+      <div class="alert alert-success alert-dismissible role="alert">
         <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -260,8 +260,7 @@
 
   <% if alert %>
       <div class="alert alert-danger alert-dismissible" role="alert">
-        <button type="button" class="close" data-bs-dismiss="alert">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>
         <%= alert %>
@@ -270,8 +269,7 @@
 
   <% if notice %>
       <div class="alert alert-success" role="alert">
-        <button type="button" class="close" data-bs-dismiss="alert">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert">
           <span class="sr-only">Close</span>
         </button>
         <%= notice %>

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -260,7 +260,7 @@
 
   <% if alert %>
       <div class="alert alert-danger alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert">
+        <button type="button" class="close" data-bs-dismiss="alert">
           <span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>
@@ -270,7 +270,7 @@
 
   <% if notice %>
       <div class="alert alert-success" role="alert">
-        <button type="button" class="close" data-dismiss="alert">
+        <button type="button" class="close" data-bs-dismiss="alert">
           <span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -67,7 +67,7 @@
         </div>
       </div>
       <div class="modal-footer sticky-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         <button type="button" class="btn btn-primary" id="<%= button_id %>">Select Path</button>
       </div>
     </div>

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -18,9 +18,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="modal-path-selector-title">Select Your Working Directory</h5>
-        <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
       

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -708,19 +708,19 @@ class ProjectManagerTest < ApplicationSystemTestCase
   test 'cant create script when project is invalid' do
     visit edit_project_launcher_path('1', '1')
     assert_current_path('/projects')
-    assert_selector('.alert-danger', text: "×\nClose\nCannot find project: 1")
+    assert_selector('.alert-danger', text: "Close\nCannot find project: 1")
   end
 
   test 'cant show script when project is invalid' do
     visit project_launcher_path('1', '1')
     assert_current_path('/projects')
-    assert_selector('.alert-danger', text: "×\nClose\nCannot find project: 1")
+    assert_selector('.alert-danger', text: "Close\nCannot find project: 1")
   end
 
   test 'cant edit script when project is invalid' do
     visit edit_project_launcher_path('1', '1')
     assert_current_path('/projects')
-    assert_selector('.alert-danger', text: "×\nClose\nCannot find project: 1")
+    assert_selector('.alert-danger', text: "Close\nCannot find project: 1")
   end
 
   test 'cant show invalid script' do

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -253,7 +253,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       HEREDOC
 
       success_message = I18n.t('dashboard.jobs_scripts_created')
-      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
+      assert_selector('.alert-success', text: "Close\n#{success_message}")
       assert_equal(expected_yml, File.read("#{dir}/projects/#{project_id}/.ondemand/scripts/#{script_id}/form.yml"))
 
       launcher_path = project_launcher_path(project_id, script_id)
@@ -304,7 +304,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       HEREDOC
 
       success_message = I18n.t('dashboard.jobs_scripts_created')
-      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
+      assert_selector('.alert-success', text: "Close\n#{success_message}")
       assert_equal(expected_yml, File.read("#{dir}/projects/#{project_id}/.ondemand/scripts/#{script_id}/form.yml"))
     end
   end
@@ -475,7 +475,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
         .returns(['', 'some error message', exit_failure])
 
       click_on 'Launch'
-      assert_selector('.alert-danger', text: "×\nClose\nsome error message")
+      assert_selector('.alert-danger', text: "Close\nsome error message")
       assert_nil YAML.safe_load(File.read("#{script_dir}/job_history.log"))
     end
   end
@@ -552,7 +552,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       # correctly saves
       click_on(I18n.t('dashboard.save'))
       success_message = I18n.t('dashboard.jobs_scripts_updated')
-      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
+      assert_selector('.alert-success', text: "Close\n#{success_message}")
       assert_current_path project_path(project_id)
 
       # note that bc_num_hours has default, min & max
@@ -639,7 +639,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       # correctly saves
       click_on(I18n.t('dashboard.save'))
       success_message = I18n.t('dashboard.jobs_scripts_updated')
-      assert_selector('.alert-success', text: "×\nClose\n#{success_message}")
+      assert_selector('.alert-success', text: "Close\n#{success_message}")
       assert_current_path project_path(project_id)
 
       expected_yml = <<~HEREDOC
@@ -728,7 +728,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       project_id = setup_project(dir)
       visit project_launcher_path(project_id, '1')
       assert_current_path("/projects/#{project_id}")
-      assert_selector('.alert-danger', text: "×\nClose\nCannot find script 1")
+      assert_selector('.alert-danger', text: "Close\nCannot find script 1")
     end
   end
 
@@ -737,7 +737,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       project_id = setup_project(dir)
       visit edit_project_launcher_path(project_id, '1')
       assert_current_path("/projects/#{project_id}")
-      assert_selector('.alert-danger', text: "×\nClose\nCannot find script 1")
+      assert_selector('.alert-danger', text: "Close\nCannot find script 1")
     end
   end
 


### PR DESCRIPTION
fixes #3591 

Changed data-dismiss to data-bs-dismiss to restore functionality.

Changed close to btn-close and removed span elements with &times to update buttons appearances to Bootstrap 5. The alignment still doesn't look quite right though:
![image](https://github.com/OSC/ondemand/assets/149011429/2c01b32c-10c0-42c8-931e-79f9860bce13)
