### PR TITLE
Updated the project directory permission allowing group to read and execute files

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -254,7 +254,6 @@ class Project
   end
 
   def update_permission
-    # Read and execute to group
     project_dataroot.chmod(0750)
     true
   rescue StandardError => e

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -117,7 +117,7 @@ class Project
     @directory = Project.dataroot.join(id.to_s).to_s if directory.blank?
     @icon = 'fas://cog' if icon.blank?
 
-    make_dir && sync_template && store_manifest(:save)
+    make_dir && update_permission && sync_template && store_manifest(:save)
   end
 
   def update(attributes)
@@ -250,6 +250,15 @@ class Project
     true
   rescue StandardError => e
     errors.add(:save, "Failed to make directory: #{e.message}")
+    false
+  end
+
+  def update_permission
+    # Read and execute to group
+    project_dataroot.chmod(0750)
+    true
+  rescue StandardError => e
+    errors.add(:save, "Failed to update permissions of the directory: #{e.message}")
     false
   end
 


### PR DESCRIPTION
Related to Issue #4121 

By default directory permissions were **rwxr-xr-x**. 
This is updated to **rwxr-x---**, thus groups can also read and execute the files inside of the project directory (as before) while others will have no permissions to ensure safety.

Locally tested the changes with OOD master branch instance running on OOD.
