### PR TITLE
backport Add file editor limit (#4256) to 4.0

### DIFF
--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -5,6 +5,7 @@ class PosixFile
 
   delegate :basename, :descend, :parent, :join, :to_s, :read, :write, :mkdir, to: :path
   delegate :directory?, :realpath, :readable?, :file?, to: :path
+  delegate :size, to: :stat
 
   # include to give us number_to_human_size
   include ActionView::Helpers::NumberHelper

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -88,6 +88,10 @@ class RemoteFile
     transfer.tap(&:perform_later)
   end
 
+  def size
+    RcloneUtil.size(remote, path)["bytes"]
+  end
+
   def mime_type
     # Rclone does not return same mime types as `file -b --mime-type` used in PosixFile
     # Results in shell scripts not being viewable as they are application/x-sh and not text/x-shellscript

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -365,6 +365,14 @@ class ConfigurationSingleton
     ENV['OOD_DOWNLOAD_DIR_MAX']&.to_i || 10737418240
   end
 
+  # The maximum size of a file that can be opened in the file editor.
+  #
+  # Default for OOD_FILE_EDITOR_MAX_SIZE is 12*1024*1024 bytes.
+  # @return [Integer]
+  def file_editor_max_size
+    ENV['OOD_FILE_EDITOR_MAX_SIZE']&.to_i || 12582912 
+  end
+
   def allowlist_paths
     (ENV['OOD_ALLOWLIST_PATH'] || ENV['WHITELIST_PATH'] || "").split(':').map{ |s| Pathname.new(s) }
   end


### PR DESCRIPTION
Add file size limit for editing both remote and local files.

Fixes #4311.