### PR TITLE
refactor OodApp and BatchConnect::App

### DIFF
--- a/apps/dashboard/app/apps/app_recategorizer.rb
+++ b/apps/dashboard/app/apps/app_recategorizer.rb
@@ -38,7 +38,7 @@ class AppRecategorizer < SimpleDelegator
       # As an example, we've configured sys/bc_desktop/pitzer.  Pitzer is a sub-app
       # of bc_desktop. We don't care if there are multiple bc_desktops sub-app links,
       # only pitzer is configured - so only _it's_ link should be returned.
-      app = batch_connect.sub_app_list.select do |sub|
+      app = sub_app_list.select do |sub|
         sub.valid? && sub.sub_app == sub_app_name
       end.first
 

--- a/apps/dashboard/app/apps/dev_router.rb
+++ b/apps/dashboard/app/apps/dev_router.rb
@@ -16,11 +16,14 @@ class DevRouter
   def self.apps(owner: OodSupport::Process.user.name)
     target = base_path(owner: owner)
     if target.directory? && target.executable? && target.readable?
-      target.children.map { |d| OodApp.new self.new(d.basename, owner) }
-        .select(&:directory?)
-        .select(&:accessible?)
-        .reject(&:hidden?)
-        .reject(&:backup?)
+      target.children.map do |d|
+        router = new(d.basename, owner)
+        app = OodApp.new(router)
+        app.batch_connect_app? ? BatchConnect::App.new(router: router) : app
+      end.select(&:directory?)
+         .select(&:accessible?)
+         .reject(&:hidden?)
+         .reject(&:backup?)
     else
       []
     end

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -184,10 +184,6 @@ class OodApp
     role == "batch_connect"
   end
 
-  def batch_connect
-    @batch_connect ||= BatchConnect::App.new(router: router)
-  end
-
   def has_gemfile?
     path.join("Gemfile").file? && path.join("Gemfile.lock").file?
   end
@@ -346,18 +342,12 @@ class OodApp
   end
 
   def sub_app_list
-    batch_connect_app? ? batch_connect.sub_app_list : []
+    []
   end
 
-  # The subapp list may only be of size 1 and actually contains
-  # this app. This returns true if there are indeed sub apps that
-  # that differ from this object.
+  # OodApps do not have sub_apps, but a child like BatchConnect::App could.
   def has_sub_apps?
-    if batch_connect_app?
-      sub_app_list.size > 1 || sub_app_list[0] != batch_connect
-    else
-      false
-    end
+    false
   end
 
   def tile

--- a/apps/dashboard/app/apps/sys_router.rb
+++ b/apps/dashboard/app/apps/sys_router.rb
@@ -11,11 +11,14 @@ class SysRouter
   def self.apps
     target = base_path
     if target.directory? && target.executable? && target.readable?
-      target.children.map { |d| OodApp.new self.new(d.basename) }
-        .select(&:directory?)
-        .select(&:accessible?)
-        .reject(&:hidden?)
-        .reject(&:backup?)
+      target.children.map do |d|
+        router = new(d.basename)
+        app = OodApp.new(router)
+        app.batch_connect_app? ? BatchConnect::App.new(router: router) : app
+      end.select(&:directory?)
+         .select(&:accessible?)
+         .reject(&:hidden?)
+         .reject(&:backup?)
     else
       []
     end

--- a/apps/dashboard/app/apps/usr_router.rb
+++ b/apps/dashboard/app/apps/usr_router.rb
@@ -50,11 +50,14 @@ class UsrRouter
   def self.apps(owner: OodSupport::Process.user.name)
     target = base_path(owner: owner)
     if target.directory? && target.executable? && target.readable?
-      target.children.map { |d| OodApp.new self.new(d.basename, owner) }
-        .select(&:directory?)
-        .select(&:accessible?)
-        .reject(&:hidden?)
-        .reject(&:backup?)
+      target.children.map do |d|
+        router = new(d.basename, owner)
+        app = OodApp.new(router)
+        app.batch_connect_app? ? BatchConnect::App.new(router: router) : app
+      end.select(&:directory?)
+         .select(&:accessible?)
+         .reject(&:hidden?)
+         .reject(&:backup?)
     else
       []
     end

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -116,8 +116,7 @@ module BatchConnect
     end
 
     def tile
-      parent_tile = OodApp.instance_method(:tile).bind(self).call
-      parent_tile.merge(form_config.fetch(:tile, {}))
+      super.merge(form_config.fetch(:tile, {}))
     end
 
     def category

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -6,7 +6,7 @@ module BatchConnect
   # This is the model representing a batch connect app. It's mostly a data object
   # holding and interpreting the configurations (notable form.yml.erb) and rendering
   # submit options based off of what's been chosen by the user.
-  class App
+  class App < OodApp
     # Router for a deployed batch connect app
     # @return [DevRouter, UsrRouter, SysRouter] router for batch connect app
     attr_accessor :router
@@ -14,8 +14,6 @@ module BatchConnect
     # The sub app
     # @return [String, nil] sub app
     attr_accessor :sub_app
-
-    delegate :type, to: :ood_app
 
     # Raised when batch connect app components could not be found
     class AppNotFound < StandardError; end
@@ -44,8 +42,8 @@ module BatchConnect
     # @param router [DevRouter, UsrRouter, SysRouter] router for batch connect
     #   app
     # @param sub_app [String, nil] sub app
-    def initialize(router:, sub_app: nil)
-      @router  = router
+    def initialize(router: nil, sub_app: nil)
+      super(router)
       @sub_app = sub_app&.to_s
     end
 
@@ -92,7 +90,7 @@ module BatchConnect
     # Default title for the batch connect app
     # @return [String] default title of app
     def default_title
-      title  = ood_app.title
+      title  = OodApp.instance_method(:title).bind(self).call
       title += ": #{sub_app.titleize}" if sub_app
       title
     end
@@ -106,31 +104,33 @@ module BatchConnect
     # Default description for the batch connect app
     # @return [String] default description of app
     def default_description
-      ood_app.manifest.description
+      OodApp.instance_method(:manifest).bind(self).call.description
     end
 
     def icon_uri
-      form_config.fetch(:icon, ood_app.icon_uri)
+      form_config.fetch(:icon, super)
     end
 
     def caption
-      form_config.fetch(:caption, ood_app.caption)
+      form_config.fetch(:caption, super)
     end
 
     def tile
-      ood_app.tile.merge(form_config.fetch(:tile, {}))
+      parent_tile = OodApp.instance_method(:tile).bind(self).call
+      parent_tile.merge(form_config.fetch(:tile, {}))
     end
 
     def category
-      form_config.fetch(:category, ood_app.category)
+      form_config.fetch(:category, super)
     end
 
     def subcategory
-      form_config.fetch(:subcategory, ood_app.subcategory)
+      form_config.fetch(:subcategory, super)
     end
 
     def metadata
-      ood_app.metadata.merge(form_config.fetch(:metadata, {}))
+      parent_md = OodApp.instance_method(:metadata).bind(self).call
+      parent_md.merge(form_config.fetch(:metadata, {}))
     end
 
     def form_header
@@ -332,10 +332,8 @@ module BatchConnect
       @sub_app_list ||= build_sub_app_list
     end
 
-    # The version of the OodApp
-    # @return [String] the version
-    def version
-      @ood_app.version
+    def has_sub_apps?
+      sub_app_list.size > 1 || sub_app_list[0] != self
     end
 
     # Convert object to string
@@ -455,11 +453,6 @@ module BatchConnect
         hsh = hsh.deep_merge read_yaml_erb(path: file, binding: binding) if file
       end
       @submit_config = hsh
-    end
-
-    # The OOD app object describing this app
-    def ood_app
-      @ood_app ||= OodApp.new(router)
     end
 
     # add a widget for choosing the cluster if one doesn't already exist

--- a/apps/dashboard/app/models/product.rb
+++ b/apps/dashboard/app/models/product.rb
@@ -102,7 +102,10 @@ class Product
   end
 
   def app
-    OodApp.new(router)
+    @app ||= begin
+      a = OodApp.new(router)
+      a.batch_connect_app? ? BatchConnect::App.new(router: router) : a
+    end
   end
 
   def gemfile


### PR DESCRIPTION
refactor OodApp and BatchConnect::App to simplify their relationship. Confusingly, these 2 objects referenced each other. An OodApp had a BatchConnect::App object and vice versa, making it very difficult to (a) reason about and (b) cache/serialize.

So this simplifies the relationship by simply having OodApp the parent class which BatchConnect::App inherets and can reference through super.

I'll comment through these changes on specific areas that I'm trying to fix.