### PR TITLE
Do not titleize the cluster title in the Cluster Status helper

### DIFF
--- a/apps/dashboard/app/helpers/system_status_helper.rb
+++ b/apps/dashboard/app/helpers/system_status_helper.rb
@@ -3,7 +3,7 @@
 # Helpers for the system status page /dashboard/systemstatus
 module SystemStatusHelper
   def title(cluster)
-    "#{cluster.metadata.title.to_s.titleize} Cluster Status"
+    "#{cluster.metadata.title.to_s} Cluster Status"
   end
 
   def status_hash(name, active, total)

--- a/apps/dashboard/app/helpers/system_status_helper.rb
+++ b/apps/dashboard/app/helpers/system_status_helper.rb
@@ -3,7 +3,7 @@
 # Helpers for the system status page /dashboard/systemstatus
 module SystemStatusHelper
   def title(cluster)
-    "#{cluster.metadata.title.to_s} Cluster Status"
+    "#{cluster.metadata.title} Cluster Status"
   end
 
   def status_hash(name, active, total)


### PR DESCRIPTION
Our cluster title contains the acronym of our institute, and I assume there will be others

Before:

<img width="652" alt="image" src="https://github.com/user-attachments/assets/1a8dd373-026b-422b-9fd7-30b10fed480d" />

After:

<img width="652" alt="image" src="https://github.com/user-attachments/assets/be10a70a-d637-4db6-bae8-2289e202a453" />


