### PR TITLE
update OOD gems in 4.0

### DIFF
--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
       ood_core (~> 0.1)
       rails (>= 6.0.0)
       redcarpet (~> 3.2)
-    ood_core (0.27.0)
+    ood_core (0.27.1)
       ffi (~> 1.16.3)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     nokogiri (1.15.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    ood_appkit (2.1.4)
+    ood_appkit (2.1.6)
       addressable (~> 2.4)
       lograge (~> 0.3)
       ood_core (~> 0.1)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       ood_core (~> 0.1)
       rails (>= 6.0.0)
       redcarpet (~> 3.2)
-    ood_core (0.27.0)
+    ood_core (0.27.1)
       ffi (~> 1.16.3)
       ood_support (~> 0.0.2)
       rexml (~> 3.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     nokogiri (1.15.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    ood_appkit (2.1.4)
+    ood_appkit (2.1.6)
       addressable (~> 2.4)
       lograge (~> 0.3)
       ood_core (~> 0.1)


### PR DESCRIPTION
Backport gem updates to 4.0. Note I've got this in draft for a minute to get ood_core ready as well.