### PR TITLE
Added support for multiple directories to deploy OOD extensions/customizations

### DIFF
--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -52,6 +52,8 @@ module Dashboard
     if plugins_dir.directory?
       plugins_dir.children.select(&:directory?).each do |installed_plugin|
         next unless installed_plugin.readable?
+        # Ignore plugins not installed by admins - plugin directory should be owned by root
+        next if ::Configuration.rails_env_production? && !File.stat(installed_plugin.to_s).uid.zero?
 
         config.paths["config/initializers"] << installed_plugin.join("initializers").to_s
         config.autoload_paths << installed_plugin.join("lib").to_s

--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -46,5 +46,17 @@ module Dashboard
       config.autoload_paths << ::Configuration.config_root.join("lib").to_s
       config.paths["app/views"].unshift ::Configuration.config_root.join("views").to_s
     end
+
+    # Enable installed plugins only if configured by administrator
+    plugins_dir = Pathname.new(::Configuration.plugins_directory)
+    if plugins_dir.directory?
+      plugins_dir.children.select(&:directory?).each do |installed_plugin|
+        next unless installed_plugin.readable?
+
+        config.paths["config/initializers"] << installed_plugin.join("initializers").to_s
+        config.autoload_paths << installed_plugin.join("lib").to_s
+        config.paths["app/views"].unshift installed_plugin.join("views").to_s
+      end
+    end
   end
 end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -74,8 +74,9 @@ class ConfigurationSingleton
       :rclone_extra_config            => nil,
       :default_profile                => nil,
       :project_size_timeout           => '15',
-      :novnc_default_compression   => '6',
-      :novnc_default_quality       => '2'
+      :novnc_default_compression      => '6',
+      :novnc_default_quality          => '2',
+      :plugins_directory              => '/var/www/ood/apps/plugins'
     }.freeze
   end
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -428,6 +428,10 @@ class ConfigurationSingleton
     sources
   end
 
+  def rails_env_production?
+    rails_env == 'production'
+  end
+
   private
 
   def can_access_core_app?(name)

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -76,7 +76,7 @@ class ConfigurationSingleton
       :project_size_timeout           => '15',
       :novnc_default_compression      => '6',
       :novnc_default_quality          => '2',
-      :plugins_directory              => '/var/www/ood/apps/plugins'
+      :plugins_directory              => '/etc/ood/config/plugins'
     }.freeze
   end
 

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -535,4 +535,20 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       assert_equal(30_000, ConfigurationSingleton.new.bc_sessions_poll_delay)
     end
   end
+
+  test "rails_env_production? should return true if production environment" do
+    with_modified_env(RAILS_ENV: 'production') do
+      assert ConfigurationSingleton.new.rails_env_production?
+    end
+  end
+
+  test "rails_env_production? should return false if development or test environment" do
+    with_modified_env(RAILS_ENV: 'development') do
+      refute ConfigurationSingleton.new.rails_env_production?
+    end
+
+    with_modified_env(RAILS_ENV: 'test') do
+      refute ConfigurationSingleton.new.rails_env_production?
+    end
+  end
 end


### PR DESCRIPTION
Experimental feature to add support for a folder based OOD extensions structure.
The idea being that administrators can deploy OOD extensions by copying a folder to the new plugins directory.

More infor about the idea in #3916

To test:
Create the plugins folder:` /var/www/ood/apps/plugins`
Download the attached zip file. It contains a folder with an OOD extension.
Add the folder, `session_metrics`, into the plugins directory.

```
/var/www/ood/apps/plugins
│── session_metrics
│    ├── initializers
│    ├── lib
│    └── views

```

The attached zip file is an OOD extension to add Job metrics to the session card.
It requires a Slurm job scheduler to work.
<img width="500" alt="Screenshot 2024-11-13 at 14 05 46" src="https://github.com/user-attachments/assets/3e39c9b5-11ee-4dee-8eca-78336f4c492b">

[session_metrics.zip](https://github.com/user-attachments/files/18025165/session_metrics.zip)

Fixes #3916