### PR TITLE
small fixups for job details panel

### DIFF
--- a/apps/dashboard/app/javascript/projects.js
+++ b/apps/dashboard/app/javascript/projects.js
@@ -31,7 +31,25 @@ function pollForJobInfo(element) {
   fetch(url, { headers: { Accept: "text/vnd.turbo-stream.html" } })
     .then(response => response.ok ? Promise.resolve(response) : Promise.reject(response.text()))
     .then((r) => r.text())
-    .then((html) => replaceHTML(element.id, html))
+    .then((html) => {
+      // if the job panel is currently open by the user, make the new
+      // html open as well.
+      const currentData = element.querySelector(`#${element.id}_data`);
+      let currentlyOpen = false;
+
+      if(currentData != null) {
+        currentlyOpen = currentData.classList.contains('show');
+      }
+
+      if(currentlyOpen) {
+        const responseElement = new DOMParser().parseFromString(html, "text/xml");
+        const dataDiv = responseElement.querySelector(`#${element.id}_data`);
+        dataDiv.classList.add('show');
+        html = (new XMLSerializer()).serializeToString(responseElement);
+      }
+
+      replaceHTML(element.id, html)
+    })
     .then(setTimeout(pollForJobInfo, 30000, element))
     .catch((err) => {
       console.log('Cannot not retrive job details due to error:');

--- a/apps/dashboard/app/models/hpc_job.rb
+++ b/apps/dashboard/app/models/hpc_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HpcJob < OodCore::Job::Info
+  include ActionView::Helpers::DateHelper
+
   attr_reader :cluster
 
   COMPLETED = 'completed'
@@ -28,6 +30,18 @@ class HpcJob < OodCore::Job::Info
   end
 
   def to_human_display
-    to_h.transform_keys { |k| k.humanize }.compact_blank
+    to_h.reject do |key, _value|
+      key == 'native'
+    end.map do |key, value|
+      if ['wallclock_time', 'wallclock_limit'].include?(key)
+        [key, fix_time(value)]
+      else
+        [key, value]
+      end
+    end.to_h.transform_keys(&:humanize).compact_blank
+  end
+
+  def fix_time(time)
+    distance_of_time_in_words(time, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
   end
 end

--- a/apps/dashboard/app/views/projects/_job_details.turbo_stream.erb
+++ b/apps/dashboard/app/views/projects/_job_details.turbo_stream.erb
@@ -10,7 +10,7 @@
         <%= job.id %> <%= status_text(job.status.to_s) %>
       </span>
     </button>
-    <div class="collapse" id="<%= id %>_data">
+    <div class="collapse col-md-4" id="<%= id %>_data">
       <div class="card card-body">
         <table class="table table-bordered table-sm m-0 mb-2">
           <% job.to_human_display.each do |name, value| %>


### PR DESCRIPTION
small fixups for job details panel. 

* The panel now stays open if it's being updated (it currently closes if it's open then updated)
* removes native from the details panel
* Fixes time displays to be a nice human readable format.

![image](https://github.com/user-attachments/assets/68ea1828-1b08-4212-9269-bffd7da6cece)
