### PR TITLE
Added skeleton for the launcher workflow class

### DIFF
--- a/apps/dashboard/app/controllers/launcher_workflows_controller.rb
+++ b/apps/dashboard/app/controllers/launcher_workflows_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# The controller for apps pages /dashboard/projects/:project_id/workflows/:workflow_id
+class LauncherWorkflowsController < ApplicationController
+
+  # GET /projects/:id/workflows/:id
+  def show
+    # TODO: Complete it
+  end
+
+  # GET /projects/:id/workflows
+  def index
+    @project = Project.find(params[:project_id])
+    LauncherWorkflow.projectroot = @project.directory
+    @workflows = LauncherWorkflow.all
+  end
+
+  # GET /projects/:id/workflows/new
+  def new
+    @workflow = LauncherWorkflow.new()
+  end
+
+  # GET /projects/:id/workflows/edit
+  def edit
+    # TODO: Complete it
+  end
+
+  # PATCH /projects/:id/workflows/patch
+  def update
+    # TODO: Complete it
+  end
+
+  # POST /projects/:id/workflows/
+  def create
+    # TODO: Complete it
+  end
+
+  # DELETE /projects/:id/workflows/:id
+  def destroy
+    # TODO: Complete it
+  end
+
+  # POST /projects/:project_id/workflows/:id/submit
+  def submit
+    # TODO: Add logic to call submit of each launcher based upon dependency DAG graph
+  end
+
+end

--- a/apps/dashboard/app/models/launcher_workflow.rb
+++ b/apps/dashboard/app/models/launcher_workflow.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class LauncherWorkflow
+  include ActiveModel::Model
+
+  class << self
+    attr_accessor :projectroot
+
+    def workflows_file
+      Pathname("#{projectroot}/.workflows").tap do |path|
+        FileUtils.touch(path.to_s) unless path.exist?
+      end
+    end
+
+    def workflows
+      f = File.read(workflows_file)
+      YAML.safe_load(f).to_h
+    rescue StandardError, Exception => e
+      Rails.logger.warn("cannot read #{projectroot}/.workflows due to error #{e}")
+      {}
+    end
+
+    def all
+      workflows.map do |id, launcher_pair|
+        LauncherWorkflow.new({ id: id, pair: launcher_pair })
+      end
+    end
+
+    def find(id)
+      # TODO: Complete it
+    end
+  end
+  
+
+  def initialize(attributes = {})
+    # TODO: Complete it
+  end
+
+  # TODO: Add logic to save the DAG relation between launchers like array of <launcher #1, launcher #2>
+
+end

--- a/apps/dashboard/app/views/launcher_workflows/index.html.erb
+++ b/apps/dashboard/app/views/launcher_workflows/index.html.erb
@@ -1,0 +1,7 @@
+<div class='page-header text-center'>
+  <h1>Workflow Manager</h1>
+  <small class="text-muted">This is a preview of the new 'Workflow Manager' for Launchers</small>
+</div>
+
+<%# TODO Show workflows created for this project %>
+<%# TODO Add support to add new workflows to this project %>

--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -100,3 +100,7 @@
     </div>
   </div>
 <% end %>
+
+<div class="d-flex justify-content-center mb-3">
+  <%= button_to t('dashboard.jobs_workflow_button'), project_launcher_workflows_path(@project.id), method: :get, class: "btn btn-primary" %>
+</div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -180,6 +180,8 @@ en:
     jobs_project_save_error: Cannot save manifest to %{path}
     jobs_project_validation_error: Invalid Request. Please review the errors below
     jobs_select_directory_placeholder: Click on project below to import to your home page (Optional)
+    jobs_workflow_button: Advance Launcher Workflows
+    jobs_workflow_submit: Submit Workflow
     launch: Launch
     motd_erb_render_error: 'MOTD was not parsed or rendered correctly: %{error_message}'
     motd_title: Message of the Day

--- a/apps/dashboard/config/locales/ja_JP.yml
+++ b/apps/dashboard/config/locales/ja_JP.yml
@@ -178,6 +178,8 @@ ja_JP:
     jobs_project_save_error: Cannot save manifest to %{path}
     jobs_project_validation_error: Invalid Request. Please review the errors below
     jobs_select_directory_placeholder: Click on project below to import to your home page (Optional)
+    jobs_workflow_button: Advance Launcher Workflows
+    jobs_workflow_submit: Submit Workflow
     launch: 起動する
     motd_erb_render_error: 'MOTD was not parsed or rendered correctly: %{error_message}'
     motd_title: Message of the Day

--- a/apps/dashboard/config/locales/zh-CN.yml
+++ b/apps/dashboard/config/locales/zh-CN.yml
@@ -174,6 +174,8 @@ zh-CN:
     jobs_project_save_error: Cannot save manifest to %{path}
     jobs_project_validation_error: Invalid Request. Please review the errors below
     jobs_select_directory_placeholder: Click on project below to import to your home page (Optional)
+    jobs_workflow_button: Advance Launcher Workflows
+    jobs_workflow_submit: Submit Workflow
     launch: 启动
     motd_erb_render_error: 'MOTD was not parsed or rendered correctly: %{error_message}'
     motd_title: 每日信息

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       delete '/jobs/:cluster/:jobid' => 'projects#delete_job', :as => 'delete_job'
       post '/jobs/:cluster/:jobid/stop' => 'projects#stop_job', :as => 'stop_job'
 
+      resources :launcher_workflows, path: 'workflows'
+
       resources :launchers do
         post 'submit', on: :member
         post 'save', on: :member


### PR DESCRIPTION
Workflows Epic Link - https://github.com/OSC/ondemand/issues/4338

* This PR is just to adding routes, agree upon class names and overall class hierarchy design.
* There are lots of TODO in it, methods and attributes will be added in next PR.

Launchers can be created from `/project/:id` page as well as `project/:id/workflows/:id/` page. While the ones we create on project page will by-default appear on each workflow, but ones created inside will only be specific to the current workflow.

**Note:** Still all the Launchers will stay part of projects and will keep a workflow_id to express their loyalty to a specific workflow. `Null` will mean that the Launcher was created in `/projects/:id` page.