### PR TITLE
change this key slightly and an env variable

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -401,7 +401,7 @@ class ConfigurationSingleton
   # to update the sessions card information.
   # The default and minimum value is 10s = 10_000
   def bc_sessions_poll_delay
-    bc_poll_delay = ENV['POLL_DELAY'] || ENV['OOD_BC_SESSIONS_POLL_DELAY']
+    bc_poll_delay = ENV['OOD_BC_SESSIONS_POLL_DELAY'] || ENV['POLL_DELAY']
     bc_poll_delay_int = bc_poll_delay.nil? ? config.fetch(:bc_sessions_poll_delay, '10000').to_i : bc_poll_delay.to_i
     bc_poll_delay_int < 10_000 ? 10_000 : bc_poll_delay_int
   end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -401,8 +401,8 @@ class ConfigurationSingleton
   # to update the sessions card information.
   # The default and minimum value is 10s = 10_000
   def bc_sessions_poll_delay
-    bc_poll_delay = ENV['POLL_DELAY']
-    bc_poll_delay_int = bc_poll_delay.nil? ? config.fetch(:sessions_poll_delay, '10000').to_i : bc_poll_delay.to_i
+    bc_poll_delay = ENV['POLL_DELAY'] || ENV['OOD_BC_SESSIONS_POLL_DELAY']
+    bc_poll_delay_int = bc_poll_delay.nil? ? config.fetch(:bc_sessions_poll_delay, '10000').to_i : bc_poll_delay.to_i
     bc_poll_delay_int < 10_000 ? 10_000 : bc_poll_delay_int
   end
 

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -510,7 +510,7 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   test 'bc_sessions_poll_delay reads from config' do
     Dir.mktmpdir do |dir|
       with_modified_env({ OOD_CONFIG_D_DIRECTORY: dir.to_s }) do
-        sessions_config = { 'sessions_poll_delay' => '99999' }
+        sessions_config = { 'bc_sessions_poll_delay' => '99999' }
         File.open("#{dir}/sessions_config.yml", 'w+') { |f| f.write(sessions_config.to_yaml) }
 
         assert_equal(99_999, ConfigurationSingleton.new.bc_sessions_poll_delay)
@@ -521,6 +521,18 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
   test "bc_sessions_poll_delay minimum value is 10_000" do
     with_modified_env('POLL_DELAY': '100') do
       assert_equal(10_000, ConfigurationSingleton.new.bc_sessions_poll_delay)
+    end
+  end
+
+  test "bc_sessions_poll_delay respnods to new environment variable" do
+    with_modified_env('OOD_BC_SESSIONS_POLL_DELAY': '30000') do
+      assert_equal(30_000, ConfigurationSingleton.new.bc_sessions_poll_delay)
+    end
+  end
+
+  test "bc_sessions_poll_delay's new variable has precedence over the old" do
+    with_modified_env('OOD_BC_SESSIONS_POLL_DELAY': '30000', POLL_DELAY: '40000') do
+      assert_equal(30_000, ConfigurationSingleton.new.bc_sessions_poll_delay)
     end
   end
 end


### PR DESCRIPTION
change this key slightly and an env variable.

Writing the docs for this and I noticed that there is no environment variable for this (POLL_DELAY being deprecated now), so this adds one. It also updates the key slightly from `sessions_poll_delay` to `bc_sessions_poll_delay` to be a little bit more specific.