### PR TITLE
3436 clean-up PM launcher editable_select interface

### DIFF
--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -1,4 +1,4 @@
-<%-
+6<%-
   field_id = "#{form.object_name}_#{attrib.id}"
   exclude_id = "#{field_id}_exclude"
   exclude_name = "#{form.object_name}[#{attrib.id}_exclude]"
@@ -25,7 +25,7 @@
 
         <li class="<%= li_classes %>">
 
-          <span data-select-value><%= choice %></span><br/>
+          <span data-select-value class="text-break"><%= choice %></span><br/>
 
           <button class="btn btn-info float-start w-45" type="button" id="<%= add_id %>"
             data-select-toggler="add" data-select-id="<%= field_id %>"

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -12,7 +12,7 @@
 
     <%= render(partial: 'launchers/editable_form_fields/edit_fixed_field',  locals: { form: form, attrib: attrib, fixed: fixed }) %>
 
-    <ol class="list-group list-group-flush text-center col-md-4 mb-3">
+    <ol class="list-group text-center col-md-4 mb-3">
       <%- attrib.select_choices(hide_excludable: false).each do |select_data| %>
         <%- 
           choice = parse_select_data(select_data)

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -25,20 +25,25 @@
 
       <li class="<%= li_classes %>">
 
-        <button class="btn btn-info float-start" type="button" id="<%= add_id %>"
-          data-select-toggler="add" data-select-id="<%= field_id %>"
-          <%= disabled ? nil : 'disabled="true"' %> >
-          <%= t('dashboard.add') %>
-        </button>
+        <span data-select-value><strong><%= choice %></strong></span>
+        <br/>
+        <div class="row">
+          <div class="col">          
+            <button class="btn btn-info float-start w-100" type="button" id="<%= add_id %>"
+              data-select-toggler="add" data-select-id="<%= field_id %>"
+              <%= disabled ? nil : 'disabled="true"' %> >
+              <%= t('dashboard.add') %>
+            </button>
+          </div>
 
-        <span data-select-value><%= choice %></span>
-
-        <button class="btn btn-warning float-end" type="button" id="<%= remove_id %>"
-          data-select-toggler="remove" data-select-id="<%= field_id %>"
-          <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
-          <%= t('dashboard.remove') %>
-        </button>
-
+          <div class="col">
+            <button class="btn btn-warning float-end w-100" type="button" id="<%= remove_id %>"
+              data-select-toggler="remove" data-select-id="<%= field_id %>"
+              <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
+              <%= t('dashboard.remove') %>
+            </button>
+          </div>
+        </div>
       </li>
       <%- end -%>
     </ol>

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -12,7 +12,7 @@
 
     <%= render(partial: 'launchers/editable_form_fields/edit_fixed_field',  locals: { form: form, attrib: attrib, fixed: fixed }) %>
 
-    <ol class="list-group text-center col-md-4 mb-3">
+    <ol class="list-group list-group-flush text-center col-md-4 mb-3">
       <%- attrib.select_choices(hide_excludable: false).each do |select_data| %>
         <%- 
           choice = parse_select_data(select_data)
@@ -25,15 +25,15 @@
 
         <li class="<%= li_classes %>">
 
-          <button class="btn btn-info float-start" type="button" id="<%= add_id %>"
+          <span data-select-value><%= choice %></span><br/>
+
+          <button class="btn btn-info float-start w-45" type="button" id="<%= add_id %>"
             data-select-toggler="add" data-select-id="<%= field_id %>"
             <%= disabled ? nil : 'disabled="true"' %> >
             <%= t('dashboard.add') %>
           </button>
 
-          <span data-select-value><%= choice %></span>
-
-          <button class="btn btn-warning float-end" type="button" id="<%= remove_id %>"
+          <button class="btn btn-warning float-end w-45" type="button" id="<%= remove_id %>"
             data-select-toggler="remove" data-select-id="<%= field_id %>"
             <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
             <%= t('dashboard.remove') %>

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -14,37 +14,31 @@
 
     <ol class="list-group text-center col-md-4 mb-3">
       <%- attrib.select_choices(hide_excludable: false).each do |select_data| %>
-      <%- 
-        choice = parse_select_data(select_data)
-        disabled = attrib.exclude_select_choices.include?(choice)
-        last_option = attrib.exclude_select_choices.length + 1 == attrib.select_choices(hide_excludable: false).length
-        li_classes = disabled ? 'list-group-item list-group-item-danger text-strike' : 'list-group-item'
-        add_id = "#{field_id}_add_#{choice}"
-        remove_id = "#{field_id}_remove_#{choice}"
-      -%>
+        <%- 
+          choice = parse_select_data(select_data)
+          disabled = attrib.exclude_select_choices.include?(choice)
+          last_option = attrib.exclude_select_choices.length + 1 == attrib.select_choices(hide_excludable: false).length
+          li_classes = disabled ? 'list-group-item list-group-item-danger text-strike' : 'list-group-item'
+          add_id = "#{field_id}_add_#{choice}"
+          remove_id = "#{field_id}_remove_#{choice}"
+        -%>
 
-      <li class="<%= li_classes %>">
+        <li class="<%= li_classes %>">
 
-        <span data-select-value><strong><%= choice %></strong></span>
-        <br/>
-        <div class="row">
-          <div class="col">          
-            <button class="btn btn-info float-start w-100" type="button" id="<%= add_id %>"
-              data-select-toggler="add" data-select-id="<%= field_id %>"
-              <%= disabled ? nil : 'disabled="true"' %> >
-              <%= t('dashboard.add') %>
-            </button>
-          </div>
+          <button class="btn btn-info float-start" type="button" id="<%= add_id %>"
+            data-select-toggler="add" data-select-id="<%= field_id %>"
+            <%= disabled ? nil : 'disabled="true"' %> >
+            <%= t('dashboard.add') %>
+          </button>
 
-          <div class="col">
-            <button class="btn btn-warning float-end w-100" type="button" id="<%= remove_id %>"
-              data-select-toggler="remove" data-select-id="<%= field_id %>"
-              <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
-              <%= t('dashboard.remove') %>
-            </button>
-          </div>
-        </div>
-      </li>
+          <span data-select-value><%= choice %></span>
+
+          <button class="btn btn-warning float-end" type="button" id="<%= remove_id %>"
+            data-select-toggler="remove" data-select-id="<%= field_id %>"
+            <%= disabled || last_option ? 'disabled="true"'.html_safe : nil %> >
+            <%= t('dashboard.remove') %>
+          </button>
+        </li>
       <%- end -%>
     </ol>
     

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_select.html.erb
@@ -1,4 +1,4 @@
-6<%-
+<%-
   field_id = "#{form.object_name}_#{attrib.id}"
   exclude_id = "#{field_id}_exclude"
   exclude_name = "#{form.object_name}[#{attrib.id}_exclude]"


### PR DESCRIPTION
Moved `add` & `remove` buttons below the `choice` label in launcher's `_editable_select` partial.