### PR TITLE
ensure filenames are not url encoded

### DIFF
--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -184,7 +184,7 @@ export class PathSelectorTable {
   }
 
   setLastVisited(path, pathType = 'd') {
-    const item = { path: path, type: pathType };
+    const item = { path: decodeURI(path), type: pathType };
     if(path) {
       localStorage.setItem(this.storageKey(), JSON.stringify(item));
     }


### PR DESCRIPTION
Fixes #4082 by ensuring we URL decode anything that's being saved in the path selector. This also adds a test to confirm.