### PR TITLE
use warn instead of Rails.logger.error

### DIFF
--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -469,7 +469,7 @@ class ConfigurationSingleton
         yml = YAML.safe_load(content, aliases: true) || {}
         conf.deep_merge!(yml.deep_symbolize_keys)
       rescue => e
-        warn("Can't read or parse #{f} because of error #{e}")
+        $stderr.puts("Can't read or parse #{f} because of error #{e}")
       end
     end
   end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -469,7 +469,7 @@ class ConfigurationSingleton
         yml = YAML.safe_load(content, aliases: true) || {}
         conf.deep_merge!(yml.deep_symbolize_keys)
       rescue => e
-        Rails.logger.error("Can't read or parse #{f} because of error #{e}")
+        warn("Can't read or parse #{f} because of error #{e}")
       end
     end
   end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -348,8 +348,8 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     with_modified_env(config_fixtures) do
       bad_erb_rex = /bad_erb.yml.erb because of error undefined local variable or method `wont_find_this_functon/
       bad_yml_rex = /not_good_yml.yml because of error \(<unknown>\): did not find expected '-' indicator while parsing a block collection at line 2 column 3/
-      Rails.logger.expects(:error).with(regexp_matches(bad_erb_rex)).at_least_once
-      Rails.logger.expects(:error).with(regexp_matches(bad_yml_rex)).at_least_once
+      expects(:warn).with(regexp_matches(bad_erb_rex)).at_least_once
+      expects(:warn).with(regexp_matches(bad_yml_rex)).at_least_once
       ConfigurationSingleton.new.send(:config)
     end
   end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -348,8 +348,8 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     with_modified_env(config_fixtures) do
       bad_erb_rex = /bad_erb.yml.erb because of error undefined local variable or method `wont_find_this_functon/
       bad_yml_rex = /not_good_yml.yml because of error \(<unknown>\): did not find expected '-' indicator while parsing a block collection at line 2 column 3/
-      expects(:warn).with(regexp_matches(bad_erb_rex)).at_least_once
-      expects(:warn).with(regexp_matches(bad_yml_rex)).at_least_once
+      $stderr.expects(:puts).with(regexp_matches(bad_erb_rex)).at_least_once
+      $stderr.expects(:puts).with(regexp_matches(bad_yml_rex)).at_least_once
       ConfigurationSingleton.new.send(:config)
     end
   end


### PR DESCRIPTION
use warn instead of Rails.logger.error because this class boots up before Rails does, so Rails.logger isn't available yet.