### PR TITLE
Fix error on file upload to directories with setgid bit

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -156,7 +156,7 @@ class FilesController < ApplicationController
     request.env[Rack::RACK_TEMPFILES].reject! { |f| f.path == params[:file].tempfile.path } unless posix_file?
 
     @transfer = @path.handle_upload(params[:file].tempfile)
-    if @transfer
+    if @transfer.kind_of?(Transfer)
       render 'transfers/show'
     else
       render json: {}


### PR DESCRIPTION
It seems that I managed to introduce a regression in #3739, which I had missed during testing, but we noticed when testing 3.1.8 in a system where setgid bits are used. Sorry about that.

Uploading files to directories with the setgid bit set causes the response to the browser to be an internal server error as `PosixFile.handle_upload` returns the number of files affected by the chown operation to set the setgid bit rather than a Transfer or nil as intended.
This PR fixes that by explicitly checking whether the return value is a Transfer or not.
