### PR TITLE
Add markdown widget for interactive app forms

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -12,32 +12,35 @@ module BatchConnect::SessionContextsHelper
       return render :partial => "batch_connect/session_contexts/fixed", :locals => { form: form, attrib: attrib, field_options: field_options, format: format }
     end
 
-    case widget
-    when 'select'
-      form.select(attrib.id, attrib.select_choices(hide_excludable: hide_excludable), field_options, attrib.html_options)
-    when 'resolution_field'
-      resolution_field(form, attrib.id, all_options)
-    when 'check_box'
-      form.form_group attrib.id, help: field_options[:help] do
-        form.check_box attrib.id, all_options, attrib.checked_value, attrib.unchecked_value
-      end
-    when 'radio', 'radio_button'
-      form.form_group attrib.id, help: field_options[:help] do
-        opts = {
-          label:   label_tag(attrib.id, attrib.label),
-          checked: (attrib.value.presence || attrib.field_options[:checked])
-        }
-        form.collection_radio_buttons(attrib.id, attrib.select_choices, :second, :first, **opts)
-      end
-    when 'path_selector'
-      form.form_group(attrib.id) do
-        render(partial: 'path_selector', locals: { form: form, attrib: attrib, field_options: field_options })
-      end
-    when 'file_attachments'
-      render :partial => "batch_connect/session_contexts/file_attachments", :locals => { form: form, attrib: attrib, field_options: field_options }
-    else
-      form.send widget, attrib.id, all_options
-    end
+    rendered =  case widget
+                when 'select'
+                  form.select(attrib.id, attrib.select_choices(hide_excludable: hide_excludable), field_options, attrib.html_options)
+                when 'resolution_field'
+                  resolution_field(form, attrib.id, all_options)
+                when 'check_box'
+                  form.form_group attrib.id, help: field_options[:help] do
+                    form.check_box attrib.id, all_options, attrib.checked_value, attrib.unchecked_value
+                  end
+                when 'radio', 'radio_button'
+                  form.form_group attrib.id, help: field_options[:help] do
+                    opts = {
+                      label:   label_tag(attrib.id, attrib.label),
+                      checked: (attrib.value.presence || attrib.field_options[:checked])
+                    }
+                    form.collection_radio_buttons(attrib.id, attrib.select_choices, :second, :first, **opts)
+                  end
+                when 'path_selector'
+                  form.form_group(attrib.id) do
+                    render(partial: 'path_selector', locals: { form: form, attrib: attrib, field_options: field_options })
+                  end
+                when 'file_attachments'
+                  render :partial => "batch_connect/session_contexts/file_attachments", :locals => { form: form, attrib: attrib, field_options: field_options }
+                else
+                  form.send widget, attrib.id, all_options
+                end
+    header = OodAppkit.markdown.render(attrib.header)
+    "#{header}#{rendered}".html_safe
+
   end
 
   def resolution_field(form, id, opts = {})

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -38,7 +38,7 @@ module BatchConnect::SessionContextsHelper
                 else
                   form.send widget, attrib.id, all_options
                 end
-    header = OodAppkit.markdown.render(attrib.header)
+    header = sanitize(OodAppkit.markdown.render(attrib.header))
     "#{header}#{rendered}".html_safe
 
   end

--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -75,6 +75,12 @@ module SmartAttributes
       (opts[:label] || id.titleize).to_s
     end
 
+    # Header to render before this attribute
+    # @return [String] header text
+    def header
+      opts[:header].to_s
+    end
+
     # Help text for this attribute
     # @param fmt [String, nil] formatting of help text
     # @return [String] help text

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -30,7 +30,7 @@ attributes:
     widget: select
     label: "Node type"
     header: |
-      <span id="test_form_element_header">Some text in a span</span>
+      <span class="test_form_element_header">Some text in a span</span>
       ## Header using Markdown
     options:
       - [

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -29,6 +29,9 @@ attributes:
   node_type:
     widget: select
     label: "Node type"
+    header: |
+      <span id="test_form_element_header">Some text in a span</span>
+      ## Header using Markdown
     options:
       - [
           "any",

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -543,7 +543,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 
     # Span exists (HTML works).
-    header_span = find(id: 'test_form_element_header', text: 'Some text in a span')
+    header_span = find(class: 'test_form_element_header', text: 'Some text in a span')
     # Markdown element exists (## => h2).
     markdown_header = header_span.find(:xpath, './/../../h2', text: 'Header using Markdown')
     # Header precedes its form element.

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -543,11 +543,9 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 
     # Span exists (HTML works).
-    header_span = find(id: 'test_form_element_header')
-    assert_equal('Some text in a span', header_span.text)
+    header_span = find(id: 'test_form_element_header', text: 'Some text in a span')
     # Markdown element exists (## => h2).
-    markdown_header = header_span.find(:xpath, './/../../h2')
-    assert_equal('Header using Markdown', markdown_header.text)
+    markdown_header = header_span.find(:xpath, './/../../h2', text: 'Header using Markdown')
     # Header precedes its form element.
     markdown_header.first(:xpath, './/following-sibling::div').find(id: 'batch_connect_session_context_node_type')
   end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -538,4 +538,17 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       assert_equal 'standard', find('#batch_connect_session_context_node_type').value
     end
   end
+
+  test 'form element headers support markdown and html' do
+    visit new_batch_connect_session_context_url('sys/bc_jupyter')
+
+    # Span exists (HTML works).
+    header_span = find(id: 'test_form_element_header')
+    assert_equal('Some text in a span', header_span.text)
+    # Markdown element exists (## => h2).
+    markdown_header = header_span.find(:xpath, './/../../h2')
+    assert_equal('Header using Markdown', markdown_header.text)
+    # Header precedes its form element.
+    markdown_header.first(:xpath, './/following-sibling::div').find(id: 'batch_connect_session_context_node_type')
+  end
 end


### PR DESCRIPTION
Allows inserting arbitrary Markdown into the app forms through the form.yml files.
The largest use case for us, which I've also seen others request on Discourse (e.g. [here](https://discourse.openondemand.org/t/custom-elements-in-form/3437) and [here](https://discourse.openondemand.org/t/how-to-create-headings-in-ood-form-yml-erb/2912)), would be use this to create headings/sections in the app form.

For example, the following form YML:
```
attributes:
  slurm_partition:
    label: "Slurm Partition"
    widget: select
    options:
      - interactive
  cores:
    label: "Memory (GB)"
    widget: number_field
    value: 2
  header_resources:
    widget: markdown
    value: |
      ---
      ## Resources
  header_settings:
    widget: markdown
    value: |
      ---
      ## Settings

form:
  - slurm_partition
  - header_resources
  - cores
  - memory
  - header_settings
  - bc_email_on_started
```
would produce the following form:
![image](https://github.com/user-attachments/assets/ae0be8a3-3c4e-4f4d-b9a1-dcc436d6ef7c)

This is not fully ready for merging (e.g. missing tests), but I'm submitting this to check whether this could be a potential solution/approach to this feature. Potentially fixes #1806.
I added `serialize?` for SmartAttributes since it would make sense to not store the value of this in any `user_defined_context.json` or saved settings file (`bc_saved_settings`), but `.select(&:serialize?)` should probably be refactored into a function if this approach is fine.