### PR TITLE
Fixed globus javascript variable declaration

### DIFF
--- a/apps/dashboard/app/javascript/files/globus.js
+++ b/apps/dashboard/app/javascript/files/globus.js
@@ -27,8 +27,7 @@ export function getGlobusLink(directory) {
   if (info) {
     let origin_path = directory.replace(info.path, info.endpoint_path);
     origin_path = origin_path.replace("//", "/");
-    url = "https://app.globus.org/file-manager?origin_id=" + info.endpoint + "&origin_path=" + origin_path;
-    return url
+    return "https://app.globus.org/file-manager?origin_id=" + info.endpoint + "&origin_path=" + origin_path;
   }
 }
 


### PR DESCRIPTION
The globus JS is failing after the `files.html.erb` layout was updated to load `files/index.js` as a module.
Loading as a module automatically actives strict mode making variable declaration compulsury.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules

This is a minor fix for the globus.js