### PR TITLE
Move system-status percentage outside of status bar

### DIFF
--- a/apps/dashboard/app/views/system_status/index.turbo_stream.erb
+++ b/apps/dashboard/app/views/system_status/index.turbo_stream.erb
@@ -9,12 +9,13 @@
 
           <% components_status(job_adapter).each do |current_status| %>
             <div class="container py-2">
-              <div><%= current_status[:message] %></div>
+              <span><%= current_status[:message] %></span>
 
               <% if valid_percent?(current_status[:percent]) %>
                 <div class="progress">
-                  <div class="progress-bar" role="progressbar" style="width: <%= current_status[:percent] %>"><%= current_status[:percent] %> in use</div>
+                  <div class="progress-bar" role="progressbar" style="width: <%= current_status[:percent] %>"></div>
                 </div>
+                <span class="text-muted"><%= current_status[:percent] %> in use</span>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
Fixes #3953 

Moves the `N% in use` message underneath the status bar instead of within in it.
![image](https://github.com/user-attachments/assets/ee5228cd-6618-4c9f-8fe2-ccd34e19b92c)
