### PR TITLE
Improvements to the saved settings menu after Bootstrap upgrade

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/batch_connect/saved_settings.scss
+++ b/apps/dashboard/app/assets/stylesheets/batch_connect/saved_settings.scss
@@ -1,10 +1,35 @@
 #saved-settings-menu {
+  i.app-icon {
+    font-size: 12px;
+  }
+
   .saved-settings-list .app-icon {
     color: rgba(0, 0, 0, 0.25);
+  }
+
+  .saved-settings-list .list-group-item {
+    border-top: none;
+    border-right: none;
+    border-left: none;
+  }
+
+  .saved-settings-list:last-child .list-group-item:last-child {
+    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border-bottom: none;
   }
 }
 
 div.settings-widget {
+  span.list-group-item {
+    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 5px;
+  }
+
+  span.list-group-item a {
+    box-shadow: none;
+  }
+
   .small {
     font-size: 0.8rem;
   }


### PR DESCRIPTION
Removed the double border and added the border radius to the saved settings navigation menu.

I have fixed, as well, the borders for the saved settings widget.

Images attached below