### PR TITLE
set the PATH so that dbus-launch comes from the OS

### DIFF
--- a/apps/bc_desktop/template/script.sh.erb
+++ b/apps/bc_desktop/template/script.sh.erb
@@ -9,7 +9,12 @@ module purge && module restore
 # Ensure that the user's configured login shell is used
 export SHELL="$(getent passwd $USER | cut -d: -f7)"
 
+# use a safe PATH to boot the desktop because dbus-launch can be
+# in another location from a python/conda installation and that will
+# conflict and cause issues. See https://github.com/OSC/ondemand/issues/700 for more.
+SAFE_PATH="/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin"
+
 # Start up desktop
 echo "Launching desktop '<%= context.desktop %>'..."
-source "<%= session.staged_root.join("desktops", "#{context.desktop}.sh") %>"
+PATH="$SAFE_PATH" source "<%= session.staged_root.join("desktops", "#{context.desktop}.sh") %>"
 echo "Desktop '<%= context.desktop %>' ended with $? status..."


### PR DESCRIPTION
Fixes #700, this time for real.  700 apparently details XFCE. This morning I went to work on something else, choosing MATE and found that it persists. This should actually fix it no matter the desktop. 