### PR TITLE
Added configurable default number of apps to show in the apps table

### DIFF
--- a/apps/dashboard/app/javascript/apps.js
+++ b/apps/dashboard/app/javascript/apps.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import { configData } from './config.js';
+import { appsDatatablePageLength } from './config.js';
 
 jQuery(function() {
-  const cfgData = configData();
+  const pageLength = appsDatatablePageLength();
   $('#all-apps-table').DataTable({
     stateSave: false,
-    pageLength: cfgData['appsDatatablePageLength']
+    pageLength: pageLength
   });
 });

--- a/apps/dashboard/app/javascript/apps.js
+++ b/apps/dashboard/app/javascript/apps.js
@@ -1,7 +1,11 @@
 'use strict';
 
+import { configData } from './config.js';
+
 jQuery(function() {
+  const cfgData = configData();
   $('#all-apps-table').DataTable({
-    stateSave: true
+    stateSave: false,
+    pageLength: cfgData['appsDatatablePageLength']
   });
 });

--- a/apps/dashboard/app/javascript/config.js
+++ b/apps/dashboard/app/javascript/config.js
@@ -91,5 +91,5 @@ export function statusIndexUrl() {
 
 export function appsDatatablePageLength() {
   const cfgData = configData();
-  return cfgData['appsDatatablePageLength'];
+  return parseInt(cfgData['appsDatatablePageLength']);
 }

--- a/apps/dashboard/app/javascript/config.js
+++ b/apps/dashboard/app/javascript/config.js
@@ -88,3 +88,8 @@ export function statusIndexUrl() {
   const cfgData = configData();
   return cfgData['statusIndexUrl'];
 }
+
+export function appsDatatablePageLength() {
+  const cfgData = configData();
+  return cfgData['appsDatatablePageLength'];
+}

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -80,7 +80,7 @@ class UserConfiguration
     ConfigurationProperty.property(name: :support_ticket, default_value: {}),
 
     # Datatables configuration for the apps pages
-    ConfigurationProperty.property(name: :apps_datatable, default_value: {})
+    ConfigurationProperty.property(name: :apps_datatable, default_value: { page_length: 10 })
   ].freeze
 
   def initialize(request_hostname: nil)

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -77,7 +77,10 @@ class UserConfiguration
     # Custom pages configuration property
     ConfigurationProperty.property(name: :custom_pages, default_value: {}),
     # Support ticket configuration property
-    ConfigurationProperty.property(name: :support_ticket, default_value: {})
+    ConfigurationProperty.property(name: :support_ticket, default_value: {}),
+
+    # Datatables configuration for the apps pages
+    ConfigurationProperty.property(name: :apps_datatable, default_value: {})
   ].freeze
 
   def initialize(request_hostname: nil)

--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -11,4 +11,5 @@
   data-bc-index-url="<%= batch_connect_sessions_path %>"
   data-status-poll-delay="<%= Configuration.status_poll_delay %>"
   data-status-index-url="<%= system_status_path if respond_to?(:system_status_path) %>"
+  data-apps-datatable-page-length="<%= @user_configuration.apps_datatable[:page_length] %>"
 ></div>

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -79,6 +79,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       interactive_apps_menu: [],
       custom_pages: {},
       support_ticket: {},
+      apps_datatable: {},
     }
 
     # ensure all properties are tested

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -79,7 +79,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       interactive_apps_menu: [],
       custom_pages: {},
       support_ticket: {},
-      apps_datatable: {},
+      apps_datatable: { page_length: 10 },
     }
 
     # ensure all properties are tested


### PR DESCRIPTION
Added configuration for the default number of items for the `Datable` object used in the apps index page table.

This config can be extended to configure more `Datatable` options.

Fixes #3637 

### Sample Config

```yaml
    apps_datatable:
      page_length: 4
```