### PR TITLE
fix some minified javascript errors

### DIFF
--- a/apps/dashboard/app/javascript/path_selector/path_selector.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector.js
@@ -21,7 +21,7 @@ function makeTable(element) {
 }
 
 function getPathSelectorOptions(element) {
-  options = {};
+  const options = {};
 
   options.filesPath           = element.dataset['filesPath'];
   options.initialDirectory    = element.dataset['initialDirectory'];

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -56,7 +56,7 @@
       <div class='card-body'>
         <div class="col">
           <div class="field">
-          <%= javascript_include_tag 'icon_picker', nonce: true %>
+          <%= javascript_include_tag('icon_picker', nonce: true, type: 'module') %>
           <%= form.text_field :icon, placeholder: "cog", id: "product_icon_select", value: @project.icon_class %>
             <% if @project.icon =~ /(fa[bsrl]?):\/\/(.*)/ %>
               <% icon = $2; style = $1 %>

--- a/apps/dashboard/app/views/projects/new.html.erb
+++ b/apps/dashboard/app/views/projects/new.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag 'projects_new', nonce: true %>
+<%= javascript_include_tag('projects_new', nonce: true, type: 'module') %>
 
 <div class='page-header text-center'>
   <h1>New Project</h1>


### PR DESCRIPTION
Fixes #4052

When minified, these files conflict with jQuery, so import them as a module. Secondly, make this object const to avoid assinments to undeclared objects.

