### PR TITLE
strengthen checks on plugin directories.

### DIFF
--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -52,13 +52,27 @@ module Dashboard
     if plugins_dir.directory?
       plugins_dir.children.select(&:directory?).each do |installed_plugin|
         next unless installed_plugin.readable?
-        # Ignore plugins not installed by admins - plugin directory should be owned by root
-        next if ::Configuration.rails_env_production? && !File.stat(installed_plugin.to_s).uid.zero?
 
-        config.paths["config/initializers"] << installed_plugin.join("initializers").to_s
-        config.autoload_paths << installed_plugin.join("lib").to_s
-        config.paths["app/views"].unshift installed_plugin.join("views").to_s
+        initers = installed_plugin.join('initializers')
+        lib = installed_plugin.join('lib')
+        views = installed_plugin.join('views')
+
+        production = ::Configuration.rails_env_production?
+
+        # only load paths in production if every single file in the directory is root owned.
+        safe_load_initers = production ? safe_load_path?(initers) : true
+        safe_load_lib = production ? safe_load_path?(lib) : true
+        safe_load_views = production ? safe_load_path?(views) : true
+
+        config.paths['config/initializers'] << initers.to_s if safe_load_initers
+        config.autoload_paths << lib.to_s if safe_load_lib
+        config.paths["app/views"].unshift(views.to_s) if safe_load_views
       end
+    end
+
+    # Determine if this path is safe to load. I.e., are all the files root owned.
+    def safe_load_path?(path)
+      path.children.all? { |f| File.stat(f).uid.zero? }
     end
   end
 end


### PR DESCRIPTION
Instead of just verifiying that the plugin directory is root owned, this verifies that _all_ files in the folders are root owned.