### PR TITLE
Feature/3985 pm manifest support for copied files

### DIFF
--- a/apps/dashboard/app/apps/ProjectManifest.rb
+++ b/apps/dashboard/app/apps/ProjectManifest.rb
@@ -1,0 +1,5 @@
+class  ProjectManifest < Manifest
+  def files
+    manifest_options[:files] || []
+  end
+end

--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -233,4 +233,10 @@ category: OSC
       false
     end
   end
+
+  class Template < Manifest
+    def files
+      manifest_options[:files] || []
+    end
+  end
 end

--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -233,10 +233,4 @@ category: OSC
       false
     end
   end
-
-  class Template < Manifest
-    def files
-      manifest_options[:files] || []
-    end
-  end
 end

--- a/apps/dashboard/test/models/manifest_test.rb
+++ b/apps/dashboard/test/models/manifest_test.rb
@@ -138,7 +138,8 @@ class ManifestTest < ActiveSupport::TestCase
              metadata: { some_key: 'value' },
              new_window: false,
              caption: 'some caption',
-             invalid_key: 'invalid value'
+             invalid_key: 'invalid value',
+             files: ['file1', 'file2']
           }
 
     valid_manifest = <<~HEREDOC
@@ -157,6 +158,49 @@ class ManifestTest < ActiveSupport::TestCase
     HEREDOC
 
     manifest = Manifest.new(opts)
+
+    Dir.mktmpdir do |dir|
+      path = dir << '/manifest.yml'
+      manifest.save(path)
+
+      assert_equal valid_manifest, File.read(path)
+    end
+  end
+
+  test 'Manifest::Template writes files entries' do
+    opts = { name: 'Ruby', 
+             description: 'test hash', 
+             icon: 'fas://cog',
+             url: '/some/location',
+             category: 'some category',
+             subcategory: 'some subcategory',
+             role: 'some role',
+             metadata: { some_key: 'value' },
+             new_window: false,
+             caption: 'some caption',
+             invalid_key: 'invalid value',
+             files: ['file1', 'file2']
+          }
+
+    valid_manifest = <<~HEREDOC
+      ---
+      name: Ruby
+      description: test hash
+      icon: fas://cog
+      url: "/some/location"
+      category: some category
+      subcategory: some subcategory
+      role: some role
+      metadata:
+        some_key: value
+      new_window: false
+      caption: some caption
+      files:
+      - file1
+      - file2
+    HEREDOC
+
+    manifest = Manifest::Template.new(opts)
 
     Dir.mktmpdir do |dir|
       path = dir << '/manifest.yml'

--- a/apps/dashboard/test/models/manifest_test.rb
+++ b/apps/dashboard/test/models/manifest_test.rb
@@ -166,47 +166,4 @@ class ManifestTest < ActiveSupport::TestCase
       assert_equal valid_manifest, File.read(path)
     end
   end
-
-  test 'Manifest::Template writes files entries' do
-    opts = { name: 'Ruby', 
-             description: 'test hash', 
-             icon: 'fas://cog',
-             url: '/some/location',
-             category: 'some category',
-             subcategory: 'some subcategory',
-             role: 'some role',
-             metadata: { some_key: 'value' },
-             new_window: false,
-             caption: 'some caption',
-             invalid_key: 'invalid value',
-             files: ['file1', 'file2']
-          }
-
-    valid_manifest = <<~HEREDOC
-      ---
-      name: Ruby
-      description: test hash
-      icon: fas://cog
-      url: "/some/location"
-      category: some category
-      subcategory: some subcategory
-      role: some role
-      metadata:
-        some_key: value
-      new_window: false
-      caption: some caption
-      files:
-      - file1
-      - file2
-    HEREDOC
-
-    manifest = Manifest::Template.new(opts)
-
-    Dir.mktmpdir do |dir|
-      path = dir << '/manifest.yml'
-      manifest.save(path)
-
-      assert_equal valid_manifest, File.read(path)
-    end
-  end
 end

--- a/apps/dashboard/test/models/project_manifest_test.rb
+++ b/apps/dashboard/test/models/project_manifest_test.rb
@@ -2,23 +2,23 @@ require 'test_helper'
 
 class ProjectManifestTest < ActiveSupport::TestCase
 
-test 'ProjectManifest writes files entries' do
-  opts = { files: ['file1', 'file2'] }
+  test 'ProjectManifest writes files entries' do
+    opts = { files: ['file1', 'file2'] }
 
-  valid_manifest = <<~HEREDOC
-    ---
-    files:
-    - file1
-    - file2
-  HEREDOC
+    valid_manifest = <<~HEREDOC
+      ---
+      files:
+      - file1
+      - file2
+    HEREDOC
 
-  manifest = ProjectManifest.new(opts)
+    manifest = ProjectManifest.new(opts)
 
-  Dir.mktmpdir do |dir|
-    path = dir << '/manifest.yml'
-    manifest.save(path)
+    Dir.mktmpdir do |dir|
+      path = dir << '/manifest.yml'
+      manifest.save(path)
 
-    assert_equal valid_manifest, File.read(path)
+      assert_equal valid_manifest, File.read(path)
+    end
   end
-end
 end

--- a/apps/dashboard/test/models/project_manifest_test.rb
+++ b/apps/dashboard/test/models/project_manifest_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ProjectManifestTest < ActiveSupport::TestCase
+
+test 'ProjectManifest writes files entries' do
+  opts = { files: ['file1', 'file2'] }
+
+  valid_manifest = <<~HEREDOC
+    ---
+    files:
+    - file1
+    - file2
+  HEREDOC
+
+  manifest = ProjectManifest.new(opts)
+
+  Dir.mktmpdir do |dir|
+    path = dir << '/manifest.yml'
+    manifest.save(path)
+
+    assert_equal valid_manifest, File.read(path)
+  end
+end
+end


### PR DESCRIPTION
Add a subclass, `Manifest::Template"`, which allows for the inclusion of:
  `files: ['.../file1', '.../directory1/file2', '.../directory2', '...etc']`
key/value pair in the template manifest file.
This is serialized as:
```
---
files
- '.../file1'
- '.../directory1/file2'
- '.../directory2'
- '...etc'
```
when `to_yaml` is called on an instance of `Template::Manifest`