### PR TITLE
specify workdir when submitting batch jobs

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -193,7 +193,6 @@ class Launcher
     render_format = adapter.class.name.split('::').last.downcase
 
     job_script = OodCore::Job::Script.new(**submit_opts(options, render_format))
-    Rails.logger.debug("Submitting with script: #{job_script.inspect}")
 
     job_id = Dir.chdir(project_dir) do
       adapter.submit(job_script)

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -193,6 +193,7 @@ class Launcher
     render_format = adapter.class.name.split('::').last.downcase
 
     job_script = OodCore::Job::Script.new(**submit_opts(options, render_format))
+    Rails.logger.debug("Submitting with script: #{job_script.inspect}")
 
     job_id = Dir.chdir(project_dir) do
       adapter.submit(job_script)
@@ -317,7 +318,13 @@ class Launcher
       sm
     end.map do |sm|
       sm.submit(fmt: render_format)
-    end.reduce(&:deep_merge)[:script]
+    end.reduce(&:deep_merge)[:script].merge(
+      # force some values for scripts like the 'workdir'. We could use auto
+      # attributes, but this is not optional and not variable.
+      {
+        workdir: project_dir.to_s
+      }
+    )
   end
 
   def adapter(cluster_id)

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -392,7 +392,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       Open3
         .stubs(:capture3)
-        .with({}, 'sbatch', '-A', 'pas2051', '--export', 'NONE', '--parsable', '-M', 'owens',
+        .with({}, 'sbatch', '-D', project_dir, '-A', 'pas2051', '--export', 'NONE', '--parsable', '-M', 'owens',
               stdin_data: "hostname\n")
         .returns(['job-id-123', '', exit_success])
 
@@ -439,8 +439,9 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       Open3
         .stubs(:capture3)
-        .with({}, 'sbatch', '-J', 'project-manager/my cool job name', '-A', 'pas2051', '--export',
-                  'NONE', '--parsable', '-M', 'owens',
+        .with({}, 'sbatch', '-D', project_dir,
+              '-J', 'project-manager/my cool job name', '-A', 'pas2051', '--export',
+              'NONE', '--parsable', '-M', 'owens',
               stdin_data: "hostname\n")
         .returns(['job-id-123', '', exit_success])
 
@@ -480,7 +481,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       Open3
         .stubs(:capture3)
-        .with({}, 'sbatch', '-A', 'pas2051', '--export', 'NONE', '--parsable', '-M', 'owens',
+        .with({}, 'sbatch', '-D', project_dir, '-A', 'pas2051', '--export', 'NONE', '--parsable', '-M', 'owens',
               stdin_data: "hostname\n")
         .returns(['', 'some error message', exit_failure])
 
@@ -959,11 +960,14 @@ class ProjectManagerTest < ApplicationSystemTestCase
       find('i.fa-atom').click
       input_data = File.read('test/fixtures/projects/chemistry-5533/assignment_1.sh')
 
+      project_dir = Dir.children(dir).select { |p| Pathname.new("#{dir}/#{p}").directory? }.first
+      project_dir = "#{dir}/#{project_dir}"
+
       # NOTE: we're using pzs1715 from sacctmgr_show_accts_alt.txt instead of psz0175
       # from the template.
       Open3
         .stubs(:capture3)
-        .with({}, 'sbatch', '-A', 'pzs1715', '--export', 'NONE', '--parsable', '-M', 'owens',
+        .with({}, 'sbatch', '-D', project_dir, '-A', 'pzs1715', '--export', 'NONE', '--parsable', '-M', 'owens',
               stdin_data: input_data)
         .returns(['job-id-123', '', exit_success])
 

--- a/apps/myjobs/app/models/resource_mgr_adapter.rb
+++ b/apps/myjobs/app/models/resource_mgr_adapter.rb
@@ -37,6 +37,7 @@ class ResourceMgrAdapter
     cluster = cluster_for_host_id(host)
     script = OodCore::Job::Script.new(
       content:           script_path.read,
+      workdir:           script_path.parent.expand_path.to_s,
       accounting_id:     account_string,
       job_array_request: workflow.job_array_request.presence,
       copy_environment:  workflow.copy_environment.eql?('1') ? true : false


### PR DESCRIPTION
Fixes #3800 

Specify `workdir` when submitting batch jobs because these could be issued on clusters that centers use `submit_host` for. When using a `submit_host` the CWD when sbatch (or similar) is issued is $HOME (because they just sshed). So the `chdir` we use sparingly, only works when commands are being issued locally.

So, just specify the `workdir` when the job is submitted.