### PR TITLE
Add return type comments

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -3,7 +3,6 @@ class BatchConnect::SessionContextsController < ApplicationController
   include BatchConnectConcern
   include UserSettingStore
 
-  # GET /batch_connect/<app_token>/session_contexts/new (returns Array)
   def new
     set_app
     set_render_format
@@ -105,12 +104,12 @@ class BatchConnect::SessionContextsController < ApplicationController
 
   private
 
-    # Set the app from the token (Returns BatchConnect::App
+    # Set the app from the token
     def set_app
       @app = BatchConnect::App.from_token params[:token]
     end
 
-    # Set list of app lists for navigation (Returns OodAppGroup | NavBar::NavItemDecorator)
+    # Set list of app lists for navigation
     def set_app_groups
       @sys_app_groups = bc_sys_app_groups
       @usr_app_groups = bc_usr_app_groups
@@ -133,7 +132,7 @@ class BatchConnect::SessionContextsController < ApplicationController
       @render_format = @app.clusters.first.job_config[:adapter] unless @app.clusters.empty?
     end
 
-    # Set the rendering format for displaying attributes (Returns Hash)
+    # Set the rendering format for displaying attributes
     def set_prefill_templates
       @prefill_templates ||= bc_templates(@app.token)
     end
@@ -149,7 +148,8 @@ class BatchConnect::SessionContextsController < ApplicationController
       params.require(:batch_connect_session_context).permit(@session_context.attributes.keys) if params[:batch_connect_session_context].present?
     end
 
-    # Store session context into a cache file (Returns Pathname)
+    # Store session context into a cache file
+    # @return [Pathname] the cachefile path
     def cache_file
       BatchConnect::Session.cache_root.tap do |p|
         p.mkpath unless p.exist?

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -3,6 +3,7 @@ class BatchConnect::SessionContextsController < ApplicationController
   include BatchConnectConcern
   include UserSettingStore
 
+  # GET /batch_connect/<app_token>/session_contexts/new
   def new
     set_app
     set_render_format

--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -3,7 +3,7 @@ class BatchConnect::SessionContextsController < ApplicationController
   include BatchConnectConcern
   include UserSettingStore
 
-  # GET /batch_connect/<app_token>/session_contexts/new
+  # GET /batch_connect/<app_token>/session_contexts/new (returns Array)
   def new
     set_app
     set_render_format
@@ -105,12 +105,12 @@ class BatchConnect::SessionContextsController < ApplicationController
 
   private
 
-    # Set the app from the token
+    # Set the app from the token (Returns BatchConnect::App
     def set_app
       @app = BatchConnect::App.from_token params[:token]
     end
 
-    # Set list of app lists for navigation
+    # Set list of app lists for navigation (Returns OodAppGroup | NavBar::NavItemDecorator)
     def set_app_groups
       @sys_app_groups = bc_sys_app_groups
       @usr_app_groups = bc_usr_app_groups
@@ -133,7 +133,7 @@ class BatchConnect::SessionContextsController < ApplicationController
       @render_format = @app.clusters.first.job_config[:adapter] unless @app.clusters.empty?
     end
 
-    # Set the rendering format for displaying attributes
+    # Set the rendering format for displaying attributes (Returns Hash)
     def set_prefill_templates
       @prefill_templates ||= bc_templates(@app.token)
     end
@@ -149,7 +149,7 @@ class BatchConnect::SessionContextsController < ApplicationController
       params.require(:batch_connect_session_context).permit(@session_context.attributes.keys) if params[:batch_connect_session_context].present?
     end
 
-    # Store session context into a cache file
+    # Store session context into a cache file (Returns Pathname)
     def cache_file
       BatchConnect::Session.cache_root.tap do |p|
         p.mkpath unless p.exist?


### PR DESCRIPTION
Fixes #3162.
Note: I'm not sure what the argument *against* the comments specifying what URL would be used to access the methods is. It seems like it would make sense to keep them.