### PR TITLE
refactor shell buttons so they can be disabled

### DIFF
--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -1,23 +1,27 @@
 <div id="shell-wrapper" class="btn-group dropend">
-  <%= link_to OodAppkit.shell.url(path: @path.to_s).to_s, id: 'open-in-terminal-btn', class: 'btn btn-outline-dark btn-sm', target: '_blank' do %>
-    <i class="fas fa-terminal" aria-hidden="true"></i>
-    Open in Terminal
-  <% end %>
+  <%=
+    render(partial: 'shared/shell_button',
+           locals: {
+              path: @path,
+              label: 'Open in Terminal',
+              classes: 'btn btn-outline-dark btn-sm',
+              icon: 'fas fa-terminal'
+            })
+  %>
   <% if Configuration.login_clusters.count > 0 %>
     <button type="button" class="btn btn-sm btn-outline-dark dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
     <ul class="dropdown-menu" data-popper-placement="right-start" id="shell-dropdown-items">
       <% Configuration.login_clusters.each do |cluster| %>
-        <%=
-          tag.li(
-            tag.a(
-              "#{cluster.metadata.title || cluster.id.to_s.titleize}",
-              href: OodAppkit.shell.url(host: cluster.login.host, path: @path.to_s),
-              title: "#{cluster.metadata.title || cluster.id.to_s.titleize}",
-              target: '_blank',
-              class: 'dropdown-item'
-            )
-          )
-        %>
+        <li>
+          <%= render(partial: 'shared/shell_button',
+                    locals: {
+                      host: cluster.login.host,
+                      path: @path.to_s,
+                      label: "#{cluster.metadata.title || cluster.id.to_s.titleize}",
+                      classes: 'dropdown-item',
+                    })
+          %>
+        </li>
       <% end %>
     </ul>
   <% end %>

--- a/apps/dashboard/app/views/products/_product.html.erb
+++ b/apps/dashboard/app/views/products/_product.html.erb
@@ -48,9 +48,7 @@
   <td>
     <div class="d-grid gap-2">
       <%= link_to 'Details', product_path(product.name, type: @type), class: 'btn btn-info' %>
-      <% if Configuration.can_access_shell? %>
-        <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
-      <% end %>
+      <%= render(partial: 'shared/shell_button', locals: { host: ENV['OOD_DEV_SSH_HOST'], path: product.router.path.realdirpath }) %>
       <% if Configuration.can_access_files? %>
         <%= link_to 'Files', OodAppkit.files.url(path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
       <% end %>

--- a/apps/dashboard/app/views/products/index.html.erb
+++ b/apps/dashboard/app/views/products/index.html.erb
@@ -7,9 +7,7 @@
 <p>
   <%= link_to 'New App', new_product_path(type: @type), class: 'btn btn-default' %>
   <span class="float-end">
-    <% if Configuration.can_access_shell? %>
-      <%= link_to 'Launch Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product_class.router.base_path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
-    <% end %>
+    <%= render(partial: 'shared/shell_button', locals: { path: product_class.router.base_path.realdirpath }) %>
     <% if Configuration.can_access_files? %>
       <%= link_to 'Launch Files', OodAppkit.files.url(path: product_class.router.base_path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <% end %>

--- a/apps/dashboard/app/views/products/index.html.erb
+++ b/apps/dashboard/app/views/products/index.html.erb
@@ -7,7 +7,7 @@
 <p>
   <%= link_to 'New App', new_product_path(type: @type), class: 'btn btn-default' %>
   <span class="float-end">
-    <%= render(partial: 'shared/shell_button', locals: { path: product_class.router.base_path.realdirpath }) %>
+    <%= render(partial: 'shared/shell_button', locals: { label: 'Launch Shell', path: product_class.router.base_path.realdirpath }) %>
     <% if Configuration.can_access_files? %>
       <%= link_to 'Launch Files', OodAppkit.files.url(path: product_class.router.base_path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <% end %>

--- a/apps/dashboard/app/views/products/show.html.erb
+++ b/apps/dashboard/app/views/products/show.html.erb
@@ -72,9 +72,7 @@
     <%= command_btn(title: "Rebuild App", key: "rebuild_passenger_rails_app", display: "RAILS_ENV=production bundle install --path=vendor/bundle && RAILS_ENV=production bin/rake assets:clobber && RAILS_ENV=production bin/rake assets:precompile && RAILS_ENV=production bin/rake tmp:clear && mkdir -p tmp && touch tmp/restart.txt", help: "Performs Bundle Install, Precompile Assets, and Restart App", color: "primary") if @type == :usr && @product.passenger_rails_app? %>
   </div><!-- /.col-md-2 -->
   <div class="d-grid gap-2 col-md-2 col-xs-6 mb-auto">
-    <% if Configuration.can_access_shell? %>
-      <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: @product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
-    <% end %>
+    <%= render(partial: 'shared/shell_button', locals: { host: ENV['OOD_DEV_SSH_HOST'],path: @product.router.path.realdirpath }) %>
     <% if Configuration.can_access_files? %>
       <%= link_to 'Files', OodAppkit.files.url(path: @product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <% end %>

--- a/apps/dashboard/app/views/shared/_shell_button.html.erb
+++ b/apps/dashboard/app/views/shared/_shell_button.html.erb
@@ -1,0 +1,19 @@
+<%- 
+  host = host || ENV['OOD_DEV_SSH_HOST']
+  label = label || 'Shell'
+  classes = classes || 'btn btn-default'
+  icon = icon || nil
+  id = id || 'shell_button'
+-%>
+<% if Configuration.can_access_shell? %>
+  <%- if icon.nil? -%>
+    <%= link_to(label, OodAppkit.shell.url(host: host, path: path).to_s, 
+                target: '_blank', class: classes, id: id)
+    %>
+  <%- else -%>
+    <%= link_to(OodAppkit.shell.url(host: host, path: path).to_s, 
+                target: '_blank', class: classes, id: id) do %>
+      <i class="<%= icon %>" aria-hidden="true"></i><%= label %>
+    <%- end -%>
+  <%- end -%>
+<% end %>

--- a/apps/dashboard/app/views/shared/_shell_button.html.erb
+++ b/apps/dashboard/app/views/shared/_shell_button.html.erb
@@ -3,7 +3,7 @@
   label = label || 'Shell'
   classes = classes || 'btn btn-default'
   icon = icon || nil
-  id = id || 'shell_button'
+  id = id || nil
 -%>
 <% if Configuration.can_access_shell? %>
   <%- if icon.nil? -%>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -311,7 +311,7 @@ class ConfigurationSingleton
 
   # Setting terminal functionality in files app
   def files_enable_shell_button
-    to_bool(config.fetch(:files_enable_shell_button, true))
+    can_access_shell? && to_bool(config.fetch(:files_enable_shell_button, true))
   end
 
   # Report performance of activejobs table rendering


### PR DESCRIPTION
refactor shell buttons so they can be disabled. This is work for #2193, though it does not complete it. That ticket has 4 tasks, this solves 3. I've saving active jobs extended data view for another pull request.