### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: 2.5.22
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -154,6 +155,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
+          bundler: "2.5.22"
           bundler-cache: true
 
       - name: Build package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,24 +14,19 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         ruby: ["3.3.5"]
-        bundler: ["2.5.16"]
         include:
           # Test versions from Ubuntu 22.04
           - os: ubuntu-latest
             ruby: "3.0.2"
-            bundler: "2.3.5"
           # Test versions from Debian 12
           - os: ubuntu-latest
             ruby: "3.1.2"
-            bundler: "2.3.7"
           # Test versions from Amazon Linux 2023 and Ubuntu 24.04
           - os: ubuntu-latest
             ruby: "3.2.2"
-            bundler: "2.4.10"
           # Test versions from RHEL8 & RHEL9
           - os: ubuntu-latest
             ruby: "3.3.5"
-            bundler: "2.5.16"
     runs-on: ${{ matrix.os }}
     name: Unit tests
 
@@ -43,7 +38,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: ${{ matrix.bundler }}
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -159,8 +153,7 @@ jobs:
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.1"
-          bundler: "2.1.4"
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Build package

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   watir
 
 BUNDLED WITH
-   2.3.6
+   2.5.22

--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -45,11 +45,10 @@ group :development do
   # gem 'ruby-openai'
 end
 
-# lock gems to versions that are compatible with ruby 2.7.0,
-# which Ubuntu 20.04 uses.
-gem 'nokogiri', '~> 1.15', '< 1.16'
-gem 'net-imap', '~> 0.3', '< 0.4'
-gem 'public_suffix', '~> 5.0', '< 6.0'
+# have to force_ruby_platform here to get the right
+# GLIBC version to compile against.
+gem 'nokogiri', force_ruby_platform: true
+
 gem 'turbo-rails', '2.0.7'
 gem 'zeitwerk', '2.6.18'
 

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    net-imap (0.3.8)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -180,7 +180,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.15.7)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     ood_appkit (2.1.6)
@@ -203,7 +203,7 @@ GEM
     psych (5.2.3)
       date
       stringio
-    public_suffix (5.1.1)
+    public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.13)
     rack-protection (3.2.0)
@@ -335,13 +335,11 @@ DEPENDENCIES
   jsbundling-rails (~> 1.0)
   local_time (~> 1.0.3)
   mocha (~> 2.1)
-  net-imap (~> 0.3, < 0.4)
-  nokogiri (~> 1.15, < 1.16)
+  nokogiri
   ood_appkit (~> 2.1.0)
   ood_core (~> 0.24)
   ood_support (~> 0.0.2)
   pry
-  public_suffix (~> 5.0, < 6.0)
   rails (= 7.0.8.5)
   redcarpet (~> 3.3)
   rest-client (~> 2.0)
@@ -358,4 +356,4 @@ DEPENDENCIES
   zip_kit (~> 6.2)
 
 BUNDLED WITH
-   2.3.6
+   2.5.22

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -65,10 +65,6 @@ gem 'ood_appkit', '~> 2.0'
 
 gem 'climate_control', '~> 0.2'
 
-# we have to lock rdoc because 6.4 depends on psych 4.0 which breaks with
-# Psych::BadAlias: Cannot load database configuration: Unknown alias: default
-gem 'rdoc', '6.3.4.1'
-
 # have to force_ruby_platform here to get the right
 # GLIBC version to compile against.
 gem 'nokogiri', force_ruby_platform: true

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -69,9 +69,8 @@ gem 'climate_control', '~> 0.2'
 # Psych::BadAlias: Cannot load database configuration: Unknown alias: default
 gem 'rdoc', '6.3.4.1'
 
-# lock gems to versions that are compatible with ruby 2.7.0,
-# which Ubuntu 20.04 uses.
-gem 'nokogiri', '~> 1.15', '< 1.16'
-gem 'net-imap', '~> 0.3', '< 0.4'
-gem 'public_suffix', '~> 5.0', '< 6.0'
+# have to force_ruby_platform here to get the right
+# GLIBC version to compile against.
+gem 'nokogiri', force_ruby_platform: true
+
 gem 'zeitwerk', '2.6.18'

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     mustache (1.1.1)
-    net-imap (0.3.8)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -149,7 +149,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.15.7)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     ood_appkit (2.1.6)
@@ -171,9 +171,12 @@ GEM
       rails (>= 5.0.0)
     pbs (2.2.1)
       ffi (~> 1.9, >= 1.9.6)
-    public_suffix (5.1.1)
+    psych (5.2.3)
+      date
+      stringio
+    public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.12)
+    rack (2.2.13)
     rack-test (2.2.0)
       rack (>= 1.3)
     rails (7.0.8.5)
@@ -212,7 +215,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.3.4.1)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     redcarpet (3.6.1)
     request_store (1.7.0)
       rack (>= 1.4)
@@ -242,6 +246,7 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    stringio (3.1.5)
     thor (1.3.2)
     tilt (2.6.0)
     timecop (0.9.10)
@@ -280,7 +285,6 @@ DEPENDENCIES
   pbs (~> 2.2.1)
   rails (= 7.0.8.5)
   rails-controller-testing
-  rdoc (= 6.3.4.1)
   sass-rails (~> 5.0)
   sdoc
   sqlite3 (= 1.4.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -274,12 +274,10 @@ DEPENDENCIES
   js-routes (~> 1.2.4)
   local_time (~> 1.0.3)
   mocha (~> 2.1)
-  net-imap (~> 0.3, < 0.4)
-  nokogiri (~> 1.15, < 1.16)
+  nokogiri
   ood_appkit (~> 2.0)
   osc_machete_rails (~> 2.1.2)
   pbs (~> 2.2.1)
-  public_suffix (~> 5.0, < 6.0)
   rails (= 7.0.8.5)
   rails-controller-testing
   rdoc (= 6.3.4.1)
@@ -291,4 +289,4 @@ DEPENDENCIES
   zeitwerk (= 2.6.18)
 
 BUNDLED WITH
-   2.3.6
+   2.5.22

--- a/ood-portal-generator/Gemfile.lock
+++ b/ood-portal-generator/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.3.6
+   2.5.22


### PR DESCRIPTION
Update dependencies now that we no longer have to hold these gems for ruby 2.7 support.