### PR TITLE
Fixed application class type for exist? method

### DIFF
--- a/apps/dashboard/config/application.rb
+++ b/apps/dashboard/config/application.rb
@@ -49,7 +49,7 @@ module Dashboard
 
     # Determine if this path is safe to load. I.e., are all the files root owned.
     def safe_load_path?(path)
-      path.exists? && path.children.all? { |f| File.stat(f).uid.zero? }
+      path.exist? && path.children.all? { |f| File.stat(f).uid.zero? }
     end
 
     # Enable installed plugins only if configured by administrator


### PR DESCRIPTION
Sorry Jeff, I inserted a type by mistake when committing the previous fix. I think it relates to pressing `ctr+s`.
This is a minor typo fix.

I tried to add a test for this, but could not figure out how to do it.