### PR TITLE
feat(bc_desktop): support gnome3

### DIFF
--- a/apps/bc_desktop/form.yml
+++ b/apps/bc_desktop/form.yml
@@ -4,6 +4,7 @@ attributes:
     label: "Desktop Environment"
     widget: select
     options:
+      - "gnome3"
       - "gnome"
       - "kde"
       - "mate"

--- a/apps/bc_desktop/template/desktops/gnome3.sh
+++ b/apps/bc_desktop/template/desktops/gnome3.sh
@@ -1,0 +1,4 @@
+# gnome won't start correctly without DBUS_SESSION_BUS_ADDRESS set.
+eval $(dbus-launch --sh-syntax)
+
+gnome-session


### PR DESCRIPTION
According to the documentation, GNOME 3 is not currently supported by the interactive desktop. The added script has been tested on Rocky Linux 8.