### PR TITLE
No margin top for path selector button

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_path_selector.html.erb
@@ -21,7 +21,7 @@
 
 <%= form.text_field(attrib.id, class: 'form-control', **options) %>
 
-<button type="button" class="btn btn-primary mt-2" data-bs-toggle="modal" data-bs-target="#<%= path_selector_id %>">
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#<%= path_selector_id %>">
   <%= I18n.t('dashboard.select_path') %>
 </button>
 


### PR DESCRIPTION
This is a small one, but the spacing between the path selector button and the form field seems to be a bit off. Currently it looks like the button belongs to next input field instead. This PR should make it a bit better, but preferably it would go even a bit closer to the input field of the path, but I couldn't find where to do that.  

Before:

<img width="710" height="343" alt="image" src="https://github.com/user-attachments/assets/a485298a-b471-40b8-bac6-0a3a9a1dbe43" />

After:

<img width="710" height="343" alt="image" src="https://github.com/user-attachments/assets/67339947-6581-413e-b4b4-037a43b314a7" />

Also without a label it still looks good:
<img width="710" height="343" alt="image" src="https://github.com/user-attachments/assets/8ad67421-d8fe-47d1-a063-5d2dc522e54e" />
