### PR TITLE
Use Smart Attribute bc_num_nodes in PM to specify number of nodes to run a job

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -12,6 +12,7 @@ class LaunchersController < ApplicationController
     :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
     :auto_queues, :auto_queues_exclude, :auto_queues_fixed,
     :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
+    :bc_num_nodes, :bc_num_nodes_fixed, :bc_num_nodes_min, :bc_num_nodes_max,
     :bc_num_slots, :bc_num_slots_fixed, :bc_num_slots_min, :bc_num_slots_max,
     :bc_num_hours, :bc_num_hours_fixed, :bc_num_hours_min, :bc_num_hours_max,
     :auto_job_name, :auto_job_name_fixed,

--- a/apps/dashboard/app/helpers/launchers_helper.rb
+++ b/apps/dashboard/app/helpers/launchers_helper.rb
@@ -45,6 +45,11 @@ module LaunchersHelper
     create_editable_widget(script_form_double, attrib)
   end
 
+  def bc_num_nodes_template
+    attrib = SmartAttributes::AttributeFactory.build_bc_num_nodes
+    create_editable_widget(script_form_double, attrib)
+  end
+
   def bc_num_slots_template
     attrib = SmartAttributes::AttributeFactory.build_bc_num_slots
     create_editable_widget(script_form_double, attrib)

--- a/apps/dashboard/app/javascript/launcher_edit.js
+++ b/apps/dashboard/app/javascript/launcher_edit.js
@@ -23,9 +23,13 @@ const newFieldData = {
     label: "Log Location",
     help: "The destination of the job's log output."
   },
-  bc_num_slots: {
+  bc_num_nodes: {
     label: "Nodes",
     help: "How many nodes the job will run on."
+  },
+  bc_num_slots: {
+    label: "Slots",
+    help: "How many slots or cores the job will run on."
   },
   auto_environment_variable: {
     label: 'Environment Variable',

--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -18,6 +18,7 @@ module SmartAttributes
   require 'smart_attributes/attributes/bc_account'
   require 'smart_attributes/attributes/bc_email_on_started'
   require 'smart_attributes/attributes/bc_num_hours'
+  require 'smart_attributes/attributes/bc_num_nodes'
   require 'smart_attributes/attributes/bc_num_slots'
   require 'smart_attributes/attributes/bc_queue'
   require 'smart_attributes/attributes/bc_vnc_idle'

--- a/apps/dashboard/app/views/launchers/edit.html.erb
+++ b/apps/dashboard/app/views/launchers/edit.html.erb
@@ -21,6 +21,10 @@
   <%= bc_num_hours_template %>
 </template>
 
+<template id="bc_num_nodes_template">
+  <%= bc_num_nodes_template %>
+</template>
+
 <template id="bc_num_slots_template">
   <%= bc_num_slots_template %>
 </template>

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -515,7 +515,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       expected_new_options = [
         'bc_num_hours', 'auto_queues', 'bc_num_slots', 'auto_cores',
         'auto_accounts', 'auto_job_name', 'auto_environment_variable',
-        'auto_log_location'
+        'auto_log_location', 'bc_num_nodes'
       ].to_set
       assert_equal expected_new_options, actual_new_options
     end


### PR DESCRIPTION
Related to issue: https://github.com/OSC/ondemand/issues/4287

Last added PR: https://github.com/OSC/ondemand/pull/4323

Current Issue:
`bc_num_slots` is used for cores on `pbspro` while nodes on other schedulers. 
`bc_num_nodes` is used for nodes on all the schedulers.
`auto_cores` is used for cored on all the schedulers.

Now we need to either 
1. Change `bc_num_slots` to specify cores in submit script for all the schedulers (which is not favored as it is a legacy code of OOD)
2. Not to use `bc_num_slots` in PM and instead keep `auto_cores` only to avoid confusion.

I am open for suggestions.