### PR TITLE
account for this error and return nil

### DIFF
--- a/nginx_stage/lib/nginx_stage.rb
+++ b/nginx_stage/lib/nginx_stage.rb
@@ -188,7 +188,8 @@ module NginxStage
     rescue ArgumentError => e
       log = Syslog::Logger.new 'ood_nginx_stage'
       log.error "cannot create user #{v} because of error '#{e.message}'"
-    end
+      nil
+    end.compact
   end
 
   # Get a hash of all the staged app configs


### PR DESCRIPTION
Work on #3879 though it doesn't fix it.

It does however fix the issue of weird behaviour and errors like `missing PID file: /var/run/ondemand-nginx/true/passenger.pid`. The `true` being mapped here must be the `log.error` return value. So just return `nil` and compact. Users can still find the error messages in the system log.