### PR TITLE
Fixed ActiveJobsHelper dependency on ApplicationHelper

### DIFF
--- a/apps/dashboard/app/controllers/active_jobs_controller.rb
+++ b/apps/dashboard/app/controllers/active_jobs_controller.rb
@@ -79,11 +79,11 @@ class ActiveJobsController < ApplicationController
       ActiveJobs::Jobstatusdata.new(data, cluster, true)
 
     rescue OodCore::JobAdapterError
-      OpenStruct.new(name: jobid, error: "No job details because job has already left the queue." , status: status_label("completed") )
+      OpenStruct.new(name: jobid, error: "No job details because job has already left the queue." , status: "completed" )
     rescue => e
       Rails.logger.info("#{e}:#{e.message}")
       Rails.logger.info(e.backtrace.join("\n"))
-      OpenStruct.new(name: jobid, error: "No job details available.\n" + e.backtrace.to_s, status: status_label("") )
+      OpenStruct.new(name: jobid, error: "No job details available.\n" + e.backtrace.to_s, status: "" )
     end
   end
 

--- a/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
+++ b/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
@@ -7,7 +7,6 @@ module ActiveJobs
   # @author Brian L. McMichael
   # @version 0.0.1
   class Jobstatusdata
-    include ActiveJobsHelper
     attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
 
     Attribute = Struct.new(:name, :value)
@@ -28,7 +27,7 @@ module ActiveJobs
       self.jobname = info.job_name
       self.username = info.job_owner
       self.account = info.accounting_id || ''
-      self.status = status_label(info.status.state.to_s)
+      self.status = info.status.state.to_s
       self.cluster = cluster.id.to_s
       self.cluster_title = cluster.metadata.title ||  cluster.id.to_s.titleize
       self.walltime_used = info.wallclock_time.to_i > 0 ? pretty_time(info.wallclock_time) : ''

--- a/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_extended_panel.html.erb
@@ -7,7 +7,7 @@
   <div class="card-header">
     <%# FIXME: ul/li with css %>
     <strong>
-      <%= data.status %>
+      <%= status_label(data.status) %>
       <span class="text-break ms-3"><%= data.jobname %></span>
       <span class="ms-3"><%= data.pbsid %></span>
     </strong>

--- a/apps/dashboard/app/views/active_jobs/extended_data.json.jbuilder
+++ b/apps/dashboard/app/views/active_jobs/extended_data.json.jbuilder
@@ -1,3 +1,3 @@
   json.html_extended_panel render(partial: 'active_jobs/extended_panel', :locals => {:data => jobstatusdata}, :formats => [:html])
-  json.status jobstatusdata.status
+  json.status status_label(jobstatusdata.status)
   json.html_ganglia_graphs_table render(partial: 'active_jobs/ganglia_graphs_table', :locals => {:d => jobstatusdata}, :formats => [:html])


### PR DESCRIPTION
After the refactoring completed in https://github.com/OSC/ondemand/pull/3700, a dependency was added to the `ActiveJobsHelper` to render the `status_label` method. The dependent method is in `ApplicationHelper`

This is breaking the Active jobs > job details AJAX call.

This is a possible fix for the issue