### PR TITLE
3176 exclude cache and logs from new template based projects

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -147,7 +147,7 @@ class Project
     File.write(Project.lookup_file, new_table.to_yaml)
     true
   rescue StandardError => e
-    errors.add(operation, "Cannot update lookup file lookup file with error #{e.class}:#{e.message}")
+    errors.add(operation, "Cannot update lookup file with error #{e.class}:#{e.message}")
     false
   end
 
@@ -156,7 +156,7 @@ class Project
     File.write(Project.lookup_file, new_table.to_yaml)
     true
   rescue StandardError => e
-    errors.add(:update, "Cannot update lookup file lookup file with error #{e.class}:#{e.message}")
+    errors.add(:update, "Cannot update lookup file with error #{e.class}:#{e.message}")
     false
   end
 
@@ -278,7 +278,9 @@ class Project
 
   def rsync_args
     [
-      'rsync', '-rltp', '--exclude', 'scripts/*',
+      'rsync', '-rltp',
+      '--exclude', 'scripts/*',
+      '--exclude', '.ondemand/job_log.yml',
       "#{template}/", project_dataroot.to_s
     ]
   end

--- a/apps/dashboard/test/models/projects_test.rb
+++ b/apps/dashboard/test/models/projects_test.rb
@@ -122,6 +122,33 @@ icon: 'fas://test')
     end
   end
 
+  test 'create project with template does not copy project specific files' do
+    Dir.mktmpdir do |tmp|
+      template_dir = File.join(tmp,'template')
+      job_log_path = "#{template_dir}/.ondemand/job_log.yml"
+      launcher_id = '50r4nd0m'
+      cache_json_path = "#{template_dir}/.ondemand/scripts/#{launcher_id}/cache.json"
+
+      file_content = <<~HEREDOC
+        some multiline content
+        echo 'multiline content'
+        description: multiline content
+      HEREDOC
+      Pathname.new("#{template_dir}/.ondemand/scripts/#{launcher_id}").mkpath
+      File.open(job_log_path, 'w') { |file| file.write(file_content) }
+      File.open(cache_json_path, 'w') { |file| file.write(file_content) }
+
+      Configuration.stubs(:project_template_dir).returns(tmp)
+      projects_path = Pathname.new(tmp)
+      project = create_project(projects_path, template: template_dir)
+      
+      assert Dir.glob(cache_json_path).present? && 
+        Dir.glob("#{project.directory}/.ondemand/scripts/*/cache.json").empty?
+      assert Dir.glob(job_log_path).present? &&
+        Dir.glob("#{project.directory}/.ondemand/*").exclude?("#{project.directory}/.ondemand/job_log.yml")
+    end
+  end
+
   test 'creates .ondemand configuration directory' do
     Dir.mktmpdir do |tmp|
       projects_path = Pathname.new(tmp)


### PR DESCRIPTION
- Excludes `cache.json` and `job_log.yml` from projects created from templates.
- Adds tests for these exclusions.