### PR TITLE
cast to string for safety

### DIFF
--- a/apps/dashboard/app/helpers/system_status_helper.rb
+++ b/apps/dashboard/app/helpers/system_status_helper.rb
@@ -3,7 +3,7 @@
 # Helpers for the system status page /dashboard/systemstatus
 module SystemStatusHelper
   def title(cluster)
-    "#{cluster.metadata.title.titleize} Cluster Status"
+    "#{cluster.metadata.title.to_s.titleize} Cluster Status"
   end
 
   def status_hash(name, active, total)


### PR DESCRIPTION
cast to string for safety to fix #4195. This can error when the cluster.d file doesn't have `v2.metadata.title`, so casting to string here avoids that.