### PR TITLE
hide download buttons for certain files

### DIFF
--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -3,7 +3,7 @@ class PosixFile
 
   attr_reader :path, :stat
 
-  delegate :basename, :descend, :parent, :join, :to_s, :read, :write, :mkdir, :directory?, :realpath, to: :path
+  delegate :basename, :descend, :parent, :join, :to_s, :read, :write, :mkdir, :directory?, :realpath, :pipe?, :readable?, to: :path
 
   # include to give us number_to_human_size
   include ActionView::Helpers::NumberHelper
@@ -53,15 +53,16 @@ class PosixFile
     return { name: basename } if stat.nil?
 
     {
-      id:         "dev-#{stat.dev}-inode-#{stat.ino}",
-      name:       basename,
-      size:       directory? ? nil : stat.size,
-      human_size: human_size,
-      directory:  directory?,
-      date:       stat.mtime.to_i,
-      owner:      PosixFile.username_from_cache(stat.uid),
-      mode:       stat.mode,
-      dev:        stat.dev
+      id:           "dev-#{stat.dev}-inode-#{stat.ino}",
+      name:         basename,
+      size:         directory? ? nil : stat.size,
+      human_size:   human_size,
+      directory:    directory?,
+      date:         stat.mtime.to_i,
+      owner:        PosixFile.username_from_cache(stat.uid),
+      mode:         stat.mode,
+      dev:          stat.dev,
+      downloadable: !pipe? && readable?
     }
   end
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -31,15 +31,16 @@ class RemoteFile
     # owner, mode and dev are not defined for remote files, leaving them empty
     files.map do |file|
       {
-        id:         file['Path'],
-        name:       file['Name'],
-        size:       file['IsDir'] ? nil : file['Size'],
-        human_size: human_size(file),
-        directory:  file['IsDir'],
-        date:       DateTime.parse(file['ModTime']).to_time.to_i,
-        owner:      '',
-        mode:       '',
-        dev:        0
+        id:           file['Path'],
+        name:         file['Name'],
+        size:         file['IsDir'] ? nil : file['Size'],
+        human_size:   human_size(file),
+        directory:    file['IsDir'],
+        date:         DateTime.parse(file['ModTime']).to_time.to_i,
+        owner:        '',
+        mode:         '',
+        dev:          0,
+        downloadable: true
       }
     end.select do |stats|
       valid_encoding = stats[:name].to_s.valid_encoding?

--- a/apps/dashboard/app/views/files/_file_action_menu.html.erb
+++ b/apps/dashboard/app/views/files/_file_action_menu.html.erb
@@ -14,7 +14,9 @@
       {{/if}}
       <li><a href="#" class="rename-file dropdown-item" data-row-index="{{row_index}}"><i class="fas fa-font" aria-hidden="true"></i> Rename</a></li>
       <%- if Configuration.download_enabled? -%>
+      {{#if data.download_url}}
       <li><a href="{{data.download_url}}" class="download-file dropdown-item" data-row-index="{{row_index}}"><i class="fas fa-download" aria-hidden="true"></i> Download</a></li>
+      {{/if}}
       <%- end -%>
       <li class="dropdown-divider mt-4"></li>
       <li><a href="#" class="delete-file dropdown-item text-danger" data-row-index="{{row_index}}"><i class="fas fa-trash" aria-hidden="true"></i> Delete</a></li>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -12,7 +12,7 @@ json.files @files do |f|
   json.name f[:name]
 
   json.url files_path(@filesystem, @path.join(f[:name]).to_s)
-  json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') # FIXME: should change for directory
+  json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') if f[:downloadable]
   json.edit_url OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s
 
   json.size f[:size]

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -596,4 +596,32 @@ class FilesTest < ApplicationSystemTestCase
       find('tbody a', exact_text: 'good_file.txt')
     end
   end
+
+  test 'files that are not downloadable' do
+    Dir.mktmpdir do |dir|
+      cant_read = 'cant_read.txt'
+      fifo = 'fifo'
+
+      `touch #{dir}/#{cant_read}`
+      `chmod 000 #{dir}/#{cant_read}`
+      `mkfifo #{dir}/#{fifo}`
+
+      visit files_url(dir)
+
+      fifo_row = find('tbody a', exact_text: fifo).ancestor('tr')
+      cant_read_row = find('tbody a', exact_text: cant_read).ancestor('tr')
+
+      fifo_row.find('button.dropdown-toggle').click
+      fifo_links = fifo_row.all('td > div.btn-group > ul > li > a').map(&:text)
+
+      cant_read_row.find('button.dropdown-toggle').click
+      cant_read_links = cant_read_row.all('td > div.btn-group > ul > li > a').map(&:text)
+
+      # NOTE: download is not an expected link.
+      expected_links = ['View', 'Edit', 'Rename', 'Delete']
+
+      assert_equal(expected_links, fifo_links)
+      assert_equal(expected_links, cant_read_links)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3029 by not showing download buttons for things that are not downloadable (i.e., files that are not readable or pipes).

In draft while I write a test case.