### PR TITLE
Dynamic poll delay for batch_connect/sessions.js

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -205,12 +205,16 @@ module BatchConnect::SessionsHelper
       end
     end
   end
-  
-  def bc_polling_enabled?(sessions)
-    sessions.any? { |s| s.starting? || s.running? || s.queued? }
-  end
 
-  def throttle_bc_polling?(sessions)
-    sessions.all? { |s| s.running? || s.completed? }
+  def adjusted_poll_delay(sessions)
+    any_active_sessions = sessions.any? { |s| s.starting? || s.running? || s.queued? }
+    throttle_polling = sessions.all? { |s| s.running? || s.completed? }
+    if any_active_sessions && throttle_polling
+      Configuration.bc_sessions_poll_delay_throttled
+    elsif any_active_sessions
+      Configuration.bc_sessions_poll_delay
+    else
+      0   # No polling needed if no active sessions
+    end
   end
 end

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -205,4 +205,12 @@ module BatchConnect::SessionsHelper
       end
     end
   end
+  
+  def bc_polling_enabled?(sessions)
+    sessions.any? { |s| s.starting? || s.running? || s.queued? }
+  end
+
+  def throttle_bc_polling?(sessions)
+    sessions.all? { |s| s.running? || s.completed? }
+  end
 end

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -57,9 +57,11 @@ function installSettingHandlers(name) {
 window.installSettingHandlers = installSettingHandlers;
 window.tryUpdateSetting = tryUpdateSetting;
 
-jQuery(function (){
-  if ($('#batch_connect_sessions').length) {
-    pollAndReplace(bcIndexUrl(), bcPollDelay(), "batch_connect_sessions", () => {
+document.addEventListener('DOMContentLoaded', function () {
+  const bcSessionsContainer = document.getElementById('batch_connect_sessions');
+  if (bcSessionsContainer) {
+    const pollDelay = bcSessionsContainer.dataset.bcPollingEnabled === "true" ? bcPollDelay() : null;
+    pollAndReplace(bcIndexUrl(), pollDelay, "batch_connect_sessions", () => {
       bindFullPageSpinnerEvent();
       checkStatusChanges();
     });

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -7,6 +7,14 @@ import { ariaNotify } from './aria_live_notify';
 
 const sessionStatusMap = new Map();
 
+function getPollDelay() {
+  const bcSessionsContainer = document.getElementById('bc_sessions_content');
+  if (!bcSessionsContainer) return bcPollDelay();
+
+  const delay = parseInt(bcSessionsContainer.dataset.adjustedPollDelay);
+  return isNaN(delay) ? bcPollDelay() : delay;
+}
+
 function checkStatusChanges() {
   const sessionCards = document.querySelectorAll('[data-bc-card]');
   
@@ -60,10 +68,10 @@ window.tryUpdateSetting = tryUpdateSetting;
 document.addEventListener('DOMContentLoaded', function () {
   const bcSessionsContainer = document.getElementById('batch_connect_sessions');
   if (bcSessionsContainer) {
-    const pollDelay = bcSessionsContainer.dataset.bcPollingEnabled === "true" ? bcPollDelay() : null;
+    const pollDelay = getPollDelay();
     pollAndReplace(bcIndexUrl(), pollDelay, "batch_connect_sessions", () => {
       bindFullPageSpinnerEvent();
       checkStatusChanges();
-    });
+    }, getPollDelay);
   }
 });

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -35,7 +35,9 @@ export function pollAndReplace(url, delay, id, callback) {
     .then((r) => r.text())
     .then((html) => replaceHTML(id, html))
     .then(() => {
-      setTimeout(pollAndReplace, delay, url, delay, id, callback);
+      if (delay) {
+        setTimeout(pollAndReplace, delay, url, delay, id, callback);
+      }
       if (typeof callback == 'function') {
         callback();
       }

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -21,7 +21,7 @@ export function replaceHTML(id, html) {
   setInnerHTML(ele, newHTML);
 }
 
-export function pollAndReplace(url, delay, id, callback) {
+export function pollAndReplace(url, delay, id, callback, getNextDelay=null) {
   fetch(url, { headers: { Accept: "text/vnd.turbo-stream.html" } })
     .then((response) => {
       if(response.status == 200) {
@@ -36,7 +36,8 @@ export function pollAndReplace(url, delay, id, callback) {
     .then((html) => replaceHTML(id, html))
     .then(() => {
       if (delay) {
-        setTimeout(pollAndReplace, delay, url, delay, id, callback);
+        const nextDelay = (typeof getNextDelay === 'function') ? getNextDelay() : delay;
+        setTimeout(pollAndReplace, nextDelay, url, nextDelay, id, callback, getNextDelay);
       }
       if (typeof callback == 'function') {
         callback();

--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -35,11 +35,7 @@ locals: {
       %>
     </nav>
     <div class="col-md-9" role="region" aria-label="Active Sessions">
-      <div 
-        id="batch_connect_sessions" 
-        data-bc-polling-enabled="<%= bc_polling_enabled?(@sessions) %>"
-        data-throttle-on-load="<%= throttle_bc_polling?(@sessions) %>"
-      >
+      <div id="batch_connect_sessions">
         <%= render(partial: 'panels') %>
       </div>
     </div>

--- a/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.html.erb
@@ -35,7 +35,11 @@ locals: {
       %>
     </nav>
     <div class="col-md-9" role="region" aria-label="Active Sessions">
-      <div id="batch_connect_sessions">
+      <div 
+        id="batch_connect_sessions" 
+        data-bc-polling-enabled="<%= bc_polling_enabled?(@sessions) %>"
+        data-throttle-on-load="<%= throttle_bc_polling?(@sessions) %>"
+      >
         <%= render(partial: 'panels') %>
       </div>
     </div>

--- a/apps/dashboard/app/views/batch_connect/sessions/index.turbo_stream.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.turbo_stream.erb
@@ -1,7 +1,11 @@
 
 <turbo-stream action="update" target="batch_connect_sessions" id="sessions_frame">
   <template>
-    <div class="batch-connect sessions">
+    <div
+      id="bc_sessions_content"
+      class="batch-connect sessions"
+      data-adjusted-poll-delay="<%= adjusted_poll_delay(@sessions) %>"
+    >
       <% if @sessions.empty? %>
         <div class="ood-appkit markdown">
           <p><%= t('dashboard.batch_connect_no_sessions') %></p>

--- a/apps/dashboard/app/views/batch_connect/sessions/index.turbo_stream.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/index.turbo_stream.erb
@@ -1,10 +1,5 @@
 
-<turbo-stream action="replace" target="batch_connect_sessions" id="sessions_frame">
-  <div class="d-flex justify-content-center">
-    <div class="spinner-border" role="status">
-      <span class="sr-only">Loading...</span>
-    </div>
-  </div>
+<turbo-stream action="update" target="batch_connect_sessions" id="sessions_frame">
   <template>
     <div class="batch-connect sessions">
       <% if @sessions.empty? %>
@@ -15,5 +10,10 @@
         <%= render partial: "panel", collection: @sessions, as: :session, formats: [:html] %>
       <% end %>
     </div>
-    </template>
+  </template>
+  <div class="d-flex justify-content-center">
+    <div class="spinner-border" role="status">
+      <span class="sr-only">Loading...</span>
+    </div>
+  </div>
 </turbo-stream>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -422,6 +422,15 @@ class ConfigurationSingleton
     bc_poll_delay_int < 10_000 ? 10_000 : bc_poll_delay_int
   end
 
+  # Returns the number of milliseconds to wait between calls to the BatchConnect Sessions resource
+  # when all sessions are in running states. This reduces server load when states are stable.
+  # The default is `bc_sessions_poll_delay` and minimum value is 10s = 10_000
+  def bc_sessions_poll_delay_throttled
+    bc_poll_delay_int = (ENV['OOD_BC_SESSIONS_POLL_DELAY_THROTTLED'] || ENV['OOD_BC_SESSIONS_POLL_DELAY'] || ENV['POLL_DELAY'] ||
+                          config[:bc_sessions_poll_delay_throttled] || config[:bc_sessions_poll_delay] || '10000').to_i
+    bc_poll_delay_int < 10_000 ? 10_000 : bc_poll_delay_int
+  end
+
   def config
     @config ||= read_config
   end


### PR DESCRIPTION
Partially addresses #3729
- Prevent polling when no sessions are active
- Introduce `bc_poll_delay_throttled` config option to throttle polling when job states are stable

Does NOT address partial caching:
https://github.com/OSC/ondemand/issues/3729#issuecomment-2298710143

Needs tests and documentation.