### PR TITLE
add descriptive messages to setup-production errors

### DIFF
--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -287,6 +287,14 @@ class OodApp
             msg += "for user #{Etc.getpwuid.name} with output: #{output}"
             raise SetupScriptFailed, msg
           end
+        else
+          msg = "Per user setup failed: file 'bin/setup-production'"
+          if !File.exist?(setup)
+            msg += " was not found at runtime."
+          elsif !File.executable?(setup)
+            msg += " is not executable. Ensure the user has access to this file."
+          end
+          raise SetupScriptFailed, msg
         end
       end
     end

--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -287,13 +287,8 @@ class OodApp
             msg += "for user #{Etc.getpwuid.name} with output: #{output}"
             raise SetupScriptFailed, msg
           end
-        else
-          msg = "Per user setup failed: file 'bin/setup-production'"
-          if !File.exist?(setup)
-            msg += " was not found at runtime."
-          elsif !File.executable?(setup)
-            msg += " is not executable. Ensure the user has access to this file."
-          end
+        elsif File.exist?(setup) && !File.executable(setup)
+          msg = "Per user setup failed: file 'bin/setup-production' is not executable. Ensure the user has access to this file."
           raise SetupScriptFailed, msg
         end
       end


### PR DESCRIPTION
Fixes #3263. Now failures in checks to setup-production file will be logged as "Per user setup failed: file 'bin/setup-production' was not found at runtime" (file did not exist) or "Per user setup failed: file 'bin/setup-production' is not executable. Ensure the user has access to this file" (file was not executable).