### PR TITLE
convert data to human sizes on the client

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -176,6 +176,17 @@ class DataTable {
         return this._table;
     }
 
+    sizeUnits = ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+    toHumanSize(number) {
+      if(number === null) {
+        return '-';
+      } else {
+        const unitIndex = number == 0 ? 0 : Math.floor(Math.log(number) / Math.log(1000));
+        return `${((number / Math.pow(1000, unitIndex)).toFixed(2))} ${['B', 'kB', 'MB', 'GB', 'TB', 'PB'][unitIndex]}`;
+      }
+    }
+
     loadDataTable() {
         this._table = $(CONTENTID).on('xhr.dt', function (e, settings, json, xhr) {
             // new ajax request for new data so update date/time
@@ -219,7 +230,7 @@ class DataTable {
                 {
                     data: 'size',
                     render: (data, type, row, meta) => {
-                        return type == "display" ? row.human_size : data;
+                        return type == "display" ? this.toHumanSize(row.size) : data;
                     }
                 }, // human_size
                 {

--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -176,8 +176,6 @@ class DataTable {
         return this._table;
     }
 
-    sizeUnits = ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-
     toHumanSize(number) {
       if(number === null) {
         return '-';

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -56,7 +56,6 @@ class PosixFile
       id:           "dev-#{stat.dev}-inode-#{stat.ino}",
       name:         basename,
       size:         directory? ? nil : stat.size,
-      human_size:   human_size,
       directory:    directory?,
       date:         stat.mtime.to_i,
       owner:        PosixFile.username_from_cache(stat.uid),

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -34,7 +34,6 @@ class RemoteFile
         id:           file['Path'],
         name:         file['Name'],
         size:         file['IsDir'] ? nil : file['Size'],
-        human_size:   human_size(file),
         directory:    file['IsDir'],
         date:         DateTime.parse(file['ModTime']).to_time.to_i,
         owner:        '',
@@ -47,14 +46,6 @@ class RemoteFile
       Rails.logger.warn("Not showing file '#{stats[:name]}' because it is not a UTF-8 filename.") unless valid_encoding
       valid_encoding
     end.sort_by { |p| p[:directory] ? 0 : 1 }
-  end
-
-  def human_size(file)
-    if file['IsDir']
-      '-'
-    else
-      ::ApplicationController.helpers.number_to_human_size(file['Size'], precision: 3)
-    end
   end
 
   def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)


### PR DESCRIPTION
Convert data to human sizes on the client.

This is an optimiztation found in #3026. I found that rails takes some time to do this calculation, so we can push it to the client instead in an attempt to speed up the responses.