### PR TITLE
Add an id tag to the version string.

### DIFF
--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -11,5 +11,5 @@
       %>
     <% end %>
   </div>
-  <span id="od_version">OnDemand version: <%= Configuration.ood_version %></span>
+  <span id="ood_version">OnDemand version: <%= Configuration.ood_version %></span>
 </footer>

--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -11,5 +11,5 @@
       %>
     <% end %>
   </div>
-  <span>OnDemand version: <%= Configuration.ood_version %></span>
+  <span id="od_version">OnDemand version: <%= Configuration.ood_version %></span>
 </footer>


### PR DESCRIPTION
This would allow you to use a specific CSS selector to hide/manipulate the version string using CSS enabling you to hide it to end-users if desired.