### PR TITLE
update from data-toggle to data-bs-toggle (#4115)

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -187,7 +187,7 @@ module BatchConnect::SessionsHelper
           content_tag(:ul, class: "nav nav-tabs") do
             tabs.map { |t| t[:title] }.map.with_index do |title, idx|
               content_tag(:li, class: "nav-item #{"active" if idx.zero?}") do
-                link_to title, "#c_#{id}_#{idx}", data: { toggle: "tab" }, aria: { selected: (true if idx.zero?) }, class: "nav-link #{"active" if idx.zero?}"
+                link_to title, "#c_#{id}_#{idx}", data: { 'bs-toggle': "tab" }, aria: { selected: (true if idx.zero?) }, class: "nav-link #{"active" if idx.zero?}"
               end
             end.join("\n").html_safe
           end

--- a/apps/dashboard/app/views/batch_connect/settings/_action_buttons.html.erb
+++ b/apps/dashboard/app/views/batch_connect/settings/_action_buttons.html.erb
@@ -5,7 +5,7 @@
       class: %w[btn px-1 py-0 btn-outline-dark edit-saved-settings-button full-page-spinner],
       title: title,
       'aria-label': title,
-      data: { toggle: "tooltip", placement: "left" }
+      data: { 'bs-toggle': "tooltip", 'bs-placement': "left" }
     ) do
       fa_icon('pen', classes: nil)
     end
@@ -24,7 +24,7 @@
         form_class: %w[d-inline],
         title: title,
         'aria-label': title,
-        data: { toggle: "tooltip", placement: "left" },
+        data: { 'bs-toggle': "tooltip", 'bs-placement': "left" },
         params: params
       ) do
         fa_icon('play', classes: nil)

--- a/apps/dashboard/app/views/batch_connect/settings/show.html.erb
+++ b/apps/dashboard/app/views/batch_connect/settings/show.html.erb
@@ -62,7 +62,7 @@ locals: {
               class: %w[btn btn-danger full-page-spinner],
               title: title,
               'aria-label': title,
-              data: { confirm: t('dashboard.bc_saved_settings.delete_confirm'), toggle: "tooltip", placement: "left"}
+              data: { confirm: t('dashboard.bc_saved_settings.delete_confirm'), 'bs-toggle': "tooltip", 'bs-placement': "left"}
             ) do
               "#{fa_icon('times-circle', classes: nil)} <span aria-hidden='true'>#{t('dashboard.delete')}</span>".html_safe
             end


### PR DESCRIPTION
update from data-toggle to data-bs-toggle to correct a few toggle panels. Specifically the native VNC connection tab, but this also fixes a tooltip or two.