### PR TITLE
update workflows to ruby 3.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.1"
-          bundler: "2.1.4"
+          ruby-version: "2.3"
+          bundler: "2.5.23"
           bundler-cache: true
 
       - name: Lint a file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.1"
-          bundler: "2.1.4"
+          ruby-version: "3.3"
+          bundler: "2.5.23"
           bundler-cache: true
       - name: Generate tar.gz
         run: bundle exec rake package:tar


### PR DESCRIPTION
update workflows to ruby 3.3 to fix the lint workflow that is currently broken. This also updates the release workflow that would have likely broken in 4.1.