### PR TITLE
exclude vim swp files from rsync

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -278,7 +278,7 @@ module BatchConnect
       staged_root.tap { |p| FileUtils.mkdir_p(p.to_s, mode: 0o0700) unless p.exist? }
 
       # Sync the template files over
-      oe, s = Open3.capture2e('rsync', '-rlpv', '--exclude', '*.erb', "#{root}/", staged_root.to_s)
+      oe, s = Open3.capture2e('rsync', '-rlpv', '--exclude', '.*.swp', '--exclude', '*.erb', "#{root}/", staged_root.to_s)
       raise oe unless s.success?
 
       # Output user submitted context attributes for debugging purposes


### PR DESCRIPTION
vim swp files can be unreadable to users, especially if editing when opened with vim -R as root. This causes the rsync to
fail and job submission to be blocked. Excluding .*.swp files fixes that issue.