### PR TITLE
Updated user_settings_file to use OOD_PORTAL value in the path

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -66,7 +66,7 @@ class ConfigurationSingleton
   def string_configs
     {
       :module_file_dir                => nil,
-      :user_settings_file             => Pathname.new("~/.config/ondemand/settings.yml").expand_path.to_s,
+      :user_settings_file             => Pathname.new("~/.config/#{ood_portal}/settings.yml").expand_path.to_s,
       :facl_domain                    => nil,
       :auto_groups_filter             => nil,
       :bc_clean_old_dirs_days         => '30',
@@ -278,12 +278,16 @@ class ConfigurationSingleton
     #
     root = ENV['OOD_DATAROOT'] || ENV['RAILS_DATAROOT']
     if rails_env == "production"
-      root ||= "~/#{ENV['OOD_PORTAL'] || 'ondemand'}/data/#{ENV['APP_TOKEN'] || 'sys/dashboard'}"
+      root ||= "~/#{ood_portal}/data/#{ENV['APP_TOKEN'] || 'sys/dashboard'}"
     else
       root ||= app_root.join("data")
     end
 
     Pathname.new(root).expand_path
+  end
+
+  def ood_portal
+    ENV['OOD_PORTAL'] || 'ondemand'
   end
 
   def locale

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -256,6 +256,18 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     end
   end
 
+  test "default value for user_settings_file" do
+    with_modified_env(OOD_PORTAL: nil) do
+      assert_equal Pathname.new('~/.config/ondemand/settings.yml').expand_path.to_s, ConfigurationSingleton.new.user_settings_file
+    end
+  end
+
+  test "user_settings_file uses OOD_PORTAL" do
+    with_modified_env(OOD_PORTAL: 'my_portal') do
+      assert_equal Pathname.new('~/.config/my_portal/settings.yml').expand_path.to_s, ConfigurationSingleton.new.user_settings_file
+    end
+  end
+
   test "quota_paths correctly parses OOD_QUOTA_PATH" do
     with_modified_env(OOD_QUOTA_PATH: '/path_a/quota.json:/path_b/quota.json') do
       assert_equal ['/path_a/quota.json', '/path_b/quota.json'], ConfigurationSingleton.new.quota_paths


### PR DESCRIPTION
At IQSS we have multiple installations of OnDemand that all share the same user home directory.

We have recently noticed that changing a profile in one installation was affecting all others and realized that this was due to the location of the `user_settings_file`.

We are currently using the `OOD_PORTAL` env variable to namespace the data for the different installations and we think that the user_settings_file should follow that pattern.

This is a possible implementation to address this issue.