### PR TITLE
Removed support of bc_num_slots as auto_cores will take its place in PM

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -13,7 +13,6 @@ class LaunchersController < ApplicationController
     :auto_queues, :auto_queues_exclude, :auto_queues_fixed,
     :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,
     :bc_num_nodes, :bc_num_nodes_fixed, :bc_num_nodes_min, :bc_num_nodes_max,
-    :bc_num_slots, :bc_num_slots_fixed, :bc_num_slots_min, :bc_num_slots_max,
     :bc_num_hours, :bc_num_hours_fixed, :bc_num_hours_min, :bc_num_hours_max,
     :auto_job_name, :auto_job_name_fixed,
     :auto_log_location, :auto_log_location_fixed

--- a/apps/dashboard/app/helpers/launchers_helper.rb
+++ b/apps/dashboard/app/helpers/launchers_helper.rb
@@ -50,11 +50,6 @@ module LaunchersHelper
     create_editable_widget(script_form_double, attrib)
   end
 
-  def bc_num_slots_template
-    attrib = SmartAttributes::AttributeFactory.build_bc_num_slots
-    create_editable_widget(script_form_double, attrib)
-  end
-
   def auto_accounts_template
     attrib = SmartAttributes::AttributeFactory.build_auto_accounts
     create_editable_widget(script_form_double, attrib)

--- a/apps/dashboard/app/javascript/launcher_edit.js
+++ b/apps/dashboard/app/javascript/launcher_edit.js
@@ -27,10 +27,6 @@ const newFieldData = {
     label: "Nodes",
     help: "How many nodes the job will run on."
   },
-  bc_num_slots: {
-    label: "Slots",
-    help: "How many slots or cores the job will run on."
-  },
   auto_environment_variable: {
     label: 'Environment Variable',
     help: 'Add an environment variable.'

--- a/apps/dashboard/app/views/launchers/edit.html.erb
+++ b/apps/dashboard/app/views/launchers/edit.html.erb
@@ -25,10 +25,6 @@
   <%= bc_num_nodes_template %>
 </template>
 
-<template id="bc_num_slots_template">
-  <%= bc_num_slots_template %>
-</template>
-
 <template id="auto_queues_template">
   <%= auto_queues_template %>
 </template>

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -513,9 +513,9 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       actual_new_options = page.all("##{new_field_id} option").map(&:value).to_set
       expected_new_options = [
-        'bc_num_hours', 'auto_queues', 'bc_num_slots', 'auto_cores',
+        'bc_num_hours', 'auto_queues', 'bc_num_nodes', 'auto_cores',
         'auto_accounts', 'auto_job_name', 'auto_environment_variable',
-        'auto_log_location', 'bc_num_nodes'
+        'auto_log_location',
       ].to_set
       assert_equal expected_new_options, actual_new_options
     end


### PR DESCRIPTION
It is a follow-up task for PR: https://github.com/OSC/ondemand/pull/4327

Related to issue: https://github.com/OSC/ondemand/issues/4287

bc_num_slots had mixed behavior, where it acted as `nodes` for some scheduler and `cores` for `pbspro` scheduler