### PR TITLE
allow empty directories to be downloaded

### DIFF
--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -185,8 +185,6 @@ class PosixFile
           error = I18n.t('dashboard.files_directory_size_calculation_error')
         elsif size.to_i > download_directory_size_limit
           error = I18n.t('dashboard.files_directory_too_large', download_directory_size_limit: download_directory_size_limit)
-        elsif size.to_i == 0
-          error = I18n.t('dashboard.files_directory_download_size_0', cmd: "timeout 10s du -cbs #{path.to_s}")
         else
           can_download = true
         end

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -168,7 +168,7 @@ class PosixFile
       if s.exitstatus == 124
         error = I18n.t('dashboard.files_directory_size_calculation_timeout')
       elsif ! s.success?
-        error = I18n.t('dashboard.files_directory_size_unknown', exit_code: s, error: e)
+        error = I18n.t('dashboard.files_directory_size_unknown', exit_code: s.exitstatus, error: e)
       else
         # Example output from: du -cbs $path
         #

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -217,7 +217,6 @@ en:
     files_download_not_enabled: "Downloading files is not enabled on this server."
     files_directory_download_error_modal_title: "Directory too large to download"
     files_directory_download_unauthorized: "You can only download a directory as zip that you have read and execute access to"
-    files_directory_download_size_0: "The directory size is 0 and has no contents for download."
     files_directory_too_large: "The directory is too large to download as a zip. The directory should be less than %{download_directory_size_limit} bytes."
     files_directory_size_calculation_error: "Timeout while trying to determine directory size."
     files_directory_size_calculation_timeout: "Timeout while trying to determine directory size."

--- a/apps/dashboard/test/models/files_test.rb
+++ b/apps/dashboard/test/models/files_test.rb
@@ -36,20 +36,20 @@ class FilesTest < ActiveSupport::TestCase
 
   test "can_download_as_zip handles erroneous output from du" do
     Dir.mktmpdir do |dir|
-      path = Pathname.new(dir)
-      Open3.stubs(:capture3).returns(["blarg \n 28d", "", exit_success])
+      error_msg = 'some failure message'
+      Open3.stubs(:capture3).returns(["blarg \n 28d", error_msg, exit_failure])
+      result = PosixFile.new(dir).can_download_as_zip?
 
-      assert_equal [false, I18n.t('dashboard.files_directory_download_size_0', cmd: "timeout 10s du -cbs #{path}")], PosixFile.new(dir).can_download_as_zip?
+      assert_equal([false, I18n.t('dashboard.files_directory_size_unknown', exit_code: '1', error: error_msg)], result)
     end 
   end
 
   test "can_download_as_zip handles files sizes of 0" do
     Dir.mktmpdir do |dir|
-      path = Pathname.new(dir)
       Open3.stubs(:capture3).returns(["0 /dev
         0 total", "", exit_success])
 
-      assert_equal [false, I18n.t('dashboard.files_directory_download_size_0', cmd: "timeout 10s du -cbs #{path}")], PosixFile.new(dir).can_download_as_zip?
+      assert_equal [true, nil], PosixFile.new(dir).can_download_as_zip?
     end 
   end
 


### PR DESCRIPTION
Fixes #3835 by simply allowing the download of an empty directory.