### PR TITLE
remove confusing app version from batch connect settings page.

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/new.html.erb
@@ -74,9 +74,6 @@ locals: {
   <div class="col-md-6">
     <h3>
       <%= @app.title %>
-      <% unless @app.version.nil? %>
-        <small>version: <%= @app.version %></small>
-      <% end %>
     </h3>
     <div class="ood-appkit markdown">
       <%= OodAppkit.markdown.render(@app.description).html_safe %>


### PR DESCRIPTION
Displaying the OOD app version after the batch connect version name is confusing. This PR removes this misleading info.