### PR TITLE
use backspace here to possibly make this test consistent

### DIFF
--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -168,7 +168,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       project_id = setup_project(dir)
 
       click_on 'Edit'
-      find('#project_name').set('my-test-project')
+      find('#project_name').set('my-test-project', clear: :backspace)
       click_on 'Save'
       assert_selector "[href='/projects/#{project_id}']", text: 'My Test Project'
       click_on 'Edit'


### PR DESCRIPTION
I can't seem to replicate this test failure locally, so I'm going to bounce this a few times to see if the test ever fails.

This is the test in question I'm trying to fix. 

![image](https://github.com/user-attachments/assets/19954a9a-350b-463d-9ec0-67179b093648)

I hope there's some issue in clearing it in javascript so that clearing it with backspaces is more consistent.