### PR TITLE
Saved imported directory into lookup_file for shared projects

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -92,7 +92,7 @@ class ProjectsController < ApplicationController
 
   # POST /projects/import
   def import_save
-    success = Project.import_to_lookup(params[:project][:directory])
+    success = Project.import_to_lookup(project_params[:project][:directory])
     if success
       redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
     else

--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -92,8 +92,7 @@ class ProjectsController < ApplicationController
 
   # POST /projects/import
   def import_save
-    # TODO: Call Project to save directory to lookup file
-    success = true
+    success = Project.import_to_lookup(params[:project][:directory])
     if success
       redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
     else

--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -92,7 +92,7 @@ class ProjectsController < ApplicationController
 
   # POST /projects/import
   def import_save
-    success = Project.import_to_lookup(project_params[:project][:directory])
+    success = Project.import_to_lookup(project_params[:directory])
     if success
       redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
     else

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -13,7 +13,7 @@ class Project
     manifest_path = Pathname("#{dir.to_s}/.ondemand/manifest.yml")
     unless manifest_path.exist?
       Rails.logger.warn("Imported directory is not a Open OnDemand project")
-      nil
+      return nil
     end
 
     contents = File.read(manifest_path)
@@ -28,7 +28,7 @@ class Project
     end
   rescue StandardError => e
     Rails.logger.warn("Cannot import project from dir #{dir} due to error #{e}")
-    false
+    nil
   end
 
   class << self

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -19,13 +19,7 @@ class Project
     contents = File.read(manifest_path)
     raw_opts = YAML.safe_load(contents)
     id = raw_opts["id"]
-
-    project = Project.find(id)
-    if project.nil?
-      Project.new({ id: id, directory: dir })
-    else
-      nil
-    end
+    Project.new({ id: id, directory: dir })
   rescue StandardError => e
     Rails.logger.warn("Cannot import project from dir #{dir} due to error #{e}")
     nil
@@ -47,8 +41,11 @@ class Project
     end
 
     def import_to_lookup(dir)
-      project = self.class.from_directory(dir)
-      project ? project.add_to_lookup(:import) : false
+      imported_project = Project.from_directory(dir)
+      if imported_project.nil?
+        return false
+      end
+      Project.find(imported_project.id) ? true : imported_project.add_to_lookup(:import)
     end
 
     def next_id


### PR DESCRIPTION
Related to Issue https://github.com/OSC/ondemand/issues/4120

This is the second PR, to add the directory of shared project path into a user's own project lookup file.
First PR: https://github.com/OSC/ondemand/pull/4178

Later, we will show the list of shared projects in import form based upon user's group-id.