### PR TITLE
rm patch ruby versions and apply permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 env:
   ACTIONS_STEP_DEBUG: true
   ACTIONS_RUNNER_DEBUG: true
@@ -21,16 +24,16 @@ jobs:
         include:
           # Test versions from Ubuntu 22.04
           - os: ubuntu-latest
-            ruby: "3.0.2"
+            ruby: "3.0"
           # Test versions from Debian 12
           - os: ubuntu-latest
-            ruby: "3.1.2"
+            ruby: "3.1"
           # Test versions from Amazon Linux 2023 and Ubuntu 24.04
           - os: ubuntu-latest
-            ruby: "3.2.2"
+            ruby: "3.2"
           # Test versions from RHEL8 & RHEL9
           - os: ubuntu-latest
-            ruby: "3.3.5"
+            ruby: "3.3"
     runs-on: ${{ matrix.os }}
     name: Unit tests
 


### PR DESCRIPTION
remove patch ruby versions and apply permissions.

I'm removing the patch ruby versions because we're having issues updating nokogiri with Ruby 3.1. It requires some patch to psych that Debian 12 actually has but ruby 3.1.2 from this action does not.