### PR TITLE
allow auto_cores to be fixed

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -8,7 +8,8 @@ class LaunchersController < ApplicationController
 
   SAVE_SCRIPT_KEYS = [
     :cluster, :auto_accounts, :auto_accounts_exclude, :auto_accounts_fixed,
-    :auto_cores, :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
+    :auto_cores, :auto_cores_fixed, :auto_cores_min, :auto_cores_max,
+    :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
     :auto_queues, :auto_queues_exclude, :auto_queues_fixed,
     :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
     :bc_num_slots, :bc_num_slots_fixed, :bc_num_slots_min, :bc_num_slots_max,

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_cores.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_cores.rb
@@ -13,8 +13,9 @@ module SmartAttributes
   
     module Attributes
       class AutoCores < Attribute
-        def opts
-          @opts.reverse_merge(min: 1, step: 1)
+        def initialize(id, opts)
+          super(id, opts)
+          @opts = @opts.reverse_merge(min: 1, step: 1)
         end
 
         def widget


### PR DESCRIPTION
Fixes #3756 

Adds `:auto_cores_fixed` (as well as min and max) to the launchers controller and initializes rather than redefines `opts` for the attribute.