### PR TITLE
turn accessibility on for the shell app

### DIFF
--- a/apps/shell/public/javascripts/ood_shell.2.js
+++ b/apps/shell/public/javascripts/ood_shell.2.js
@@ -42,6 +42,7 @@ OodShell.prototype.runTerminal = function () {
 
   // Connect terminal to sacrificial DOM node
   this.term.decorate(this.element);
+  this.term.setAccessibilityEnabled(true);
 
   // Warn user if he/she unloads page
   window.onbeforeunload = function() {


### PR DESCRIPTION
turn accessibility on for the shell app

Fixes #672

hterm documentation says this is off by default because of performance issues. I considered making this a checkbox or similar to turn on and off, but I don't notice any performance issues. Happy to have someone else give this and see if there are any performance issues when it's always on.