### PR TITLE
Navbar logo and padding fixes after Bootstrp5 upgrade

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -24,12 +24,17 @@
 // get in the way
 // $navbar-height: 20px;
 
+nav.navbar {
+  padding: 0.5rem 1rem;
+}
+
 // styles to make a logo fill the navbar height if using a logo for the navbar title
 .navbar-brand.navbar-brand-logo {
   padding: 0px;
 }
 
 a.navbar-brand.navbar-brand-logo {
+  display: inline-block;
   height: 2em;
 }
 


### PR DESCRIPTION
The navbar logo image size and padding for the whole navbar seems odd.

These are CSS fixes to bring them back as they were before the Boostrap5 upgrade.

If the new look and feel is expected, please cancel this PR.
We can fix the logo and padding for our installation using the custom CSS feature.

Images attached below.