### PR TITLE
fix this test after last 2 merges

### DIFF
--- a/apps/dashboard/test/models/launcher_test.rb
+++ b/apps/dashboard/test/models/launcher_test.rb
@@ -150,7 +150,7 @@ class LauncherTest < ActiveSupport::TestCase
       refute(launcher.save)
       assert(launcher.errors.size, 1)
       assert_equal(launcher.errors.full_messages[0], "Id ID does not match #{Launcher::ID_REX.inspect}")
-      assert(Dir.empty?(Launcher.scripts_dir(tmp).to_s))
+      refute(Dir.exist?(Launcher.scripts_dir(tmp).to_s))
     end
   end
 end


### PR DESCRIPTION
fix this test after last 2 merges. Tests started to fail. Now when you save launchers and they fail, the launcher directory is never actually created.