### PR TITLE
Fixed support ticket javascript after updates to support Bootstrap 5

### DIFF
--- a/apps/dashboard/app/javascript/support_ticket.js
+++ b/apps/dashboard/app/javascript/support_ticket.js
@@ -36,7 +36,7 @@ jQuery(function (){
     }
 
     function showAttachmentsError(message) {
-        const $attachmentsElement = $("[data-toggle='attachments-error']");
+        const $attachmentsElement = $("[data-bs-toggle='attachments-error']");
         $attachmentsElement.parent().addClass("has-error");
         $attachmentsElement.after(`<div class="help-block" id="attachments_error">${message}</div>`);
     }
@@ -76,14 +76,14 @@ jQuery(function (){
         `<div class="attachment-input" id="${newAttachmentContainerId}">
            <div class="form-control attachment-input-content">
               <label class="attachment-file-label" for="${newFileInputId}">No file selected</label>
-              <span class="attachment-delete" data-toggle="attachment-delete" data-attachment-container="${newAttachmentContainerId}" title="Delete attachment"><i class="fas fa-trash-alt"></i></span>
+              <span class="attachment-delete" data-bs-toggle="attachment-delete" data-attachment-container="${newAttachmentContainerId}" title="Delete attachment"><i class="fas fa-trash-alt"></i></span>
            </div>
            <input class="form-control"  type="file" name="support_ticket[attachments][]" id="${newFileInputId}">
         </div>`;
 
         attachmentPlacementCallback(newAttachment);
         $("input[type='file']").on("change", updateAttachmentContent);
-        $("[data-toggle='attachment-delete']").on("click", deleteAttachment);
+        $("[data-bs-toggle='attachment-delete']").on("click", deleteAttachment);
         return newAttachment;
     }
 
@@ -100,7 +100,7 @@ jQuery(function (){
     }
 
     $(function() {
-        $("[data-toggle='attachments-add']").on("click", addAttachment);
+        $("[data-bs-toggle='attachments-add']").on("click", addAttachment);
         $("#new_support_ticket").submit(validateForm);
     });
 


### PR DESCRIPTION
When upgrading to Bootstrap 5, references to `data-toggle` were updated to `data-bs-toggle`.
These were updated for the file-attachement widget, but not in the support ticket javascript file.

This fixes the support ticket javascript to reference the right elements for attachments.