### PR TITLE
update the update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,8 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["2.7.1"]
-        bundler: ["2.1.4"]
+        ruby: ["3"]
     runs-on: ${{ matrix.os }}
     name: Update Dependencies
 
@@ -21,11 +20,10 @@ jobs:
       - name: Checkout ${{ github.sha	}}
         uses: actions/checkout@v3
 
-      - name: Setup Ruby ${{ matrix.ruby }} using Bundler ${{ matrix.bundler }}
+      - name: Setup Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: ${{ matrix.bundler }}
 
       - name: Cache dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
This workflow is broken right now trying to update the ffi gem for some reason.

This updates the ruby version to 3 which is more inline with the ruby version on most systems. It also removes the specific version of bundler just because I don't think it needs to be set and the most recent version should work fine.

I should also note that I can't replicate the issue locally. And I'm guessing it's because of the bundler version is smart enough to lock ffi from ood_core.