### PR TITLE
PM job state management

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -103,7 +103,7 @@ class ProjectsController < ApplicationController
 
   # GET /projects/:project_id/jobs/:cluster/:jobid
   def job_details
-    project = Project.find(params[:project_id])
+    project = Project.find(job_details_params[:project_id])
     cluster_str = job_details_params[:cluster].to_s
     cluster = OodAppkit.clusters[cluster_str.to_sym]
     render(:status => 404) if cluster.nil?

--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -103,12 +103,13 @@ class ProjectsController < ApplicationController
 
   # GET /projects/:project_id/jobs/:cluster/:jobid
   def job_details
+    project = Project.find(params[:project_id])
     cluster_str = job_details_params[:cluster].to_s
     cluster = OodAppkit.clusters[cluster_str.to_sym]
     render(:status => 404) if cluster.nil?
 
-    job_info = cluster.job_adapter.info(job_details_params[:jobid].to_s)
-    hpc_job = HpcJob.from_core_info(info: job_info, cluster: cluster_str)
+    hpc_job = project.job_from_id(job_details_params[:jobid].to_s, cluster_str)
+
     render(partial: 'job_details', locals: { job: hpc_job })
   end
 

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -203,6 +203,14 @@ class Project
     end.flatten
   end
 
+  def job_from_id(job_id, cluster)
+    launchers = Launcher.all(directory)
+    launchers.each do |launcher|
+      job = launcher.job_from_id(job_id, cluster)
+      return job unless job.nil?
+    end
+  end
+
   def readme_path
     file = Dir.glob("#{directory}/README.{md,txt}").first.to_s
     File.readable?(file) ? file : nil


### PR DESCRIPTION
Fixes #3685 

Updates the job log whenever a job is queried from the adapter, and does not query when the job is logged as being completed.