### PR TITLE
Added XDMoD analytics metrics to jobs widget

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -173,6 +173,7 @@ small.form-text {
 @import "editor";
 @import "icon_picker";
 @import "pinned_apps";
+@import "xdmod";
 @import "support_ticket";
 @import "data_tables";
 @import "projects";

--- a/apps/dashboard/app/assets/stylesheets/xdmod.scss
+++ b/apps/dashboard/app/assets/stylesheets/xdmod.scss
@@ -1,0 +1,20 @@
+/** Job Analytics **/
+#jobsPanelDiv {
+  .hiddenRow {
+    padding: 0 !important;
+  }
+
+  i.app-icon {
+    width: 0.9rem;
+    height: 0.9rem;
+    font-size: 0.9rem;
+  }
+
+  tr[aria-expanded=true] .closed {
+    display: none;
+  }
+
+  tr[aria-expanded=false] .open {
+    display: none;
+  }
+}

--- a/apps/dashboard/app/assets/stylesheets/xdmod.scss
+++ b/apps/dashboard/app/assets/stylesheets/xdmod.scss
@@ -26,5 +26,9 @@
     strong {
       font-weight: 600;
     }
+
+    .badge {
+      vertical-align: 1px;
+    }
   }
 }

--- a/apps/dashboard/app/assets/stylesheets/xdmod.scss
+++ b/apps/dashboard/app/assets/stylesheets/xdmod.scss
@@ -10,6 +10,10 @@
     font-size: 0.9rem;
   }
 
+  tr {
+    position: relative;
+  }
+
   tr[aria-expanded=true] .closed {
     display: none;
   }
@@ -18,17 +22,38 @@
     display: none;
   }
 
-  .job-analytics {
-    display: flex;
-    justify-content: space-between;
-    padding: 0.75rem 0.5rem;
+  tr[aria-expanded=true] td:not(.job-analytics) {
+    padding-bottom: 45px;
+  }
 
-    strong {
-      font-weight: 600;
-    }
+  tr.error[aria-expanded=true] td:not(.job-analytics) {
+    padding-bottom: 200px;
+  }
 
-    .badge {
-      vertical-align: 1px;
+  tr.error td.job-analytics {
+    border-bottom: none;
+  }
+
+  td.job-analytics {
+    position: absolute;
+    top: 35px;
+    left: 0;
+    z-index: 1000;
+    width: 100%;
+    padding: 0;
+
+    div.job-analytics-content {
+      display: flex;
+      justify-content: space-between;
+      padding: 0.5rem 0.5rem;
+
+      strong {
+        font-weight: 600;
+      }
+
+      .badge {
+        vertical-align: 1px;
+      }
     }
   }
 }

--- a/apps/dashboard/app/assets/stylesheets/xdmod.scss
+++ b/apps/dashboard/app/assets/stylesheets/xdmod.scss
@@ -17,4 +17,17 @@
   tr[aria-expanded=false] .open {
     display: none;
   }
+
+  .job-analytics {
+    padding: 0.50rem 0.25rem;
+
+    span {
+      padding-left: 8px;
+      padding-right: 8px;
+    }
+
+    strong {
+      font-weight: 600;
+    }
+  }
 }

--- a/apps/dashboard/app/assets/stylesheets/xdmod.scss
+++ b/apps/dashboard/app/assets/stylesheets/xdmod.scss
@@ -21,7 +21,7 @@
   .job-analytics {
     display: flex;
     justify-content: space-between;
-    padding: 0.50rem 0.5rem;
+    padding: 0.75rem 0.5rem;
 
     strong {
       font-weight: 600;

--- a/apps/dashboard/app/assets/stylesheets/xdmod.scss
+++ b/apps/dashboard/app/assets/stylesheets/xdmod.scss
@@ -19,12 +19,9 @@
   }
 
   .job-analytics {
-    padding: 0.50rem 0.25rem;
-
-    span {
-      padding-left: 8px;
-      padding-right: 8px;
-    }
+    display: flex;
+    justify-content: space-between;
+    padding: 0.50rem 0.5rem;
 
     strong {
       font-weight: 600;

--- a/apps/dashboard/app/javascript/utils.js
+++ b/apps/dashboard/app/javascript/utils.js
@@ -1,3 +1,4 @@
+import {analyticsPath} from "./config";
 
 export function cssBadgeForState(state){
   switch (state) {
@@ -101,4 +102,13 @@ export function setInnerHTML(element, html) {
 
     currentElement.parentNode.replaceChild(newElement, currentElement);
   });
+}
+
+// Helper method to report errors from the front end via AJAX
+export function reportErrorForAnalytics(path, error) {
+  // error - report back for analytics purposes
+  const analyticsUrl = new URL(analyticsPath(path), document.location);
+  analyticsUrl.searchParams.append('error', error);
+  // Fire and Forget
+  fetch(analyticsUrl);
 }

--- a/apps/dashboard/app/javascript/xdmod.js
+++ b/apps/dashboard/app/javascript/xdmod.js
@@ -85,12 +85,12 @@ var efficiencyHelpers = {
   }
 };
 
-function promiseLoginToXDMoD(xdmodUrl){
+function promiseLoginToXDMoD(){
   return new Promise(function(resolve, reject){
 
     var promise_to_receive_message_from_iframe = new Promise(function(resolve, reject){
       window.addEventListener("message", function(event){
-        if (event.origin !== xdmodUrl){
+        if (event.origin !== xdmodUrl()){
           console.log('Received message from untrusted origin, discarding');
           return;
         }
@@ -107,8 +107,8 @@ function promiseLoginToXDMoD(xdmodUrl){
       }, false);
     });
 
-    fetch(xdmodUrl + '/rest/auth/idpredirect?returnTo=%2Fgui%2Fgeneral%2Flogin.php')
-      .then(response => response.ok ? Promise.resolve(response) : Promise.reject())
+    fetch(xdmodUrl() + '/rest/auth/idpredirect?returnTo=%2Fgui%2Fgeneral%2Flogin.php')
+      .then(response => response.ok ? Promise.resolve(response) : Promise.reject(new Error('Login failed: IDP redirect failed')))
       .then(response => response.json())
       .then(function(data){
         return new Promise(function(resolve, reject){
@@ -280,7 +280,7 @@ function createEfficiencyWidgets() {
     return;
   }
 
-  promiseLoggedIntoXDMoD(xdmodUrl)
+  promiseLoggedIntoXDMoD()
   .then((user_data) => fetch(aggregateDataUrl(user_data), { credentials: 'include' }))
   .then(response => response.ok ? Promise.resolve(response) : Promise.reject(new Error(response.statusText)))
   .then(response => response.json())

--- a/apps/dashboard/app/javascript/xdmod.js
+++ b/apps/dashboard/app/javascript/xdmod.js
@@ -245,20 +245,6 @@ function createJobsWidget() {
     });
 }
 
-function addAnalyticsToJob(jobId) {
-  const analyticsContainer = `#details_${jobId}`;
-  fetch(jobAnalyticsUrl(jobId), { credentials: 'include' })
-      .then(response => response.ok ? Promise.resolve(response) : Promise.reject(new Error(response.statusText)))
-      .then(response => response.json())
-      .then((data) => renderJobAnalytics(data, analyticsContainer))
-      .catch((error) => {
-        console.error(error);
-        renderJobAnalytics({error: error}, analyticsContainer);
-
-        reportErrorForAnalytics('xdmod_jobs_analytics_widget_error', error);
-      });
-}
-
 function createEfficiencyWidgets() {
   const jobPanel = $(`#${jobEfficiencyPanelId}`);
   const corePanel = $(`#${coreEfficiencyPanelId}`);

--- a/apps/dashboard/app/javascript/xdmod/jobs.js
+++ b/apps/dashboard/app/javascript/xdmod/jobs.js
@@ -9,7 +9,7 @@ export function jobsPanel(context, helpers){
   return div;
 }
 
-export function jobAnalyticsTable(context, jobHelpers) {
+export function jobAnalyticsHtml(context, jobHelpers) {
   if(context.error !== undefined) {
     return errorBody(context.error, jobHelpers);
   }
@@ -21,10 +21,12 @@ export function jobAnalyticsTable(context, jobHelpers) {
   const cpuEfficiency = jobHelpers.efficiency_label(dataByKey['CPU User']?.value, false)
   const memEfficiency = jobHelpers.efficiency_label(dataByKey['Memory Headroom']?.value, true)
   const walltimeEfficiency = jobHelpers.efficiency_label(dataByKey['Walltime Accuracy']?.value, false)
-  const analyticsContent = `<td>${cpuEfficiency}</td>
-                            <td>${memEfficiency}</td>
-                            <td>${walltimeEfficiency}</td>`;
-  return analyticsTable(analyticsContent);
+  const analyticsContent = `<div class="job-analytics">
+                                <span><strong>CPU:</strong> ${cpuEfficiency}</span>
+                                <span><strong>Mem:</strong> ${memEfficiency}</span>
+                                <span><strong>Walltime:</strong> ${walltimeEfficiency}</span>
+                            </div>`;
+  return analyticsContent
 }
 
 function card(context, helpers) {
@@ -96,6 +98,7 @@ function table(context, helpers) {
   tableElement.classList.add('table', 'table-sm', 'table-striped', 'table-condensed');
 
   const thead = document.createElement('thead');
+  // Empty th to accommodate for the job analytics button
   thead.innerHTML = '<tr> \
                       <th></th> \
                       <th>ID</th> \
@@ -173,36 +176,18 @@ function tableRows(context, helpers) {
 
     // Add job analytics placeholder
     const analyticsRow = document.createElement('tr');
-    const analyticsData = analyticsTable('<td colspan="3">LOADING...</td>')
     analyticsRow.innerHTML = `
       <td colspan="4" class="hiddenRow">
         <div class="collapse" id="details_${job.jobid}">
-          ${analyticsData}
+          <div class="job-analytics">
+            <span>LOADING...</span>
+          </div>
         </div>
       </td>`;
     rows.push(analyticsRow);
   });
 
   return rows;
-}
-
-function analyticsTable(analyticsContent) {
-  const analyticsTable = `
-      <table class="table table-sm table-condensed">
-        <thead>
-        <tr>
-          <th>CPU</th>
-          <th>Mem</th>
-          <th>Walltime</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-          ${analyticsContent}
-        </tr>
-        </tbody>
-      </table>`;
-  return analyticsTable;
 }
 
 function jobLink(url, id){

--- a/apps/dashboard/app/javascript/xdmod/jobs.js
+++ b/apps/dashboard/app/javascript/xdmod/jobs.js
@@ -157,7 +157,7 @@ function tableRows(context, helpers) {
     const td4 = document.createElement('td');
     td4.id = `details_${job.jobid}`;
     td4.classList.add('job-analytics', 'collapse');
-    td4.innerHTML = '<div class="job-analytics-content"><span>LOADING...</span></div>'
+    td4.innerHTML = '<div class="job-analytics-content"><span>LOADING...</span></div>';
     // Call JobAnalytics API after the collapse is fully open to avoid awkward animation.
     td4.addEventListener('shown.bs.collapse', function(event) {
       getJobAnalytics(job, helpers);

--- a/apps/dashboard/app/javascript/xdmod/jobs.js
+++ b/apps/dashboard/app/javascript/xdmod/jobs.js
@@ -9,6 +9,24 @@ export function jobsPanel(context, helpers){
   return div;
 }
 
+export function jobAnalyticsTable(context, jobHelpers) {
+  if(context.error !== undefined) {
+    return errorBody(context.error, jobHelpers);
+  }
+
+  const dataByKey = context.data.reduce((acc, obj) => {
+    acc[obj.key] = obj;
+    return acc;
+  }, {});
+  const cpuEfficiency = jobHelpers.efficiency_label(dataByKey['CPU User']?.value, false)
+  const memEfficiency = jobHelpers.efficiency_label(dataByKey['Memory Headroom']?.value, true)
+  const walltimeEfficiency = jobHelpers.efficiency_label(dataByKey['Walltime Accuracy']?.value, false)
+  const analyticsContent = `<td>${cpuEfficiency}</td>
+                            <td>${memEfficiency}</td>
+                            <td>${walltimeEfficiency}</td>`;
+  return analyticsTable(analyticsContent);
+}
+
 function card(context, helpers) {
   const div = document.createElement('div');
   div.classList.add('card', 'mt-3');
@@ -77,15 +95,15 @@ function table(context, helpers) {
   // <table class="table table-sm table-striped table-condensed">
   tableElement.classList.add('table', 'table-sm', 'table-striped', 'table-condensed');
 
-  thead = document.createElement('thead');
+  const thead = document.createElement('thead');
   thead.innerHTML = '<tr> \
+                      <th></th> \
                       <th>ID</th> \
                       <th>Name</th> \
                       <th>Date</th> \
-                      <th>CPU</th> \
                     </tr>';
 
-  tbody = document.createElement('tbody');
+  const tbody = document.createElement('tbody');
   tbody.append(...tableRows(context, helpers));
 
   tableElement.append(thead);
@@ -97,12 +115,12 @@ function table(context, helpers) {
 }
 
 function tableRows(context, helpers) {
-  jobs = context.results;
+  const jobs = context.results;
   if (jobs === undefined || jobs.length == 0) {
     return [ noDataRow() ];
   }
 
-  rows = [];
+  const rows = [];
 
   // <tr title="{{job_name}} - {{local_job_id}}">
   //   <td class="text-nowrap"><a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span></a></td>
@@ -113,6 +131,19 @@ function tableRows(context, helpers) {
   jobs.forEach(job => {
     const tr = document.createElement('tr');
     tr.title = `${job.job_name} - ${job.local_job_id}`;
+    // Job Analytics metadata => Required for the AJAX request and collapse behaviour
+    tr.setAttribute('data-xdmod-jobid', job.jobid);
+    tr.setAttribute('data-bs-toggle', 'collapse');
+    tr.setAttribute('data-bs-target', `#details_${job.jobid}`);
+    tr.setAttribute('aria-expanded', 'false');
+
+    // Job analytics collapse icons
+    const td0 = document.createElement('td');
+    td0.innerHTML = `
+      <button class="btn btn-default btn-xs">
+        <i class="fa fa-plus fa-fw app-icon closed" aria-hidden="true"></i>
+        <i class="fa fa-minus fa-fw app-icon open" aria-hidden="true"></i>
+      </button>`
     
     //  <td class="text-nowrap">
     //    <a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span>
@@ -132,15 +163,46 @@ function tableRows(context, helpers) {
     td3.innerText = helpers.date(job);
 
     // <td>{{cpu_label cpu_user}}</td>
-    const td4 = document.createElement('td');
-    td4.innerHTML = helpers.cpu_label(job.cpu_user);
+    // Not used with new analytics data
+    // const td4 = document.createElement('td');
+    // td4.innerHTML = helpers.efficiency_label(job.cpu_user);
 
-    tr.append(td1, td2, td3, td4);
+    tr.append(td0, td1, td2, td3);
 
     rows.push(tr);
+
+    // Add job analytics placeholder
+    const analyticsRow = document.createElement('tr');
+    const analyticsData = analyticsTable('<td colspan="3">LOADING...</td>')
+    analyticsRow.innerHTML = `
+      <td colspan="4" class="hiddenRow">
+        <div class="collapse" id="details_${job.jobid}">
+          ${analyticsData}
+        </div>
+      </td>`;
+    rows.push(analyticsRow);
   });
 
   return rows;
+}
+
+function analyticsTable(analyticsContent) {
+  const analyticsTable = `
+      <table class="table table-sm table-condensed">
+        <thead>
+        <tr>
+          <th>CPU</th>
+          <th>Mem</th>
+          <th>Walltime</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          ${analyticsContent}
+        </tr>
+        </tbody>
+      </table>`;
+  return analyticsTable;
 }
 
 function jobLink(url, id){

--- a/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
+++ b/apps/dashboard/app/views/widgets/_xdmod_widget_jobs.html.erb
@@ -1,59 +1,6 @@
 <%=  javascript_include_tag 'xdmod', nonce: true %>
 
 <div class="xdmod">
+  <%# This XDMoD widget is rendered using Javascript %>
   <div id="jobsPanelDiv"></div>
-
-  <script id="jobs-template" type="text/x-handlebars-template">
-    <div class="card mt-3">
-
-      <div class="card-header">
-        <a href="{{xdmod_url}}" class="float-end">Open XDMoD <span class="fa fa-external-link-square-alt"></span></a>
-        <h3>{{title}} - {{date_range}}</h3>
-      </div>
-
-      {{#if error}}
-        <div class="card-body">
-          <div class="alert alert-danger mb-0">{{error}} Please ensure you are <a href="{{xdmod_url}}">logged into Open XDMoD first</a>, and then try again.</div>
-        </div>
-      {{else}}
-      {{#if loading}}
-        <div class="card-body">
-          <p class="card-text">LOADING...</p>
-        </div>
-      {{else}}
-        <div class="card-body">
-          <div class="table-responsive">
-            <table class="table table-sm table-striped table-condensed">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Name</th>
-                  <th>Date</th>
-                  <th>CPU</th>
-                </tr>
-              </thead>
-              <tbody>
-                {{#each results}}
-                <tr title="{{job_name}} - {{local_job_id}}">
-                  <td class="text-nowrap"><a target="_blank" href="{{job_url}}">{{local_job_id}}&nbsp;<span class="fa fa-external-link-square-alt"></span></a></td>
-                  <td class="overflow-hidden d-inline-block text-truncate mw-150px">{{job_name}}</td>
-                  <td>{{date}}</td>
-                  <td>{{cpu_label cpu_user}}</td>
-                </tr>
-                {{else}}
-                <tr><td colspan="7">No data available.</td></tr>
-                {{/each}}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="card-footer">
-          Showing first {{page_limit}} of {{totalCount}} jobs. See <a href="{{xdmod_url}}">your Open XDMoD dashboard&nbsp;<span class="fa fa-external-link-square-alt"></span></a> for more information.
-        </div>
-        {{/if}}
-      {{/if}}
-    </div>
-  </script>
-
 </div>

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -134,7 +134,7 @@ icon: 'fas://test')
   test 'creates manifest.yml in .ondemand config directory' do
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
-      project = create_project(projects_path)
+      project = create_project(projects_path, id: "test-#{Project.next_id}")
 
       assert project.errors.inspect
       assert_equal "#{projects_path}/projects/#{project.id}", project.directory.to_s
@@ -172,7 +172,8 @@ icon: 'fas://test')
   test 'update project manifest.yml file' do
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)
-      project = create_project(projects_path)
+
+      project = create_project(projects_path, id: "test-#{Project.next_id}")
 
       name          = 'test-project-2'
       description   = 'my test project'


### PR DESCRIPTION
Added analytics metrics from XDMoD to the jobs widget.
The analytics are added on demand, with an AJAX call to each job. This call is triggered when the user clicks on one of the jobs.

Fixes #998 