### PR TITLE
fix test ci for 3.1 (#3832)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,14 +47,16 @@ jobs:
           path: ~/vendor/bundle
           key: ${{ runner.os }}-${{ matrix.ruby }}-unit-gems-${{ hashFiles('apps/*/Gemfile.lock', 'Gemfile.lock') }}-1
 
+      - name: Setup os dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rclone libsqlite3-dev
+
       - name: Setup Bundler
         run: |
           bundle config path ~/vendor/bundle
           bundle install
           gem install rake
-
-      - name: Setup rclone
-        run: sudo apt-get update && sudo apt-get install rclone
 
       - name: Run unit tests
         run: bundle exec rake test:unit

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -507,11 +507,11 @@ class FilesTest < ApplicationSystemTestCase
       dir_to_dl = "#{dir}/test_dir"
       `mkdir -p #{dir_to_dl}/first_level_dir`
       `mkdir #{dir_to_dl}/.first_level_hidden_dir`
-      `touch #{dir_to_dl}/real_file`
-      `touch #{dir_to_dl}/first_level_dir/.second_level_hidden_file`
-      `touch #{dir_to_dl}/first_level_dir/second_level_real_file`
-      `touch #{dir_to_dl}/.first_level_hidden_dir/.another_second_level_hidden_file`
-      `touch #{dir_to_dl}/.first_level_hidden_dir/another_second_level_real_file`
+      `echo 'abc123' > #{dir_to_dl}/real_file`
+      `echo 'abc123' > #{dir_to_dl}/first_level_dir/.second_level_hidden_file`
+      `echo 'abc123' > #{dir_to_dl}/first_level_dir/second_level_real_file`
+      `echo 'abc123' > #{dir_to_dl}/.first_level_hidden_dir/.another_second_level_hidden_file`
+      `echo 'abc123' > #{dir_to_dl}/.first_level_hidden_dir/another_second_level_real_file`
 
       visit files_url(dir)
       find('tbody a', exact_text: 'test_dir').ancestor('tr').click


### PR DESCRIPTION
Fix test ci by populating these test files so that the directory isn't empty. This backports #3832 to 3.1.