### PR TITLE
Added 404 JSON reponse to projects.show method

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -8,7 +8,11 @@ class ProjectsController < ApplicationController
     project_id = show_project_params[:id]
     @project = Project.find(project_id)
     if @project.nil?
-      redirect_to(projects_path, alert: I18n.t('dashboard.jobs_project_not_found', project_id: project_id))
+      respond_to do |format|
+        message = I18n.t('dashboard.jobs_project_not_found', project_id: project_id)
+        format.html { redirect_to(projects_path, alert: message) }
+        format.json { render json: { message: message }, status: :not_found }
+      end
     else
       @scripts = Launcher.all(@project.directory)
       @valid_project = Launcher.clusters?


### PR DESCRIPTION
I saw that the GitHub actions tests are sometimes failing due to the `ProjectsController` test.

This seems to the related to the Ajax call to get the project size made by the page after the project has been deleted.
This seems to be a race condition in the test and directory cleanup.

This fix will return a JSON 404 when the project is not available avoiding the redirect and the error due to the missing JSON response for the index page.