### PR TITLE
The command exec "${PWD}/bin/node" does not work

### DIFF
--- a/nginx_stage/bin/node
+++ b/nginx_stage/bin/node
@@ -9,7 +9,7 @@
 #
 
 if [[ -x "${PWD}/bin/node" ]]; then
-  exec "${PWD}/bin/node" "$@"
+  exec "${PWD}"/bin/node "$@"
 else
   exec node "$@"
 fi

--- a/nginx_stage/bin/python
+++ b/nginx_stage/bin/python
@@ -9,7 +9,7 @@
 #
 
 if [[ -x "${PWD}/bin/python" ]]; then
-  exec "${PWD}/bin/python" "$@"
+  exec "${PWD}"/bin/python "$@"
 else
   exec python "$@"
 fi

--- a/nginx_stage/bin/ruby
+++ b/nginx_stage/bin/ruby
@@ -9,7 +9,7 @@
 #
 
 if [[ -x "${PWD}/bin/ruby" ]]; then
-  exec "${PWD}/bin/ruby" "$@"
+  exec "${PWD}"/bin/ruby "$@"
 else
   exec ruby "$@"
 fi


### PR DESCRIPTION
The command exec "${PWD}/bin/node" does not work because the shell interprets the double quotes around the entire path as a single argument. This means the shell looks for a file named literally ${PWD}/bin/node, which does not exist.

This causes Passenger to exit with an access denied error.