### PR TITLE
Added brute force lookup into shared_projects_paths to look for potential shared projects

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -41,6 +41,12 @@ class ProjectsController < ApplicationController
     @project = Project.new
   end
 
+  # GET /projects/import
+  def import
+    @templates = []
+    @project = Project.new
+  end
+
   # GET /projects/:id/edit
   def edit
     project_id = show_project_params[:id]
@@ -83,6 +89,21 @@ class ProjectsController < ApplicationController
       render :new
     end
   end
+
+    # POST /projects/import
+    def import_save
+      # TODO fetch the project details from .ondemand and save into .project_lookup
+      # @project = Project.new(project_params)
+  
+      # if @project.save
+        redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
+      # else
+      #   message = @project.errors[:save].empty? ? I18n.t('dashboard.jobs_project_validation_error') : I18n.t('dashboard.jobs_project_generic_error', error: @project.collect_errors)
+      #   flash.now[:alert] = message
+      #   @templates = templates if project_params.key?(:template)
+      #   render :new
+      # end
+    end
 
   # DELETE /projects/:id
   def destroy

--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -92,14 +92,11 @@ class ProjectsController < ApplicationController
 
     # POST /projects/import
     def import_save
-      success = Project.add_shared_to_lookup(:import)
+      success = Project.import_to_lookup(params[:project][:directory])
       if success
         redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
       else
-        message = @project.errors[:save].empty? ? I18n.t('dashboard.jobs_project_validation_error') : I18n.t('dashboard.jobs_project_generic_error', error: @project.collect_errors)
-        flash.now[:alert] = message
-        @templates = templates if project_params.key?(:template)
-        render :new
+        redirect_to project_import_path, alert: I18n.t('dashboard.jobs_project_generic_error')
       end
     end
 

--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -92,17 +92,15 @@ class ProjectsController < ApplicationController
 
     # POST /projects/import
     def import_save
-      # TODO fetch the project details from .ondemand and save into .project_lookup
-      # @project = Project.new(project_params)
-  
-      # if @project.save
+      success = Project.add_shared_to_lookup(:import)
+      if success
         redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
-      # else
-      #   message = @project.errors[:save].empty? ? I18n.t('dashboard.jobs_project_validation_error') : I18n.t('dashboard.jobs_project_generic_error', error: @project.collect_errors)
-      #   flash.now[:alert] = message
-      #   @templates = templates if project_params.key?(:template)
-      #   render :new
-      # end
+      else
+        message = @project.errors[:save].empty? ? I18n.t('dashboard.jobs_project_validation_error') : I18n.t('dashboard.jobs_project_generic_error', error: @project.collect_errors)
+        flash.now[:alert] = message
+        @templates = templates if project_params.key?(:template)
+        render :new
+      end
     end
 
   # DELETE /projects/:id

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -171,6 +171,20 @@ class Project
     false
   end
 
+  def add_shared_to_lookup(operation, dir)
+    # fetch _id by opening .ondemand/manifest.yml
+    manifest_path = Pathname("#{dir.to_s}/.ondemand/manifest.yml")
+    contents = File.read(manifest_path)
+    raw_opts = YAML.safe_load(contents)
+    id = raw_opts["id"]
+    new_table = Project.lookup_table.merge(Hash[id, dir.to_s])
+    File.write(Project.lookup_file, new_table.to_yaml)
+    true
+  rescue StandardError => e
+    errors.add(operation, "Cannot update lookup file with error #{e.class}:#{e.message}")
+    false
+  end
+
   def remove_from_lookup
     new_table = Project.lookup_table.except(id)
     File.write(Project.lookup_file, new_table.to_yaml)

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -9,15 +9,6 @@ class Project
   extend JobLogger
 
   class << self
-    def shared_projects_paths
-      vendor_path = ENV['VENDOR_SHARED_FILESYSTEM'] || ''
-      [
-        Pathname.new('/fs/projects'),
-        Pathname.new('/fs/scratch'),
-        Pathname.new(vendor_path)
-      ]
-    end
-
     def lookup_file
       Pathname("#{dataroot}/.project_lookup").tap do |path|
         FileUtils.touch(path.to_s) unless path.exist?
@@ -41,7 +32,8 @@ class Project
         Project.new({ id: id, directory: directory })
       end
 
-      shared_projects_paths.each do |path|
+      # TODO: Move this out of here
+      Configuration.shared_projects_root.each do |path|
         if path.exist?
           CurrentUser.group_names.each do |group|
             dir_path = path.join(group)

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -1,6 +1,6 @@
 <%
-  edit_project_action = action_name != "new" && action_name != "create"
-
+  edit_project_action = action_name != "new" && action_name != "create" && action_name != "import"
+  import_project_action = action_name == "import"
   path_selector_id = "project_directory_path_selector"
 
   path_selector_locals = {
@@ -27,10 +27,13 @@
     <div class='card'>
       <div class='card-body'>
         <div class="col">
+
+        <% if !import_project_action %>
           <div class="field">
             <%= form.text_field :name, placeholder: I18n.t('dashboard.jobs_project_name_placeholder'),
                     help: I18n.t('dashboard.jobs_project_name_validation') %>
           </div>
+        <% end %>
 
           <div class="field">
             <%= form.text_field(:directory, placeholder: I18n.t('dashboard.jobs_project_directory_placeholder'),
@@ -46,31 +49,35 @@
             <%= render(partial: 'shared/path_selector_table', locals: path_selector_locals ) %>
           </div>
 
+        <% if !import_project_action %>
           <div class="field">
             <%= form.text_area :description, placeholder: I18n.t('dashboard.jobs_project_description_placeholder') %>
           </div>
+        <% end %>
         </div>
       </div>
       </div>
       <div class="card">
       <div class='card-body'>
         <div class="col">
-          <div class="field">
-          <%= javascript_include_tag('icon_picker', nonce: true, type: 'module') %>
-          <%= form.text_field :icon, placeholder: "cog", id: "product_icon_select", value: @project.icon_class %>
-            <% if @project.icon =~ /(fa[bsrl]?):\/\/(.*)/ %>
-              <% icon = $2; style = $1 %>
-              <p class="text-center">
-                <%= fa_icon(icon, fa_style: style, id: "product_icon")  %>
-              </p>
-            <% else %>
-              <p class="text-center">
-                <%= fa_icon("cog", fa_style: "fas", id: "product_icon") %>
-              </p>
-            <% end %>
-              <ul id="icon_picker_list">
-              </ul>
-          </div>
+          <% if !import_project_action %>
+            <div class="field">
+            <%= javascript_include_tag('icon_picker', nonce: true, type: 'module') %>
+            <%= form.text_field :icon, placeholder: "cog", id: "product_icon_select", value: @project.icon_class %>
+              <% if @project.icon =~ /(fa[bsrl]?):\/\/(.*)/ %>
+                <% icon = $2; style = $1 %>
+                <p class="text-center">
+                  <%= fa_icon(icon, fa_style: style, id: "product_icon")  %>
+                </p>
+              <% else %>
+                <p class="text-center">
+                  <%= fa_icon("cog", fa_style: "fas", id: "product_icon") %>
+                </p>
+              <% end %>
+                <ul id="icon_picker_list">
+                </ul>
+            </div>
+          <% end %>
         </div>
       </div>
       </div>

--- a/apps/dashboard/app/views/projects/import.html.erb
+++ b/apps/dashboard/app/views/projects/import.html.erb
@@ -1,0 +1,9 @@
+<div class='page-header text-center pb-3'>
+  <h1>
+    Import a Shared Project
+  </h1>
+</div>
+
+<%= bootstrap_form_for(@project, url: import_projects_path, method: :patch) do |form| %>
+  <%= render partial: "form", locals: { form: form }%>
+<% end %>

--- a/apps/dashboard/app/views/projects/import.html.erb
+++ b/apps/dashboard/app/views/projects/import.html.erb
@@ -4,6 +4,6 @@
   </h1>
 </div>
 
-<%= bootstrap_form_for(@project, url: import_projects_path, method: :patch) do |form| %>
+<%= bootstrap_form_for(@project, url: project_import_save_path, method: :post) do |form| %>
   <%= render partial: "form", locals: { form: form }%>
 <% end %>

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -67,7 +67,7 @@
       <%- end -%>
 
       <div class="mt-5 justify-content-center text-center project-icon">
-        <%= link_to(import_projects_path,
+        <%= link_to(project_import_path,
                       title: I18n.t('dashboard.jobs_import_shared_project'),
                       class: 'text-dark btn btn-link') do
         %>

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -66,5 +66,19 @@
         </div> 
       <%- end -%>
 
+      <div class="mt-5 justify-content-center text-center project-icon">
+        <%= link_to(import_projects_path,
+                      title: I18n.t('dashboard.jobs_import_shared_project'),
+                      class: 'text-dark btn btn-link') do
+        %>
+          <div class="text-center d-flex justify-content-center">
+            <strong>
+              <%= icon_tag(URI.parse("fas://file-import")) %><br>
+              <%= I18n.t('dashboard.jobs_import_shared_project') %>
+            </strong>
+          </div>
+        <% end %>
+      </div>
+
   </div>
 </div>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -529,4 +529,20 @@ class ConfigurationSingleton
       end
     end
   end
+
+  def shared_projects_root
+    # This environment varible will support ':' colon separated paths
+    vendor_path = ENV['VENDOR_SHARED_FILESYSTEM'] || ''
+    path_list = vendor_path.split(":")
+
+    paths = []
+    path_list.each do |path|
+      temp_path = Pathname.new(path)
+      if temp_path.exists? 
+        paths.append(temp_path)
+      end
+    end
+    
+    return paths
+  end
 end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -433,6 +433,22 @@ class ConfigurationSingleton
     rails_env == 'production'
   end
 
+  def shared_projects_root
+    # This environment varible will support ':' colon separated paths
+    vendor_path = ENV['VENDOR_SHARED_FILESYSTEM'] || ''
+    path_list = vendor_path.split(":")
+
+    paths = []
+    path_list.each do |path|
+      temp_path = Pathname.new(path)
+      if temp_path.exists? 
+        paths.append(temp_path)
+      end
+    end
+    
+    return paths
+  end
+
   private
 
   def can_access_core_app?(name)
@@ -528,21 +544,5 @@ class ConfigurationSingleton
         send(cfg_item).nil?
       end
     end
-  end
-
-  def shared_projects_root
-    # This environment varible will support ':' colon separated paths
-    vendor_path = ENV['VENDOR_SHARED_FILESYSTEM'] || ''
-    path_list = vendor_path.split(":")
-
-    paths = []
-    path_list.each do |path|
-      temp_path = Pathname.new(path)
-      if temp_path.exists? 
-        paths.append(temp_path)
-      end
-    end
-    
-    return paths
   end
 end

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -145,6 +145,7 @@ en:
     files_remote_error_listing_remotes: 'Error listing Rclone remotes: %{error}'
     jobs_create_blank_project: Create a new project
     jobs_create_template_project: Create a new project from a template
+    jobs_import_shared_project: Import a shared project
     jobs_launchers: Launchers
     jobs_launchers_created: Launcher successfully created!
     jobs_launchers_default_created: A 'hello_world.sh' was also added to this project.
@@ -156,6 +157,7 @@ en:
     jobs_launchers_updated: Launcher manifest updated!
     jobs_new_launcher: New Launcher
     jobs_project_created: Project successfully created!
+    jobs_project_imported: Project successfully imported!
     jobs_project_delete_project_confirmation: Delete all contents of project directory?
     jobs_project_deleted: Project successfully deleted!
     jobs_project_description_placeholder: Project description

--- a/apps/dashboard/config/locales/ja_JP.yml
+++ b/apps/dashboard/config/locales/ja_JP.yml
@@ -145,6 +145,7 @@ ja_JP:
     files_remote_error_listing_remotes: 'Error listing Rclone remotes: %{error}'
     jobs_create_blank_project: Create a new project
     jobs_create_template_project: Create a new project from a template
+    jobs_import_shared_project: Import a shared project
     jobs_launchers: Launchers
     jobs_launchers_created: Launcher successfully created!
     jobs_launchers_default_created: A 'hello_world.sh' was also added to this project.

--- a/apps/dashboard/config/locales/zh-CN.yml
+++ b/apps/dashboard/config/locales/zh-CN.yml
@@ -141,6 +141,7 @@ zh-CN:
     files_remote_error_listing_remotes: 'Error listing Rclone remotes: %{error}'
     jobs_create_blank_project: Create a new project
     jobs_create_template_project: Create a new project from a template
+    jobs_import_shared_project: Import a shared project
     jobs_launchers: Launchers
     jobs_launchers_created: Launcher successfully created!
     jobs_launchers_default_created: A 'hello_world.sh' was also added to this project.

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
       get '/jobs/:cluster/:jobid' => 'projects#job_details', :defaults => { :format => 'turbo_stream' }, :as => 'job_details'
       delete '/jobs/:cluster/:jobid' => 'projects#delete_job', :as => 'delete_job'
       post '/jobs/:cluster/:jobid/stop' => 'projects#stop_job', :as => 'stop_job'
+      get '/import' => 'projects#import', :as => 'import'
+      post '/import' => 'projects#import_save', :as => 'import_save'
 
       resources :launchers do
         post 'submit', on: :member

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -4,13 +4,14 @@ require 'authz/app_developer_constraint'
 
 Rails.application.routes.draw do
   if Configuration.can_access_projects?
+    get 'projects/import' => 'projects#import', :as => 'project_import'
+    post 'projects/import' => 'projects#import_save', :as => 'project_import_save'
+
     resources :projects do
       root 'projects#index'
       get '/jobs/:cluster/:jobid' => 'projects#job_details', :defaults => { :format => 'turbo_stream' }, :as => 'job_details'
       delete '/jobs/:cluster/:jobid' => 'projects#delete_job', :as => 'delete_job'
       post '/jobs/:cluster/:jobid/stop' => 'projects#stop_job', :as => 'stop_job'
-      get '/import' => 'projects#import', :as => 'import'
-      post '/import' => 'projects#import_save', :as => 'import_save'
 
       resources :launchers do
         post 'submit', on: :member


### PR DESCRIPTION
Related to Issue https://github.com/OSC/ondemand/issues/4120

Added support for env variable "VENDOR_SHARED_FILESYSTEM" to allow users to set up shared path in case those are different from `/fs/scratch` and `/fs/project`

During brute force looking for project we just need to check if there exists a .ondemand folder in any project path, if so, then it is an OOD project
`<shared_projects_paths>/<group_id>/<brute force all child folders>/.ondemand`