### PR TITLE
account for clusters with - or _ characters

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -96,7 +96,7 @@ function snakeCaseWords(str) {
 
   // find all the captial case words and if none are found, we'll just bascially
   // return the same string.
-  const rex = /([A-Z]{1}[a-z]*[0-9]*)|.+/g;
+  const rex = /([A-Z]{1}[a-z]*[0-9]*)|([^-_]+)/g;
   const words = str.match(rex);
 
   // filter out emtpy matches to avoid having a _ at the end.


### PR DESCRIPTION
Fixes #4244 by accounting for `-` and `_` to correctly separate clusters like `nextgen-ascend`. I need to fix something at OSC for the same, but should create a test for this before this gets merged.