### PR TITLE
Fixed safe_load_path? method definition to avoid runtime errors

### DIFF
--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -47,6 +47,11 @@ module Dashboard
       config.paths["app/views"].unshift ::Configuration.config_root.join("views").to_s
     end
 
+    # Determine if this path is safe to load. I.e., are all the files root owned.
+    def safe_load_path?(path)
+      path.exists? && path.children.all? { |f| File.stat(f).uid.zero? }
+    end
+
     # Enable installed plugins only if configured by administrator
     plugins_dir = Pathname.new(::Configuration.plugins_directory)
     if plugins_dir.directory?
@@ -68,11 +73,6 @@ module Dashboard
         config.autoload_paths << lib.to_s if safe_load_lib
         config.paths["app/views"].unshift(views.to_s) if safe_load_views
       end
-    end
-
-    # Determine if this path is safe to load. I.e., are all the files root owned.
-    def safe_load_path?(path)
-      path.children.all? { |f| File.stat(f).uid.zero? }
     end
   end
 end


### PR DESCRIPTION
After installing OODv4.0.0 and configure the plugins directory, I was getting the following error:

```
App 240 output: Error: The application encountered the following error: undefined method `safe_load_path?' for class Dashboard::Application (NoMethodError)
App 240 output:     /opt/ood/ondemand/root/usr/share/gems/3.3/ondemand/4.0.0-1/gems/railties-7.0.8.5/lib/rails/railtie.rb:228:in `method_missing'
```
This PR fixes this issue.

It would be great to retrofit to OODv4.0.0 branch so that it goes into the next release.