### PR TITLE
Fix slurm walltime

### DIFF
--- a/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
+++ b/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
@@ -117,7 +117,7 @@ module ActiveJobs
       attributes.push Attribute.new "Node List", self.nodes.join(", ") unless self.nodes.blank?
       attributes.push Attribute.new "Total CPUs", info.native[:cpus]
       attributes.push Attribute.new "Time Limit", info.native[:time_limit]
-      attributes.push Attribute.new "Time Used", info.native[:time_used]
+      attributes.push Attribute.new "Time Used", self.walltime_used
       attributes.push Attribute.new "Start Time", safe_parse_time(info.native[:start_time])
       attributes.push Attribute.new "End Time", safe_parse_time(info.native[:end_time])
       attributes.push Attribute.new "Memory", info.native[:min_memory]

--- a/apps/dashboard/app/views/active_jobs/extended_data.json.jbuilder
+++ b/apps/dashboard/app/views/active_jobs/extended_data.json.jbuilder
@@ -1,3 +1,3 @@
-  json.html_extended_panel render partial: 'active_jobs/extended_panel', :locals => {:data => jobstatusdata}
+  json.html_extended_panel render(partial: 'active_jobs/extended_panel', :locals => {:data => jobstatusdata}, :formats => [:html])
   json.status jobstatusdata.status
-  json.html_ganglia_graphs_table render partial: 'active_jobs/ganglia_graphs_table', :locals => {:d => jobstatusdata}
+  json.html_ganglia_graphs_table render(partial: 'active_jobs/ganglia_graphs_table', :locals => {:d => jobstatusdata}, :formats => [:html])


### PR DESCRIPTION
Fix slurm walltime, fixing this issue brought up on discourse: https://discourse.openondemand.org/t/how-to-change-time-used-format/3613/3

Additionally, this specifies the format of the extended panels to fix an error due to the rails 7 upgrade (related to #3489) 