### PR TITLE
Fix large remote file uploads

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -151,9 +151,16 @@ class FilesController < ApplicationController
     parse_path(upload_path)
     validate_path!
 
-    @path.handle_upload(params[:file].tempfile)
+    # Need to remove the tempfile from list of Rack tempfiles to prevent it
+    # being cleaned up once request completes since Rclone uses the files.
+    request.env[Rack::RACK_TEMPFILES].reject! { |f| f.path == params[:file].tempfile.path } unless posix_file?
 
-    render json: {}
+    @transfer = @path.handle_upload(params[:file].tempfile)
+    if @transfer
+      render "transfers/show"
+    else
+      render json: {}
+    end
   rescue AllowlistPolicy::Forbidden => e
     render json: { error_message: e.message }, status: :forbidden
   rescue Errno::EACCES => e

--- a/apps/dashboard/app/javascript/files/file_ops.js
+++ b/apps/dashboard/app/javascript/files/file_ops.js
@@ -27,6 +27,7 @@ const EVENTNAME = {
 
 
 let fileOps = null;
+export {fileOps};
 
 jQuery(function() {
   fileOps = new FileOps();  

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -5,6 +5,7 @@ import XHRUpload from '@uppy/xhr-upload'
 import _ from 'lodash';
 import {CONTENTID, EVENTNAME as DATATABLE_EVENTNAME} from './data_table.js';
 import { maxFileSize, csrfToken, uppyLocale } from '../config.js';
+import { fileOps } from './file_ops.js';
 
 let uppy = null;
 
@@ -113,6 +114,7 @@ jQuery(function() {
 
   uppy.on('complete', (result) => {
     if(result.successful.length > 0){
+      result.successful.forEach(handleUploadSuccess);
       reloadTable();
     }
   });
@@ -190,5 +192,17 @@ function updateEndpoint() {
 
 function reloadTable() {
   $(CONTENTID).trigger(DATATABLE_EVENTNAME.reloadTable,{});
+}
+
+// Uploads may return the status of a transfer for remote uploads.
+function handleUploadSuccess(result) {
+  // These extra checks might not be needed.
+  const body = result?.response?.body;
+  if (!body || !(typeof body === "object" && !Array.isArray(body) && body !== null)) {
+    return;
+  }
+  if (Object.keys(body).length > 0 && !body.completed) {
+    fileOps.reportTransfer(body);
+  }
 }
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -77,8 +77,15 @@ class RemoteFile
   end
 
   def handle_upload(tempfile)
-    # FIXME: upload to the remote asynchronously
-    RcloneUtil.moveto(remote, path, tempfile.path)
+    # Start a transfer that moves the Rack tempfile to the remote.
+    transfer = RemoteTransfer.build(
+      action: "mv",
+      files: { tempfile.path => path.to_s },
+      src_remote: RcloneUtil::LOCAL_FS_NAME,
+      dest_remote: remote,
+      tempfile: tempfile
+    )
+    transfer.tap(&:perform_later)
   end
 
   def mime_type

--- a/apps/dashboard/app/models/remote_transfer.rb
+++ b/apps/dashboard/app/models/remote_transfer.rb
@@ -132,6 +132,7 @@ class RemoteTransfer < Transfer
     errors.add :base, e.message
   ensure
     self.status = OodCore::Job::Status.new(state: :completed)
+    tempfile&.close(true)
   end
 
   def from

--- a/apps/dashboard/app/models/remote_transfer.rb
+++ b/apps/dashboard/app/models/remote_transfer.rb
@@ -43,7 +43,7 @@ class RemoteTransfer < Transfer
     end
   end
 
-  attr_accessor :src_remote, :dest_remote, :filesizes, :transferred
+  attr_accessor :src_remote, :dest_remote, :tempfile, :filesizes, :transferred
 
   class << self
     def transfers
@@ -51,7 +51,7 @@ class RemoteTransfer < Transfer
       Transfer.transfers
     end
 
-    def build(action:, files:, src_remote:, dest_remote:)
+    def build(action:, files:, src_remote:, dest_remote:, tempfile: nil)
       if files.is_a?(Array)
         # rm action will want to provide an array of files
         # so if it is an Array we convert it to a hash:
@@ -59,8 +59,7 @@ class RemoteTransfer < Transfer
         # convert [a1, a2, a3] to {a1 => nil, a2 => nil, a3 => nil}
         files = Hash[files.map { |f| [f, nil] }].with_indifferent_access
       end
-
-      self.new(action: action, files: files, src_remote: src_remote, dest_remote: dest_remote)
+      self.new(action: action, files: files, src_remote: src_remote, dest_remote: dest_remote, tempfile: tempfile)
     end
   end
 


### PR DESCRIPTION
Uploading large files to remote filesystems has had problems for a long time (#2250), so I spent some time trying to find a solution and this was the result. I attempted to find some alternative solutions as Jeff commented on that issue, but was not able to find any.

This PR fixes #2250 by making the actual upload from the Rails temporary file to the remote filesystem happen in an Active Job instead of during the 60 second period (Apache `ProxyTimeout`) before Apache will return an error to the browser.

I was able to reuse most of the existing code for file transfers. The back end for uploads now sends a JSON response with a transfer if one was created, i.e. a transfer from `/tmp/RackMultipart...` to `s3remote:/mybucket/myobject`. The front end then queries the status of that transfer.
