### PR TITLE
Optimize allowlist handling

### DIFF
--- a/apps/dashboard/app/models/allowlist_policy.rb
+++ b/apps/dashboard/app/models/allowlist_policy.rb
@@ -82,9 +82,7 @@ class AllowlistPolicy
     # Expand both paths to evaluate any potential ".." components to be able to compare them as strings.
     p = parent.expand_path.to_s
     c = child.expand_path.to_s
-    # Child path shorter than parent => not a child.
-    return false if c.size < p.size
-    # Child path is same as parent path, or has additional components after parent path (has "/" after parent path).
-    c[0...p.size] == p && (c.size == p.size || c[p.size] == "/")
+    # Child path if it is same as parent path, or has additional components after "/".
+    c.start_with?(p) && (c.size == p.size || c[p.size] == "/")
   end
 end

--- a/apps/dashboard/app/models/allowlist_policy.rb
+++ b/apps/dashboard/app/models/allowlist_policy.rb
@@ -17,10 +17,11 @@ class AllowlistPolicy
   # @raises ArgumentError if any allowlist path or permitted? argument
   #         has the form ~user/some/path where user doesn't exist
   def permitted?(path)
+    return true if allowlist.blank?
     real_path = real_expanded_path(path.to_s)
     key = path_to_key(real_path)
     Rails.cache.fetch(key) do
-      allowlist.blank? || allowlist.any? { |parent| child?(Pathname.new(parent), real_path) }
+      allowlist.any? { |parent| child?(Pathname.new(parent), real_path) }
     end
   end
 
@@ -71,19 +72,19 @@ class AllowlistPolicy
     Pathname.new(path).expand_path
   end
 
-  # Determine if child is a subpath of parent
-  #
-  # If the relative path from the child to the supposed parent includes '..'
-  # then child is not a subpath of parent
+  # Determine if child is a subpath of parent.
+  # This does not access the filesystem, so symlinks should be evaluated before this.
   #
   # @param parent [Pathname]
   # @param child [Pathname]
   # @return Boolean
   def child?(parent, child)
-    !child.expand_path.relative_path_from(
-      parent.expand_path
-    ).each_filename.to_a.include?(
-      '..'
-    )
+    # Expand both paths to evaluate any potential ".." components to be able to compare them as strings.
+    p = parent.expand_path.to_s
+    c = child.expand_path.to_s
+    # Child path shorter than parent => not a child.
+    return false if c.size < p.size
+    # Child path is same as parent path, or has additional components after parent path (has "/" after parent path).
+    c[0...p.size] == p && (c.size == p.size || c[p.size] == "/")
   end
 end


### PR DESCRIPTION
Thanks to the benchmark setup provided by Jeff in #3026, we were able to spend some time attempting to optimize the file browser file listing.
These optimizations were low hanging fruit with a decent impact on the runtime. It now returns early if no allowlist is defined (always allowed), and child paths are now determined by using strings rather than `Pathname`.

With an allowlist (`/users:/scratch:/projappl`, listing files in `/tmp`), there was a 2x speedup (50k files, 5 runs, 100s => 50s). Without an allowlist, the speedup was >3x (50k files, 5 runs, 49s => 14s).
The speedup depends heavily on the situation though, and the listing is only a part of the problem, as seen in #3801.
When manually testing the performance in a browser, the response time listing a directory with 50k files with no allowlist went from ~18s to ~13s.

<details>
  <summary>Benchmarks</summary>

  We decided to slightly customize Jeff's benchmark setup as follows:
  <details>
    <summary>Benchmark setup</summary>

```diff
diff --git a/apps/dashboard/Gemfile b/apps/dashboard/Gemfile
index 113d021f..e812039e 100644
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -79,3 +79,5 @@ gem "sinatra-contrib", require: false
 gem "erubi", require: false
 gem "dalli", require: false
 
+gem 'rails-perftest', :git => 'https://github.com/rails/rails-perftest.git'
+gem 'ruby-prof'
diff --git a/apps/dashboard/test/performance/posix_file_test.rb b/apps/dashboard/test/performance/posix_file_test.rb
new file mode 100644
index 00000000..0c536847
--- /dev/null
+++ b/apps/dashboard/test/performance/posix_file_test.rb
@@ -0,0 +1,39 @@
+require 'test_helper'
+require 'rails/performance_test_help'
+
+N_RUNS = ENV.fetch("N_RUNS", 30).to_i
+N_FILES = ENV.fetch("N_FILES", 300).to_i
+N_CACHE_USES = ENV.fetch("N_CACHE_USES", 0).to_i
+
+FILES_PATH = ENV.fetch("FILES_PATH", "/tmp/file-profile-test")
+OUTPUT_PATH = ENV.fetch("OUTPUT_PATH", "/tmp/performance")
+
+class PosixFileTest < ActionDispatch::PerformanceTest
+  # Refer to the documentation for all available options #[:wall_time, :memory, :cpu_time, :process_time],
+  self.profile_options = { runs: N_RUNS, metrics: [:wall_time],
+                           output: OUTPUT_PATH, formats: [:flat, :graph_html, :call_tree, :call_stack] }
+
+  def setup
+    @dir = FILES_PATH
+    if N_CACHE_USES == 0
+      Dir.mkdir(@dir)
+      Dir.chdir(@dir) do
+        (0...N_FILES).each { |num| `touch foo_#{num}.txt` }
+      end
+    end
+
+    @mem = ActiveSupport::Cache::MemoryStore.new
+    Rails.stubs(:cache).returns(@mem)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir) unless N_CACHE_USES > 0
+  end
+
+  test "listing" do
+    f = PosixFile.new(@dir)
+    for _ in 0..(N_CACHE_USES) do
+      f.ls
+    end
+  end
+end
```
  </details>
The benchmarks without allowlist were run as:

```
bin/rake test N_RUNS=5 N_FILES=50000 TEST=test/performance/posix_file_test.rb
```

The benchmarks with allowlist were run as:
```
bin/rake test OOD_ALLOWLIST_PATH="/users:/scratch:/projappl" N_RUNS=5 N_FILES=50000 TEST=test/performance/posix_file_test.rb
```
No allowlist, before PR:
![no_allowlist_unopt](https://github.com/user-attachments/assets/b2ba85a8-84aa-465c-851c-dc7630461f1c)

No allowlist, after PR:
![no_allowlist_opt](https://github.com/user-attachments/assets/05d80c2e-4a3b-4d1a-a7cb-93ae82b5251d)

With allowlist, before PR:
![allowlist_unopt](https://github.com/user-attachments/assets/403cc557-a205-4e67-ad1d-fc32ed37c2e5)

With allowlist, after PR:
![allowlist_opt](https://github.com/user-attachments/assets/27e02865-f471-4b78-bf7a-d062c3258c72)
</details>

Note that these benchmarks always run with an empty allowlist cache, i.e. the time taken by `ActiveSupport::Cache::Store#fetch` includes evaluating the new cache value. `N_CACHE_USES` in the benchmarks can be increased to see the effect when the cache is actually used.

