### PR TITLE
Used brute force to create a list of shared path to a user

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -2,6 +2,9 @@
 
 # The controller for project pages /dashboard/projects.
 class ProjectsController < ApplicationController
+  include ProjectsHelper
+  @@cache_shared_path = true
+
   # GET /projects/:id
   def show
     project_id = show_project_params[:id]
@@ -32,6 +35,11 @@ class ProjectsController < ApplicationController
   def index
     @projects = Project.all
     @templates = templates
+
+    if @@cache_shared_path
+      self.save_shared_dir
+      @@cache_shared_path = false
+    end
   end
 
   # GET /projects/new

--- a/apps/dashboard/app/helpers/projects_helper.rb
+++ b/apps/dashboard/app/helpers/projects_helper.rb
@@ -31,4 +31,38 @@ module ProjectsHelper
       status
     end
   end
+
+  # This will always create a local shared lookup file
+  # It will save directory path of shared OOD projects in this file after brute forcing all possible path
+  def save_shared_dir
+    shared_path = []
+    Configuration.shared_projects_root.each do |path|
+      CurrentUser.group_names.each do |group|
+        dir_path = path.join(group)
+        # {shared_projects_path}/<UNIX group ID>/<project>/.ondemand
+        if dir_path.exist? && dir_path.directory? 
+          Dir.each_child(dir_path) do |child|
+            if File.directory?(File.join(dir_path, child, '.ondemand'))
+              shared_path << File.join(dir_path, child)
+            end
+          end
+        end
+
+      end
+    end
+
+    # TODO: First brute force all path and do `ls -l` to check if it is part of user group
+    # save to local varible shared_path
+    # Next check if any child in shared path is ood project and save it to ood_shared_projects
+    # finally save this local varible below to lookup file
+    
+    # Cache the shared path, so these are visible accross instances of project controller
+    dataroot = OodAppkit.dataroot.join('projects')
+    shared_cache = Pathname("#{dataroot}/.shared_lookup")
+    File.open(shared_cache, "w") do |file|
+      shared_path.each do |path|
+        file.puts path
+      end
+    end
+  end
 end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -433,6 +433,22 @@ class ConfigurationSingleton
     rails_env == 'production'
   end
 
+  def shared_projects_root
+    # This environment varible will support ':' colon separated paths
+    vendor_path = ENV['VENDOR_SHARED_FILESYSTEM'] || ''
+    path_list = vendor_path.split(":")
+
+    paths = []
+    path_list.each do |path|
+      temp_path = Pathname.new(path)
+      if temp_path.exists? 
+        paths.append(temp_path)
+      end
+    end
+
+    return paths
+  end
+
   private
 
   def can_access_core_app?(name)


### PR DESCRIPTION
Related to Issue https://github.com/OSC/ondemand/issues/4120

This is the third PR, to get the list of all possible shared paths to a user and cache it locally. 

First PR: https://github.com/OSC/ondemand/pull/4178
Second PR: https://github.com/OSC/ondemand/pull/4189

The caching happens only once you route to `/projects`.
Later, we will use this cached information to show a form to the user to pick a project to import.