### PR TITLE
Refactor motd tests 1540

### DIFF
--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -287,6 +287,14 @@ class OodApp
             msg += "for user #{Etc.getpwuid.name} with output: #{output}"
             raise SetupScriptFailed, msg
           end
+        else
+          msg = "Per user setup failed: file 'bin/setup-production'"
+          if !File.exist?(setup)
+            msg += " was not found at runtime."
+          elsif !File.executable?(setup)
+            msg += " is not executable. Ensure the user has access to this file."
+          end
+          raise SetupScriptFailed, msg
         end
       end
     end

--- a/apps/dashboard/test/models/motd_formatter/motd_formatter_markdown_erb_test.rb
+++ b/apps/dashboard/test/models/motd_formatter/motd_formatter_markdown_erb_test.rb
@@ -1,88 +1,65 @@
 require 'test_helper'
 
 class MotdFormatterMarkdownErbTest < ActiveSupport::TestCase
-  include MotdFormatter
   test "motd-formatter-md-erb returns valid motd file when given a valid motd file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_valid"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdownErb.new(motd_file)
-    expected_file = OodAppkit.markdown.render(motd_file.content)
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_valid" }) do
+      motd_file = MotdFile.new
+      expected_file = OodAppkit.markdown.render(motd_file.content)
 
-    assert_equal expected_file, formatted_motd.content
+      assert_equal expected_file, motd_file.formatter.content
+    end
   end
 
   test "motd-formatter-md-erb returns valid motd md-erb rendered file when given a valid motd md-erb file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_valid_erb_md"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdownErb.new(motd_file)
-    expected_file = OodAppkit.markdown.render("# Welcome to the Ohio Supercomputer Center!")
-    
-    assert_equal expected_file, formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_valid_erb_md" }) do
+      expected_file = OodAppkit.markdown.render("# Welcome to the Ohio Supercomputer Center!")
+      assert_equal expected_file, MotdFile.new.formatter.content
+    end
   end
 
   test "motd-formatter-md-erb returns a standard error when given a invalid motd erb file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_erb_standard_error"
-    motd_file = MotdFile.new(path)
-    
-    assert_raises(Exception) {
-      MotdFormatterMarkdownErb.new(motd_file)
-    }
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_erb_standard_error" }) do
+      assert_raises(Exception) {
+        MotdFile.new.formatter
+      }
+    end
   end
 
   test "motd-formatter-md-erb returns an empty string when given an empty motd file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_empty"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdownErb.new(motd_file)
-
-    assert_equal '', formatted_motd.content
-  end
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_empty" }) do
+      assert_equal '', MotdFile.new.formatter.content
+    end
+  end 
 
   test "motd-formatter-md-erb returns an empty string when given a missing file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_missing"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdownErb.new(motd_file)
-
-    assert_equal '', formatted_motd.content
-  end
-
-  test "motd-formatter-md-erb returns an empty stirng when given nill" do
-    motd_file = nil
-    formatted_motd = MotdFormatterMarkdownErb.new(motd_file)
-
-    assert_not_nil formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_missing" }) do
+      assert_nil MotdFile.new.formatter
+    end
   end
 
   test 'content is html safe by default' do
-    path = "#{Rails.root}/test/fixtures/files/motd_md_erb_w_html"
-    motd = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdownErb.new(motd)
-    content = formatted_motd.content
-
-    expected_content = "<h1>Some Markdown file</h1>\n" \
-    "\n" \
-    "var msg = 'this was a script';\n"
-
-    assert_not_nil(content)
-    assert_equal(expected_content, content)
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_md_erb_w_html" }) do
+      expected_content = "<h1>Some Markdown file</h1>\n" \
+      "\n" \
+      "var msg = 'this was a script';\n"
+      result_content = MotdFile.new.formatter.content
+      assert_not_nil(result_content)
+      assert_equal(expected_content, result_content)
+    end
   end
 
   # this test is very similar to above, but the content
   # has a <script> tag still in it.
   test 'content can contain html if configured' do
     Configuration.stubs(:motd_render_html).returns(true)
-
-    path = "#{Rails.root}/test/fixtures/files/motd_md_erb_w_html"
-    motd = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdownErb.new(motd)
-    content = formatted_motd.content
-
-    expected_content = "<h1>Some Markdown file</h1>\n" \
-    "\n" \
-    "<script>var msg = 'this was a script';</script>\n"
-
-    assert_not_nil(content)
-    assert_equal(expected_content, content)
+    with_modified_env({ 'MOTD_FORMAT': "markdown_erb",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_md_erb_w_html" }) do  
+      expected_content = "<h1>Some Markdown file</h1>\n" \
+      "\n" \
+      "<script>var msg = 'this was a script';</script>\n"
+      content = MotdFile.new.formatter.content
+      assert_not_nil(content)
+      assert_equal(expected_content, content)
+    end
   end
-
 end
 

--- a/apps/dashboard/test/models/motd_formatter/motd_formatter_markdown_test.rb
+++ b/apps/dashboard/test/models/motd_formatter/motd_formatter_markdown_test.rb
@@ -3,36 +3,24 @@
 require 'test_helper'
 
 class MotdFormatterMarkdownTest < ActiveSupport::TestCase
-  include MotdFormatter
   test 'test when motd formatter_markdown_valid' do
-    path = "#{Rails.root}/test/fixtures/files/motd_valid"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdown.new(motd_file)
-    expected_file = OodAppkit.markdown.render(motd_file.content)
+    with_modified_env({ 'MOTD_FORMAT': "markdown",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_valid" }) do
+      motd_file = MotdFile.new
+      expected_file = OodAppkit.markdown.render(motd_file.content)
 
-    assert_equal expected_file, formatted_motd.content
-  end
-
-  test 'test when motd_formatter_markdown empty' do
-    path = "#{Rails.root}/test/fixtures/files/motd_empty"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdown.new(motd_file)
-
-    assert_equal '', formatted_motd.content
+      assert_equal expected_file, motd_file.formatter.content
+    end
   end
 
   test 'test when motd formatter_markdown_missing' do
-    path = "#{Rails.root}/test/fixtures/files/motd_missing"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterMarkdown.new(motd_file)
-
-    assert_equal '', formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "markdown",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_missing" }) do
+      assert_nil MotdFile.new.formatter
+    end
   end
 
-  test 'test when motd formatter_markdown_nil' do
-    motd_file = nil
-    formatted_motd = MotdFormatterMarkdown.new(motd_file)
-
-    assert_not_nil formatted_motd.content
+  test 'test when motd_formatter_markdown empty' do
+    with_modified_env({ 'MOTD_FORMAT': "markdown",'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_empty" }) do
+      assert_equal '', MotdFile.new.formatter.content
+    end
   end
 end

--- a/apps/dashboard/test/models/motd_formatter/motd_formatter_osc_test.rb
+++ b/apps/dashboard/test/models/motd_formatter/motd_formatter_osc_test.rb
@@ -6,62 +6,57 @@ module MotdFormatter
   class OscTest < ActiveSupport::TestCase
     include MotdFormatter
     # test date order of example Motd file
-    #
+    # 
     test 'motd message date format' do
       date = Date.new(2016, 5, 4)
-
       # assume year month day
       msg = "2016/05/04\n--- NEW CLUSTER\n\nSomething good!"
-      assert_equal date, MotdFormatterOsc::Message.from(msg).date
+      assert_equal date, MotdFormatter::Osc::Message.from(msg).date
       msg = "2016-05-04\n--- NEW CLUSTER\n\nSomething good!"
-      assert_equal date, MotdFormatterOsc::Message.from(msg).date
+      assert_equal date, MotdFormatter::Osc::Message.from(msg).date
       msg = "2016.05.04\n--- NEW CLUSTER\n\nSomething good!"
-      assert_equal date, MotdFormatterOsc::Message.from(msg).date
+      assert_equal date, MotdFormatter::Osc::Message.from(msg).date
       msg = "2016 05 04\n--- NEW CLUSTER\n\nSomething good!"
-      assert_nil MotdFormatterOsc::Message.from(msg)
+      assert_nil MotdFormatter::Osc::Message.from(msg)
       msg = "2016+05+04\n--- NEW CLUSTER\n\nSomething good!"
-      assert_nil MotdFormatterOsc::Message.from(msg)
+      assert_nil MotdFormatter::Osc::Message.from(msg)
     end
 
     test 'test when motd formatter_osc_valid' do
       path = "#{Rails.root}/test/fixtures/files/motd_valid"
-      motd_file = MotdFile.new(path)
-      formatted_motd = MotdFormatterOsc.new motd_file
-      expected_file = File.open(path).read
+      with_modified_env({ 'MOTD_FORMAT': "osc", 'MOTD_PATH': path }) do
+        motd_file = MotdFile.new
+        expected_file = File.open(path).read
 
-      assert_equal true, motd_file.exist?
-      assert_equal path, motd_file.motd_path
-      assert_equal expected_file, motd_file.content
-      assert_equal 3, formatted_motd.messages.count
+        assert motd_file.exist?
+        assert_equal path, motd_file.motd_path
+        assert_equal expected_file, motd_file.content
+        assert_equal 3, motd_file.formatter.messages.count
+      end
     end
-
+    
     test 'test when motd_formatter_osc empty' do
       path = "#{Rails.root}/test/fixtures/files/motd_empty"
-      motd_file = MotdFile.new(path)
-      formatted_motd = MotdFormatterOsc.new motd_file
-
-      assert_equal true, motd_file.exist?
-      assert_equal path, motd_file.motd_path
-      assert_equal '', motd_file.content
-      assert_equal 0, formatted_motd.messages.count
+      with_modified_env({ 'MOTD_FORMAT': "osc", 'MOTD_PATH': path }) do
+        motd_file = MotdFile.new
+        
+        assert_equal true, motd_file.exist?
+        assert_equal path, motd_file.motd_path
+        assert_equal '', motd_file.content
+        assert_equal 0, motd_file.formatter.messages.count
+      end
     end
 
     test 'test when motd formatter_osc_missing' do
       path = "#{Rails.root}/test/fixtures/files/motd_missing"
-      motd_file = MotdFile.new(path)
-      formatted_motd = MotdFormatterOsc.new motd_file
+      with_modified_env({ 'MOTD_FORMAT': "osc", 'MOTD_PATH': path }) do
+        motd_file = MotdFile.new
 
-      assert_equal false, motd_file.exist?
-      assert_equal path, motd_file.motd_path
-      assert_equal '', motd_file.content
-      assert_equal 0, formatted_motd.messages.count
-    end
-
-    test 'test when motd formatter_osc_nil' do
-      motd_file = nil
-      formatted_motd = MotdFormatterOsc.new motd_file
-
-      assert_not_nil formatted_motd.content
+        assert_equal false, motd_file.exist?
+        assert_equal path, motd_file.motd_path
+        assert_equal '', motd_file.content
+        assert_nil motd_file.formatter
+      end
     end
   end
 end

--- a/apps/dashboard/test/models/motd_formatter/motd_formatter_plaintext_erb_test.rb
+++ b/apps/dashboard/test/models/motd_formatter/motd_formatter_plaintext_erb_test.rb
@@ -1,55 +1,41 @@
 require 'test_helper'
 
 class MotdFormatter::PlaintextErbTest < ActiveSupport::TestCase
-  include MotdFormatter
   test "plaintext-formatter-erb returns a valid motd file when given a valid motd file" do
     path = "#{Rails.root}/test/fixtures/files/motd_valid"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintextErb.new(motd_file)
-    expected_file = File.open(path).read
+    with_modified_env({ 'MOTD_FORMAT': "text_erb", 'MOTD_PATH': path }) do
+      expected_file = File.open(path).read
 
-    assert_equal expected_file, formatted_motd.content
+      assert_equal expected_file, MotdFile.new.formatter.content
+    end
   end
 
   test "plaintext-formatter-erb returns an empty string when given an empty motd file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_empty"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintextErb.new(motd_file)
-
-    assert_equal '', formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "text_erb", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_empty" }) do
+      assert_equal '', MotdFile.new.formatter.content
+    end
   end
 
   test "plaintext-formatter-erb throws a standard error when given an invalid motd erb file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_erb_standard_error"
-    motd_file = MotdFile.new(path)
-    
-    assert_raises(Exception) {
-      MotdFormatterPlaintextErb.new(motd_file)
-    }
+    with_modified_env({ 'MOTD_FORMAT': "text_erb", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_erb_standard_error" }) do
+      assert_raises(Exception) {
+        MotdFile.new.formatter
+      }
+    end
   end
 
   test "plaintext-formatter-erb returns a valid motd erb file when given a valid motd erb file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_valid_erb"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintextErb.new(motd_file)
-    expected_file = "\nWelcome to the Ohio Supercomputer Center!\n"
-    
-    assert_equal expected_file, formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "text_erb", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_valid_erb" }) do
+      expected_file = "\nWelcome to the Ohio Supercomputer Center!\n"
+      
+      assert_equal expected_file, MotdFile.new.formatter.content
+    end
   end
   
-  test "plaintext-formatter-erb returns an empty string when given a missing file" do
-    path = "#{Rails.root}/test/fixtures/files/motd_missing"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintextErb.new(motd_file)
-
-    assert_equal '', formatted_motd.content
-  end
-
-  test "plaintext-formatter-erb returns an empty string when given nil" do
-    motd_file = nil
-    formatted_motd = MotdFormatterPlaintextErb.new(motd_file)
-
-    assert_not_nil formatted_motd.content
+  test "MotdFile.formatter returns nil when given a missing file" do
+    with_modified_env({ 'MOTD_FORMAT': "text_erb", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_missing" }) do
+      assert_nil MotdFile.new.formatter
+    end
   end
 end
 

--- a/apps/dashboard/test/models/motd_formatter/motd_formatter_plaintext_test.rb
+++ b/apps/dashboard/test/models/motd_formatter/motd_formatter_plaintext_test.rb
@@ -6,33 +6,22 @@ class MotdFormatterPlaintextTest < ActiveSupport::TestCase
   include MotdFormatter
   test 'test when motd formatter_plaintext_valid' do
     path = "#{Rails.root}/test/fixtures/files/motd_valid"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintext.new(motd_file)
-    expected_file = File.open(path).read
+    with_modified_env({ 'MOTD_FORMAT': "text", 'MOTD_PATH': path }) do
+      expected_file = File.open(path).read
 
-    assert_equal expected_file, formatted_motd.content
+      assert_equal expected_file, MotdFile.new.formatter.content
+    end
   end
 
   test 'test when motd_formatter_plaintext empty' do
-    path = "#{Rails.root}/test/fixtures/files/motd_empty"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintext.new(motd_file)
-
-    assert_equal '', formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "text", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_empty" }) do
+      assert_equal '', MotdFile.new.formatter.content
+    end
   end
 
   test 'test when motd formatter_plaintext_missing' do
-    path = "#{Rails.root}/test/fixtures/files/motd_missing"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterPlaintext.new(motd_file)
-
-    assert_equal '', formatted_motd.content
-  end
-
-  test 'test when motd formatter_plaintext_nil' do
-    motd_file = nil
-    formatted_motd = MotdFormatterPlaintext.new(motd_file)
-
-    assert_not_nil formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "text", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_missing" }) do
+      assert_nil MotdFile.new.formatter
+    end
   end
 end

--- a/apps/dashboard/test/models/motd_formatter/motd_formatter_rss_test.rb
+++ b/apps/dashboard/test/models/motd_formatter/motd_formatter_rss_test.rb
@@ -3,42 +3,26 @@ require 'test_helper'
 class MotdTest < ActiveSupport::TestCase
   include MotdFormatter
   test "test when motd formatter_rss_valid" do
-
-    path = "#{Rails.root}/test/fixtures/files/motd_rss"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterRss.new motd_file
-
-    assert formatted_motd.content.items.is_a? Enumerable
+    with_modified_env({ 'MOTD_FORMAT': "rss", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_rss" }) do
+      assert MotdFile.new.formatter.content.items.is_a? Enumerable
+    end
   end
 
   test "test when motd_formatter_rss invalid" do
-    path = "#{Rails.root}/test/fixtures/files/motd_rss_invalid"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterRss.new motd_file
-
-    assert_nil formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "rss", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_rss_invalid" }) do
+      assert_nil MotdFile.new.formatter.content
+    end
   end
 
   test "test when motd_formatter_rss empty" do
-    path = "#{Rails.root}/test/fixtures/files/motd_empty"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterRss.new motd_file
-
-    assert_nil formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "rss", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_empty" }) do
+      assert_nil MotdFile.new.formatter.content
+    end
   end
 
   test "test when motd formatter_rss_missing" do
-    path = "#{Rails.root}/test/fixtures/files/motd_missing"
-    motd_file = MotdFile.new(path)
-    formatted_motd = MotdFormatterRss.new motd_file
-
-    assert_nil formatted_motd.content
-  end
-
-  test "test when motd formatter_rss_nil" do
-    motd_file = nil
-    formatted_motd = MotdFormatterRss.new motd_file
-
-    assert_nil formatted_motd.content
+    with_modified_env({ 'MOTD_FORMAT': "rss", 'MOTD_PATH': "#{Rails.root}/test/fixtures/files/motd_missing" }) do
+      assert_nil MotdFile.new.formatter
+    end
   end
 end


### PR DESCRIPTION
Response to #1540 to adjust tests to use MotdFile class and the formatter factory instead of calling formatters directly. Tests for missing files were modified to reflect a nil response from the factory, and tests where the MotdFile object was nil were removed because formatters should only ever be created by non-nil MotdFile instances.