### PR TITLE
sanitize template paths

### DIFF
--- a/apps/dashboard/app/models/concerns/path_sanitizer.rb
+++ b/apps/dashboard/app/models/concerns/path_sanitizer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# module PathSanitizer
+# A simple module to sanitize a path using the same
+# algorithm that ActiveStorage::Filename#sanitized uses.
+module PathSanitizer
+  # Sanitize a path. Uses the same algorithm as ActiveStorage::Filename#sanitized
+  def sanitized_path(path)
+    replaced = path.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '�')
+    replaced = replaced.strip.tr("\u{202E}%$|:;/\t\r\n\\", '-')
+    Pathname.new(replaced)
+  end
+end

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -85,7 +85,7 @@ class Project
     update_attrs(attributes)
     @directory = attributes[:directory]
     @directory = File.expand_path(@directory) unless @directory.blank?
-    @template = sanitize_path(attributes[:template])
+    @template = sanitized_path(attributes[:template])
 
     return if new_record?
 

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -6,6 +6,7 @@ class Project
   include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
   include IconWithUri
+  include PathSanitizer
   extend JobLogger
 
   class << self
@@ -84,7 +85,7 @@ class Project
     update_attrs(attributes)
     @directory = attributes[:directory]
     @directory = File.expand_path(@directory) unless @directory.blank?
-    @template = attributes[:template]
+    @template = sanitize_path(attributes[:template])
 
     return if new_record?
 


### PR DESCRIPTION
sanitize template paths based off of `ActiveStorage::Filename#sanitized` because we can't (or at least don't) use the `activestorage` gem.