### PR TITLE
backport fix CI (#4225)

### DIFF
--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1484,6 +1484,7 @@ class BatchConnectTest < ApplicationSystemTestCase
         click_on('Save')
 
         click_on('Launch', wait: 30)
+        sleep 3
         expected = output_fixture('user_settings/simple_bc_test.yml')
         actual = File.read("#{dir}/settings.yml")
 
@@ -1508,10 +1509,11 @@ class BatchConnectTest < ApplicationSystemTestCase
 
         check('batch_connect_session_save_template')
         fill_in('modal_input_template_new_name', with: 'test template')
-        sleep 5 # modal needs to sleep?
+        sleep 2 # modal needs to sleep?
         click_on('Save')
 
         click_on('Save settings and close', wait: 30)
+        sleep 2
         expected = output_fixture('user_settings/simple_bc_test.yml')
         actual = File.read("#{dir}/settings.yml")
 

--- a/apps/dashboard/test/system/preset_apps_navbar_test.rb
+++ b/apps/dashboard/test/system/preset_apps_navbar_test.rb
@@ -25,6 +25,7 @@ class PresetAppsNavbarTest < ApplicationSystemTestCase
     click_on 'Interactive Apps'
     click_on 'Test App: Preset'
 
+    sleep 1.5
     verify_bc_alert('sys/preset_app/preset', err_header, err_msg)
   end
 
@@ -37,6 +38,7 @@ class PresetAppsNavbarTest < ApplicationSystemTestCase
     assert_equal new_batch_connect_session_context_path('sys/preset_app/choice'), current_path
     click_on 'Launch'
 
+    sleep 1.5
     verify_bc_alert('sys/preset_app/choice', err_header, err_msg)
   end
 end

--- a/apps/dashboard/test/system/preset_apps_pinned_test.rb
+++ b/apps/dashboard/test/system/preset_apps_pinned_test.rb
@@ -29,6 +29,7 @@ class PresetAppsPinnedTest < ApplicationSystemTestCase
   test 'preset apps in pinned apps directly launch' do
     visit root_path
     click_on 'Test App: Preset'
+    sleep 1.5
     verify_bc_alert('sys/preset_app/preset', err_header, err_msg)
   end
 
@@ -40,6 +41,7 @@ class PresetAppsPinnedTest < ApplicationSystemTestCase
     assert_equal new_batch_connect_session_context_path('sys/preset_app/choice'), current_path
     click_on 'Launch'
 
+    sleep 1.5
     verify_bc_alert('sys/preset_app/choice', err_header, err_msg)
   end
 end

--- a/apps/dashboard/test/system/products_dev_test.rb
+++ b/apps/dashboard/test/system/products_dev_test.rb
@@ -118,6 +118,7 @@ class ProductsDevTest < ApplicationSystemTestCase
 
       assert_equal 'fas fa-dumpster-fire fa-fw app-icon', find_css_class('product_icon')
       click_on 'Save'
+      sleep 1
       actual_manifest = File.read("#{dir}/dashboard/manifest.yml")
       expected_manifest = <<~HEREDOC
         ---
@@ -126,8 +127,8 @@ class ProductsDevTest < ApplicationSystemTestCase
         icon: fas://dumpster-fire
       HEREDOC
 
-      assert_equal current_path, product_path('dev', 'dashboard')
-      assert_equal expected_manifest, actual_manifest
+      assert_equal(product_path('dev', 'dashboard'), current_path)
+      assert_equal(expected_manifest, actual_manifest)
     end
   end
 end

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -780,6 +780,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       launcher_id = setup_launcher(project_id)
       add_account(project_id, launcher_id)
 
+      sleep 0.5
       visit edit_project_launcher_path(project_id, launcher_id)
 
       find('#edit_launcher_auto_accounts').click
@@ -845,6 +846,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       launcher_id = setup_launcher(project_id)
       add_account(project_id, launcher_id)
 
+      sleep 0.5
       visit edit_project_launcher_path(project_id, launcher_id)
 
       find('#edit_launcher_auto_accounts').click
@@ -913,6 +915,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       assert_equal('', File.read("#{dir}/.project_lookup"))
 
       click_on(I18n.t('dashboard.save'))
+      sleep 2
 
       assert_equal(2, Dir.children(dir).size)
       project_dir = Dir.children(dir).select { |path| File.directory?("#{dir}/#{path}") }.first

--- a/spec/e2e/proxy_spec.rb
+++ b/spec/e2e/proxy_spec.rb
@@ -26,7 +26,9 @@ describe 'Node and Rnode proxies' do
   end
 
   it 'rnode proxies directly to the origin' do
+    sleep 10
     browser.goto "#{ctr_base_url}/rnode/localhost/5000/simple-page"
+    sleep 10
     expect(browser.url).to eq("#{ctr_base_url}/rnode/localhost/5000/simple-page")
     expect(browser.div(id: 'test-div').present?).to be true
   end


### PR DESCRIPTION
Fix the CI by adding sleep calls all over the place. Not the best thing to do, but it is sort of the only thing I can do at this time to keep moving forward.

Note that all these sleeps are only needed for the github CI - running the CI locally 'just works'.

This is a backport to 4.0.