### PR TITLE
account for more than just \w for usernames

### DIFF
--- a/ood_auth_map/lib/ood_auth_map/helpers.rb
+++ b/ood_auth_map/lib/ood_auth_map/helpers.rb
@@ -9,7 +9,7 @@ class OodAuthMap
       # @param auth_user [String] authenticated username
       # @return [String, nil] mapped user name or {nil} if no match
       def parse_mapfile(file, auth_user)
-        parse_file(file, %r[^"#{Regexp.quote auth_user}" (\w+)$])
+        parse_file(file, %r[^"#{Regexp.quote auth_user}" ([\w.-@]+)$])
       end
 
       # Parse a file using a given regular expression pattern and output the

--- a/ood_auth_map/lib/ood_auth_map/helpers.rb
+++ b/ood_auth_map/lib/ood_auth_map/helpers.rb
@@ -9,7 +9,7 @@ class OodAuthMap
       # @param auth_user [String] authenticated username
       # @return [String, nil] mapped user name or {nil} if no match
       def parse_mapfile(file, auth_user)
-        parse_file(file, %r[^"#{Regexp.quote auth_user}" ([\w.-@]+)$])
+        parse_file(file, %r[^"#{Regexp.quote auth_user}" ([\w\.-@]+)$])
       end
 
       # Parse a file using a given regular expression pattern and output the


### PR DESCRIPTION
From discourse: 
https://discourse.openondemand.org/t/user-mapping-doesnt-work-for-ad-users-with-accounts-in-etc-passwd/3714/4

Looks like we have to account for more in this regex. Specifically `@`s and `.`s.