### PR TITLE
greatly simplify snakeCaseWords

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby }}-unit-gems-${{ hashFiles('apps/*/Gemfile.lock', 'Gemfile.lock') }}-2
+          key: ${{ runner.os }}-${{ matrix.ruby }}-unit-gems-${{ hashFiles('apps/*/Gemfile.lock', 'Gemfile.lock') }}-1
 
       - name: Setup os dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby }}-unit-gems-${{ hashFiles('apps/*/Gemfile.lock', 'Gemfile.lock') }}-1
+          key: ${{ runner.os }}-${{ matrix.ruby }}-unit-gems-${{ hashFiles('apps/*/Gemfile.lock', 'Gemfile.lock') }}-2
 
       - name: Setup os dependencies
         run: |

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -93,27 +93,10 @@ function mountainCaseWords(str) {
 function snakeCaseWords(str) {
   if(str === undefined) return undefined;
 
-  let snakeCase = "";
+  const rex = /([A-Z]{1}[a-z]*[0-9]*)/g;
+  const words = str.match(rex);
 
-  str.split('').forEach((c, index) => {
-    if(c === '-' || c === '_') {
-      snakeCase += '_';
-    } else if (index == 0) {
-      snakeCase += c.toLowerCase();
-    } else if(c == c.toUpperCase() && isNaN(c)) {
-      const nextIsUpper = (index + 1 !== str.length) ? str[index + 1] === str[index + 1].toUpperCase() : true;
-      const nextIsNum = !isNaN(str[index + 1]);
-      if ((str[index-1] === '_' || nextIsUpper) && !nextIsNum) {
-        snakeCase += c.toLowerCase();
-      } else {
-        snakeCase += `_${c.toLowerCase()}`;
-      }
-    } else {
-      snakeCase += c;
-    }
-  });
-
-  return snakeCase;
+  return words.map(word => word.toLowerCase()).join('_');
 }
 
 /**

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -93,10 +93,13 @@ function mountainCaseWords(str) {
 function snakeCaseWords(str) {
   if(str === undefined) return undefined;
 
-  const rex = /([A-Z]{1}[a-z]*[0-9]*)/g;
+  // find all the captial case words and if none are found, we'll just bascially
+  // return the same string.
+  const rex = /([A-Z]{1}[a-z]*[0-9]*)|.+/g;
   const words = str.match(rex);
 
-  return words.map(word => word.toLowerCase()).join('_');
+  // filter out emtpy matches to avoid having a _ at the end.
+  return words.filter(word => word != '').map(word => word.toLowerCase()).join('_');
 }
 
 /**

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -214,4 +214,33 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       refute(find("##{bc_ele_id('eastern_city')}", visible: false).visible?)
     end
   end
+
+  test 'weird ids like aa_b_cc work' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+        form:
+        - aa
+        - aa_b_cc
+        attributes:
+          aa:
+            widget: select
+            options:
+              - [ "foo", "foo",	data-hide-aa-b-cc: true]
+              - ['bar', 'bar']
+          aa_b_cc:
+            widget: text_field
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # foo is default, so aa_b_cc should be hidden
+      assert('foo', find("##{bc_ele_id('aa')}").value)
+      refute(find("##{bc_ele_id('aa_b_cc')}", visible: false).visible?)
+
+      # select bar, and now aa_b_cc is available.
+      select('bar', from: bc_ele_id('aa'))
+      assert(find("##{bc_ele_id('aa_b_cc')}").visible?)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3538

First, I want to see how this tests, because I'm not 100% sure on it. I think it works for most cases, but tests will tell the tale.

Looking through the `git blame` I can see that #2158 added a lot of complication to fix #1658, but looking at #1658 a second time, I wonder if that even matters.

The issue in #1658 complained about mapping `OSC_JUPYTER` to `o_s_c_j_u_p_y_t_e_r`. But the issue is that this mapping is done to normalize keys in the tables. I'm thinking now that that odd mapping doesn't really matter.  As long as it's consistent, what's it matter?