### PR TITLE
3037 path select filename filter

### DIFF
--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     dalli (3.2.8)
-    date (3.4.1)
+    date (3.4.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -127,7 +127,7 @@ GEM
       railties (>= 6.0.0)
     local_time (1.0.3)
       coffee-rails
-    logger (1.6.2)
+    logger (1.6.1)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -147,9 +147,10 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1203)
+    mime-types-data (3.2024.1105)
     mini_mime (1.1.5)
-    minitest (5.25.4)
+    mini_portile2 (2.8.8)
+    minitest (5.25.2)
     mocha (2.6.1)
       ruby2_keywords (>= 0.0.5)
     multi_json (1.15.0)
@@ -166,7 +167,8 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.15.7-x86_64-linux)
+    nokogiri (1.15.6)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     ood_appkit (2.1.4)
       addressable (~> 2.4)
@@ -182,8 +184,7 @@ GEM
     pry (0.15.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (5.2.1)
-      date
+    psych (5.2.0)
       stringio
     public_suffix (5.1.1)
     racc (1.8.1)
@@ -211,9 +212,9 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.1)
+    rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
-      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+      nokogiri (~> 1.14)
     railties (7.0.8.5)
       actionpack (= 7.0.8.5)
       activesupport (= 7.0.8.5)
@@ -274,7 +275,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webrick (1.9.1)
+    webrick (1.9.0)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -285,7 +286,7 @@ GEM
     zip_kit (6.3.1)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   addressable (~> 2.4)
@@ -327,4 +328,4 @@ DEPENDENCIES
   zip_kit (~> 6.2)
 
 BUNDLED WITH
-   2.3.27
+   2.3.6

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     dalli (3.2.8)
-    date (3.4.0)
+    date (3.4.1)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -127,7 +127,7 @@ GEM
       railties (>= 6.0.0)
     local_time (1.0.3)
       coffee-rails
-    logger (1.6.1)
+    logger (1.6.2)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -147,10 +147,9 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1105)
+    mime-types-data (3.2024.1203)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
-    minitest (5.25.2)
+    minitest (5.25.4)
     mocha (2.6.1)
       ruby2_keywords (>= 0.0.5)
     multi_json (1.15.0)
@@ -167,8 +166,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.15.6)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.15.7-x86_64-linux)
       racc (~> 1.4)
     ood_appkit (2.1.4)
       addressable (~> 2.4)
@@ -184,7 +182,8 @@ GEM
     pry (0.15.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (5.2.0)
+    psych (5.2.1)
+      date
       stringio
     public_suffix (5.1.1)
     racc (1.8.1)
@@ -212,9 +211,9 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
+    rails-html-sanitizer (1.6.1)
       loofah (~> 2.21)
-      nokogiri (~> 1.14)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.0.8.5)
       actionpack (= 7.0.8.5)
       activesupport (= 7.0.8.5)
@@ -275,7 +274,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webrick (1.9.0)
+    webrick (1.9.1)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -286,7 +285,7 @@ GEM
     zip_kit (6.3.1)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4)
@@ -328,4 +327,4 @@ DEPENDENCIES
   zip_kit (~> 6.2)
 
 BUNDLED WITH
-   2.3.6
+   2.3.27

--- a/apps/dashboard/app/javascript/path_selector/path_selector.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector.js
@@ -31,6 +31,7 @@ function getPathSelectorOptions(element) {
   options.inputFieldId        = element.dataset['inputFieldId'];
   options.showFiles           = element.dataset['showFiles'];
   options.showHidden          = element.dataset['showHidden'];
+  options.filePattern         = element.dataset['filePattern']
   options.modalId             = element.id;
 
   return options;

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -1,3 +1,4 @@
+import { alert } from '../alert';
 
 export class PathSelectorTable {
   _table = null;

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -12,6 +12,7 @@ export class PathSelectorTable {
   modalId             = undefined;
   showHidden          = undefined;
   showFiles           = undefined;
+  filePattern         = undefined;
 
   constructor(options) {
       this.tableId             = options.tableId;
@@ -23,6 +24,7 @@ export class PathSelectorTable {
       this.modalId             = options.modalId;
       this.showHidden          = options.showHidden === 'true';
       this.showFiles           = options.showFiles === 'true';
+      this.filePattern         = options.filePattern;
 
       this.initDataTable();
       this.reloadTable(this.initialUrl());
@@ -216,7 +218,16 @@ export class PathSelectorTable {
       } else if(isHidden) {
         return this.showHidden;
       } else if(isFile) {
-        return this.showFiles;
+        if (this.filePattern !== "") {
+          if (file.name.match(RegExp(this.filePattern))) {
+            return this.showFiles;
+          } else {
+            return false;
+          }
+        }
+        else {
+          return this.showFiles;
+        }
       } else {
         return true;
       }

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -218,16 +218,7 @@ export class PathSelectorTable {
       } else if(isHidden) {
         return this.showHidden;
       } else if(isFile) {
-        if (this.filePattern !== "") {
-          if (file.name.match(RegExp(this.filePattern))) {
-            return this.showFiles;
-          } else {
-            return false;
-          }
-        }
-        else {
-          return this.showFiles;
-        }
+        return this.filteredByFilename(file);
       } else {
         return true;
       }
@@ -235,5 +226,18 @@ export class PathSelectorTable {
 
     data.files = filteredFiles;
     return data;
+  }
+
+  filteredByFilename(file) {
+    if (this.filePattern !== "") {
+      if (file.name.match(RegExp(this.filePattern))) {
+        return this.showFiles;
+      } else {
+        return false;
+      }
+    }
+    else {
+      return this.showFiles;
+    }
   }
 }

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -230,10 +230,17 @@ export class PathSelectorTable {
 
   filteredByFilename(file) {
     if (this.filePattern !== "") {
-      if (file.name.match(RegExp(this.filePattern))) {
-        return this.showFiles;
-      } else {
-        return false;
+      try {
+        const regex = RegExp(this.filePattern)
+
+        if (file.name.match(regex)) {
+          return this.showFiles;
+        } else {
+          return false;
+        }
+
+      } catch (e) {
+        alert("The regular expression provided for this path selector did not compile");
       }
     }
     else {

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -209,6 +209,16 @@ export class PathSelectorTable {
 
   // filter the response from the files API to remove things like hidden files/directories
   filterFileResponse(data) {
+    let regex = undefined
+
+    try {
+      if (this.filePattern !== undefined) {
+        regex = RegExp(this.filePattern);
+      }
+    } catch {
+      alert("The regular expression provided for this path selector did not compile");
+    }
+
     const filteredFiles = data.files.filter((file) => {
       const isHidden = file.name.startsWith('.');
       const isFile = file.type == "f";
@@ -218,7 +228,7 @@ export class PathSelectorTable {
       } else if(isHidden) {
         return this.showHidden;
       } else if(isFile) {
-        return this.filteredByFilename(file);
+        return this.filteredByFilename(file, regex);
       } else {
         return true;
       }
@@ -228,19 +238,12 @@ export class PathSelectorTable {
     return data;
   }
 
-  filteredByFilename(file) {
-    if (this.filePattern !== "") {
-      try {
-        const regex = RegExp(this.filePattern)
-
-        if (file.name.match(regex)) {
-          return this.showFiles;
-        } else {
-          return false;
-        }
-
-      } catch (e) {
-        alert("The regular expression provided for this path selector did not compile");
+  filteredByFilename(file, regex) {
+    if (regex !== undefined) {
+      if (file.name.match(regex)) {
+        return this.showFiles;
+      } else {
+        return false;
       }
     }
     else {

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -6,6 +6,7 @@
   locals = {
     show_hidden: field_options.fetch(:show_hidden, false),
     show_files: field_options.fetch(:show_files, true),
+    file_pattern: field_options.fetch(:file_pattern, ''),
     initial_directory: field_options.fetch(:directory, CurrentUser.home),
     favorites: pathselector_favorites(field_options.try(:[], :favorites)),
 

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -7,6 +7,7 @@
     path_selector_id: path_selector_id,
     show_files: false,
     show_hidden: false,
+    file_pattern: '',
     initial_directory: CurrentUser.home,
     table_id: "#{path_selector_id}_table",
     breadcrumb_id: "#{path_selector_id}_breadcrumb",

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -12,7 +12,7 @@
     breadcrumb_id: "#{path_selector_id}_breadcrumb",
     button_id: "#{path_selector_id}_button",
     input_field_id: 'project_directory',
-    favorites: false
+    favorites: false,
   }
 %>
 

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -12,6 +12,7 @@
     data-breadcrumb-id="<%= breadcrumb_id %>"
     data-select-button-id="<%= button_id %>"
     data-input-field-id="<%= input_field_id %>"
+    data-file-pattern="<%= file_pattern %>"
     >
 
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg" role="document">

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -146,6 +146,45 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'path_selector handles no provided file pattern' do
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+      
+      Tempfile.new("test.py", "#{Rails.root}/tmp")
+      Tempfile.new("test.rb", "#{Rails.root}/tmp")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - path
+        attributes:
+          path:
+            widget: 'path_selector'
+            directory: "#{Rails.root}/tmp"
+            show_files: true
+      HEREDOC
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+      base_id = 'batch_connect_session_context_path'
+
+      visit new_batch_connect_session_context_url('sys/app')
+
+      click_on 'Select Path'
+
+      table_id = "batch_connect_session_context_path_path_selector_table"
+      shown_dirs_and_files = find_all("##{table_id} tr td").map { |td| td["innerHTML"] }
+
+      assert shown_dirs_and_files.any? { |file| file.match("test.py") }
+      assert shown_dirs_and_files.any? { |file| file.match("test.rb") } 
+    end
+  end
+
   test 'data-label-* allows select options to dynamically change the label of another form element' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -79,6 +79,9 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       stub_scontrol
       stub_sacctmgr
       stub_git("#{dir}/app")
+      
+      Tempfile.new("test.py", "#{Rails.root}/tmp")
+      Tempfile.new("test.rb", "#{Rails.root}/tmp")
 
       form = <<~HEREDOC
         ---
@@ -89,14 +92,23 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
         attributes:
           path:
             widget: 'path_selector'
-            directory: "#{Rails.root}"
-            data-target-file-pattern: \.py$
+            directory: "#{Rails.root}/tmp"
+            show_files: true
+            file_pattern: \.py
       HEREDOC
 
       Pathname.new("#{dir}/app/").join('form.yml').write(form)
       base_id = 'batch_connect_session_context_path'
 
       visit new_batch_connect_session_context_url('sys/app')
+
+      click_on 'Select Path'
+
+      table_id = "batch_connect_session_context_path_path_selector_table"
+      shown_dirs_and_files = find_all("##{table_id} tr td").map { |td| td["innerHTML"] }
+
+      assert shown_dirs_and_files.any? { |file| file.match("test.py") }
+      refute shown_dirs_and_files.any? { |file| file.match("test.rb") }    
     end
   end
 

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -140,7 +140,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       Pathname.new("#{dir}/app/").join('form.yml').write(form)
       base_id = 'batch_connect_session_context_path'
 
-      accept_alert("The regular expression provided for this path selector did not compile!") do
+      accept_alert("The regular expression provided for this path selector did not compile") do
         visit new_batch_connect_session_context_url('sys/app')
       end
     end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -140,9 +140,9 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       Pathname.new("#{dir}/app/").join('form.yml').write(form)
       base_id = 'batch_connect_session_context_path'
 
-      accept_alert("The regular expression provided for this path selector did not compile") do
-        visit new_batch_connect_session_context_url('sys/app')
-      end
+      visit new_batch_connect_session_context_url('sys/app')
+
+      find('.alert-danger')
     end
   end
 

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -112,6 +112,40 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'path_selector handles invalid regular expressions' do
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+      
+      Tempfile.new("test.py", "#{Rails.root}/tmp")
+      Tempfile.new("test.rb", "#{Rails.root}/tmp")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - path
+        attributes:
+          path:
+            widget: 'path_selector'
+            directory: "#{Rails.root}/tmp"
+            show_files: true
+            file_pattern: \.doesn't(compile
+      HEREDOC
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+      base_id = 'batch_connect_session_context_path'
+
+      accept_alert("The regular expression provided for this path selector did not compile!") do
+        visit new_batch_connect_session_context_url('sys/app')
+      end
+    end
+  end
+
   test 'data-label-* allows select options to dynamically change the label of another form element' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -72,6 +72,34 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'path_selector can filter by file type matching an expression' do
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - path
+        attributes:
+          path:
+            widget: 'path_selector'
+            directory: "#{Rails.root}"
+            data-target-file-pattern: \.py$
+      HEREDOC
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+      base_id = 'batch_connect_session_context_path'
+
+      visit new_batch_connect_session_context_url('sys/app')
+    end
+  end
+
   test 'data-label-* allows select options to dynamically change the label of another form element' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }


### PR DESCRIPTION
Fixes #3037 

The following form.yml will generate a Select Path modal that shows only directories and Ruby files.

```
form:
  - path

attributes:
  path:
    widget: "path_selector"
    show_hidden: false
    file_pattern: \.rb$
```