### PR TITLE
correctly reset Capybara before these tests

### DIFF
--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -7,7 +7,9 @@ class FilesTest < ApplicationSystemTestCase
   def setup
     FileUtils.rm_rf(DOWNLOAD_DIRECTORY.to_s)
     FileUtils.mkdir_p(DOWNLOAD_DIRECTORY.to_s)
-    Capybara.reset_session!
+
+    # we want to clear the console logs from any previous test.
+    Capybara.current_session.quit
   end
 
   test "visiting files app doesn't raise js errors" do


### PR DESCRIPTION
Correctly reset Capybara before these tests so that this test about checking for console logs really only applies to the files app and not some other page where we logged something.