### PR TITLE
Various typo and language fixes

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -25,7 +25,7 @@ with regard to the WCAG 3.0 standard.
 
 Specifically, it outlines where Open OnDemand does not meet this standard.
 It may also link to a ticket that developers track. You can search
-[all accessability issues](https://github.com/OSC/ondemand/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Faccessibility)
+[all accessibility issues](https://github.com/OSC/ondemand/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Faccessibility)
 as well.
 
 ## 3rd Party Apps
@@ -40,7 +40,7 @@ are not documented here.
 ## Accessibility by URL
 
 Each section below documents a single webpage. If the section heading
-includes sub URLs this means the same webpage is used to genereate content
+includes sub URLs this means the same webpage is used to generate content
 based on the URL.
 
 As an example in the section entitled `/pun/sys/dashboard/files and sub URLs`,
@@ -52,9 +52,9 @@ as `/pun/sys/files/fs/home/jessie`.
 These issues affect all or most URLs.
 
 - Most URLs have the main navigation bar. This is a list of issues with that navigation
-  bar. See this issue for [navigation bar accessability issue](https://github.com/OSC/ondemand/issues/945)
+  bar. See this issue for [navigation bar accessibility issue](https://github.com/OSC/ondemand/issues/945)
   for more details.
-  - Screen readers will see the navigation bar landark as 'banner landmark', 'navigation'
+  - Screen readers will see the navigation bar landmark as 'banner landmark', 'navigation'
     and 'navigation landmark', where really we should only have 1 single landmark.
 - Many [alerts don't notify screen readers.](https://github.com/OSC/ondemand/issues/2077)
   As an example, when you start an interactive session there's an alert to notify the user
@@ -66,8 +66,8 @@ This is the landing page and what the root URL `/` redirects to.
 
 The landing page allows for site administrators to create panels. The panels we
 distribute are covered in this document. Panels specifically created at any
-given site are unknown to us (the developers), have not and will not be assesed
-for accessability.
+given site are unknown to us (the developers), have not and will not be assessed
+for accessibility.
 
 - [The welcome logo does not provide alt text.](https://github.com/OSC/ondemand/issues/2067)
 - [Message of the Day and pinned apps use heading levels 3 & 4 instead of 2 & 3.](https://github.com/OSC/ondemand/issues/2074).
@@ -80,7 +80,7 @@ for accessability.
   There are several issues with batch connect session cards.
     - First when they change state, say from 'Queued' to 'Running' there's no notification that this happened.
     - Secondly, there's no good organization of these cards. They should probably be in a list.
-    - Lastly some of the text is off, like the session id link that is a UUID. It's an ambigous link.
+    - Lastly some of the text is off, like the session id link that is a UUID. It's an ambiguous link.
 
 #### Batch connect app web forms
 
@@ -95,8 +95,8 @@ may have included.
 - [Dynamic form updates do not update the user.](https://github.com/OSC/ondemand/issues/2075)  When a
   user updates a form field, another form field may automatically be updated.  There is no screen reader
   notification when this occurs.
-- [Resolution fields don't have the right labels.](https://github.com/OSC/ondemand/issues/2076)  Resulution
-  form fields have labels visible to sigted users, but screen-reader navigation does not automatically read
+- [Resolution fields don't have the right labels.](https://github.com/OSC/ondemand/issues/2076)  Resolution
+  form fields have labels visible to sighted users, but screen-reader navigation does not automatically read
   them. The user is forced to navigate around the form element to hear the label.
 
 ### /pun/sys/dashboard/noVNC-1.1.0/vnc.html
@@ -115,7 +115,7 @@ where we come to this conclusion.
 - [The files table does not notify users of updates](https://github.com/OSC/ondemand/issues/2080).
   When a user clicks through to another directory in the file browser table the table updates
   with the contents of the chosen directory. However, screen-readers are not notified that this
-  change has occured.
+  change has occurred.
 - [Screen-Readers read the sorting arrows in the files table](https://github.com/OSC/ondemand/issues/2081)
   when they should only read the column name.
 - [File browsing landmarks could be better.](https://github.com/OSC/ondemand/issues/2079)  There's
@@ -125,12 +125,12 @@ where we come to this conclusion.
 
 The shell application is considered completely inaccessible.  Screen
 readers do work on it a little, but it's so little as to be rendered
-completey useless.
+completely useless.
 
 The underlying library `hterm` does have support for accessibility but
 we need some mechanism to turn it on.
 
-We have this ticket concerning [shell accessability](https://github.com/OSC/ondemand/issues/672)
+We have this ticket concerning [shell accessibility](https://github.com/OSC/ondemand/issues/672)
 to tracks this.
 
 ### /pun/sys/myjobs and sub URLs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Ensure to include what issue this fixes in the **PR comment** to help with autom
 
 ### Linters
 
-For any Ruby librares/apps there is a `.rubocop.yml` at the top of this project. If you
+For any Ruby libraries/apps there is a `.rubocop.yml` at the top of this project. If you
 work in IDEs where you want to only open a part of this project, executing `rake lint:setup`
 and it will copy copy lint config files to various locations. Watch out though, `rake clean`
 will remove them!
@@ -155,7 +155,7 @@ methods.
 * avoid using semi-colons `;`
 * Spaces:
   * around operators `=`, `+`, `-`, `*`, `%`
-  * around curly bracies `{` `}`
+  * around curly braces `{` `}`
   * after commas , colons, and semicolons
 
     ```ruby
@@ -175,7 +175,7 @@ methods.
     end
     ```
 
-* Empty line between method defintions.
+* Empty line between method definitions.
 
     ```ruby
     def method1(arg1)
@@ -406,7 +406,7 @@ function snakeCaseWords(str) {
 
 Beyond the [ESLint] configuration files, we follow these styles:
 
-* File names use underscores, `_`, for word seperators.
+* File names use underscores, `_`, for word separators.
 * Variables are `camelCase` named and are `const` or `let`. Using `var` is discouraged.
 * Function names are `camelCase`.
 
@@ -415,13 +415,13 @@ Beyond the [ESLint] configuration files, we follow these styles:
 In general, when making html elements (or Ruby/Js/Etc models of)
 we'll follow this style.
 
-* IDs use underscores `_` for word seperation. This follows the Rails `form_for` convention.
+* IDs use underscores `_` for word separation. This follows the Rails `form_for` convention.
 
 
 ### CSS Style
 
 * Applicable SCSS conventions like hyphenated variables and those variables are in the `_variables.scss` file.
-* class names use hyphens, `-` for word seperators. If for no other reason than to follow bootstrap
+* class names use hyphens, `-` for word separators. If for no other reason than to follow bootstrap
   which we use quite extensively.
 * classes should mostly use relative sizes (`em` and `rem`), rarely pixel values (`px`).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Developing Open-OnDemand
+# Developing Open OnDemand
 
 This a a guide to developing Open OnDemand.
 
@@ -57,7 +57,7 @@ However, you may choose to have a different development runtime, and that's fine
 OSC maintainers use `modules` on compute nodes instead of developing on the webnodes
 themselves.
 
-It should be noted here that any Ruby module installation needs configured with
+It should be noted here that any Ruby module installation needs to be configured with
 `--enable-shared` flag to be compatible with the Ruby running on the webnode.
 
 Now run `bin/setup` from within this directory to fetch all the dependencies
@@ -227,7 +227,7 @@ variables you may want and/or need.
 For example if you need additional Linux capabilities you can use `OOD_CTR_CAPABILITIES`
 with a comma separated list of the capabilities you want.
 
-If `privileged` is in this list, no capabilies are used and the container is ran with
+If `privileged` is in this list, no capabilities are used and the container is ran with
 the `--privileged` flag.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open OnDemand is an NSF-funded open-source HPC portal. The goal of Open OnDemand
 ![Open ondemand demo demonstrating integration with Open XDMOD; interactive jobs with desktops, Jupyter and visual studio code; file browsing, creation, editing and deletion.](docs/imgs/open_ondemand_demo.gif)
 
 ## Installation
-Installing Open OnDemand simple, use our `.rpm` or `.deb` packages. Get started by visiting the [installation instructions] in our documentation.
+Installing Open OnDemand is simple, use our `.rpm` or `.deb` packages. Get started by visiting the [installation instructions] in our documentation.
 
 ### Container demos
 

--- a/VERSIONING_POLICY.md
+++ b/VERSIONING_POLICY.md
@@ -16,7 +16,7 @@ Minor versions will contain new functionality that's backward compatible. They m
 also contain bug fixes that are not in the prior releases' patch versions.
 
 Minor versions will also introduce deprecations to functionality or configurations
-that maybe be removed in the next major version.
+that may be removed in the next major version.
 
 ## Patch Versions
 Patch versions will only contain security fixes and bug fixes.


### PR DESCRIPTION
- Skimmed through .md files with `aspell --lang=en_US`
- Miscellaneous wording improvements