### PR TITLE
account for clusters with - or _ characters (#4245)

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -96,7 +96,7 @@ function snakeCaseWords(str) {
 
   // find all the captial case words and if none are found, we'll just bascially
   // return the same string.
-  const rex = /([A-Z]{1}[a-z]*[0-9]*)|.+/g;
+  const rex = /([A-Z]{1}[a-z]*[0-9]*)|([^-_]+)/g;
   const words = str.match(rex);
 
   // filter out emtpy matches to avoid having a _ at the end.


### PR DESCRIPTION
backport #4245 to release 4.x.