### PR TITLE
drop support for Ubuntu 20.04 and Ruby 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["2.7.1"]
-        bundler: ["2.1.4"]
+        ruby: ["3.3.5"]
+        bundler: ["2.5.16"]
         include:
           # Test versions from Ubuntu 22.04
           - os: ubuntu-latest
@@ -125,7 +125,6 @@ jobs:
           - el8
           - el9
           - amzn2023
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - debian-12
@@ -142,8 +141,6 @@ jobs:
           - dist: amzn2023
             arch: ppc64le
           # Ubuntu and Debian doesn't have way to get NodeJS 20+ on ppc64le
-          - dist: ubuntu-20.04
-            arch: ppc64le
           - dist: ubuntu-22.04
             arch: ppc64le
           - dist: ubuntu-24.04

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rake'
 gem 'dotenv', '~> 2.1'
 
 group :package do
-  gem 'ood_packaging', '~> 0.16.2'
+  gem 'ood_packaging', '~> 0.17.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     oga (3.3)
       ast
       ruby-ll (~> 2.1)
-    ood_packaging (0.16.2)
+    ood_packaging (0.17.0)
       rake (~> 13.0.1)
     open_uri_redirections (0.2.1)
     parallel (1.21.0)
@@ -177,7 +177,7 @@ DEPENDENCIES
   beaker-docker (~> 1.4.0)
   beaker-rspec
   dotenv (~> 2.1)
-  ood_packaging (~> 0.16.2)
+  ood_packaging (~> 0.17.0)
   rake
   rspec
   rubocop

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -73,8 +73,6 @@ def codename
     'noble'
   when 'ubuntu-22.04'
     'jammy'
-  when 'ubuntu-20.04'
-    'focal'
   when 'debian-12'
     'bookworm'
   end


### PR DESCRIPTION
Fixes #4186 by removing Ubuntu 20.04 from the test CI and also removing Ruby 2.7.

Don't know if the defaults are correct or not.