### PR TITLE
allow auto_job_name to be fixed

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -13,7 +13,7 @@ class LaunchersController < ApplicationController
     :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
     :bc_num_slots, :bc_num_slots_fixed, :bc_num_slots_min, :bc_num_slots_max,
     :bc_num_hours, :bc_num_hours_fixed, :bc_num_hours_min, :bc_num_hours_max,
-    :auto_job_name
+    :auto_job_name, :auto_job_name_fixed
   ].freeze
 
   def new

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_job_name.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_job_name.rb
@@ -2,7 +2,6 @@
 
 module SmartAttributes
   class AttributeFactory
-
     # Build this attribute object. Must specify a valid directory in opts
     #
     # @param opts [Hash] attribute's options
@@ -18,8 +17,7 @@ module SmartAttributes
       # Defaults to ondemand/[dev,sys]/projects
       # @return [String] attribute value
       def value
-        env = Rails.env.production? ? 'sys' : 'dev'
-        opts[:value] || "ondemand/#{env}/projects"
+        job_name(opts[:value] || 'Project Manager Job')
       end
 
       def widget
@@ -35,6 +33,15 @@ module SmartAttributes
       # @return [Hash] submission hash
       def submit(*)
         { script: { job_name: value } }
+      end
+
+      def job_name(name)
+        [
+          ENV['OOD_PORTAL'], # the OOD portal id
+          ENV['RAILS_RELATIVE_URL_ROOT'].to_s.sub(%r{^/[^/]+/}, ''), # the OOD app
+          'project-manager',
+          name # the user supplied job name
+        ].reject(&:blank?).join('/')
       end
     end
   end

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_job_name.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_job_name.rb
@@ -35,6 +35,7 @@ module SmartAttributes
         { script: { job_name: value } }
       end
 
+      # TODO: need to sanitize the job name for some schedulers
       def job_name(name)
         [
           ENV['OOD_PORTAL'], # the OOD portal id

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -429,7 +429,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       Open3
         .stubs(:capture3)
-        .with({}, 'sbatch', '-J', 'my cool job name', '-A', 'pas2051', '--export',
+        .with({}, 'sbatch', '-J', 'project-manager/my cool job name', '-A', 'pas2051', '--export',
                   'NONE', '--parsable', '-M', 'owens',
               stdin_data: "hostname\n")
         .returns(['job-id-123', '', exit_success])


### PR DESCRIPTION
Fixes #3749 by allowing fixed to be set. It also tweaks the actual job name to be a little more compliant with the other apps.