### PR TITLE
More job details in pm

### DIFF
--- a/apps/dashboard/app/helpers/active_jobs_helper.rb
+++ b/apps/dashboard/app/helpers/active_jobs_helper.rb
@@ -61,27 +61,7 @@ module ActiveJobsHelper
   end
 
   def status_label(status)
-    case status
-    when "completed"
-      label = "Completed"
-      labelclass = "bg-success"
-    when "running"
-      label = "Running"
-      labelclass = "bg-primary"
-    when "queued"
-      label = "Queued"
-      labelclass = "bg-info"
-    when "queued_held"
-      label = "Hold"
-      labelclass = "bg-warning"
-    when "suspended"
-      label = "Suspend"
-      labelclass = "bg-warning"
-    else
-      label = "Undetermined"
-      labelclass = "bg-secondary"
-    end
-    "<span class='badge #{labelclass}'>#{label}</span>".html_safe
+    "<span class='badge #{status_class(status)}'>#{status_text(status)}</span>".html_safe
   end
 
   def filters

--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -110,4 +110,40 @@ module ApplicationHelper
       { src: File.join(@user_configuration.public_url, js_file_src), type: js_file_type }
     end.compact
   end
+
+  # Assigns text corresponding to a job status
+  def status_text(status)
+    case status
+    when 'completed'
+      'Completed'
+    when 'running'
+      'Running'
+    when 'queued'
+      'Queued'
+    when 'qued_held'
+      'Hold'
+    when 'suspended'
+      'Suspend'
+    else
+      'Undetermined'
+    end
+  end
+
+  # Assigns a bootstrap class corresponding to the status of a job
+  def status_class(status)
+    case status
+    when 'completed'
+      'bg-success'
+    when 'running'
+      'bg-primary'
+    when 'queued'
+      'bg-info'
+    when 'queued_held'
+      'bg-warning'
+    when 'suspended'
+      'bg-warning'
+    else
+      'bg-secondary'
+    end
+  end
 end

--- a/apps/dashboard/app/views/projects/_job_details.turbo_stream.erb
+++ b/apps/dashboard/app/views/projects/_job_details.turbo_stream.erb
@@ -5,8 +5,10 @@
 
 <turbo-stream action="replace" target="<%= id %>">
   <template>
-    <div>
-      <%= job.id %> is currently <%= job.status.to_s %>.
-    </div>
+    <button class="badge bg-primary rounded-pill border-0 btn">
+      <span>
+        <%= job.id %> <%= job.status.to_s %>
+      </span>
+    </button>
     </template>
 </turbo-stream>

--- a/apps/dashboard/app/views/projects/_job_details.turbo_stream.erb
+++ b/apps/dashboard/app/views/projects/_job_details.turbo_stream.erb
@@ -1,14 +1,30 @@
 
 <%- 
   id = "job_#{job.cluster}_#{job.id}"
+  data = {
+    :cluster => job.cluster,
+    :gpus => job.gpus
+  }
 -%>
 
 <turbo-stream action="replace" target="<%= id %>">
   <template>
-    <button class="badge bg-primary rounded-pill border-0 btn">
+    <button class="badge <%= status_class(job.status.to_s) %> rounded-pill border-0 btn" type="button" data-bs-toggle="collapse" data-bs-target="#<%= id %>Data">
       <span>
-        <%= job.id %> <%= job.status.to_s %>
+        <%= job.id %> <%= status_text(job.status.to_s) %>
       </span>
     </button>
+    <div class="collapse" id="<%= id %>Data">
+      <div class="card card-body col-md-4">
+        <table>
+          <% data.each do |k, v| %>
+            <tr>
+              <td><%= k %></td>
+              <td><%= v %></td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
     </template>
 </turbo-stream>


### PR DESCRIPTION
Work on #3686 

Renders each job as a clickable pill that expands to reveal job information.

This will need to be updated to refine the format of the data, provide more information, and prevent expanded cards from disappearing every time that the turbo stream updates