### PR TITLE
Require latest ondemand-passenger and ondemand-nginx (#4089) - 4.0

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -16,7 +16,7 @@ Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends},
   ruby, apache2, sudo, lsof, lua-posix, tzdata, file,
   nodejs (>= 20.0), nodejs (<< 21.0),
-  ondemand-nginx (= 1.26.1.p6.0.23.ood4.0), ondemand-passenger (= 6.0.23.ood4.0)
+  ondemand-nginx (= 1.26.1.p6.0.23.ood4.0.1), ondemand-passenger (= 6.0.23.ood4.0.1)
 Recommends: rclone
 Description: Open OnDemand is an open source release of the Ohio SuperComputer Center's
   OnDemand platform to provide HPC access via a web browser, supporting web based file

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -74,8 +74,8 @@ Requires:        python3
 Requires:        rclone
 %endif
 Requires:        ondemand-apache = %{runtime_version_full}
-Requires:        ondemand-nginx = 1.26.1-1.p6.0.23.ood%{runtime_version}%{?dist}
-Requires:        ondemand-passenger = 6.0.23-1.ood%{runtime_version}%{?dist}
+Requires:        ondemand-nginx = 1.26.1-2.p6.0.23.ood%{runtime_version}%{?dist}
+Requires:        ondemand-passenger = 6.0.23-2.ood%{runtime_version}%{?dist}
 Requires:        ondemand-ruby = %{runtime_version_full}
 Requires:        ondemand-nodejs = %{runtime_version_full}
 Requires:        ondemand-runtime = %{runtime_version_full}


### PR DESCRIPTION
Backport #4089 to the 4.0 release.