### PR TITLE
Permissive constraints on owner segment for apps/show (#4133)

### DIFF
--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -68,8 +68,8 @@ Rails.application.routes.draw do
   # analytics request appears in the access logs and google analytics
   get 'analytics/:type' => proc { [204, {}, ['']] }, :as => 'analytics'
 
-  get 'apps/show/:name(/:type(/:owner))' => 'apps#show', :as => 'app', :defaults => { type: 'sys' }
-  get 'apps/icon/:name(/:type(/:owner))' => 'apps#icon', :as => 'app_icon', :defaults => { type: 'sys' }
+  get 'apps/show/:name(/:type(/:owner))' => 'apps#show', :as => 'app', :defaults => { type: 'sys' }, :constraints => { owner: %r{[^/]+} }
+  get 'apps/icon/:name(/:type(/:owner))' => 'apps#icon', :as => 'app_icon', :defaults => { type: 'sys' }, :constraints => { owner: %r{[^/]+} }
   get 'apps/index' => 'apps#index'
 
   get 'apps/restart' => 'apps#restart' if Configuration.app_sharing_enabled?


### PR DESCRIPTION
Backports #4133 to 4.0.

Permissive constraints on owner segment for apps/show to allow for usernames with dots and so on.