### PR TITLE
Fixed tooltip for edit and re-launch buttons in the session card

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -103,7 +103,7 @@ module BatchConnect::SessionsHelper
       data: { toggle: "tooltip", placement: "left" },
       params: params
     ) do
-      "#{fa_icon('sync', classes: nil, title: '')}".html_safe
+      "#{fa_icon('sync', classes: nil, title: nil)}".html_safe
     end
   end
 
@@ -119,7 +119,7 @@ module BatchConnect::SessionsHelper
       data: { toggle: "tooltip", placement: "left" },
       params: {session_id: session.id}
     ) do
-      "#{fa_icon('pen', classes: nil, title: '')}".html_safe
+      "#{fa_icon('pen', classes: nil, title: nil)}".html_safe
     end
   end
 


### PR DESCRIPTION
Fixes to the tooltips for the edit and relaunch buttons in the session card.

All the buttons on the session card were using the Bootstrap tooltip feature that stopped working when Turbo Streams was introduced to render the cards.

This fix is for the default browser tooltip to work with these buttons.