### PR TITLE
Fix to_bool logic in dashboard and make it more predictable

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -93,7 +93,11 @@ class ConfigurationSingleton
   end
 
   def ood_bc_ssh_to_compute_node
-    to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
+    if !ENV['OOD_BC_SSH_TO_COMPUTE_NODE'].nil?
+      to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'])
+    else
+      true
+    end
   end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
@@ -141,7 +145,7 @@ class ConfigurationSingleton
   end
 
   def load_external_config?
-    to_bool(ENV['OOD_LOAD_EXTERNAL_CONFIG'] || (rails_env == 'production'))
+    to_bool(ENV['OOD_LOAD_EXTERNAL_CONFIG']) || (rails_env == 'production')
   end
 
   # The root directory that holds configuration information for Batch Connect
@@ -151,7 +155,7 @@ class ConfigurationSingleton
   end
 
   def load_external_bc_config?
-    to_bool(ENV["OOD_LOAD_EXTERNAL_BC_CONFIG"] || (rails_env == "production"))
+    to_bool(ENV["OOD_LOAD_EXTERNAL_BC_CONFIG"]) || (rails_env == "production")
   end
 
   # The paths to the JSON files that store the quota information
@@ -250,7 +254,7 @@ class ConfigurationSingleton
 
   def app_development_enabled?
     return @app_development_enabled if defined? @app_development_enabled
-    to_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.directory? || DevRouter.base_path.symlink?)
+    to_bool(ENV['OOD_APP_DEVELOPMENT']) || DevRouter.base_path.directory? || DevRouter.base_path.symlink?
   end
   alias_method :app_development_enabled, :app_development_enabled?
 
@@ -261,7 +265,11 @@ class ConfigurationSingleton
   alias_method :app_sharing_enabled, :app_sharing_enabled?
 
   def batch_connect_global_cache_enabled?
-    to_bool(ENV["OOD_BATCH_CONNECT_CACHE_ATTR_VALUES"] || true )
+    if !ENV["OOD_BATCH_CONNECT_CACHE_ATTR_VALUES"].nil?
+      to_bool(ENV["OOD_BATCH_CONNECT_CACHE_ATTR_VALUES"])
+    else
+      true
+    end
   end
 
   def developer_docs_url
@@ -388,7 +396,7 @@ class ConfigurationSingleton
   #
   # @return [Boolean] true if by default open apps in new window
   def open_apps_in_new_window?
-    if ENV['OOD_OPEN_APPS_IN_NEW_WINDOW']
+    if !ENV['OOD_OPEN_APPS_IN_NEW_WINDOW'].nil?
       to_bool(ENV['OOD_OPEN_APPS_IN_NEW_WINDOW'])
     else
       true


### PR DESCRIPTION
The combination of to_bool and || shortcircuiting has some subtle possibilities for misunderstandings.  Boolean environment variables can be expected to be either nil, '0', '1', 'true' or 'false'. Notably any nonzero string is thruthy in ruby.  The to_bool function follows a different logic, assigning false to '0', 'false', etc.  When short circuiting || the first truthy value will be used as the result so '0' || true -> '0'.
This produces unintuitive results like to_bool('0' || true) == 0.

In some cases this produces bugs like
to_bool(ENV['OOD_APP_DEVELOPMENT']) || DevRouter.base_path.directory? || DevRouter.base_path.symlink? evaluating to false even if DevRouter.base_path exists. Other cases explicitly rely on this confusing logic like to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true).

This commits tries to resolve the resulting issues and make the logic more understandable by only using to_bool to cast environment variables to bool and avoiding short circuit operations before this cast has occured.

This fixes #4305.