### PR TITLE
Added dismissible and required features to announcements

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -7,6 +7,13 @@ class ApplicationController < ActionController::Base
   before_action :set_user, :set_user_configuration, :set_pinned_apps, :set_nav_groups, :set_announcements
   before_action :set_my_balances, only: [:index, :new, :featured]
   before_action :set_featured_group, :set_custom_navigation
+  before_action :check_required_announcements
+
+  def check_required_announcements
+    return if instance_of?(SettingsController)
+
+    render inline: '', layout: :default if @announcements.select(&:required?).reject(&:completed?).any?
+  end
 
   def set_user
     @user = CurrentUser

--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -8,7 +8,11 @@ class ProjectsController < ApplicationController
     project_id = show_project_params[:id]
     @project = Project.find(project_id)
     if @project.nil?
-      redirect_to(projects_path, alert: I18n.t('dashboard.jobs_project_not_found', project_id: project_id))
+      respond_to do |format|
+        message = I18n.t('dashboard.jobs_project_not_found', project_id: project_id)
+        format.html { redirect_to(projects_path, alert: message) }
+        format.json { render json: { message: message }, status: :not_found }
+      end
     else
       @scripts = Launcher.all(@project.directory)
       @valid_project = Launcher.clusters?

--- a/apps/dashboard/app/controllers/settings_controller.rb
+++ b/apps/dashboard/app/controllers/settings_controller.rb
@@ -52,10 +52,7 @@ class SettingsController < ApplicationController
 
   def read_settings(params)
     {}.tap do |settings|
-      params&.each do |key, value|
-        value = value.to_h if value.is_a?(ActionController::Parameters)
-        settings[key] = value
-      end
+      params&.each { |key, value| settings[key] = value }
     end
   end
 end

--- a/apps/dashboard/app/controllers/settings_controller.rb
+++ b/apps/dashboard/app/controllers/settings_controller.rb
@@ -4,42 +4,15 @@
 # Current supported settings: profile, announcement
 class SettingsController < ApplicationController
   include UserSettingStore
-  ALLOWED_SETTINGS = [:profile, :announcement].freeze
+  ALLOWED_SETTINGS = [:profile, { announcements: {} }].freeze
 
   def update
     new_settings = read_settings(settings_param)
-    if new_settings.empty?
-      respond_to do |format|
-        format.html { redirect_to root_url, alert: I18n.t('dashboard.settings_invalid_request') }
-        format.json { head :bad_request }
-      end
+    update_user_settings(new_settings) unless new_settings.empty?
 
-      return
-    end
-
-    # Only ALLOWED_SETTINGS methods will be called
-    setting, value = new_settings.first
-    send("update_#{setting}", value)
-  end
-
-  def update_profile(profile)
-    profile_settings = { profile: profile }
-    update_user_settings(profile_settings)
-
-    logger.info "settings: updated user settings for profile to: #{profile_settings}"
+    logger.info "settings: updated user settings to: #{new_settings}"
     respond_to do |format|
-      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_profile_updated') }
-      format.json { head :no_content }
-    end
-  end
-
-  def update_announcement(announcement_id)
-    announcements_settings = { announcements: { announcement_id => Time.now.localtime.strftime('%Y-%m-%d %H:%M:%S') } }
-    update_user_settings(announcements_settings) unless announcement_id.empty?
-
-    logger.info "settings: set announcement to completed: #{announcements_settings}"
-    respond_to do |format|
-      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_announcements_updated') }
+      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_updated') }
       format.json { head :no_content }
     end
   end
@@ -51,8 +24,6 @@ class SettingsController < ApplicationController
   end
 
   def read_settings(params)
-    {}.tap do |settings|
-      params&.each { |key, value| settings[key] = value }
-    end
+    params.to_h
   end
 end

--- a/apps/dashboard/app/controllers/settings_controller.rb
+++ b/apps/dashboard/app/controllers/settings_controller.rb
@@ -3,7 +3,7 @@
 # The Controller for user level settings /dashboard/settings.
 class SettingsController < ApplicationController
   include UserSettingStore
-  ALLOWED_SETTINGS = [:profile].freeze
+  ALLOWED_SETTINGS = [:profile, { announcements: {} }].freeze
 
   def update
     new_settings = read_settings(settings_param)
@@ -24,7 +24,10 @@ class SettingsController < ApplicationController
 
   def read_settings(params)
     {}.tap do |settings|
-      params&.each { |key, value| settings[key] = value }
+      params&.each do |key, value|
+        value = value.to_h if value.is_a?(ActionController::Parameters)
+        settings[key] = value
+      end
     end
   end
 end

--- a/apps/dashboard/app/controllers/settings_controller.rb
+++ b/apps/dashboard/app/controllers/settings_controller.rb
@@ -1,17 +1,45 @@
 # frozen_string_literal: true
 
 # The Controller for user level settings /dashboard/settings.
+# Current supported settings: profile, announcement
 class SettingsController < ApplicationController
   include UserSettingStore
-  ALLOWED_SETTINGS = [:profile, { announcements: {} }].freeze
+  ALLOWED_SETTINGS = [:profile, :announcement].freeze
 
   def update
     new_settings = read_settings(settings_param)
-    update_user_settings(new_settings) unless new_settings.empty?
+    if new_settings.empty?
+      respond_to do |format|
+        format.html { redirect_to root_url, alert: I18n.t('dashboard.settings_invalid_request') }
+        format.json { head :bad_request }
+      end
 
-    logger.info "settings: updated user settings to: #{new_settings}"
+      return
+    end
+
+    # Only ALLOWED_SETTINGS methods will be called
+    setting, value = new_settings.first
+    send("update_#{setting}", value)
+  end
+
+  def update_profile(profile)
+    profile_settings = { profile: profile }
+    update_user_settings(profile_settings)
+
+    logger.info "settings: updated user settings for profile to: #{profile_settings}"
     respond_to do |format|
-      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_updated') }
+      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_profile_updated') }
+      format.json { head :no_content }
+    end
+  end
+
+  def update_announcement(announcement_id)
+    announcements_settings = { announcements: { announcement_id => Time.now.localtime.strftime('%Y-%m-%d %H:%M:%S') } }
+    update_user_settings(announcements_settings) unless announcement_id.empty?
+
+    logger.info "settings: set announcement to completed: #{announcements_settings}"
+    respond_to do |format|
+      format.html { redirect_to root_url, notice: I18n.t('dashboard.settings_announcements_updated') }
       format.json { head :no_content }
     end
   end

--- a/apps/dashboard/app/models/announcement.rb
+++ b/apps/dashboard/app/models/announcement.rb
@@ -32,8 +32,20 @@ class Announcement
     msg.blank? ? nil : msg
   end
 
+  # The announcement's id. Used when storing that it has been dismissed.
+  #  @return [String] the id
+  def id
+    @id ||= begin
+              default_id = Digest::SHA1.hexdigest(msg) if msg
+              opts.fetch(:id, default_id)
+            end
+  end
+
+  # The announcement's button text displayed for required or dismissible announcements
+  #  @return [String] the button text
   def button_text
-    opts.fetch(:button_text, I18n.t('dashboard.announcements_button_text')).to_s
+    default_text = required? ? I18n.t('dashboard.announcements_required_button') : I18n.t('dashboard.announcements_dismissible_button')
+    opts.fetch(:button_text, default_text).to_s
   end
 
   # Whether this is a valid announcement
@@ -46,22 +58,22 @@ class Announcement
     true
   end
 
+  # Whether this announcement has been dismissed.
+  # @return [Boolean] whether it has been dismissed
   def completed?
-    dismissible? && user_settings.dig(:announcements, id.to_sym)
+    dismissible? && user_settings.dig(:announcements, id.to_s.to_sym).present?
   end
 
+  # Whether this is a dismissible announcement.
+  # @return [Boolean] whether it is dismissible
   def dismissible?
-    required? || opts.fetch(:dismissible, false)
+    required? || opts.fetch(:dismissible, true)
   end
 
+  # Whether this is a required announcement.
+  # @return [Boolean] whether it is required
   def required?
     opts.fetch(:required, false)
-  end
-
-  def id
-    default_id = @path.basename.to_s if @path
-    # default_id = Digest::SHA1.hexdigest(@path.basename.to_s) if @path
-    opts.fetch(:id, default_id)
   end
 
   private

--- a/apps/dashboard/app/models/announcement.rb
+++ b/apps/dashboard/app/models/announcement.rb
@@ -2,6 +2,7 @@
 
 # Announcements show up on the dashboard to convey a message to users.
 class Announcement
+  include UserSettingStore
   # List of valid announcement types
   TYPES = [:warning, :info, :success, :danger].freeze
 
@@ -31,10 +32,36 @@ class Announcement
     msg.blank? ? nil : msg
   end
 
+  def button_text
+    opts.fetch(:button_text, I18n.t('dashboard.announcements_button_text')).to_s
+  end
+
   # Whether this is a valid announcement
   # @return [Boolean] whether it is valid
   def valid?
-    !!msg
+    return false unless msg
+
+    return false if dismissible? && !id
+
+    true
+  end
+
+  def completed?
+    dismissible? && user_settings.dig(:announcements, id.to_sym)
+  end
+
+  def dismissible?
+    required? || opts.fetch(:dismissible, false)
+  end
+
+  def required?
+    opts.fetch(:required, false)
+  end
+
+  def id
+    default_id = @path.basename.to_s if @path
+    # default_id = Digest::SHA1.hexdigest(@path.basename.to_s) if @path
+    opts.fetch(:id, default_id)
   end
 
   private

--- a/apps/dashboard/app/views/layouts/_announcements.html.erb
+++ b/apps/dashboard/app/views/layouts/_announcements.html.erb
@@ -1,0 +1,18 @@
+<% @announcements.select(&:valid?).reject(&:completed?).each do |announcement| %>
+  <div class="alert alert-<%= announcement.type %> announcement" role="alert">
+    <%= raw OodAppkit.markdown.render(announcement.msg) %>
+    <% if announcement.dismissible? %>
+      <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+        <%=
+          button_to(
+            settings_path("settings[announcements][#{announcement.id}]" => 'completed'),
+            method: :post,
+            class: "btn btn-#{announcement.type} me-md-2"
+          ) do
+            announcement.button_text
+          end
+        %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/apps/dashboard/app/views/layouts/_announcements.html.erb
+++ b/apps/dashboard/app/views/layouts/_announcements.html.erb
@@ -9,7 +9,7 @@
             method: :post,
             form_class: 'announcement-form',
             class: "btn btn-#{announcement.type} me-md-2 announcement-button",
-            params: { settings: { announcement: announcement.id } }
+            params: { settings: { announcements: { announcement.id => Time.now.localtime.strftime('%Y-%m-%d %H:%M:%S') } } }
           ) do
             announcement.button_text
           end

--- a/apps/dashboard/app/views/layouts/_announcements.html.erb
+++ b/apps/dashboard/app/views/layouts/_announcements.html.erb
@@ -1,13 +1,15 @@
 <% @announcements.select(&:valid?).reject(&:completed?).each do |announcement| %>
-  <div class="alert alert-<%= announcement.type %> announcement" role="alert">
-    <%= raw OodAppkit.markdown.render(announcement.msg) %>
+  <div id="announcement-<%=announcement.id%>" class="alert alert-<%= announcement.type %> announcement" role="alert">
+    <div class="announcement-body"><%= raw OodAppkit.markdown.render(announcement.msg) %></div>
     <% if announcement.dismissible? %>
       <div class="d-grid gap-2 d-md-flex justify-content-md-end">
         <%=
           button_to(
-            settings_path("settings[announcements][#{announcement.id}]" => 'completed'),
+            settings_path,
             method: :post,
-            class: "btn btn-#{announcement.type} me-md-2"
+            form_class: 'announcement-form',
+            class: "btn btn-#{announcement.type} me-md-2 announcement-button",
+            params: { settings: { announcement: announcement.id } }
           ) do
             announcement.button_text
           end

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -63,11 +63,7 @@
 
   <div class="<%= local_assigns[:layout_container_class] || 'container-md' %> content mt-4" role="main">
 
-    <% @announcements.select(&:valid?).each do |announcement| %>
-      <div class="alert alert-<%= announcement.type %> announcement" role="alert">
-        <%= raw OodAppkit.markdown.render(announcement.msg) %>
-      </div>
-    <% end %>
+    <%= render "layouts/announcements" %>
 
     <%= render "layouts/browser_warning" %>
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -260,8 +260,12 @@ en:
     jobs_scripts_fixed_field: "Fixed Value"
 
     settings_updated: "Settings updated"
+    settings_invalid_request: "Invalid settings submitted"
+    settings_profile_updated: "Profile updated"
+    settings_announcements_updated: "Announcement updated"
 
-    announcements_button_text: "OK"
+    announcements_required_button: "Accept"
+    announcements_dismissible_button: "OK"
 
     bc_saved_settings:
       title: "Saved Settings"

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -261,6 +261,8 @@ en:
 
     settings_updated: "Settings updated"
 
+    announcements_button_text: "OK"
+
     bc_saved_settings:
       title: "Saved Settings"
       no_settings_title: "You have no saved settings."

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -261,8 +261,6 @@ en:
 
     settings_updated: "Settings updated"
     settings_invalid_request: "Invalid settings submitted"
-    settings_profile_updated: "Profile updated"
-    settings_announcements_updated: "Announcement updated"
 
     announcements_required_button: "Accept"
     announcements_dismissible_button: "OK"

--- a/apps/dashboard/test/fixtures/config/announcements/announcement_id.yml
+++ b/apps/dashboard/test/fixtures/config/announcements/announcement_id.yml
@@ -1,0 +1,2 @@
+type: info
+msg: This is yaml

--- a/apps/dashboard/test/fixtures/config/announcements/announcement_md.md
+++ b/apps/dashboard/test/fixtures/config/announcements/announcement_md.md
@@ -1,0 +1,1 @@
+This is md

--- a/apps/dashboard/test/fixtures/config/announcements/announcement_view.yml
+++ b/apps/dashboard/test/fixtures/config/announcements/announcement_view.yml
@@ -1,0 +1,4 @@
+type: danger
+msg: This is the announcement.
+id: view_id
+dismissible: true

--- a/apps/dashboard/test/fixtures/config/announcements/announcement_yml.yml
+++ b/apps/dashboard/test/fixtures/config/announcements/announcement_yml.yml
@@ -1,0 +1,5 @@
+type: danger
+msg: This is yaml
+id: yml_id
+dismissible: true
+required: true

--- a/apps/dashboard/test/fixtures/file_output/user_settings/announcements.yml
+++ b/apps/dashboard/test/fixtures/file_output/user_settings/announcements.yml
@@ -1,0 +1,3 @@
+---
+announcements:
+  completed_id: '2024-07-11 13:37:03'

--- a/apps/dashboard/test/integration/announcement_views_test.rb
+++ b/apps/dashboard/test/integration/announcement_views_test.rb
@@ -1,17 +1,34 @@
 require 'test_helper'
 
 class AnnouncementViewsTest < ActionDispatch::IntegrationTest
-  test "announcement is displayed if exists" do
-    f = Tempfile.open(["announcement", ".md"])
-    f.write %{Test announcement.}
+  test 'announcement is displayed if exists' do
+    f = Tempfile.open(%w[announcement .md])
+    f.write %(Test announcement.)
     f.close
 
-    stub_user_configuration({announcement_path: [f.path]})
+    stub_user_configuration({ announcement_path: [f.path] })
 
     begin
-      get "/"
+      get '/'
       assert_response :success
-      assert_select "div.announcement", "Test announcement."
+      assert_select 'div.announcement div.announcement-body', 'Test announcement.'
+    ensure
+      stub_user_configuration({})
+    end
+  end
+
+  test 'dismissible announcement have a button to close the announcement' do
+    file = "#{Rails.root}/test/fixtures/config/announcements/announcement_view.yml"
+    stub_user_configuration({ announcement_path: [file] })
+
+    begin
+      get '/'
+      assert_response :success
+      assert_select 'div.announcement div.announcement-body', 'This is the announcement.'
+      assert_select 'div.announcement .announcement-button', I18n.t('dashboard.announcements_dismissible_button')
+      form = css_select('div.announcement .announcement-form')
+      assert_equal 1, form.size
+      assert_equal settings_path(action: 'announcement'), form[0]['action']
     ensure
       stub_user_configuration({})
     end

--- a/apps/dashboard/test/integration/settings_controller_test.rb
+++ b/apps/dashboard/test/integration/settings_controller_test.rb
@@ -20,13 +20,13 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
       data[:settings][:profile] = 'first_profile'
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_profile_updated'), flash[:notice]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
       assert_equal 'first_profile', TestUserSettings.new.user_settings[:profile]
 
       data[:settings][:profile] = 'override_profile'
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_profile_updated'), flash[:notice]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
       assert_equal 'override_profile', TestUserSettings.new.user_settings[:profile]
     end
   end
@@ -39,13 +39,13 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
       data[:settings][:profile] = ''
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_profile_updated'), flash[:notice]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
       assert_equal '', TestUserSettings.new.user_settings[:profile]
 
       data[:settings][:profile] = nil
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_profile_updated'), flash[:notice]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
       assert_nil TestUserSettings.new.user_settings[:profile]
     end
   end
@@ -55,18 +55,19 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
       Configuration.stubs(:user_settings_file).returns("#{temp_data_dir}/settings.yml")
       data = { settings: {} }
 
-      data[:settings][:announcement] = 'announcement_id'
+      value =  Time.now.localtime.strftime('%Y-%m-%d %H:%M:%S')
+      data[:settings] = { announcements: { 'announcement_id' => value } }
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_announcements_updated'), flash[:notice]
-      assert_not_nil TestUserSettings.new.user_settings[:announcements][:announcement_id]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
+      assert_equal value, TestUserSettings.new.user_settings[:announcements][:announcement_id]
 
-      data[:settings][:announcement] = 'other_announcement_id'
+      data[:settings] = { announcements: { 'other_announcement_id' => value } }
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_announcements_updated'), flash[:notice]
-      assert_not_nil TestUserSettings.new.user_settings[:announcements][:announcement_id]
-      assert_not_nil TestUserSettings.new.user_settings[:announcements][:other_announcement_id]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
+      assert_equal value, TestUserSettings.new.user_settings[:announcements][:announcement_id]
+      assert_equal value, TestUserSettings.new.user_settings[:announcements][:other_announcement_id]
     end
   end
 
@@ -77,8 +78,8 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_invalid_request'), flash[:alert]
-      assert_nil TestUserSettings.new.user_settings[:profile]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
+      assert_empty TestUserSettings.new.user_settings
     end
   end
 
@@ -89,8 +90,8 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_invalid_request'), flash[:alert]
-      assert_nil TestUserSettings.new.user_settings[:profile]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
+      assert_empty TestUserSettings.new.user_settings
     end
   end
 
@@ -101,8 +102,8 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
       post settings_path, params: data, headers: @headers
       assert_response :redirect
-      assert_equal I18n.t('dashboard.settings_invalid_request'), flash[:alert]
-      assert_nil TestUserSettings.new.user_settings[:profile]
+      assert_equal I18n.t('dashboard.settings_updated'), flash[:notice]
+      assert_empty TestUserSettings.new.user_settings
     end
   end
 

--- a/apps/dashboard/test/models/announcement_test.rb
+++ b/apps/dashboard/test/models/announcement_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Announcement model basic tests
+class AnnouncementTest < ActiveSupport::TestCase
+
+  test 'default values' do
+    target = Announcement.new({})
+
+    assert_equal(:warning, target.type)
+    assert_nil(target.msg)
+    assert_nil(target.id)
+    assert_equal(false, target.completed?)
+    assert_equal(true, target.dismissible?)
+    assert_equal(false, target.required?)
+  end
+
+  test 'default id for announcement file is msg sha1' do
+    path = Rails.root.join('test/fixtures/config/announcements/announcement_id.yml').to_s
+    target = Announcement.new(path)
+
+    assert_equal('9b4ad10e7b43c149e08c1530db6810c7a6bbea13', target.id)
+  end
+
+  test 'can set values with hash' do
+    target = Announcement.new(
+      { type:        'info',
+        msg:         'This is the message',
+        id:          '12345',
+        dismissible: true,
+        required:    true }
+    )
+
+    assert_equal(:info, target.type)
+    assert_equal('This is the message', target.msg)
+    assert_equal('12345', target.id)
+    assert_equal(false, target.completed?)
+    assert_equal(true, target.dismissible?)
+    assert_equal(true, target.required?)
+  end
+
+  test 'can set values with YAML file' do
+    path = Rails.root.join('test/fixtures/config/announcements/announcement_yml.yml').to_s
+    target = Announcement.new(path)
+
+    assert_equal(:danger, target.type)
+    assert_equal('This is yaml', target.msg)
+    assert_equal('yml_id', target.id)
+    assert_equal(false, target.completed?)
+    assert_equal(true, target.dismissible?)
+    assert_equal(true, target.required?)
+  end
+
+  test 'can set message with MD file' do
+    path = Rails.root.join('test/fixtures/config/announcements/announcement_md.md').to_s
+    target = Announcement.new(path)
+
+    assert_equal(:warning, target.type)
+    assert_equal('This is md', target.msg)
+    assert_equal('77b8dd73d876bb58be9eae133fb8f5c614b95171', target.id)
+    assert_equal(false, target.completed?)
+    assert_equal(true, target.dismissible?)
+    assert_equal(false, target.required?)
+  end
+
+  test 'required announcements are dismissible' do
+    target = Announcement.new({ required: true })
+    assert_equal(true, target.dismissible?)
+    assert_equal(true, target.required?)
+  end
+
+  test 'required takes precedence over dismissible' do
+    target = Announcement.new(
+      { dismissible: false,
+        required:    true }
+    )
+    assert_equal(true, target.dismissible?)
+    assert_equal(true, target.required?)
+  end
+
+  test 'valid? should be false if msg is not present' do
+    target = Announcement.new({id: '12345', dismissible: true, required: true})
+    assert_equal(false, target.valid?)
+  end
+
+  test 'valid? should be true if msg is present' do
+    target = Announcement.new({ msg: 'message value' })
+    assert_equal(true, target.valid?)
+  end
+
+  test 'valid? should be true if required? is true and id and msg are present' do
+    target = Announcement.new({ msg: 'message value', id: '12345', required: true })
+    assert_equal(true, target.valid?)
+  end
+
+  test 'completed? should be true if announcement is dismissible and id is stored in the user settings' do
+    file = "#{Rails.root}/test/fixtures/file_output/user_settings/announcements.yml" if file.blank?
+    Configuration.stubs(:user_settings_file).returns(file)
+    target = Announcement.new({ id: 'completed_id', dismissible: false })
+    assert_equal(false, target.completed?)
+
+    target = Announcement.new({ id: 'completed_id', dismissible: true })
+    assert_equal(true, target.completed?)
+  end
+end


### PR DESCRIPTION
This is a prototype PR and will require more work to complete the implementation.

Adding dismissible and required features to announcements.
 - **Dismissible Announcements:** Will add a button to the announcement. When executed, the system will store that the announcement was completed in the user settings.

 - **Required Announcements:** The same as dismissible, but will block all request to the application and only display an empty homepage with all the announcements until all required announcements have been executed.

Possbile implementation for #3634 