### PR TITLE
only show nodes if it's positive (#4074)

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
@@ -14,10 +14,14 @@
     <span class="card-text"> (<%= session.job_id %>)</span>
     <div class="float-end">
       <%- if session.starting? || session.running? -%>
+      <%- if num_nodes.positive? -%>
       <span class="badge <%= badge_class %> rounded-pill"><%= pluralize(num_nodes, "node") %></span>
       <span class="card-text"> | </span>
+      <%- end -%>
+      <%- if num_cores.positive? -%>
       <span class="badge <%= badge_class %> rounded-pill"><%= pluralize(num_cores, "core") %></span>
       <span class="card-text"> | </span>
+      <%- end -%>
       <%- end -%>
       <%= status(session) %>
       <%- if session.completed? && !session.app.preset? -%>


### PR DESCRIPTION
Backport #4074 to 4.0

Only show nodes & cores in batch connect cards when they're positive.

And add a test case for the same.