### PR TITLE
raise an error under certain conditions.

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -76,6 +76,12 @@ module OodPortalGenerator
 
     # determine if this config would enable dex configurations.
     def set_enable(config)
+      if !Dex.installed? && config != NO_CONFIG && config != false
+        msg = 'You do not have dex installed, but are trying to configure it. Please install ondemand-dex' \
+              ' or remove the configurations to continue.'
+        raise(ArgumentError, msg)
+      end
+
       @enable = if config == NO_CONFIG || config == false || !Dex.installed?
                   false
                 else

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -467,6 +467,14 @@ describe OodPortalGenerator::Application do
         expect(described_class.dex_output).to receive(:write).with(expected_dex_yaml)
         described_class.generate()
       end
+
+      it 'raises an error when config is provided, but dex is not installed' do
+        allow(OodPortalGenerator::Dex).to receive(:installed?).and_return(false)
+        expect {
+          allow(described_class).to receive(:context).and_return({ dex: nil })
+          described_class.generate
+        }.to(raise_error(ArgumentError, /You do not have dex installed/))
+      end
     end
   end
 


### PR DESCRIPTION
raise an error when dex configurations are provided, but dex is not installed. This is to fail fast and alert the user of the state.

Fixes #1994