### PR TITLE
refactor how jobs are logged in the project manager

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -108,7 +108,7 @@ class ProjectsController < ApplicationController
     cluster = OodAppkit.clusters[cluster_str.to_sym]
     render(:status => 404) if cluster.nil?
 
-    hpc_job = project.job_from_id(job_details_params[:jobid].to_s, cluster_str)
+    hpc_job = project.job(job_details_params[:jobid].to_s, cluster_str)
 
     render(partial: 'job_details', locals: { job: hpc_job })
   end

--- a/apps/dashboard/app/models/concerns/job_logger.rb
+++ b/apps/dashboard/app/models/concerns/job_logger.rb
@@ -1,0 +1,48 @@
+
+module JobLogger
+
+  def upsert_job!(directory, job)
+    existing_jobs = jobs(directory)
+    stored_job = existing_jobs.detect { |j| j.id == job.id && j.cluster == job.cluster }
+
+    if stored_job.nil?
+      new_jobs = (existing_jobs + [job.to_h]).map(&:to_h)
+    else
+      new_jobs = existing_jobs.map(&:to_h)
+      idx = existing_jobs.index(stored_job)
+      new_jobs[idx].merge!(job.to_h) { |_key, old_val, new_val| new_val.nil? ? old_val : new_val }
+    end
+
+    JobLoggerHelper.write_log(directory, new_jobs)
+  end
+
+  # def write_job_log!(directory, jobs)
+  #   JobLoggerHelper.write_log!(directory, jobs)
+  # endd
+
+  def jobs(directory)
+    file = JobLoggerHelper.log_file(directory)
+    begin
+      data = YAML.safe_load(File.read(file.to_s), permitted_classes: [Time]).to_a
+      data.map { |job_data| HpcJob.new(**job_data) }
+    rescue StandardError => e
+      Rails.logger.error("Cannot read job log file '#{file}' due to error: #{e}")
+      []
+    end
+  end
+
+  # helper methods here are located here so that they don't
+  # bleed into the class that uses this module
+  class JobLoggerHelper
+    class << self
+      def log_file(directory)
+        Pathname.new("#{directory}/.ondemand/job_log.yml")
+      end
+
+      def write_log(directory, jobs)
+        file = log_file(directory)
+        File.write(file.to_s, jobs.to_yaml)
+      end
+    end
+  end
+end


### PR DESCRIPTION
refactor how jobs are logged in the project manager

Fixes #3707 by adding a module to take care of updating these log files. Of course this moves the log file location so it breaks current jobs which is fine because this is still beta.