### PR TITLE
Permissive constraints on owner segment for apps/show

### DIFF
--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -68,10 +68,8 @@ Rails.application.routes.draw do
   # analytics request appears in the access logs and google analytics
   get 'analytics/:type' => proc { [204, {}, ['']] }, :as => 'analytics'
 
-  get 'apps/show/:name(/:type(/:owner))' => 'apps#show', :as => 'app', :defaults => { type: 'sys' },
-      :constraints => { owner: %r{[^/]+} }
-  get 'apps/icon/:name(/:type(/:owner))' => 'apps#icon', :as => 'app_icon', :defaults => { type: 'sys' },
-      :constraints => { owner: %r{[^/]+} }
+  get 'apps/show/:name(/:type(/:owner))' => 'apps#show', :as => 'app', :defaults => { type: 'sys' }, :constraints => { owner: %r{[^/]+} }
+  get 'apps/icon/:name(/:type(/:owner))' => 'apps#icon', :as => 'app_icon', :defaults => { type: 'sys' }, :constraints => { owner: %r{[^/]+} }
   get 'apps/index' => 'apps#index'
 
   get 'apps/restart' => 'apps#restart' if Configuration.app_sharing_enabled?


### PR DESCRIPTION
Added permissive constraints to the owner parameter in the dashboard's `apps/show` route. This allows usernames to have any character except a slash in their name.

Rails disallows periods in dynamic segments by default because the format specifier uses a period, however from my testing it disallows a period regardless of the format path matching being enabled on the route.

https://guides.rubyonrails.org/routing.html#dynamic-segments

> By default, dynamic segments don't accept dots - this is because the dot is used as a separator for formatted routes. If you need to use a dot within a dynamic segment, add a constraint that overrides this – for example, id: /[^\/]+/ allows anything except a slash.

This issue could crop up as an edge case in other places in the codebase, but since at our site all of our users have at least one period in their name and we have not seen any other issues like this, this might be a non-issue outside of this.

https://discourse.openondemand.org/t/my-sandbox-apps-links-to-not-found/4022