### PR TITLE
account for /dex (dex_uri) when enabling maintenance mode

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -53,6 +53,7 @@
   RewriteCond /var/www/ood/public/maintenance/index.html -f
   RewriteCond /etc/ood/maintenance.enable -f
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
+  RewriteCond %{REQUEST_URI} !/dex.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=302,L]
 
   TraceEnable off

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -67,6 +67,7 @@
   RewriteCond /var/www/ood/public/maintenance/index.html -f
   RewriteCond /etc/ood/maintenance.enable -f
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
+  RewriteCond %{REQUEST_URI} !/dex.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=302,L]
 
   TraceEnable off

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -67,6 +67,7 @@
   RewriteCond /var/www/ood/public/maintenance/index.html -f
   RewriteCond /etc/ood/maintenance.enable -f
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
+  RewriteCond %{REQUEST_URI} !/dex.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=302,L]
 
   TraceEnable off

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -67,6 +67,7 @@
   RewriteCond /var/www/ood/public/maintenance/index.html -f
   RewriteCond /etc/ood/maintenance.enable -f
   RewriteCond %{REQUEST_URI} !/public/maintenance/.*$
+  RewriteCond %{REQUEST_URI} !/dex.*$
   RewriteRule ^.*$ /public/maintenance/index.html [R=302,L]
 
   TraceEnable off

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -101,6 +101,9 @@ Listen <%= addr_port %>
   RewriteCond <%= @public_root %>/maintenance/index.html -f
   RewriteCond /etc/ood/maintenance.enable -f
   RewriteCond %{REQUEST_URI} !<%= @public_uri %>/maintenance/.*$
+  <%- if @dex_uri && @dex_enabled -%>
+  RewriteCond %{REQUEST_URI} !<%= @dex_uri %>.*$
+  <%- end -%>
   <%- @maintenance_ip_allowlist.each do |ip| -%>
   RewriteCond %{REMOTE_ADDR} !^<%= escape_ip(ip) %>
   <%- end -%>


### PR DESCRIPTION
Fixes #3673 by accounting for `/dex` (`dex_uri`) when enabling maintenance mode.