### PR TITLE
rescue Exceptions in dashboard widgets

### DIFF
--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -42,11 +42,19 @@ module DashboardHelper
     begin
       render partial: "widgets/#{widget}"
     rescue SyntaxError, StandardError => e
-      render partial: 'shared/widget_error', locals: { error: e, widget: widget.to_s }
+      render_error_widget(e, widget.to_s)
+      # rubocop:disable Lint/RescueException - because these can throw all sorts of errors.
+    rescue Exception => e
+      # rubocop:enable Lint/RescueException
+      render_error_widget(e, widget.to_s)
     end
   end
 
   private
+
+  def render_error_widget(error, widget_name)
+    render(partial: 'shared/widget_error', locals: { error: error, widget: widget_name })
+  end
 
   def default_dashboard_layout
     if xdmod?

--- a/apps/dashboard/test/fixtures/config/views/widgets/_load_error.html.erb
+++ b/apps/dashboard/test/fixtures/config/views/widgets/_load_error.html.erb
@@ -1,0 +1,1 @@
+<%-  require 'the_missing_gem' -%>

--- a/apps/dashboard/test/integration/dashboard_layout_test.rb
+++ b/apps/dashboard/test/integration/dashboard_layout_test.rb
@@ -245,12 +245,16 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
                                   {
                                     columns: [
                                       {
-                                        width:   6,
+                                        width:   4,
                                         widgets: 'this_widget_doesnt_exist'
                                       },
                                       {
-                                        width:   6,
+                                        width:   4,
                                         widgets: 'syntax_error'
+                                      },
+                                      {
+                                        width:   4,
+                                        widgets: 'load_error'
                                       }
                                     ]
                                   }
@@ -263,12 +267,13 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
     end
 
     assert_select 'div.row', 1
-    assert_select 'div.row > div.col-md-6', 2
+    assert_select 'div.row > div.col-md-4', 3
 
-    error_widgets = css_select('div.row > div.col-md-6 > div.alert.alert-danger.card > div.card-body')
-    assert_equal 2, error_widgets.size
+    error_widgets = css_select('div.row > div.col-md-4 > div.alert.alert-danger.card > div.card-body')
+    assert_equal 3, error_widgets.size
     assert_equal true, %r{Missing partial widgets/_this_widget_doesnt_exist}.match?(error_widgets[0].text)
     assert_equal true, /undefined method `woops!'/.match?(error_widgets[1].text)
+    assert_equal true, /cannot load such file -- the_missing_gem/.match?(error_widgets[2].text)
   end
 
   test 'should render brand new widgets with shipped widgets' do


### PR DESCRIPTION
Fixes #3539 by rescuing `Exception`s as well as errors.