### PR TITLE
backport - encrypt password fields when caching them (#4326) - to 3.1

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -2,6 +2,7 @@
 class BatchConnect::SessionContextsController < ApplicationController
   include BatchConnectConcern
   include UserSettingStore
+  include EncryptedCache
 
   # GET /batch_connect/<app_token>/session_contexts/new
   def new
@@ -38,7 +39,8 @@ class BatchConnect::SessionContextsController < ApplicationController
     @session = BatchConnect::Session.new
     respond_to do |format|
       if @session.save(app: @app, context: @session_context, format: @render_format)
-        cache_file.write(@session_context.to_json)  # save context to cache file
+        cache_data = encypted_cache_data(app: @app, data: @session_context.to_openstruct.to_h)
+        cache_file.write(cache_data.to_json) # save context to cache file
         save_template
         # We need to set the prefill templates only after storing the new one
         # so that the new one is included / updated in the list
@@ -84,13 +86,13 @@ class BatchConnect::SessionContextsController < ApplicationController
 
     # Set the rendering format for displaying attributes
     def set_prefill_templates
-      @prefill_templates ||= bc_templates(@app.token)
+      @prefill_templates ||= bc_templates(@app)
     end
 
     def save_template
       return unless params[:save_template].present? && params[:save_template] == "on" && params[:template_name].present?
 
-      save_bc_template(@app.token, params[:template_name], @session_context.to_h)
+      save_bc_template(@app, params[:template_name], @session_context.to_h)
     end
 
     # Only permit certian parameters

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -20,6 +20,8 @@ module BatchConnect
     # Raised when batch connect app components could not be found
     class AppNotFound < StandardError; end
 
+    include EncryptedCache
+
     class << self
       # Generate an object from a token
       # @param token [String] the token
@@ -164,6 +166,9 @@ module BatchConnect
     def update_session_with_cache(session_context, cache_file)
       cache = cache_file.file? ? JSON.parse(cache_file.read) : {}
       cache.delete('cluster') if delete_cached_cluster?(cache['cluster'].to_s)
+      cache = cache.symbolize_keys
+
+      cache = decypted_cache_data(app: self, data: cache)
 
       session_context.update_with_cache(cache)
     end

--- a/apps/dashboard/app/models/concerns/encrypted_cache.rb
+++ b/apps/dashboard/app/models/concerns/encrypted_cache.rb
@@ -1,0 +1,43 @@
+module EncryptedCache
+
+  def decypted_cache_data(app: nil, data: {})
+    encrypt_decript(app: app, data: data, action: :decrypt)
+
+  # catch the error for backward compatability. i.e., what's cached is not encrypted.
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    data
+  end
+
+  def encypted_cache_data(app: nil, data: {})
+    encrypt_decript(app: app, data: data, action: :encrypt)
+  end
+
+  def encrypt_decript(app: nil, data: {}, action: :encrypt)
+    return {} if app.nil?
+
+    secret_fields = app.attributes.select { |a| a.widget == 'password_field' }.map(&:id)
+
+    if secret_fields.empty?
+      data
+    else
+      modified_data = {}
+
+      secret_fields.each do |field|
+        raw = data[field.to_sym]
+        next if raw.to_s.empty?
+
+        modified_data[field.to_sym] = if action == :encrypt
+                                        encryptor.encrypt_and_sign(raw)
+                                      else
+                                        encryptor.decrypt_and_verify(raw)
+                                      end
+      end
+
+      data.merge(modified_data)
+    end
+  end
+
+  def encryptor
+    @encryptor ||= ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..31])
+  end
+end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -15,13 +15,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     Configuration.stubs(:bc_dynamic_js).returns(true)
     Configuration.stubs(:bc_dynamic_js?).returns(true) #stub the alias too
   end
-    
-  def stub_git(dir)
-    Open3.stubs(:capture3)
-      .with('git', 'describe', '--always', '--tags', chdir: dir)
-      .returns(['1.2.3', '', exit_success])
-  end
-    
+
   def make_bc_app(dir, form)
     SysRouter.stubs(:base_path).returns(Pathname.new(dir))
     app_dir = "#{dir}/app".tap { |d| Dir.mkdir(d) }

--- a/apps/dashboard/test/test_helper.rb
+++ b/apps/dashboard/test/test_helper.rb
@@ -111,6 +111,17 @@ module ActiveSupport
     def output_fixture(file)
       File.read("#{Rails.root}/test/fixtures/file_output/#{file}")
     end
+
+    def sys_bc_app(app: 'bc_paraview')
+      r = SysRouter.new(app)
+      BatchConnect::App.new(router: r)
+    end
+
+    def stub_git(dir)
+      Open3.stubs(:capture3)
+        .with('git', 'describe', '--always', '--tags', chdir: dir)
+        .returns(['1.2.3', '', exit_success])
+    end
   end
 end
 


### PR DESCRIPTION
Encrypt password fields when caching them while catching the error for backward compatibility.

This also replaces the integration test with a system test.