### PR TITLE
Global form items

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -23,4 +23,5 @@ module SmartAttributes
   require 'smart_attributes/attributes/bc_vnc_resolution'
   require 'smart_attributes/attributes/auto_environment_variable'
   require 'smart_attributes/attributes/auto_cores'
+  require 'smart_attributes/attributes/global_attribute'
 end

--- a/apps/dashboard/app/lib/smart_attributes/attribute_factory.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute_factory.rb
@@ -3,6 +3,7 @@ module SmartAttributes
 
     AUTO_MODULES_REX = /\Aauto_modules_([\w-]+)\z/.freeze
     AUTO_ENVIRONMENT_VARIABLE_REX = /\Aauto_environment_variable_([\w-]+)\z/.freeze
+    GLOBAL_ATTRIBUTE_REX = /\Aglobal_([\w-]+)\z/.freeze
 
     class << self
       # Build an attribute object from an id and its options
@@ -11,6 +12,7 @@ module SmartAttributes
       # @return [Attribute] the attribute object
       def build(id, opts = {})
         id = id.to_s
+
         if id.match?(AUTO_MODULES_REX)
           hpc_mod = id.match(AUTO_MODULES_REX)[1]
           id = 'auto_modules'
@@ -19,6 +21,10 @@ module SmartAttributes
           env_variable = id.match(AUTO_ENVIRONMENT_VARIABLE_REX)[1]
           id = 'auto_environment_variable'
           opts = opts.merge({'key' => env_variable})
+        elsif id.match?(GLOBAL_ATTRIBUTE_REX)
+          real_id = id
+          id = 'global_attribute'
+          opts = opts.merge({ 'key' => real_id })
         end
 
         build_method = "build_#{id}"

--- a/apps/dashboard/app/lib/smart_attributes/attributes/global_attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/global_attribute.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SmartAttributes
+  class AttributeFactory
+    # Build this attribute object with defined options
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::GlobalAttribute] the attribute object
+    def self.build_global_attribute(opts = {})
+      id = opts.delete('key').to_s
+
+      config = Configuration.global_attribute(id)
+
+      # this behaves like a normal Attribute if there's no actual configuration for it.
+      config = opts if config.nil? || config.empty?
+      Attributes::GlobalAttribute.new(id, config)
+    end
+  end
+
+  module Attributes
+    class GlobalAttribute < Attribute
+    end
+  end
+end

--- a/apps/dashboard/app/lib/smart_attributes/attributes/global_attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/global_attribute.rb
@@ -8,7 +8,7 @@ module SmartAttributes
     def self.build_global_attribute(opts = {})
       id = opts.delete('key').to_s
 
-      config = Configuration.global_attribute(id)
+      config = Configuration.global_bc_form_item(id)
 
       # this behaves like a normal Attribute if there's no actual configuration for it.
       config = opts if config.nil? || config.empty?

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -214,10 +214,10 @@ class ConfigurationSingleton
     config.fetch(:launcher_default_items, []).to_a
   end
 
-  def global_attribute(key)
+  def global_bc_form_item(key)
     return nil if key.nil? || key.to_s.empty?
 
-    all = config.fetch(:global_attributes, {}).to_h
+    all = config.fetch(:global_bc_form_items, {}).to_h
     all[key.to_sym]
   end
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -214,6 +214,13 @@ class ConfigurationSingleton
     config.fetch(:launcher_default_items, []).to_a
   end
 
+  def global_attribute(key)
+    return nil if key.nil? || key.to_s.empty?
+
+    all = config.fetch(:global_attributes, {}).to_h
+    all[key.to_sym]
+  end
+
   # Load the dotenv local files first, then the /etc dotenv files and
   # the .env and .env.production or .env.development files.
   #


### PR DESCRIPTION
Fixes #1763 by defining batch connect attributes in an `ondemand.d` file that can be used in batch connect forms. Note that these global configurations need to have the `global_` prefix to their name.