### PR TITLE
Path selector #4398

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -14,7 +14,8 @@
     table_id: "#{path_selector_id}_table",
     breadcrumb_id: "#{path_selector_id}_breadcrumb",
     button_id: "#{path_selector_id}_button",
-    input_field_id: input_field_id
+    input_field_id: input_field_id,
+    popup_title: field_options.fetch(:popup_title, "#{attrib.id}" )
   }
 %>
 

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -13,12 +13,13 @@
     data-select-button-id="<%= button_id %>"
     data-input-field-id="<%= input_field_id %>"
     data-file-pattern="<%= file_pattern %>"
+    data-popup_title="<%= popup_title %>"
     >
 
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="modal-path-selector-title">Select Your Working Directory</h5>
+        <h5 class="modal-title" id="modal-path-selector-title"><%= popup_title %></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">


### PR DESCRIPTION
Resolves #4398 

Adds a new attribute to path_selector widget of `popup_title`. More than welcome to change the name. This will replace the current title of "Select Your Working Directory" to the value of `popup_title`.

If no option is set for `popup_title` it will default to the name of the widget instead (`#{attrib.id}`).
```
    popup_title: field_options.fetch(:popup_title, "#{attrib.id}" )
```
