### PR TITLE
Add user_home_t to SELinux tunable (#4142) (release 4.0 backport)

### DIFF
--- a/packaging/rpm/ondemand-selinux.te
+++ b/packaging/rpm/ondemand-selinux.te
@@ -6,6 +6,7 @@ require {
   type shell_exec_t;
   type rsync_exec_t;
   type ptmx_t;
+  type user_home_t;
   type user_home_dir_t;
   type proc_t;
   type vmblock_t;
@@ -105,6 +106,8 @@ read_lnk_files_pattern(httpd_t, ood_apps_public_t, ood_apps_public_t)
 gen_tunable(ondemand_manage_user_home_dir, false)
 
 tunable_policy(`ondemand_manage_user_home_dir',`
+  manage_dirs_pattern(ood_pun_t, user_home_t, user_home_t)
+  manage_files_pattern(ood_pun_t, user_home_t, user_home_t)
   manage_dirs_pattern(ood_pun_t, user_home_dir_t, user_home_dir_t)
   manage_files_pattern(ood_pun_t, user_home_dir_t, user_home_dir_t)
 ')


### PR DESCRIPTION
On RHEL 9, some files in the home directory are labeled with user_home_t rather than user_home_dir_t https://danwalsh.livejournal.com/63586.html appears to suggest that this is expected behaviour