### PR TITLE
backport - Add option to disable Passenger telemetry (#4355) - to 4.0

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -79,6 +79,10 @@ module NginxStage
       @passenger_log_file&.%({ user: user })
     end
 
+    # Option to disable the Passenger telemetry
+    # @return [String] the value for passenger_disable_anonymous_telemetry
+    attr_accessor :passenger_disable_anonymous_telemetry
+
     attr_writer :passenger_log_file
 
     # Hash of Passenger configuration options
@@ -451,6 +455,7 @@ module NginxStage
 
       self.passenger_pool_idle_time = 300
       self.passenger_log_file = nil
+      self.passenger_disable_anonymous_telemetry = 'on'
       self.passenger_options = {}
 
       self.pun_custom_env      = {}

--- a/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
+++ b/nginx_stage/lib/nginx_stage/views/pun_config_view.rb
@@ -73,6 +73,12 @@ module NginxStage
       NginxStage.passenger_log_file(user: user)
     end
 
+    # Option to disable the Passenger telemetry.
+    # @return [String] the value for passenger_disable_anonymous_telemetry
+    def passenger_disable_anonymous_telemetry
+      NginxStage.passenger_disable_anonymous_telemetry
+    end
+
     # Hash of Passenger configuration options
     # @return [Hash] Hash of Passenger configuration options
     def passenger_options

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -105,6 +105,11 @@
 #
 #passenger_log_file: '/var/log/ondemand-nginx/%{user}/error.log'
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+#passenger_disable_anonymous_telemetry: on
+
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored
 #

--- a/nginx_stage/templates/pun.conf.erb
+++ b/nginx_stage/templates/pun.conf.erb
@@ -61,6 +61,9 @@ http {
   <%- if passenger_log_file -%>
   passenger_log_file <%= passenger_log_file %>;
   <%- end -%>
+  <%- unless passenger_options.to_h.has_key?(:passenger_disable_anonymous_telemetry) -%>
+  passenger_disable_anonymous_telemetry <%= passenger_disable_anonymous_telemetry %>;
+  <%- end -%>
 <%- passenger_options.to_h.each_pair do |key, value| -%>
   <%= key %> <%= value %>;
 <%- end -%>


### PR DESCRIPTION
Add option to disable Passenger telemetry while also accounting for sites that have it already set in passenger_options.