### PR TITLE
use asset_nil here for fix deprecation warnings

### DIFF
--- a/apps/dashboard/test/lib/smart_attributes/auto_log_location_test.rb
+++ b/apps/dashboard/test/lib/smart_attributes/auto_log_location_test.rb
@@ -37,7 +37,7 @@ module SmartAttributes
         }
         attribute = SmartAttributes::AttributeFactory.build('auto_log_location', options)
 
-        assert_equal(nil, attribute.value)
+        assert_nil(attribute.value)
       end
     end
 
@@ -49,7 +49,7 @@ module SmartAttributes
         }
         attribute = SmartAttributes::AttributeFactory.build('auto_log_location', options)
 
-        assert_equal(nil, attribute.value)
+        assert_nil(attribute.value)
       end
     end
   end


### PR DESCRIPTION
use asset_nil here for fix deprecation warnings.

Specifically, these warnings:
```
DEPRECATED: Use assert_nil if expecting nil from test/lib/smart_attributes/auto_log_location_test.rb:52. This will fail in Minitest 6.
DEPRECATED: Use assert_nil if expecting nil from test/lib/smart_attributes/auto_log_location_test.rb:40. This will fail in Minitest 6.
```