### PR TITLE
Fixed CSS selectors for active navigation link color

### DIFF
--- a/apps/dashboard/app/views/layouts/nav/_styles.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_styles.html.erb
@@ -7,11 +7,11 @@
   background-color: <%= bg_color || 'rgb(248, 248, 248)' %>;
 }
 
-.navbar-dark ul.navbar-nav > li.nav-item > a:focus, .navbar-dark ul.navbar-nav > li.nav-item.show > a {
+.navbar-dark ul.navbar-nav li.nav-item > a:focus, .navbar-dark ul.navbar-nav li.nav-item > a.dropdown-toggle.show {
   background-color: <%= link_active_color || 'rgb(59, 61, 63)' %>;
   border-radius: 0.25em;
 }
-.navbar-light ul.navbar-nav > li.nav-item > a:focus, .navbar-light ul.navbar-nav > li.nav-item.show > a {
+.navbar-light ul.navbar-nav li.nav-item > a:focus, .navbar-light ul.navbar-nav li.nav-item > a.dropdown-toggle.show {
   background-color: <%= link_active_color || 'rgb(231, 231, 231)' %>;
   border-radius: 0.25em;
 }


### PR DESCRIPTION
CSS selector update for the background color of the active navigation item.
It works on my local machine, but someone needs to verify this is the expected behaviour.

Fixes: #4181 

Add a value to the `brand_link_active_bg_color` property in the configuration or to `OOD_BRAND_LINK_ACTIVE_BG_COLOR` environment variable:

```YAML
brand_link_active_bg_color: red
```