### PR TITLE
Fixed _config partial when system-status app is not enabled

### DIFF
--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -10,5 +10,5 @@
   data-bc-poll-delay="<%= Configuration.bc_sessions_poll_delay %>"
   data-bc-index-url="<%= batch_connect_sessions_path %>"
   data-status-poll-delay="<%= Configuration.status_poll_delay %>"
-  data-status-index-url="<%= system_status_path %>"
+  data-status-index-url="<%= system_status_path if respond_to?(:system_status_path) %>"
 ></div>


### PR DESCRIPTION
Updated `_config.html.erb` partial to make `system_status_path` optional.

When system-status app is not enabled or deployed, the dashboard application breaks as `system_status_path` is not defined.