### PR TITLE
import files/index.js as a module to avoid minified collisions

### DIFF
--- a/apps/dashboard/app/views/layouts/files.html.erb
+++ b/apps/dashboard/app/views/layouts/files.html.erb
@@ -1,6 +1,6 @@
 <%
 content_for :head do
-  javascript_include_tag 'files/index', nonce: true
+  javascript_include_tag('files/index', nonce: true, type: 'module')
 end
 %>
 


### PR DESCRIPTION
Fixes #3958 by importing `files/index.js` as a module to avoid minified collisions.