### PR TITLE
script#edit don't allow user to remove last option

### DIFF
--- a/apps/dashboard/app/javascript/launcher_edit.js
+++ b/apps/dashboard/app/javascript/launcher_edit.js
@@ -258,12 +258,6 @@ function enableOrDisableSelectOption(event) {
   const optionToToggle = selectOptions.filter(opt => opt.text == choice)[0];
   const selectOptionsEnabled = selectOptions.filter(opt => !opt.disabled);
 
-  if(selectOptionsEnabled.length <= 1 && toggleAction == 'remove') {
-    alert("Cannot remove the last option available")
-    event.target.disabled = false;
-    return
-  }
-
   if(toggleAction == 'add') {
     enableRemoveOption(li);
     removeFromExcludeInput(excludeId, choice);
@@ -277,6 +271,28 @@ function enableOrDisableSelectOption(event) {
       // if we can remove, there is always another option
       selectOptionsEnabled.filter(opt => opt.text !== choice)[0].selected = true;
     }
+  }
+  enableOrDisableLastOption(li.parentElement);
+}
+
+function enableOrDisableLastOption(optionsOl) {
+  const optionLis = Array.from(optionsOl.children);
+
+  const optionsEnabled = Array.from(optionLis.filter((child) => {
+    return !child.classList.contains('text-strike');
+  }));
+
+  if(optionsEnabled.length > 1) {
+    // Make sure there are no options that have both the add and remove button disabled
+    const bothButtonsDisabled = optionsEnabled.filter((option) => {
+      return option.querySelectorAll('button:disabled').length == 2;
+    });
+    for(const option of bothButtonsDisabled) {
+      enableRemoveOption(option);
+    }
+  } else {
+    // Disable the remove button on the last option
+    enableRemoveOption(optionsEnabled[0], true);
   }
 }
 

--- a/apps/dashboard/app/javascript/launcher_edit.js
+++ b/apps/dashboard/app/javascript/launcher_edit.js
@@ -345,6 +345,8 @@ function initSelect(selectElement) {
       enableAddOption(configItem);
     }
   });
+
+  enableOrDisableLastOption(selectOptionsConfig[0].parentElement);
 }
 
 

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -17,6 +17,7 @@
       <%- 
         choice = parse_select_data(select_data)
         disabled = attrib.exclude_select_choices.include?(choice)
+        last_option = attrib.exclude_select_choices.length + 1 == attrib.select_choices(hide_excludable: false).length
         li_classes = disabled ? 'list-group-item list-group-item-danger text-strike' : 'list-group-item'
         add_id = "#{field_id}_add_#{choice}"
         remove_id = "#{field_id}_remove_#{choice}"
@@ -34,7 +35,7 @@
 
         <button class="btn btn-warning float-end" type="button" id="<%= remove_id %>"
           data-select-toggler="remove" data-select-id="<%= field_id %>"
-          <%= disabled ? 'disabled="true"'.html_safe : nil %> >
+          <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
           <%= t('dashboard.remove') %>
         </button>
 

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -17,7 +17,6 @@
       <%- 
         choice = parse_select_data(select_data)
         disabled = attrib.exclude_select_choices.include?(choice)
-        last_option = attrib.exclude_select_choices.length + 1 == attrib.select_choices(hide_excludable: false).length
         li_classes = disabled ? 'list-group-item list-group-item-danger text-strike' : 'list-group-item'
         add_id = "#{field_id}_add_#{choice}"
         remove_id = "#{field_id}_remove_#{choice}"
@@ -35,7 +34,7 @@
 
         <button class="btn btn-warning float-end" type="button" id="<%= remove_id %>"
           data-select-toggler="remove" data-select-id="<%= field_id %>"
-          <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
+          <%= disabled ? 'disabled="true"'.html_safe : nil %> >
           <%= t('dashboard.remove') %>
         </button>
 

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -27,7 +27,7 @@
 
         <button class="btn btn-info float-start" type="button" id="<%= add_id %>"
           data-select-toggler="add" data-select-id="<%= field_id %>"
-          <%= disabled ? nil : 'disabled="true"'.html_safe %> >
+          <%= disabled ? nil : 'disabled="true"' %> >
           <%= t('dashboard.add') %>
         </button>
 


### PR DESCRIPTION
Fixes #3050 

Disables the remove button for the last option.

Note that this does not actually fix the attribute, just removes the ability for the user to click the remove button on the last option.

If we want to fix the option, it might make sense to allow the user to unfix the attribute by adding an item another item instead of disabling all of them. Otherwise, if the the attribute was fixed when there is only one option left, the "Fixed" checkbox would need to be unchecked and some arbitrary second option would need to be enabled.