### PR TITLE
backport #4291 to 4.0

### DIFF
--- a/apps/dashboard/app/views/batch_connect/shared/_app_menu.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_app_menu.html.erb
@@ -1,3 +1,18 @@
+<%- usr_app_groups.each do |app_group| -%>
+  <%=
+    render(
+      partial: "batch_connect/shared/app_list",
+      locals: {
+        title: app_group.title,
+        apps: app_group.apps,
+        current_url: local_assigns[:current_url],
+        group_by: :category,
+        show_owner: true
+      }
+    )
+  %>
+<%- end -%>
+
 <%- if apps_menu_group -%>
   <%=
     render(
@@ -11,20 +26,6 @@
     )
   %>
 <%- else -%>
-  <%- usr_app_groups.each do |app_group| -%>
-    <%=
-      render(
-          partial: "batch_connect/shared/app_list",
-          locals: {
-            title: app_group.title,
-            apps: app_group.apps,
-            current_url: local_assigns[:current_url],
-            group_by: :category,
-            show_owner: true
-          }
-      )
-    %>
-  <%- end -%>
   <%- sys_app_groups.each do |app_group| -%>
     <%=
       render(

--- a/apps/dashboard/test/integration/batch_connect_test.rb
+++ b/apps/dashboard/test/integration/batch_connect_test.rb
@@ -49,6 +49,31 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'shared apps left menu should render when nav_bar property defined' do
+    stub_usr_router
+    BatchConnect::SessionContextsController.any_instance.stubs(:t).with('dashboard.batch_connect_apps_menu_title').returns('Interactive apps title')
+    BatchConnect::SessionContextsController.any_instance.stubs(:t).with('dashboard.shared_apps_title').returns('Shared apps title')
+    stub_user_configuration(
+      {
+        nav_bar: [
+          { title: 'Test Apps',
+            links: [
+              { apps: 'sys/bc_paraview' }
+            ] }
+        ]
+      }
+    )
+
+    get new_batch_connect_session_context_url('sys/bc_jupyter')
+    assert_response :success
+
+    assert_select 'div.col-md-3 div.card div.card-header' do |menu_headers|
+      assert_equal 2, menu_headers.size
+      assert_equal 'Shared apps title', menu_headers[0].text
+      assert_equal 'Interactive apps title', menu_headers[1].text
+    end
+  end
+
   test 'interactive_apps_menu override renders correctly' do
     stub_user_configuration({
       interactive_apps_menu: {

--- a/apps/dashboard/test/integration/sessions_controller_test.rb
+++ b/apps/dashboard/test/integration/sessions_controller_test.rb
@@ -60,8 +60,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     get batch_connect_sessions_path
     assert_response :success
+    File.write('delme.html', @response.body)
 
-    assert_select 'nav.col-md-3 div.card div.card-header' do |menu_headers|
+    assert_select 'div.col-md-3 div.card div.card-header' do |menu_headers|
       assert_equal 2, menu_headers.size
       assert_equal 'Shared apps title', menu_headers[0].text
       assert_equal 'Interactive apps title', menu_headers[1].text

--- a/apps/dashboard/test/integration/sessions_controller_test.rb
+++ b/apps/dashboard/test/integration/sessions_controller_test.rb
@@ -43,6 +43,31 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'shared apps left menu should render when nav_bar property defined' do
+    stub_usr_router
+    BatchConnect::SessionsController.any_instance.stubs(:t).with('dashboard.batch_connect_apps_menu_title').returns('Interactive apps title')
+    BatchConnect::SessionsController.any_instance.stubs(:t).with('dashboard.shared_apps_title').returns('Shared apps title')
+    stub_user_configuration(
+      {
+        nav_bar: [
+          { title: 'Test Apps',
+            links: [
+              { apps: 'sys/bc_paraview' }
+            ] }
+        ]
+      }
+    )
+
+    get batch_connect_sessions_path
+    assert_response :success
+
+    assert_select 'nav.col-md-3 div.card div.card-header' do |menu_headers|
+      assert_equal 2, menu_headers.size
+      assert_equal 'Shared apps title', menu_headers[0].text
+      assert_equal 'Interactive apps title', menu_headers[1].text
+    end
+  end
+
   test 'interactive_apps_menu override renders correctly' do
     stub_user_configuration(
       {


### PR DESCRIPTION
Fixed rendering shared apps left hand menu when custom navigation is configured.