### PR TITLE
Revert "Fix for apache 2.4.62 - Update node_proxy.lua"

### DIFF
--- a/mod_ood_proxy/lib/node_proxy.lua
+++ b/mod_ood_proxy/lib/node_proxy.lua
@@ -34,7 +34,7 @@ function node_proxy_handler(r)
   local conn = {}
   conn.user = user
   conn.server = host .. ":" .. port
-  conn.uri = uri and (r.args and (uri .. "?" .. r.args) or uri) or r.uri
+  conn.uri = uri and (r.args and (uri .. "?" .. r.args) or uri) or r.unparsed_uri
 
   -- last ditch effort to ensure that the uri is at least something
   -- because the request-line of an HTTP request _has_ to have something for a URL


### PR DESCRIPTION
Reverts OSC/ondemand#3776

Testing this in 3.1.8 has issues with Rstudio. You can see here the `?dark=0&refresh=1` is being url encoded and added to the URL, while they appear again correctly `?dark=0&refresh=1`. Of course Rstudio returns a 404 here because it thinks that's still a part of the URL.

```
2024-09-24T17:37:11.332015Z [rserver] DEBUG - Start server proxy request GET /theme/default/solarized_light.rstheme%3Fdark=0&refresh=1?dark=0&refresh=1 (johrstrom:113) for local stream: /tmp/run/rstudio-rsession/johrstrom-d
2024-09-24T17:37:11.334152Z [rserver] DEBUG -- sent server proxy response for: /theme/default/solarized_light.rstheme%3Fdark=0&refresh=1?dark=0&refresh=1 (johrstrom:113) in 0.2s id:: 404
```