### PR TITLE
Add support for interactive app form descriptions

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -133,6 +133,10 @@ module BatchConnect
       ood_app.metadata.merge(form_config.fetch(:metadata, {}))
     end
 
+    def form_header
+      form_config.fetch(:form_header, '')
+    end
+
     def ssh_allow?
       form_config[:ssh_allow]
     end

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -1,4 +1,6 @@
 
+<%= OodAppkit.markdown.render(@app.form_header).html_safe %>
+
 <%= render "prefill_templates" if Configuration.bc_saved_settings? %>
 
 <%= bootstrap_form_for(@session_context, html: { autocomplete: "off" }) do |f| %>

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -1,5 +1,5 @@
 
-<%= OodAppkit.markdown.render(@app.form_header).html_safe %>
+<%= sanitize OodAppkit.markdown.render(@app.form_header) %>
 
 <%= render "prefill_templates" if Configuration.bc_saved_settings? %>
 

--- a/apps/dashboard/test/fixtures/apps/bc_with_subapps/form.yml
+++ b/apps/dashboard/test/fixtures/apps/bc_with_subapps/form.yml
@@ -1,5 +1,6 @@
 ---
 description: BC with sub apps description
+form_header: BC with sub apps form header
 
 attributes:
   desktop: "mate"

--- a/apps/dashboard/test/fixtures/apps/bc_with_subapps/local/owens.yml
+++ b/apps/dashboard/test/fixtures/apps/bc_with_subapps/local/owens.yml
@@ -1,6 +1,7 @@
 ---
 title: "Owens Desktop"
 description: "Owens Description"
+form_header: "Owens Form Header"
 icon: fa://clock
 caption: 'gnome desktop on the owens cluster'
 category: Interactive Apps Overridden

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -6,9 +6,9 @@ cluster:
 description: |
   This is a test jupyter app.
 form_header: |
-  <div id="form_header_supports_html">
+  <span class="form_header_supports_some_html">
     This is Markdown with [a link](https://openondemand.org).
-  <div>
+  </span>
 attributes:
   mode:
     widget: "radio"

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -5,6 +5,10 @@ cluster:
   - "oakley"
 description: |
   This is a test jupyter app.
+form_header: |
+  <div id="form_header_supports_html">
+    This is Markdown with [a link](https://openondemand.org).
+  <div>
 attributes:
   mode:
     widget: "radio"

--- a/apps/dashboard/test/integration/batch_connect_test.rb
+++ b/apps/dashboard/test/integration/batch_connect_test.rb
@@ -109,4 +109,11 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
       assert_equal 'edit_name', css_select('input[name="template_name"]').first['value']
     end
   end
+
+  test 'form header is rendered correctly' do
+    get new_batch_connect_session_context_url('sys/bc_jupyter')
+    header_link = css_select('div[id="form_header_supports_html"]>a').first
+    assert_equal 'a link', header_link.text
+    assert_equal 'https://openondemand.org', header_link['href']
+  end
 end

--- a/apps/dashboard/test/integration/batch_connect_test.rb
+++ b/apps/dashboard/test/integration/batch_connect_test.rb
@@ -112,7 +112,7 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
 
   test 'form header is rendered correctly' do
     get new_batch_connect_session_context_url('sys/bc_jupyter')
-    header_link = css_select('div[id="form_header_supports_html"]>a').first
+    header_link = css_select('span.form_header_supports_some_html>a').first
     assert_equal 'a link', header_link.text
     assert_equal 'https://openondemand.org', header_link['href']
   end

--- a/apps/dashboard/test/models/batch_connect/app_test.rb
+++ b/apps/dashboard/test/models/batch_connect/app_test.rb
@@ -295,7 +295,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     end
   end
 
-  test 'subapps can override title, description, icon, caption, category, subcategory, and metadata from form' do
+  test 'subapps can override title, description, icon, caption, category, subcategory, metadata and form_header from form' do
     r = PathRouter.new('test/fixtures/apps/bc_with_subapps/')
     app = BatchConnect::App.new(router: r)
     sub_apps = app.sub_app_list
@@ -304,6 +304,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     # Oakley uses defaults
     assert_equal'Desktops: Oakley', sub_apps[0].title
     assert_equal'BC with sub apps description', sub_apps[0].description
+    assert_equal'BC with sub apps form header', sub_apps[0].form_header
     assert_equal'fa://desktop', sub_apps[0].icon_uri
     assert_equal'Interactive Apps', sub_apps[0].category
     assert_equal'Desktops', sub_apps[0].subcategory
@@ -319,6 +320,7 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     # Owens uses overrides
     assert_equal'Owens Desktop', sub_apps[1].title
     assert_equal'Owens Description', sub_apps[1].description
+    assert_equal'Owens Form Header', sub_apps[1].form_header
     assert_equal'fa://clock', sub_apps[1].icon_uri
     assert_equal'Interactive Apps Overridden', sub_apps[1].category
     assert_equal'Desktops Overridden', sub_apps[1].subcategory


### PR DESCRIPTION
This PR fixes #3405 by implementing a `form_header` option for the form YMLs. The form header will be shown only in the interactive app forms, as seen in the example screenshots in #3405.

Example usage:
```
# form.yml.erb
form_header: |
  [Documentation](/link/to/documentation)

  The shell / SSH session will stay open and any programs started there will stay running...
attributes:
  ...
form:
  ...
```

