### PR TITLE
Normalize bc keys

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -15,7 +15,7 @@ module SmartAttributes
     # @param id [#to_s] id of attribute
     # @param opts [#to_h] options for attribute
     def initialize(id, opts = {})
-      @id   = id.to_s
+      @id   = id.to_s.downcase
       @opts = opts.to_h.symbolize_keys
     end
 

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -182,4 +182,36 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       assert_equal('Global Queues', label.text)
     end
   end
+
+  test 'forms correctly deal with capitalized ids' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+        ---
+        form:
+          - switcher
+          - Eastern_City
+          - Western_City
+        attributes:
+          switcher:
+            widget: 'select'
+            options:
+              - ["east", data-hide-Western-City: true]
+              - ["west", data-hide-Eastern-City: true]
+      HEREDOC
+
+      make_bc_app(dir, form)
+
+      visit(new_batch_connect_session_context_url('sys/app'))
+
+      # select east, and west is no longer visible. Also note that the id is lowercase.
+      select('east', from: bc_ele_id('switcher'))
+      assert(find("##{bc_ele_id('eastern_city')}").visible?)
+      refute(find("##{bc_ele_id('western_city')}", visible: false).visible?)
+
+      # select west, and now ease is no longer visible
+      select('west', from: bc_ele_id('switcher'))
+      assert(find("##{bc_ele_id('western_city')}").visible?)
+      refute(find("##{bc_ele_id('eastern_city')}", visible: false).visible?)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3381 by lowercasing ids so that they always work with dynamic directives. 