### PR TITLE
use a hidden_field for apps shared across clusters

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -472,8 +472,8 @@ module BatchConnect
                                }
                              else
                                {
-                                 value: clusters.first.id.to_s,
-                                 fixed: true
+                                 value:  clusters.first.id.to_s,
+                                 widget: 'hidden_field'
                                }
                              end
     end


### PR DESCRIPTION
Fixes #3857 so that clusters are a `hidden_field` and not fixed. This allows dynamic javascript directives to continue to key off of the cluster field.