### PR TITLE
correct this env variable and the ondemand.d config key

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -391,8 +391,8 @@ class ConfigurationSingleton
   # Returns the number of milliseconds to wait between calls to the system status page
   # The default is 30s and the minimum is 10s.
   def status_poll_delay
-    status_poll_delay = ENV['STATUS_POLL_DELAY']
-    status_poll_delay_int = status_poll_delay.nil? ? config.fetch(:status_delay, '30000').to_i : status_poll_delay.to_i
+    status_poll_delay = ENV['OOD_STATUS_POLL_DELAY']
+    status_poll_delay_int = status_poll_delay.nil? ? config.fetch(:status_poll_delay, '30000').to_i : status_poll_delay.to_i
     status_poll_delay_int < 10_000 ? 10_000 : status_poll_delay_int
   end
 


### PR DESCRIPTION
correct this env variable and the ondemand.d config key.

I just happened to notice this when working on something else. 
* Environment variables should have the OOD_ prefix like the others do
* this key should have _poll_ (i.e., `status_poll_delay`) in it to match the environment variable.