### PR TITLE
Added support ticket to active jobs page

### DIFF
--- a/apps/dashboard/app/apps/request_tracker_service.rb
+++ b/apps/dashboard/app/apps/request_tracker_service.rb
@@ -15,9 +15,10 @@ class RequestTrackerService
     end
   end
 
-  def create_ticket(support_ticket_request, session)
+  def create_ticket(support_ticket_request, session, job)
     ticket_template_context = {
       session:     session,
+      job:         job,
       description: support_ticket_request.description,
       username:    support_ticket_request.username
     }

--- a/apps/dashboard/app/apps/support_ticket_email_service.rb
+++ b/apps/dashboard/app/apps/support_ticket_email_service.rb
@@ -4,6 +4,8 @@
 #
 # It implements the support ticket interface as defined in the SupportTicketController
 class SupportTicketEmailService
+  include SupportTicketService
+
   attr_reader :support_ticket_config
 
   # Constructor
@@ -11,32 +13,6 @@ class SupportTicketEmailService
   # @param [Hash] support_ticket_config Support ticket configuration
   def initialize(support_ticket_config)
     @support_ticket_config = support_ticket_config
-  end
-
-  # Creates a support ticket model with default data.
-  # will load an interactive session if a session_id provided in the request parameters.
-  #
-  # @param [Hash] request_params Request data sent to the controller
-  #
-  # @return [SupportTicket] support_ticket model
-  def default_support_ticket(request_params)
-    support_ticket = SupportTicket.from_config(support_ticket_config)
-    support_ticket.username = CurrentUser.name
-    support_ticket.session_id = request_params[:session_id]
-    set_session(support_ticket)
-  end
-
-  # Uses SupportTicket model to create and validate the request data.
-  # The model needs to be validated before returning
-  #
-  # @param [Hash] request_data Request data posted to the controller
-  #
-  # @return [SupportTicket] support_ticket model
-  def validate_support_ticket(request_data = {})
-    support_ticket = SupportTicket.from_config(support_ticket_config)
-    support_ticket.attributes = request_data
-    set_session(support_ticket)
-    support_ticket.tap(&:validate)
   end
 
   # Sends an email with the support ticket data
@@ -47,9 +23,11 @@ class SupportTicketEmailService
   def deliver_support_ticket(support_ticket)
     email_service_config = support_ticket_config.fetch(:email, {})
     session = get_session(support_ticket)
+    job = get_job(support_ticket)
     context = OpenStruct.new({
                                support_ticket: support_ticket,
-                               session:        session
+                               session:        session,
+                               job:            job
                              })
 
     SupportTicketMailer.support_email(support_ticket_config, context).deliver_now
@@ -57,21 +35,4 @@ class SupportTicketEmailService
                                I18n.t('dashboard.support_ticket.creation_success', to: email_service_config.fetch(:to)))
   end
 
-  private
-
-  def set_session(support_ticket)
-    session = get_session(support_ticket)
-    if session
-      created_at = session.created_at ? Time.at(session.created_at).localtime.strftime('%Y-%m-%d %H:%M:%S %Z') : 'N/A'
-      support_ticket.session_description = "#{session.title}(#{session.job_id}) - #{session.status} - #{created_at}"
-    end
-
-    support_ticket
-  end
-
-  def get_session(support_ticket)
-    if !support_ticket.session_id.blank? && BatchConnect::Session.exist?(support_ticket.session_id)
-      BatchConnect::Session.find(support_ticket.session_id)
-    end
-  end
 end

--- a/apps/dashboard/app/apps/support_ticket_rt_service.rb
+++ b/apps/dashboard/app/apps/support_ticket_rt_service.rb
@@ -4,6 +4,7 @@
 #
 # It implements the support ticket interface as defined in the SupportTicketController
 class SupportTicketRtService
+  include SupportTicketService
 
   attr_reader :support_ticket_config
 
@@ -14,34 +15,6 @@ class SupportTicketRtService
     @support_ticket_config = support_ticket_config
   end
 
-  # Creates a support ticket model with default data.
-  # Will load an interactive session if a session_id provided in the request parameters.
-  # Accepts a queue parameter to override the default. Useful for testing.
-  #
-  # @param [Hash] request_params Request data sent to the controller
-  #
-  # @return [SupportTicket] support_ticket model
-  def default_support_ticket(request_params)
-    support_ticket = SupportTicket.from_config(support_ticket_config)
-    support_ticket.username = CurrentUser.name
-    support_ticket.session_id = request_params[:session_id]
-    support_ticket.queue = request_params[:queue]
-    set_session(support_ticket)
-  end
-
-  # Uses SupportTicket model to create and validate the request data.
-  # The model needs to be validated before returning
-  #
-  # @param [Hash] request_data Request data posted to the controller
-  #
-  # @return [SupportTicket] support_ticket model
-  def validate_support_ticket(request_data = {})
-    support_ticket = SupportTicket.from_config(support_ticket_config)
-    support_ticket.attributes = request_data
-    set_session(support_ticket)
-    support_ticket.tap(&:validate)
-  end
-
   # Creates a support ticket in the request tracker system configured
   #
   # @param [SupportTicket] support_ticket support ticket created in validate_support_ticket
@@ -50,26 +23,10 @@ class SupportTicketRtService
   def deliver_support_ticket(support_ticket)
     service_config = support_ticket_config.fetch(:rt_api, {})
     session = get_session(support_ticket)
+    job = get_job(support_ticket)
     rts = RequestTrackerService.new(service_config)
-    ticket_id = rts.create_ticket(support_ticket, session)
+    ticket_id = rts.create_ticket(support_ticket, session, job)
     service_config.fetch(:success_message, I18n.t('dashboard.support_ticket.rt.creation_success', ticket_id: ticket_id))
   end
 
-  private
-
-  def set_session(support_ticket)
-    session = get_session(support_ticket)
-    if session
-      created_at = session.created_at ? Time.at(session.created_at).localtime.strftime("%Y-%m-%d %H:%M:%S %Z") : "N/A"
-      support_ticket.session_description = "#{session.title}(#{session.job_id}) - #{session.status} - #{created_at}"
-    end
-
-    support_ticket
-  end
-
-  def get_session(support_ticket)
-    if !support_ticket.session_id.blank? && BatchConnect::Session.exist?(support_ticket.session_id)
-      BatchConnect::Session.find(support_ticket.session_id)
-    end
-  end
 end

--- a/apps/dashboard/app/apps/support_ticket_service_now_service.rb
+++ b/apps/dashboard/app/apps/support_ticket_service_now_service.rb
@@ -4,6 +4,7 @@
 #
 # It implements the support ticket interface as defined in the SupportTicketController
 class SupportTicketServiceNowService
+  include SupportTicketService
 
   attr_reader :support_ticket_config
 
@@ -14,32 +15,6 @@ class SupportTicketServiceNowService
     @support_ticket_config = support_ticket_config
   end
 
-  # Creates a support ticket model with default data.
-  # Will load an interactive session if a session_id provided in the request parameters.
-  #
-  # @param [Hash] request_params Request data sent to the controller
-  #
-  # @return [SupportTicket] support_ticket model
-  def default_support_ticket(request_params)
-    support_ticket = SupportTicket.from_config(support_ticket_config)
-    support_ticket.username = CurrentUser.name
-    support_ticket.session_id = request_params[:session_id]
-    set_session(support_ticket)
-  end
-
-  # Uses SupportTicket model to create and validate the request data.
-  # The model needs to be validated before returning
-  #
-  # @param [Hash] request_data Request data posted to the controller
-  #
-  # @return [SupportTicket] support_ticket model
-  def validate_support_ticket(request_data = {})
-    support_ticket = SupportTicket.from_config(support_ticket_config)
-    support_ticket.attributes = request_data
-    set_session(support_ticket)
-    support_ticket.tap(&:validate)
-  end
-
   # Creates a support ticket in the ServiceNow system configured
   #
   # @param [SupportTicket] support_ticket support ticket created in validate_support_ticket
@@ -48,7 +23,8 @@ class SupportTicketServiceNowService
   def deliver_support_ticket(support_ticket)
     service_config = support_ticket_config.fetch(:servicenow_api, {})
     session = get_session(support_ticket)
-    description = create_description_text(service_config, support_ticket, session)
+    job = get_job(support_ticket)
+    description = create_description_text(service_config, support_ticket, session, job)
     payload = {
       caller_id:         support_ticket.email,
       watch_list:        support_ticket.cc,
@@ -80,31 +56,16 @@ class SupportTicketServiceNowService
 
   private
 
-  def create_description_text(service_config, support_ticket_request, session)
+  def create_description_text(service_config, support_ticket_request, session, job)
     ticket_template_context = {
       session:        session,
+      job:            job,
       support_ticket: support_ticket_request,
     }
 
     template = service_config.fetch(:template, 'servicenow_content.text.erb')
     ticket_content_template = ERB.new(File.read(Rails.root.join('app/views/support_ticket/servicenow').join(template)))
     ticket_content_template.result_with_hash({ context: ticket_template_context, helpers: TemplateHelpers.new })
-  end
-
-  def set_session(support_ticket)
-    session = get_session(support_ticket)
-    if session
-      created_at = session.created_at ? Time.at(session.created_at).localtime.strftime("%Y-%m-%d %H:%M:%S %Z") : "N/A"
-      support_ticket.session_description = "#{session.title}(#{session.job_id}) - #{session.status} - #{created_at}"
-    end
-
-    support_ticket
-  end
-
-  def get_session(support_ticket)
-    if !support_ticket.session_id.blank? && BatchConnect::Session.exist?(support_ticket.session_id)
-      BatchConnect::Session.find(support_ticket.session_id)
-    end
   end
 
   class TemplateHelpers

--- a/apps/dashboard/app/controllers/active_jobs_controller.rb
+++ b/apps/dashboard/app/controllers/active_jobs_controller.rb
@@ -15,8 +15,7 @@ class ActiveJobsController < ApplicationController
           cluster_id: params[:jobcluster],
           controller: self,
           params: params,
-          response: response,
-          user_config: @user_configuration
+          response: response
         ).render
       }
     end

--- a/apps/dashboard/app/controllers/active_jobs_controller.rb
+++ b/apps/dashboard/app/controllers/active_jobs_controller.rb
@@ -15,7 +15,8 @@ class ActiveJobsController < ApplicationController
           cluster_id: params[:jobcluster],
           controller: self,
           params: params,
-          response: response
+          response: response,
+          user_config: @user_configuration
         ).render
       }
     end

--- a/apps/dashboard/app/controllers/support_ticket_controller.rb
+++ b/apps/dashboard/app/controllers/support_ticket_controller.rb
@@ -11,7 +11,9 @@
 #  Sends the support ticket to the third party system.
 class SupportTicketController < ApplicationController
   # GET /support?session_id=<session_UUID>
+  # GET /support?job_id=<job_id>&cluster=<cluster>
   # session_id [UUID] optional session to add data to the support ticket
+  # job_id [Integer] cluster [String] optional job id and cluster to add data to the support ticket
   def new
     support_service = create_service_class
     @support_ticket = support_service.default_support_ticket(params)

--- a/apps/dashboard/app/javascript/active_jobs.js
+++ b/apps/dashboard/app/javascript/active_jobs.js
@@ -257,9 +257,27 @@ function create_datatable(options){
                 data:               null,
                 "autoWidth":        true,
                 render: function(data, type, row, meta) {
-                  let { jobname, pbsid, delete_path } = data
-                  if(data.delete_path == "" || data.status == "completed") {
-                    return ""
+                  let { jobname, pbsid, delete_path, support_path } = data
+                  let support_ticket = "";
+                  if (support_path != "") {
+                    support_ticket = `
+                        <a
+                          class="btn btn-primary btn-xs"
+                          href="${escapeHtml(support_path)}"
+                          aria-labeled-by"title"
+                          aria-label="Submit support ticket for job with ID ${pbsid}"
+                          data-toggle="tooltip"
+                          title="Submit Support Ticket"
+                        >
+                          <i class='fas fa-medkit fa-fw' aria-hidden='true'></i>
+                        </a>
+                    `;
+                  }
+                  if(delete_path == "") {
+                    return "";
+                  } else if (data.status == "completed") {
+                    // This will be empty when support ticket is disabled.
+                    return `<div>${support_ticket}</div>`;
                   } else {
                     return `
                       <div>
@@ -275,6 +293,7 @@ function create_datatable(options){
                         >
                           <i class='fas fa-trash-alt fa-fw' aria-hidden='true'></i>
                         </a>
+                        ${support_ticket}
                       </div>
                     `;
                   }

--- a/apps/dashboard/app/javascript/active_jobs.js
+++ b/apps/dashboard/app/javascript/active_jobs.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import oboe from 'oboe';
+import { supportPath } from './config.js';
 import { cssBadgeForState, capitalizeFirstLetter } from './utils.js'
 
 window.fetch_table_data = fetch_table_data;
@@ -18,6 +19,8 @@ var entityMap = {
   '`': '&#x60;',
   '=': '&#x3D;'
 };
+
+const support_path = supportPath();
 
 function escapeHtml (string) {
   return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
@@ -257,13 +260,16 @@ function create_datatable(options){
                 data:               null,
                 "autoWidth":        true,
                 render: function(data, type, row, meta) {
-                  let { jobname, pbsid, delete_path, support_path } = data
+                  let { jobname, pbsid, cluster, delete_path } = data;
                   let support_ticket = "";
                   if (support_path != "") {
+                    const support_url = new URL(support_path, document.location);
+                    support_url.searchParams.set("job_id", pbsid);
+                    support_url.searchParams.set("cluster", cluster);
                     support_ticket = `
                         <a
                           class="btn btn-primary btn-xs"
-                          href="${escapeHtml(support_path)}"
+                          href="${escapeHtml(support_url.toString())}"
                           aria-labeled-by"title"
                           aria-label="Submit support ticket for job with ID ${pbsid}"
                           data-toggle="tooltip"

--- a/apps/dashboard/app/javascript/config.js
+++ b/apps/dashboard/app/javascript/config.js
@@ -94,6 +94,13 @@ export function statusIndexUrl() {
   return cfgData['statusIndexUrl'];
 }
 
+export function supportPath() {
+  const cfgData = configData();
+  const supportPath = cfgData['supportPath'];
+
+  return supportPath;
+}
+
 export function appsDatatablePageLength() {
   const cfgData = configData();
   return parseInt(cfgData['appsDatatablePageLength']);

--- a/apps/dashboard/app/models/active_jobs/jobs_json_request_handler.rb
+++ b/apps/dashboard/app/models/active_jobs/jobs_json_request_handler.rb
@@ -2,18 +2,17 @@ module ActiveJobs
   # Utility class for responding to json activejobs requests. This class generates
   # the resulting json body that the controller will ultimately repond with.
   class JobsJsonRequestHandler
-    attr_reader :controller, :params, :response, :filter_id, :cluster_id, :user_config
+    attr_reader :controller, :params, :response, :filter_id, :cluster_id
 
     # additional attrs to request when calling info_all
     JOB_ATTRS = [:accounting_id, :allocated_nodes, :job_name, :job_owner, :queue_name, :wallclock_time ]
 
-    def initialize(filter_id:, cluster_id:, controller:, params:, response:, user_config:)
+    def initialize(filter_id:, cluster_id:, controller:, params:, response:)
       @filter_id = filter_id
       @cluster_id = cluster_id
       @controller = controller
       @params = params
       @response = response
-      @user_config = user_config
     end
 
     def filter

--- a/apps/dashboard/app/models/active_jobs/jobs_json_request_handler.rb
+++ b/apps/dashboard/app/models/active_jobs/jobs_json_request_handler.rb
@@ -86,9 +86,7 @@ module ActiveJobs
           username: j.job_owner,
           extended_available: extended_available,
           nodes: j.allocated_nodes.map{ |node| node.name }.reject(&:blank?),
-          delete_path: users_job?(j.job_owner) ? UrlHelper.instance.delete_job_path(pbsid: j.id, cluster: cluster.id.to_s) : "",
-          # Check if Support Ticket is enabled via the support_path definition
-          support_path: users_job?(j.job_owner) && !user_config.support_ticket.empty? ? UrlHelper.instance.support_path(job_id: j.id, cluster: cluster.id.to_s) : ""
+          delete_path: users_job?(j.job_owner) ? UrlHelper.instance.delete_job_path(pbsid: j.id, cluster: cluster.id.to_s) : ""
         }
       }
     end

--- a/apps/dashboard/app/models/concerns/support_ticket_service.rb
+++ b/apps/dashboard/app/models/concerns/support_ticket_service.rb
@@ -1,0 +1,75 @@
+#
+# Common methods to all Support Ticket backend services
+#
+module SupportTicketService
+
+  # Creates a support ticket model with default data.
+  # will load an interactive session if a session_id provided in the request parameters.
+  #
+  # @param [Hash] request_params Request data sent to the controller
+  #
+  # @return [SupportTicket] support_ticket model
+  def default_support_ticket(request_params)
+    support_ticket = SupportTicket.from_config(support_ticket_config)
+    support_ticket.username = CurrentUser.name
+    support_ticket.session_id = request_params[:session_id]
+    support_ticket.job_id = request_params[:job_id]
+    support_ticket.cluster = request_params[:cluster]
+    support_ticket.queue = request_params[:queue]
+    set_session(support_ticket)
+    set_job(support_ticket)
+  end
+
+  # Uses SupportTicket model to create and validate the request data.
+  # The model needs to be validated before returning
+  #
+  # @param [Hash] request_data Request data posted to the controller
+  #
+  # @return [SupportTicket] support_ticket model
+  def validate_support_ticket(request_data = {})
+    support_ticket = SupportTicket.from_config(support_ticket_config)
+    support_ticket.attributes = request_data
+    set_session(support_ticket)
+    set_job(support_ticket)
+    support_ticket.tap(&:validate)
+  end
+
+  private
+
+  def set_session(support_ticket)
+    session = get_session(support_ticket)
+    if session
+      created_at = session.created_at ? Time.at(session.created_at).localtime.strftime('%Y-%m-%d %H:%M:%S %Z') : 'N/A'
+      support_ticket.session_description = "#{session.title}(#{session.job_id}) - #{session.status} - #{created_at}"
+    end
+
+    support_ticket
+  end
+
+  def set_job(support_ticket)
+    job = get_job(support_ticket)
+    if job
+      submission_time = job.submission_time ? Time.at(job.submission_time).localtime.strftime('%Y-%m-%d %H:%M:%S %Z') : 'N/A'
+      support_ticket.job_description = "Job: #{job.id} - #{job.status} - #{submission_time}"
+    end
+
+    support_ticket
+  end
+
+  def get_session(support_ticket)
+    if !support_ticket.session_id.blank? && BatchConnect::Session.exist?(support_ticket.session_id)
+      BatchConnect::Session.find(support_ticket.session_id)
+    end
+  end
+
+  def get_job(support_ticket)
+    if !support_ticket.job_id.blank? && !support_ticket.cluster.blank?
+      cluster = OODClusters[support_ticket.cluster.to_sym]
+      cluster.job_adapter.info(support_ticket.job_id)
+    end
+  rescue => e
+    Rails.logger.info("SupportTicket - Invalid job id: #{support_ticket.job_id} - #{e}:#{e.message}")
+    nil
+  end
+
+end

--- a/apps/dashboard/app/models/support_ticket.rb
+++ b/apps/dashboard/app/models/support_ticket.rb
@@ -93,6 +93,16 @@ class SupportTicket
         hide_when_empty: true,
         disabled: true,
       },
+      job_id: {
+        widget: "hidden_field",
+      },
+      cluster: {
+        widget: "hidden_field",
+      },
+      job_description: {
+        hide_when_empty: true,
+        disabled: true,
+      },
       attachments: {
         widget: "file_attachments",
       },

--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -12,5 +12,6 @@
   data-bc-index-url="<%= batch_connect_sessions_path %>"
   data-status-poll-delay="<%= Configuration.status_poll_delay %>"
   data-status-index-url="<%= system_status_path if respond_to?(:system_status_path) %>"
+  data-support-path="<%= support_path if respond_to?(:support_path) %>"
   data-apps-datatable-page-length="<%= @user_configuration.apps_datatable[:page_length] %>"
 ></div>

--- a/apps/dashboard/app/views/support_ticket/email/_email.text.erb
+++ b/apps/dashboard/app/views/support_ticket/email/_email.text.erb
@@ -30,3 +30,20 @@ Interactive Session Information:
 <% else %>
   No session was selected.
 <% end %>
+-------------------------------------
+Job Information:
+<% if @context.job %>
+  <%= JSON.pretty_generate(
+        {
+          id: @context.job.id,
+          job_name: @context.job.job_name,
+          status:  @context.job.status,
+          queue_name: @context.job.queue_name,
+          submission_time: @context.job.submission_time,
+          wallclock_limit: @context.job.wallclock_limit,
+          native: filter_session_parameters(@context.job.native),
+        })
+  %>
+<% else %>
+  No job was selected.
+<% end %>

--- a/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
+++ b/apps/dashboard/app/views/support_ticket/rt/rt_ticket_content.text.erb
@@ -16,7 +16,7 @@ Session Information:
 <%= JSON.pretty_generate(
       {
         id: context[:session].id,
-        clusterId:context[:session].cluster_id,
+        clusterId: context[:session].cluster_id,
         jobId: context[:session].job_id,
         createdAt: Time.at(context[:session].created_at).iso8601,
         token: context[:session].token,
@@ -28,4 +28,21 @@ Session Information:
 %>
 <% else %>
 No session was selected.
+<% end %>
+-------------------------------------
+Job Information:
+<% if context[:job] %>
+<%= JSON.pretty_generate(
+      {
+        id: context[:job].id,
+        job_name: context[:job].job_name,
+        status:  context[:job].status,
+        queue_name: context[:job].queue_name,
+        submission_time: context[:job].submission_time,
+        wallclock_limit: context[:job].wallclock_limit,
+        native: helpers.filter_session_parameters(context[:job].native),
+      })
+%>
+<% else %>
+  No job was selected.
 <% end %>

--- a/apps/dashboard/app/views/support_ticket/servicenow/servicenow_content.text.erb
+++ b/apps/dashboard/app/views/support_ticket/servicenow/servicenow_content.text.erb
@@ -32,3 +32,20 @@ Session Information:
 <% else %>
 No session was selected.
 <% end %>
+-------------------------------------
+Job Information:
+<% if context[:job] %>
+<%= JSON.pretty_generate(
+      {
+        id: context[:job].id,
+        job_name: context[:job].job_name,
+        status:  context[:job].status,
+        queue_name: context[:job].queue_name,
+        submission_time: context[:job].submission_time,
+        wallclock_limit: context[:job].wallclock_limit,
+        native: helpers.filter_session_parameters(context[:job].native),
+      })
+%>
+<% else %>
+  No job was selected.
+<% end %>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -252,7 +252,7 @@ en:
     unknown: Unknown
     uppy: Uppy
     user_configuration:
-      support_ticket_error: support_ticket is misconfigured. "email" or "rt_api" sections are required in the configuration YAML.
+      support_ticket_error: support_ticket is misconfigured. Please add a backend implementation in the configuration YAML.
     welcome_html: |
       %{logo_img_tag}
       <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>

--- a/apps/dashboard/test/apps/request_tracker_service_test.rb
+++ b/apps/dashboard/test/apps/request_tracker_service_test.rb
@@ -35,14 +35,17 @@ class RequestTrackerServiceTest < ActiveSupport::TestCase
       param_hash[:Cc] == support_ticket.cc &&
       param_hash[:Subject] == support_ticket.subject &&
       param_hash[:Queue] == "Standard" &&
-      param_hash[:Priority] == "10"
+      param_hash[:Priority] == "10" &&
+      param_hash[:Text].include?('"id": "session_id"') &&
+      param_hash[:Text].include?('"id": "job_id"')
     end
     .returns("support_ticket_id")
 
-    session = BatchConnect::Session.new(id: 'session', created_at: Time.now)
+    session = BatchConnect::Session.new(id: 'session_id', created_at: Time.now)
+    job = OodCore::Job::Info.new(id: 'job_id', status: 'running')
     RequestTrackerClient.stubs(:new).returns(mock_rt_client)
 
-    result = RequestTrackerService.new(config).create_ticket(support_ticket, session)
+    result = RequestTrackerService.new(config).create_ticket(support_ticket, session, job)
 
     assert_equal "support_ticket_id", result
   end
@@ -67,9 +70,10 @@ class RequestTrackerServiceTest < ActiveSupport::TestCase
     .returns("support_ticket_id")
 
     session = BatchConnect::Session.new(id: 'session', created_at: Time.now)
+    job = OodCore::Job::Info.new(id: '12345', status: 'running')
     RequestTrackerClient.stubs(:new).returns(mock_rt_client)
 
-    result = RequestTrackerService.new(config).create_ticket(support_ticket, session)
+    result = RequestTrackerService.new(config).create_ticket(support_ticket, session, job)
 
     assert_equal "support_ticket_id", result
   end
@@ -83,8 +87,9 @@ class RequestTrackerServiceTest < ActiveSupport::TestCase
     support_ticket = SupportTicket.from_config({})
     support_ticket.attributes = {email: "email@example.com", cc: "cc@example.com", subject: "Subject", queue: "Not_A_Queue"}
     session = BatchConnect::Session.new(id: 'session', created_at: Time.now)
+    job = OodCore::Job::Info.new(id: '12345', status: 'running')
 
-    assert_raises(ArgumentError) { RequestTrackerService.new(config).create_ticket(support_ticket, session) }
+    assert_raises(ArgumentError) { RequestTrackerService.new(config).create_ticket(support_ticket, session, job) }
 
   end
 end

--- a/apps/dashboard/test/apps/support_ticket_email_service_test.rb
+++ b/apps/dashboard/test/apps/support_ticket_email_service_test.rb
@@ -1,100 +1,37 @@
-require "test_helper"
+require 'test_helper'
 
 class SupportTicketEmailServiceTest < ActiveSupport::TestCase
 
   def setup
     config = {
       email: {
-        to: "to_address@support.ticket.com"
+        to: 'to_address@support.ticket.com'
       }
     }
     @target = SupportTicketEmailService.new(config)
-    attachment_mock = stub({size: 100})
-    @params = {
-      username: "username",
-      email: "test@example.com",
-      cc: "cc@example.com",
-      subject: "support ticket subject",
-      description: "support ticket description",
-      attachments: [attachment_mock, attachment_mock],
-      session_id: "123456"
-    }
-
-    @session_mock = stub({title: 'session_title', job_id: '1234', status: "Running", created_at: nil})
   end
 
-  test "default_support_ticket should return a SupportTicket model" do
-    result = @target.default_support_ticket({})
-    assert_equal "SupportTicket", result.class.name
-  end
-
-  test "default_support_ticket should set session_description when session_id provided" do
-    BatchConnect::Session.expects(:exist?).with("1234").returns(true)
-    BatchConnect::Session.expects(:find).with("1234").returns(@session_mock)
-    result = @target.default_support_ticket({session_id: "1234"})
-
-    assert_equal "1234", result.session_id
-    assert_equal 'session_title(1234) - Running - N/A', result.session_description
-  end
-
-  test "validate_support_ticket should return a SupportTicket model" do
-    result = @target.validate_support_ticket({})
-    assert_equal "SupportTicket", result.class.name
-  end
-
-  test "validate_support_ticket should set all SupportTicket fields when provided" do
-    result = @target.validate_support_ticket(@params)
-
-    assert_equal "username", result.username
-    assert_equal "test@example.com", result.email
-    assert_equal "cc@example.com", result.cc
-    assert_equal "support ticket subject", result.subject
-    assert_equal "support ticket description", result.description
-    assert_equal @params[:attachments], result.attachments
-    assert_equal "123456", result.session_id
-  end
-
-  test "validate_support_ticket should set session_description when session_id provided" do
-    BatchConnect::Session.expects(:exist?).with("1234").returns(true)
-    BatchConnect::Session.expects(:find).with("1234").returns(@session_mock)
-    result = @target.validate_support_ticket({session_id: "1234"})
-
-    assert_equal "1234", result.session_id
-    assert_equal 'session_title(1234) - Running - N/A', result.session_description
-  end
-
-  test "validate_support_ticket should set errors if any" do
-    result = @target.validate_support_ticket({})
-
-    assert_equal false, result.errors.empty?
-    assert_equal false, result.errors['username'].blank?
-    assert_equal false, result.errors['email'].blank?
-    assert_equal false, result.errors['subject'].blank?
-    assert_equal false, result.errors['description'].blank?
-
-  end
-
-  test "deliver_support_ticket should delegate to SupportTicketMailer class and return success message" do
+  test 'deliver_support_ticket should delegate to SupportTicketMailer class and return success message' do
     SupportTicketMailer.expects(:support_email).returns(stub(:deliver_now => nil))
-    I18n.stubs(:t).returns("validation message for all support ticket fields")
-    I18n.expects(:t).with('dashboard.support_ticket.creation_success', to: "to_address@support.ticket.com").returns("success message")
+    I18n.stubs(:t).returns('validation message for all support ticket fields')
+    I18n.expects(:t).with('dashboard.support_ticket.creation_success', to: 'to_address@support.ticket.com').returns('success message')
     result = @target.deliver_support_ticket(SupportTicket.new)
 
-    assert_equal "success message", result
+    assert_equal 'success message', result
   end
 
-  test "deliver_support_ticket should delegate to SupportTicketMailer class and return success message override when provided" do
+  test 'deliver_support_ticket should delegate to SupportTicketMailer class and return success message override when provided' do
     config = {
       email: {
-        to: "to_address@support.ticket.com",
-        success_message: "success message override"
+        to: 'to_address@support.ticket.com',
+        success_message: 'success message override'
       }
     }
     target = SupportTicketEmailService.new(config)
     SupportTicketMailer.expects(:support_email).returns(stub(:deliver_now => nil))
     result = target.deliver_support_ticket(SupportTicket.new)
 
-    assert_equal "success message override", result
+    assert_equal 'success message override', result
   end
 
 end

--- a/apps/dashboard/test/apps/support_ticket_rt_service_test.rb
+++ b/apps/dashboard/test/apps/support_ticket_rt_service_test.rb
@@ -3,67 +3,9 @@
 require 'test_helper'
 
 class SupportTicketRtServiceTest < ActiveSupport::TestCase
+
   def setup
     @target = SupportTicketRtService.new({})
-    attachment_mock = stub({ size: 100 })
-    @params = {
-      username:    'username',
-      email:       'test@example.com',
-      cc:          'cc@example.com',
-      subject:     'support ticket subject',
-      description: 'support ticket description',
-      attachments: [attachment_mock, attachment_mock],
-      session_id:  '123456',
-      queue:       'General'
-    }
-    @session_mock = stub({ title: 'session_title', job_id: '1234', status: 'Running', created_at: nil })
-  end
-
-  test 'default_support_ticket should return a SupportTicket model' do
-    result = @target.default_support_ticket({})
-    assert_equal 'SupportTicket', result.class.name
-  end
-
-  test 'default_support_ticket should set a session when session_id provided' do
-    BatchConnect::Session.expects(:exist?).with('1234').returns(true)
-    BatchConnect::Session.expects(:find).with('1234').returns(@session_mock)
-    result = @target.default_support_ticket({ session_id: '1234' })
-
-    assert_equal '1234', result.session_id
-    assert_equal 'session_title(1234) - Running - N/A', result.session_description
-  end
-
-  test 'default_support_ticket should set queue when provided' do
-    result = @target.default_support_ticket({ queue: 'queue_name' })
-
-    assert_equal 'queue_name', result.queue
-  end
-
-  test 'validate_support_ticket should return a SupportTicket model' do
-    result = @target.validate_support_ticket({})
-    assert_equal 'SupportTicket', result.class.name
-  end
-
-  test 'validate_support_ticket should set all SupportTicket fields when provided' do
-    result = @target.validate_support_ticket(@params)
-
-    assert_equal 'username', result.username
-    assert_equal 'test@example.com', result.email
-    assert_equal 'cc@example.com', result.cc
-    assert_equal 'support ticket subject', result.subject
-    assert_equal 'support ticket description', result.description
-    assert_equal @params[:attachments], result.attachments
-    assert_equal '123456', result.session_id
-    assert_equal 'General', result.queue
-  end
-
-  test 'validate_support_ticket should set a session when session_id provided' do
-    BatchConnect::Session.expects(:exist?).with('1234').returns(true)
-    BatchConnect::Session.expects(:find).with('1234').returns(@session_mock)
-    result = @target.validate_support_ticket({ session_id: '1234' })
-
-    assert_equal '1234', result.session_id
-    assert_equal 'session_title(1234) - Running - N/A', result.session_description
   end
 
   test 'deliver_support_ticket should delegate to RequestTrackerService class and return success message' do

--- a/apps/dashboard/test/apps/support_ticket_service_now_service_test.rb
+++ b/apps/dashboard/test/apps/support_ticket_service_now_service_test.rb
@@ -3,59 +3,9 @@
 require 'test_helper'
 
 class SupportTicketServiceNowServiceTest < ActiveSupport::TestCase
+
   def setup
     @target = SupportTicketServiceNowService.new({})
-    attachment_mock = stub({ size: 100 })
-    @params = {
-      username:    'username',
-      email:       'test@example.com',
-      cc:          'cc@example.com',
-      subject:     'support ticket subject',
-      description: 'support ticket description',
-      attachments: [attachment_mock, attachment_mock],
-      session_id:  '123456'
-    }
-    @session_mock = stub({ title: 'session_title', job_id: '1234', status: 'Running', created_at: nil })
-  end
-
-  test 'default_support_ticket should return a SupportTicket model' do
-    result = @target.default_support_ticket({})
-    assert_equal 'SupportTicket', result.class.name
-  end
-
-  test 'default_support_ticket should set a session when session_id provided' do
-    BatchConnect::Session.expects(:exist?).with('1234').returns(true)
-    BatchConnect::Session.expects(:find).with('1234').returns(@session_mock)
-    result = @target.default_support_ticket({ session_id: '1234' })
-
-    assert_equal '1234', result.session_id
-    assert_equal 'session_title(1234) - Running - N/A', result.session_description
-  end
-
-  test 'validate_support_ticket should return a SupportTicket model' do
-    result = @target.validate_support_ticket({})
-    assert_equal 'SupportTicket', result.class.name
-  end
-
-  test 'validate_support_ticket should set all SupportTicket fields when provided' do
-    result = @target.validate_support_ticket(@params)
-
-    assert_equal 'username', result.username
-    assert_equal 'test@example.com', result.email
-    assert_equal 'cc@example.com', result.cc
-    assert_equal 'support ticket subject', result.subject
-    assert_equal 'support ticket description', result.description
-    assert_equal @params[:attachments], result.attachments
-    assert_equal '123456', result.session_id
-  end
-
-  test 'validate_support_ticket should set a session when session_id provided' do
-    BatchConnect::Session.expects(:exist?).with('1234').returns(true)
-    BatchConnect::Session.expects(:find).with('1234').returns(@session_mock)
-    result = @target.validate_support_ticket({ session_id: '1234' })
-
-    assert_equal '1234', result.session_id
-    assert_equal 'session_title(1234) - Running - N/A', result.session_description
   end
 
   test 'deliver_support_ticket should generate default payload' do

--- a/apps/dashboard/test/integration/support_ticket_integration_test.rb
+++ b/apps/dashboard/test/integration/support_ticket_integration_test.rb
@@ -8,7 +8,7 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
       {
         support_ticket: {
           email: {
-            to: "to_address@support.ticket.com",
+            to: 'to_address@support.ticket.com',
             delivery_method: 'test'
           }
         }
@@ -16,7 +16,7 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
     Rails.application.reload_routes!
   end
 
-  test "GET should render support ticket page" do
+  test 'GET should render support ticket page' do
     get support_path
     assert :success
 
@@ -35,7 +35,7 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
     assert_select "input[type='submit']", 1
   end
 
-  test "POST should should create support ticket via email" do
+  test 'POST should should create support ticket via email' do
     get support_path
     assert :success
 
@@ -45,7 +45,7 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
 
     data = {
       support_ticket: {
-        username: "test",
+        username: 'test',
         email: 'name@domain.com',
         cc: 'cc@domain.com',
         subject: 'test subject',
@@ -64,12 +64,14 @@ class SupportTicketIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal number_of_emails + 1, ActionMailer::Base.deliveries.size
     # Check email details
     ActionMailer::Base.deliveries.last.tap do |email|
-      assert_equal ["to_address@support.ticket.com"], email.to
-      assert_equal ["name@domain.com"], email.from
-      assert_equal ["name@domain.com"], email.reply_to
-      assert_equal ["cc@domain.com"], email.cc
-      assert_equal "test subject", email.subject
+      assert_equal ['to_address@support.ticket.com'], email.to
+      assert_equal ['name@domain.com'], email.from
+      assert_equal ['name@domain.com'], email.reply_to
+      assert_equal ['cc@domain.com'], email.cc
+      assert_equal 'test subject', email.subject
       assert_match 'description', email.body.encoded
+      assert_match 'Session Information:', email.body.encoded
+      assert_match 'Job Information:', email.body.encoded
     end
 
   end

--- a/apps/dashboard/test/models/concerns/support_ticket_service_test.rb
+++ b/apps/dashboard/test/models/concerns/support_ticket_service_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SupportTicketServiceTest < ActionView::TestCase
+  include SupportTicketService
+
+  def setup
+    attachment_mock = stub({ size: 100 })
+    @params = {
+      username:    'username',
+      email:       'test@example.com',
+      cc:          'cc@example.com',
+      subject:     'support ticket subject',
+      description: 'support ticket description',
+      attachments: [attachment_mock, attachment_mock],
+      session_id:  '123456',
+      job_id:      '99123',
+      cluster:     'test_cluster'
+    }
+
+    @session_mock = stub({ title: 'session_title', job_id: '1234', status: 'Running', created_at: nil })
+    @job_mock = stub({ id: '99123', status: 'running', submission_time: nil })
+  end
+
+  def support_ticket_config
+    {}
+  end
+
+  test 'default_support_ticket should return a SupportTicket model' do
+    result = default_support_ticket({})
+    assert_equal 'SupportTicket', result.class.name
+  end
+
+  test 'default_support_ticket should set session_description when session_id provided' do
+    BatchConnect::Session.expects(:exist?).with('1234').returns(true)
+    BatchConnect::Session.expects(:find).with('1234').returns(@session_mock)
+    result = default_support_ticket({session_id: '1234'})
+
+    assert_equal '1234', result.session_id
+    assert_equal 'session_title(1234) - Running - N/A', result.session_description
+  end
+
+  test 'default_support_ticket should set job_description when job_id and cluster provided' do
+    cluster = stub({ job_adapter: stub({ info: @job_mock }) })
+    OODClusters.expects(:[]).with(:test_cluster).returns(cluster)
+    result = default_support_ticket({ job_id: '99123', cluster: 'test_cluster' })
+
+    assert_equal '99123', result.job_id
+    assert_equal 'test_cluster', result.cluster
+    assert_equal 'Job: 99123 - running - N/A', result.job_description
+  end
+
+  test 'validate_support_ticket should return a SupportTicket model' do
+    result = validate_support_ticket({})
+    assert_equal 'SupportTicket', result.class.name
+  end
+
+  test 'validate_support_ticket should set all SupportTicket fields when provided' do
+    result = validate_support_ticket(@params)
+
+    assert_equal 'username', result.username
+    assert_equal 'test@example.com', result.email
+    assert_equal 'cc@example.com', result.cc
+    assert_equal 'support ticket subject', result.subject
+    assert_equal 'support ticket description', result.description
+    assert_equal @params[:attachments], result.attachments
+    assert_equal '123456', result.session_id
+    assert_equal '99123', result.job_id
+    assert_equal 'test_cluster', result.cluster
+  end
+
+  test 'validate_support_ticket should set session_description when session_id provided' do
+    BatchConnect::Session.expects(:exist?).with('1234').returns(true)
+    BatchConnect::Session.expects(:find).with('1234').returns(@session_mock)
+    result = validate_support_ticket({ session_id: '1234' })
+
+    assert_equal '1234', result.session_id
+    assert_equal 'session_title(1234) - Running - N/A', result.session_description
+  end
+
+  test 'validate_support_ticket should set job_description when job_id and cluster provided' do
+    cluster = stub({ job_adapter: stub({ info: @job_mock }) })
+    OODClusters.expects(:[]).with(:osc_cluster).returns(cluster)
+    result = validate_support_ticket({ job_id: '99123', cluster: 'osc_cluster' })
+
+    assert_equal '99123', result.job_id
+    assert_equal 'osc_cluster', result.cluster
+    assert_equal 'Job: 99123 - running - N/A', result.job_description
+  end
+
+  test 'validate_support_ticket should set errors if any' do
+    result = validate_support_ticket({})
+
+    assert_equal false, result.errors.empty?
+    assert_equal false, result.errors['username'].blank?
+    assert_equal false, result.errors['email'].blank?
+    assert_equal false, result.errors['subject'].blank?
+    assert_equal false, result.errors['description'].blank?
+  end
+
+end

--- a/apps/dashboard/test/models/support_ticket_test.rb
+++ b/apps/dashboard/test/models/support_ticket_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class SupportTicketTest < ActiveSupport::TestCase
@@ -5,50 +6,56 @@ class SupportTicketTest < ActiveSupport::TestCase
   def setup
     attachment_mock = stub({size: 100})
     @valid_hash = {
-      username: "username",
-      email: "test@example.com",
-      cc: "cc@example.com",
-      subject: "support ticket subject",
-      description: "support ticket description",
+      username: 'username',
+      email: 'test@example.com',
+      cc: 'cc@example.com',
+      subject: 'support ticket subject',
+      description: 'support ticket description',
       attachments: [attachment_mock, attachment_mock],
-      session_id: "123456",
-      session_description: "session description",
-      queue: "queue_name"
+      session_id: '123456',
+      session_description: 'session description',
+      job_id: '987654',
+      cluster: 'cluster',
+      job_description: 'job description',
+      queue: 'queue_name'
     }
   end
 
-  test "configures default fields" do
+  test 'configures default fields' do
     target = SupportTicket.from_config({})
-    assert_equal %w[username email cc subject session_id session_description attachments description queue], target.attributes.map(&:id)
+    assert_equal %w[username email cc subject session_id session_description job_id cluster job_description attachments description queue], target.attributes.map(&:id)
   end
 
-  test "sets all fields from hash and is valid" do
+  test 'sets all fields from hash and is valid' do
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
 
-    assert_equal "username", target.username
-    assert_equal "test@example.com", target.email
-    assert_equal "cc@example.com", target.cc
-    assert_equal "support ticket subject", target.subject
-    assert_equal "support ticket description", target.description
+    assert_equal 'username', target.username
+    assert_equal 'test@example.com', target.email
+    assert_equal 'cc@example.com', target.cc
+    assert_equal 'support ticket subject', target.subject
+    assert_equal 'support ticket description', target.description
     assert_equal @valid_hash[:attachments], target.attachments
-    assert_equal "123456", target.session_id
-    assert_equal "session description", target.session_description
-    assert_equal "queue_name", target.queue
+    assert_equal '123456', target.session_id
+    assert_equal 'session description', target.session_description
+    assert_equal '987654', target.job_id
+    assert_equal 'cluster', target.cluster
+    assert_equal 'job description', target.job_description
+    assert_equal 'queue_name', target.queue
 
     assert_equal true, target.valid?
     assert_equal true, target.errors.empty?
   end
 
-  test "configures custom fields" do
+  test 'configures custom fields' do
     config = {
-      form: ["email", "custom1", "custom2"]
+      form: ['email', 'custom1', 'custom2']
     }
     target = SupportTicket.from_config(config)
-    assert_equal %w[email custom1 custom2], target.attributes.map(&:id)
+    assert_equal ['email', 'custom1', 'custom2'], target.attributes.map(&:id)
   end
 
-  test "username is required" do
+  test 'username is required' do
     @valid_hash[:username] = nil
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
@@ -57,7 +64,7 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:username].blank?
   end
 
-  test "email is required" do
+  test 'email is required' do
     @valid_hash[:email] = nil
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
@@ -66,8 +73,8 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:email].blank?
   end
 
-  test "email should be an email address" do
-    @valid_hash[:email] = "no_email"
+  test 'email should be an email address' do
+    @valid_hash[:email] = 'no_email'
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
 
@@ -75,8 +82,8 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:email].blank?
   end
 
-  test "cc should be an email address if provided" do
-    @valid_hash[:cc] = "no_email"
+  test 'cc should be an email address if provided' do
+    @valid_hash[:cc] = 'no_email'
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
 
@@ -84,7 +91,7 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:cc].blank?
   end
 
-  test "subject is required" do
+  test 'subject is required' do
     @valid_hash[:subject] = nil
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
@@ -93,7 +100,7 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:subject].blank?
   end
 
-  test "description is required" do
+  test 'description is required' do
     @valid_hash[:description] = nil
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
@@ -102,7 +109,7 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:description].blank?
   end
 
-  test "only 4 attachments are allowed by default" do
+  test 'only 4 attachments are allowed by default' do
     attachment_mock = stub({size: 100})
     @valid_hash[:attachments] = [attachment_mock, attachment_mock, attachment_mock, attachment_mock, attachment_mock]
     target = SupportTicket.from_config({})
@@ -112,9 +119,9 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:attachments].blank?
   end
 
-  test "attachments size should be smaller than 6MB by default" do
+  test 'attachments size should be smaller than 6MB by default' do
     #10MB = 10485760
-    attachment_mock = stub({size: 10485760})
+    attachment_mock = stub({size: 10_485_760})
     @valid_hash[:attachments] = [attachment_mock]
     target = SupportTicket.from_config({})
     target.attributes = @valid_hash
@@ -123,14 +130,14 @@ class SupportTicketTest < ActiveSupport::TestCase
     assert_equal false, target.errors[:attachments].blank?
   end
 
-  test "validate default restrictions" do
+  test 'validate default restrictions' do
     target = SupportTicket.from_config({})
 
     assert_equal 6_291_456, target.restrictions[:max_size]
     assert_equal 4, target.restrictions[:max_items]
   end
 
-  test "restrictions should be overridden from configuration" do
+  test 'restrictions should be overridden from configuration' do
     target = SupportTicket.from_config({attachments: {max_size: 1234, max_items: 100}})
 
     assert_equal 1234, target.restrictions[:max_size]


### PR DESCRIPTION
While doing a review of the support ticket functionality, I realized that the active jobs page does not currently integrate with the support ticket functionality.

Active jobs shows more than the interactive sessions running in the cluster and it could be really helpful for the user and the operations team to get information about the specific job when submitting a ticket.

This PR adds the support to include job information as well as adding the icon in the actives jobs page.

PS: Sorry for another PR 🙏 , this one looks bigger than it is. I needed to make the changes to all backend implementations.
