### PR TITLE
memorize announcements and filter for existing files

### DIFF
--- a/apps/dashboard/app/controllers/application_controller.rb
+++ b/apps/dashboard/app/controllers/application_controller.rb
@@ -77,10 +77,10 @@ class ApplicationController < ActionController::Base
   end
 
   def set_announcements
-    @announcements = Announcements.all(@user_configuration.announcement_path)
+    @announcements ||= Announcements.all(@user_configuration.announcement_path)
   rescue => e
     logger.warn "Error parsing announcements: #{e.message}"
-    @announcements = []
+    @announcements ||= []
   end
 
   # Set a list of my quotas which can be used to display warnings if there is

--- a/apps/dashboard/app/models/announcements.rb
+++ b/apps/dashboard/app/models/announcements.rb
@@ -16,7 +16,11 @@ class Announcements
         rescue
           p
         end
-      end.map { |p| Announcement.new(p) }
+      end.select do |path|
+        File.exist?(path)
+      end.map do |p|
+        Announcement.new(p)
+      end
 
       new(announcements)
     end

--- a/apps/dashboard/test/models/announcements_test.rb
+++ b/apps/dashboard/test/models/announcements_test.rb
@@ -13,13 +13,13 @@ class AnnouncementsTest < ActiveSupport::TestCase
     assert_equal 0, announcements.count
   end
 
-  test "should create invalid announcement for file that doesn't exist" do
+  test "should not create announcements for a file that doesn't exist" do
     f = Tempfile.open(['announcement', '.md'])
     path = f.path
     f.close(true)
 
     announcements = Announcements.all(path)
-    assert_equal 1, announcements.count
+    assert_equal 0, announcements.count
     assert_equal 0, announcements.select(&:valid?).count
   end
 
@@ -159,7 +159,8 @@ class AnnouncementsTest < ActiveSupport::TestCase
     Dir.mkdir("#{f6}/invalid4.yml")
 
     announcements = Announcements.all([f1.path, f2.path, f3.path, f4_path, f5.path, f6, f7])
-    assert_equal 12, announcements.count
+    # could have been 12, but 2 were dropped because they don't exist.
+    assert_equal 10, announcements.count
     assert_equal 4, announcements.select(&:valid?).count
   end
 end


### PR DESCRIPTION
memorize announcements and filter for existing files to reduce warnings about `Announcement file not found:` here: https://github.com/OSC/ondemand/blob/1a685ab85ba2b228dd91e4c703fa9abbeb43923a/apps/dashboard/app/models/announcement.rb#L92