### PR TITLE
Update data-target attributes to data-bs-target

### DIFF
--- a/apps/dashboard/app/views/batch_connect/shared/_saved_settings_menu.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_saved_settings_menu.html.erb
@@ -13,7 +13,7 @@
         link = app.link
       %>
         <p class="list-group-item mb-0 header">
-          <a href="#" class="" data-bs-toggle="collapse" data-target="<%= "#saved-settings-#{index}" %>" aria-expanded="true" aria-controls="<%= "saved-settings-#{index}" %>">
+          <a href="#" class="" data-bs-toggle="collapse" data-bs-target="<%= "#saved-settings-#{index}" %>" aria-expanded="true" aria-controls="<%= "saved-settings-#{index}" %>">
             <%= icon_tag(link.icon_uri) unless link.icon_uri.to_s.blank? %>
             <%= app.title %>
           </a>

--- a/apps/dashboard/app/views/files/_default_label_error_messages.html.erb
+++ b/apps/dashboard/app/views/files/_default_label_error_messages.html.erb
@@ -7,7 +7,7 @@
   {{#if error_summary}}
     <div id="{{id}}" class="alert alert-danger alert-dismissible fade show" role="alert">
       <b><i class="fas fa-exclamation-triangle"></i> {{error_summary}}</b>
-      <button class="btn btn-outline-dark btn-sm ms-3 collapsed" type="button" data-bs-toggle="collapse" data-target="#{{id}}-error-report" aria-expanded="false" aria-controls="#{{id}}-error-report">See details</button>
+      <button class="btn btn-outline-dark btn-sm ms-3 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{id}}-error-report" aria-expanded="false" aria-controls="#{{id}}-error-report">See details</button>
       <div id="{{id}}-error-report" class="collapse">
         <div class="mt-3 card">
           <pre class="card-body">{{error_message}}</pre>

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
       <ul class="navbar-nav w-100 align-items-center" role="menubar">
         <%= render partial: 'layouts/nav/logo' %>
       
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
 

--- a/apps/dashboard/app/views/layouts/editor.html.erb
+++ b/apps/dashboard/app/views/layouts/editor.html.erb
@@ -22,7 +22,7 @@
   <!-- navbar  -->
   <nav class="navbar navbar-expand-md shadow-sm navbar-color navbar-<%= @user_configuration.navbar_type %>" role="navigation">
 
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 


### PR DESCRIPTION
fixes #3580 

Replaces all defined `data-target` attributes with `data-bs-target` as is used in Bootstrap 5.