### PR TITLE
Fix Quota bar display when over 100% usage

### DIFF
--- a/apps/dashboard/app/views/shared/_insufficient_quota_progress_bar.html.erb
+++ b/apps/dashboard/app/views/shared/_insufficient_quota_progress_bar.html.erb
@@ -1,5 +1,5 @@
 <div class="progress">
-<div class="progress-bar bg-danger w-<%= percent.round %>"
+<div class="progress-bar bg-danger w-<%= [percent.round, 100].min %>"
     role="progressbar"
     aria-valuenow="<%= percent %>"
     aria-valuemin="0"


### PR DESCRIPTION
Resolves #4227

Sets the width to the smallest of percentage or 100.

![Screenshot 2025-03-20 112925](https://github.com/user-attachments/assets/40f4e159-3f61-4075-8123-f0d2fcb1ebfa)

#jam