### PR TITLE
Launchers now support 'after', 'afterok' etc. job-id lists in submit()

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -193,9 +193,13 @@ class Launcher
     render_format = adapter.class.name.split('::').last.downcase
 
     job_script = OodCore::Job::Script.new(**submit_opts(options, render_format))
+    after = Array(options[:after])
+    afterok = Array(options[:afterok])
+    afternotok = Array(options[:afternotok])
+    afterany = Array(options[:afterany])
 
     job_id = Dir.chdir(project_dir) do
-      adapter.submit(job_script)
+      adapter.submit(job_script, after, afterok, afternotok, afterany)
     end
     update_job_log(job_id, cluster_id.to_s)
     write_job_options_to_cache(options)

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -193,13 +193,9 @@ class Launcher
     render_format = adapter.class.name.split('::').last.downcase
 
     job_script = OodCore::Job::Script.new(**submit_opts(options, render_format))
-    after = Array(options[:after])
-    afterok = Array(options[:afterok])
-    afternotok = Array(options[:afternotok])
-    afterany = Array(options[:afterany])
 
     job_id = Dir.chdir(project_dir) do
-      adapter.submit(job_script, after, afterok, afternotok, afterany)
+      adapter.submit(job_script, **dependency_helper(options))
     end
     update_job_log(job_id, cluster_id.to_s)
     write_job_options_to_cache(options)
@@ -209,6 +205,15 @@ class Launcher
     errors.add(:submit, e.message)
     Rails.logger.error("ERROR: #{e.class} - #{e.message}")
     nil
+  end
+
+  def dependency_helper(options)
+    {
+      after: Array(options[:after]),
+      afterok: Array(options[:afterok]),
+      afternotok: Array(options[:afternotok]),
+      afterany: Array(options[:afterany])
+    }
   end
 
   def create_default_script


### PR DESCRIPTION
Workflows Epic Link - https://github.com/OSC/ondemand/issues/4338

We can now add dependent job-id list to the submit() call of Launchers.