### PR TITLE
dont use tmpfiles here

### DIFF
--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -80,7 +80,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       stub_sacctmgr
       stub_git("#{dir}/app")
       
-      ['test.py', 'test.rb'].each do |file|
+      ['test.py', 'test.rbpy'].each do |file|
         FileUtils.touch("#{Rails.root}/tmp/#{file}")
       end
 
@@ -95,7 +95,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
             widget: 'path_selector'
             directory: "#{Rails.root}/tmp"
             show_files: true
-            file_pattern: \.py
+            file_pattern: \\.py
       HEREDOC
 
       Pathname.new("#{dir}/app/").join('form.yml').write(form)

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -80,8 +80,9 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       stub_sacctmgr
       stub_git("#{dir}/app")
       
-      Tempfile.new("test.py", "#{Rails.root}/tmp")
-      Tempfile.new("test.rb", "#{Rails.root}/tmp")
+      ['test.py', 'test.rb'].each do |file|
+        FileUtils.touch("#{Rails.root}/tmp/#{file}")
+      end
 
       form = <<~HEREDOC
         ---


### PR DESCRIPTION
Work on #4090 

Using `Tempfile` here generates a file with a bunch of random characters appended to the end. I.e., we're filtering for `\.py` and that matches `test.rb2025pysaf` 

Here's a demonstration of what's going on.
![image](https://github.com/user-attachments/assets/91021ceb-a936-421d-a8fc-157619bf4f18)

The solution is 2 fold - correct the regular expression and don't add extensions to the temporary file names.
