### PR TITLE
Fixed session card relaunch button

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -91,7 +91,7 @@ module BatchConnect::SessionsHelper
     return unless batch_connect_app.valid?
 
     user_context = session.user_context
-    params = batch_connect_app.attributes.map{|attribute| ["batch_connect_session_context[#{attribute.id}]", user_context.fetch(attribute.id, '')]}.to_h
+    params = batch_connect_app.attributes.map{|attribute| ["batch_connect_session_context[#{attribute.id}]", user_context.fetch(attribute.id, nil)]}.to_h.compact
     title = "#{t('dashboard.batch_connect_sessions_relaunch_title')} #{session.title} #{t('dashboard.batch_connect_sessions_word')}"
     button_to(
       batch_connect_session_contexts_path(token: batch_connect_app.token),


### PR DESCRIPTION
While testing locally using the OOD version from source code, I started getting an error in some session cards when using the relaunch button. The error was: `"The cluster was never set. Either set it in form.yml.erb with `cluster` or `form.cluster` or set `cluster` in submit.yml.erb."`

After investigating, this is due to the changes to the cluster SmartAttribute that is added automatically to the session context. cluster is now a `hidden` attribute instead of `fixed`.

The issue is that sessions created before this change, will not have a value for `cluster` in the `user_defined_context.json` file. When generating the relaunch form, it will try to add a value from the user context for cluster these sessions will not have one.

The fix is simply to remove all the fields that do not have a value in the `user_defined_context.json` file.
This will avoid errors for the relaunch button when transitioning from 3.x versions to 4.x