### PR TITLE
dynamic bc also respond to hide: false

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -467,7 +467,7 @@ function updateVisibility(event, changeId) {
 
   // safe to access directly?
   const hide = hideLookup[id].get(changeId, val);
-  if(hide === undefined && !initializing) {
+  if((hide === false) || (hide === undefined && !initializing)) {
     changeElement.show();
   }else if(hide === true) {
     changeElement.hide();


### PR DESCRIPTION
dynamic bc also respond to hide: false.

I tried recently to use `data-hide-something: false` and it didn't work which is a bit annoying. Leaving it undefined (i.e., not there at all) is the current workaround, but it seems like it should also respond to `false` if it can.