### PR TITLE
Files app - apply search to select all

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -61,7 +61,7 @@ jQuery(function () {
 
     $('#select_all').on('click', function() {
         if ($(this).is(":checked")) {
-            table.getTable().rows().select();
+            table.getTable().rows({ search: 'applied' }).select();
         } else {
             table.getTable().rows().deselect();
         }


### PR DESCRIPTION
Fixes #3785 

Applies search to select all so that only visible rows are selected.