### PR TITLE
Some file manager style changes + rounded breadcrumbs

### DIFF
--- a/apps/dashboard/app/views/batch_connect/shared/_breadcrumb.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_breadcrumb.html.erb
@@ -1,7 +1,7 @@
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb rounded">
     <% links.each_with_index do |link, idx| %>
-      <%= tag.li class: current_page?(link) ? 'breadcrumb-item' : 'breadcrumb-item active' do %>
+      <%= tag.li class: current_page?(link) ? 'breadcrumb-item align-content-center' : 'breadcrumb-item align-content-center active' do %>
         <%= tag.a link[:text], aria: ({ current: 'page' } if (links.length - 1 == idx)), href: (link[:href] unless link.key?('href') || link[:disabled]) %>
       <% end %>
     <% end %>

--- a/apps/dashboard/app/views/batch_connect/shared/_breadcrumb.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_breadcrumb.html.erb
@@ -1,5 +1,5 @@
 <nav aria-label="Breadcrumb">
-  <ol class="breadcrumb">
+  <ol class="breadcrumb rounded">
     <% links.each_with_index do |link, idx| %>
       <%= tag.li class: current_page?(link) ? 'breadcrumb-item' : 'breadcrumb-item active' do %>
         <%= tag.a link[:text], aria: ({ current: 'page' } if (links.length - 1 == idx)), href: (link[:href] unless link.key?('href') || link[:disabled]) %>

--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -1,8 +1,6 @@
 <div class="col-md-9">
   <%# TODO put search box ABOVE the breadcrumbs %>
-  <div class='mt-3'>
-
-    <ol id="path-breadcrumbs" class="breadcrumb breadcrumb-no-delimiter">
+    <ol id="path-breadcrumbs" class="breadcrumb breadcrumb-no-delimiter rounded">
       <%= render partial: 'breadcrumb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path } %>
     </ol>
 
@@ -25,7 +23,4 @@
       </tbody>
     </table>
     <%= render partial: "spinner" %>
-  </div>
-</div>
-
 </div>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -1,6 +1,6 @@
 <%# z-index:999 cause dropdowns are 1000 default sticky-top is 1020 https://getbootstrap.com/docs/4.6/layout/overview/#z-index %>
 
-<div class="text-end sticky-top bg-white border-bottom p-2 m-3 z-index-999">
+<div class="text-end sticky-top bg-white p-2 mb-4 z-index-999">
   <!-- terminal button href is set via JavaScript because the URL is based on the current directory -->
   <% if Configuration.files_enable_shell_button %>
     <%= render partial: 'shell_dropdown' %>
@@ -20,7 +20,7 @@
 
 <hr>
 
-<div class="row">
+<div class="row gap-3 gap-md-0">
   <div class="col-md-3">
     <%= render partial: "favorites" %>
     <%= render partial: "copy_move_popup" %>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -1,6 +1,6 @@
 <%# z-index:999 cause dropdowns are 1000 default sticky-top is 1020 https://getbootstrap.com/docs/4.6/layout/overview/#z-index %>
 
-<div class="text-end sticky-top bg-white p-2 mb-4 z-index-999">
+<div class="text-end sticky-top bg-white p-2 mb-4 d-flex flex-wrap gap-2 justify-content-end z-index-999">
   <!-- terminal button href is set via JavaScript because the URL is based on the current directory -->
   <% if Configuration.files_enable_shell_button %>
     <%= render partial: 'shell_dropdown' %>

--- a/apps/dashboard/app/views/products/_breadcrumbs.html.erb
+++ b/apps/dashboard/app/views/products/_breadcrumbs.html.erb
@@ -1,5 +1,5 @@
 <nav aria-label="Breadcrumb">
-  <ol class="breadcrumb">
+  <ol class="breadcrumb rounded">
     <li class="breadcrumb-item">
       <%= link_to "Home", root_path %>
     </li>

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -39,7 +39,7 @@
         
       
             <div class="<%= favorites ? 'col-sm-7' : 'col-sm-12' %>">
-              <ol id="<%= breadcrumb_id %>" class="breadcrumb breadcrumb-no-delimiter">
+              <ol id="<%= breadcrumb_id %>" class="breadcrumb breadcrumb-no-delimiter rounded">
               </ol>
 
               <div class="d-none alert alert-warning" role="alert" id="forbidden-warning">


### PR DESCRIPTION
With this PR I am taking the liberty to propose some style changes by adding some bootstrap classes here and there. 

Before:
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/93829c39-38fe-4aff-9c5c-9c15fbb186f7" />

After:
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/ce99dc76-c549-430b-8a46-983aca50f46a" />

Before:
<img width="378" alt="image" src="https://github.com/user-attachments/assets/da4e22d1-4f70-4099-87ff-ac1577656f99" />


After:
<img width="378" alt="image" src="https://github.com/user-attachments/assets/b4b2f419-7b46-4659-842c-3126e23288fe" />


Summary:
- Rounded borders for breadcrumbs
- Consistent spacing in files
- Gap + flex wrapping button array files for mobile mode
- No double border at files


I am new to this project so please tell me if I should do things differently! 

