### PR TITLE
Do not provide href links to files when download is disabled.

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -228,7 +228,7 @@ class DataTable {
                     }
                 },
                 { data: 'type', render: (data, type, row, meta) => data == 'd' ? '<span title="directory" class="fa fa-folder" style="color: gold"><span class="sr-only"> dir</span></span>' : '<span title="file" class="fa fa-file" style="color: lightgrey"><span class="sr-only"> file</span></span>' }, // type
-                { name: 'name', data: 'name', className: 'text-break', render: (data, type, row, meta) => `<a class="${row.type} name ${row.type == 'd' ? '' : 'view-file'}" href="${row.url}">${Handlebars.escapeExpression(data)}</a>` }, // name
+                { name: 'name', data: 'name', className: 'text-break', render: (data, type, row, meta) => this.renderNameColumn(data, type, row, meta) }, // name
                 { name: 'actions', orderable: false, searchable: false, data: null, render: (data, type, row, meta) => this.actionsBtnTemplate({ row_index: meta.row, file: row.type != 'd', data: row }) },
                 {
                     data: 'size',
@@ -377,6 +377,17 @@ class DataTable {
         });
     }
 
+    renderNameColumn(data, type, row, meta) {
+        const cssClass = `${row.type} name ${row.type == 'd' ? '' : 'view-file'}`;
+        const text = Handlebars.escapeExpression(data);
+
+        if(row.type == 'f' && !downloadEnabled()) {
+            return `<span class="${cssClass}">${text}</span>`;
+        } else {
+            return `<a class="${cssClass}" href="${row.url}">${text}</a>`;
+        }
+    }
+
     actionsBtnTemplate(options) {
         // options: { row_index: meta.row,
         //            file: row.type != 'd',
@@ -411,7 +422,7 @@ class DataTable {
           
         // Check if this is a file and create View and Edit options
         if (file) {
-            if (data.url) {
+            if (data.url && downloadEnabled()) {
                 const viewItem = document.createElement('li');
                 const viewLink = document.createElement('a');
                 viewLink.href = data.url;

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -67,7 +67,7 @@ class PosixFile
   end
 
   def downloadable?
-    (directory? || file?) && readable?
+    Configuration.download_enabled? && (directory? || file?) && readable?
   end
 
   def human_size

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -11,7 +11,7 @@ json.files @files do |f|
   json.type f[:directory] ? 'd' : 'f'
   json.name f[:name]
 
-  json.url files_path(@filesystem, @path.join(f[:name]).to_s)
+  json.url files_path(@filesystem, @path.join(f[:name]).to_s) if f[:downloadable]
   json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') if f[:downloadable]
   json.edit_url OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s
 

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -635,8 +635,8 @@ class FilesTest < ApplicationSystemTestCase
       cant_read_row.find('button.dropdown-toggle').click
       cant_read_links = cant_read_row.all('td > div.btn-group > ul > li > a').map(&:text)
 
-      # NOTE: download is not an expected link.
-      expected_links = ['View', 'Edit', 'Rename', 'Delete']
+      # NOTE: download and view are not an expected links.
+      expected_links = ['Edit', 'Rename', 'Delete']
 
       assert_equal(expected_links, fifo_links)
       assert_equal(expected_links, cant_read_links)
@@ -650,8 +650,8 @@ class FilesTest < ApplicationSystemTestCase
     null_row.find('button.dropdown-toggle').click
     null_links = null_row.all('td > div.btn-group > ul > li > a').map(&:text)
 
-    # NOTE: download is not an expected link.
-    expected_links = ['View', 'Edit', 'Rename', 'Delete']
+    # NOTE: download and view are not an expected links.
+    expected_links = ['Edit', 'Rename', 'Delete']
 
     assert_equal(expected_links, null_links)
   end


### PR DESCRIPTION
Do not provide href links to files when download is disabled and remove the 'view' button when downloading is disabled.

Fixes #4159 by showing only text for files when download is disabled (i.e., a `span` tag not an `a` tag with an `href`) and not showing the `View` button when downloading is disabled.