### PR TITLE
rename this function so it doesn't collide with window.alert

### DIFF
--- a/apps/dashboard/app/javascript/alert.js
+++ b/apps/dashboard/app/javascript/alert.js
@@ -1,5 +1,5 @@
 
-export function alert(message) {
+export function OODAlert(message) {
   const div = alertDiv(message);
   const main = document.getElementById('main_container');
   main.prepend(div);

--- a/apps/dashboard/app/javascript/files/sweet_alert.js
+++ b/apps/dashboard/app/javascript/files/sweet_alert.js
@@ -1,5 +1,5 @@
 import Swal from 'sweetalert2';
-import { alert } from '../alert';
+import { OODAlert } from '../alert';
 import {CONTENTID, EVENTNAME as DATATABLE_EVENTNAME} from './data_table.js';
 
 export {EVENTNAME};
@@ -17,7 +17,7 @@ let sweetAlert = null;
 jQuery(function() {
   sweetAlert = new SweetAlert();
   $(CONTENTID).on(EVENTNAME.showError, function(e,options) {
-    alert(options.message);
+    OODAlert(options.message);
   });
 
   $(CONTENTID).on(EVENTNAME.showPrompt, function(e,options) {

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -1,4 +1,4 @@
-import { alert } from '../alert';
+import { OODAlert } from '../alert';
 import { hide, show } from "../utils";
 
 export class PathSelectorTable {
@@ -218,7 +218,7 @@ export class PathSelectorTable {
         regex = RegExp(this.filePattern);
       }
     } catch {
-      alert("The regular expression provided for this path selector did not compile");
+      OODAlert("The regular expression provided for this path selector did not compile");
     }
 
     const filteredFiles = data.files.filter((file) => {

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -6,7 +6,7 @@
 */
 
 import { setInnerHTML } from './utils';
-import { alert } from './alert';
+import { OODAlert } from './alert';
 
 export function replaceHTML(id, html) {
   const ele = document.getElementById(id);
@@ -44,9 +44,9 @@ export function pollAndReplace(url, delay, id, callback) {
     })
     .catch((err) => {
       if (typeof err == 'string') {
-        alert(err);
+        OODAlert(err);
       } else {
-        alert('This page has encountered an unexpected error. Please refresh the page.');
+        OODAlert('This page has encountered an unexpected error. Please refresh the page.');
       }
       console.log(err);
     });


### PR DESCRIPTION
Rename this function so it doesn't collide with `window.alert` which it currently does.  `OODAlert` was the best name I could come up with. don't know if there's a `railsAlert` or similar, but didn't want to try it and potentially collide with _it_ now or in the future.