### PR TITLE
change the PM's icon

### DIFF
--- a/apps/projects/manifest.yml
+++ b/apps/projects/manifest.yml
@@ -1,9 +1,9 @@
 ---
 name: Projects
 description: |-
-  The Open OnDemand Jobs Composer App
+  The Open OnDemand Project Manager
 category: Jobs
-icon: fa://magic
+icon: fa://wrench
 role: projects
 url: projects
 new_window: false


### PR DESCRIPTION
change the PM's icon because the project manager uses `magic` and they appear right next to each other in the menu.