### PR TITLE
just supply zipname and have rails format it

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -52,7 +52,7 @@ class FilesController < ApplicationController
                                         end
 
           if can_download
-            zipname = "#{@path.basename.to_s.gsub('"', '\"')}.zip"
+            zipname = "#{@path.basename}.zip"
             response.set_header 'Content-Disposition', "attachment; filename=\"#{zipname}\""
             response.set_header 'Content-Type', 'application/zip'
             response.set_header 'Last-Modified', Time.now.httpdate

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -53,8 +53,6 @@ class FilesController < ApplicationController
 
           if can_download
             zipname = "#{@path.basename}.zip"
-            response.set_header 'Content-Disposition', "attachment; filename=\"#{zipname}\""
-            response.set_header 'Content-Type', 'application/zip'
             response.set_header 'Last-Modified', Time.now.httpdate
             response.sending_file = true
             response.cache_control[:public] ||= false
@@ -62,7 +60,7 @@ class FilesController < ApplicationController
             zip_headers = ZipKit::OutputEnumerator.new.streaming_http_headers
             response.headers.merge!(zip_headers)
 
-            send_stream(filename: zipname) do |stream|
+            send_stream(filename: zipname, disposition: 'attachment', type: :zip) do |stream|
               ZipKit::Streamer.open(stream) do |zip|
                 @path.files_to_zip.each do |file|
                   next unless File.readable?(file.realpath)


### PR DESCRIPTION
CodeQl is complaining about this line not escaping backslashes (though it's not supposed to? it's escaping `"`s.) 

Upon investigation, it turns out Rails formats this for us and has a whole class for ContentDispositon header.

https://github.com/rails/rails/blob/bfd3cfdbfc38b25e53e5fe85f1c77a61c9c600b7/actionpack/lib/action_controller/metal/live.rb#L357

So I figure, let's remove the `gsub` call and let Rails do it's thing.  I could be convinced to duplicate what Rails does just to be sure, but it seems extraneous. 