### PR TITLE
Project validations

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -10,9 +10,7 @@ class Launcher
 
   class << self
     def scripts_dir(project_dir)
-      Pathname.new("#{project_dir}/.ondemand/scripts").tap do |path|
-        path.mkpath unless path.exist?
-      end
+      Pathname.new("#{project_dir}/.ondemand/scripts")
     end
 
     def find(id, project_dir)

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -297,8 +297,10 @@ class Project
 
   def project_template_invalid
     # This validation is to prevent the template directory being manipulated in the form.
-    if !template.blank? && Project.templates.map { |template| template.directory.to_s }.exclude?(template.to_s)
-      errors.add(:template, :invalid)
-    end
+    return if template.blank?
+
+    template_path = Pathname.new(template)
+    errors.add(:template, :invalid) if Project.templates.map { |t| t.directory.to_s }.exclude?(template.to_s)
+    errors.add(:template, :invalid) unless template_path.exist? && template_path.readable?
   end
 end

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -28,10 +28,12 @@ class ProjectsTest < ActiveSupport::TestCase
 template: '/invalid/template' })
 
       assert_not project.save
-      assert_equal 2, project.errors.size
+      assert_equal 3, project.errors.size
       assert_not_equal invalid_icon, project.icon 
       assert_not project.errors[:directory].empty?
       assert_not project.errors[:template].empty?
+      assert_equal(1, project.errors[:directory].size)
+      assert_equal(2, project.errors[:template].size)
     end
   end
 


### PR DESCRIPTION
CodeQl doesn't account for Rails validations, but even so I thought I'd strengthen them a bit.  I also just noticed that `scripts_dir` doesn't need to create the directory when it's called.