### PR TITLE
find chrome version and automatically dl the right driver

### DIFF
--- a/lib/tasks/test.rb
+++ b/lib/tasks/test.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'net/http'
+require 'json'
+
 desc 'Test OnDemand'
 task :test => 'test:all'
 
@@ -60,31 +63,62 @@ namespace :test do
     require 'rspec/core/rake_task'
     RSpec::Core::RakeTask.new(:e2e) do |task|
       ENV['BEAKER_setdir'] = PROJ_DIR.join('spec', 'e2e', 'nodesets').to_s
-      ENV['PATH'] = PROJ_DIR.join('tests').to_s + ":#{ENV['PATH']}"
+      ENV['PATH'] = PROJ_DIR.join("tests/chromedriver-#{platform}").to_s + ":#{ENV['PATH']}"
       task.pattern = "#{PROJ_DIR.join('spec', 'e2e')}/*_spec.rb"
       task.rspec_opts = ['--format documentation']
     end
   rescue LoadError
   end
 
+  def chrome_version
+    `google-chrome --version`.split.last
+  end
+
+  def chrome_dl_data(version)
+    json_uri = URI('https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json')
+    data = Net::HTTP.get(json_uri)
+    json = JSON.parse(data)
+    maj_version = version.split('.').first
+
+    json['versions'].select do |driver_data|
+      driver_major_version = driver_data['version'].split('.').first
+      driver_major_version == maj_version
+    end.last
+  end
+
+  def chrome_dl_url(dl_data)
+    drivers = dl_data['downloads']['chromedriver']
+    driver = drivers.select { |d| d['platform'] == platform }.first
+    driver['url']
+  end
+
+  def platform
+    @platform ||= begin
+      uname = `uname -s`
+      case uname.chomp
+      when 'Darwin'
+        if `uname -m`.chomp == 'arm64'
+          'mac-arm64'
+        else
+          'mac-x64'
+        end
+      when 'Linux'
+        'linux64'
+      end
+    end
+  end
+
   desc 'Get chromedriver'
   task :chromedriver, [:version] do |_t, args|
-    version = args[:version] || '87.0.4280.88'
-    uname = `uname -s`
-    case uname.chomp
-    when 'Darwin'
-      file = if `uname -m`.chomp == 'arm64'
-               'chromedriver_mac_arm64.zip'
-             else
-               'chromedriver_mac64.zip'
-             end
-    when 'Linux'
-      file = 'chromedriver_linux64.zip'
-    end
-    url = "https://chromedriver.storage.googleapis.com/#{version}/#{file}"
-    sh "curl -o tests/#{file} #{url}"
+    version = args[:version] || chrome_version
+    puts "Fetching chromedriver #{version}"
+
+    data = chrome_dl_data(version)
+    url = chrome_dl_url(data)
+
+    sh "curl -o tests/chromedriver.zip #{url}"
     chdir PROJ_DIR.join('tests') do
-      sh "unzip -o #{file}"
+      sh 'unzip -o chromedriver.zip'
     end
   end
 


### PR DESCRIPTION
Fixes #3071 by finding the appropriate version of chromedriver and downloading it without folks having to search the json endpoints and download manually.