### PR TITLE
Ensure minimum 1000 UIDs/GIDs are mapped for the dev container

### DIFF
--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -58,9 +58,9 @@ namespace :dev do
       '--security-opt', 'label=disable',
       "--uidmap=#{user.uid}:0:1", "--uidmap=0:1:#{user.uid}",
       "--gidmap=#{user.gid}:0:1", "--gidmap=0:1:#{user.gid}",
-      *("--uidmap=#{user.uid+1}:#{user.uid+1}:1000" if user.uid < 1000),
-      *("--gidmap=#{user.gid+1}:#{user.gid+1}:1000" if user.gid < 1000),
-    ].tap do |arr|
+      user.uid < 1000 ? "--uidmap=#{user.uid+1}:#{user.uid+1}:1000" : nil,
+      user.gid < 1000 ? "--gidmap=#{user.gid+1}:#{user.gid+1}:1000" : nil,
+    ].compact.tap do |arr|
       arr.concat ['--cap-add', 'sys_ptrace'] unless additional_caps.include?('--privileged')
     end.freeze
   end

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -57,7 +57,9 @@ namespace :dev do
     [
       '--security-opt', 'label=disable',
       "--uidmap=#{user.uid}:0:1", "--uidmap=0:1:#{user.uid}",
-      "--gidmap=#{user.gid}:0:1", "--gidmap=0:1:#{user.gid}"
+      "--gidmap=#{user.gid}:0:1", "--gidmap=0:1:#{user.gid}",
+      *("--uidmap=#{user.uid+1}:#{user.uid+1}:1000" if user.uid < 1000),
+      *("--gidmap=#{user.gid+1}:#{user.gid+1}:1000" if user.gid < 1000),
     ].tap do |arr|
       arr.concat ['--cap-add', 'sys_ptrace'] unless additional_caps.include?('--privileged')
     end.freeze


### PR DESCRIPTION
This fixes #4078 by ensuring at least ~1000 UIDs/GIDs available for the dev container.
The dev container previously failed to start services correctly due to there not being enough UIDs and GIDs mapped for the system accounts in the container. This issue occured when the host UID or GID were < 1000.


Before:
```
 "IDMappings": {
      "UidMap": [
           "0:1:90760",
           "90760:0:1"
      ],
      "GidMap": [
           "0:1:101",
           "101:0:1"
      ]
 },
```
After:
```
 "IDMappings": {
      "UidMap": [
           "0:1:90760",
           "90760:0:1"
      ],
      "GidMap": [
           "0:1:101",
           "101:0:1",
           "102:102:1000"
      ]
 },
```