### PR TITLE
Dropright is now dropend

### DIFF
--- a/apps/dashboard/app/views/apps/_app_group_rows.html.erb
+++ b/apps/dashboard/app/views/apps/_app_group_rows.html.erb
@@ -2,7 +2,7 @@
   <%- if app.role == "files" -%>
     <tr id="<%= row_id(app.url) %>">
       <td>
-      <div class="btn-group dropright">
+      <div class="btn-group dropend">
         <%= link_to app.links.first.url, class: 'btn btn-primary', target: '_blank' do %>
           <span title="FontAwesome icon specified: folder" aria-hidden="true" class="fas fa-folder fa-fw"></span> Files
         <% end %>

--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div id="shell-wrapper" class="btn-group dropright">
+<div id="shell-wrapper" class="btn-group dropend">
   <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm', target: '_blank' do %>
     <i class="fas fa-terminal" aria-hidden="true"></i>
     Open in Terminal


### PR DESCRIPTION
`dropright`, used to indicate the direction of a dropdown, is now `dropend` in bootstrap 5.