### PR TITLE
use real tabs in file editor

### DIFF
--- a/apps/dashboard/app/javascript/editor.js
+++ b/apps/dashboard/app/javascript/editor.js
@@ -200,6 +200,8 @@ jQuery(function () {
       editor.setTheme($("#theme option:selected").val());
       $("#wordwrap").prop("checked", getUserPreference('wordwrap') === "true");
       editor.getSession().setUseWrapMode($("#wordwrap").is(':checked'));
+
+      editor.session.setUseSoftTabs(false);
     };
 
     initializeEditor();

--- a/apps/dashboard/app/javascript/editor.js
+++ b/apps/dashboard/app/javascript/editor.js
@@ -146,6 +146,12 @@ jQuery(function () {
       setUserPreference('wordwrap', $("#wordwrap").is(':checked'));
     });
 
+    // Change the soft tab setting
+    $("#soft_tabs").on('change', function () {
+      editor.getSession().setUseSoftTabs(this.checked);
+      setUserPreference('soft_tabs', this.checked);
+    });
+
     // Save button onclick handler
     // sends the content to the cloudcmd api via PUT request
     $("#save-button").on('click', function () {
@@ -201,7 +207,13 @@ jQuery(function () {
       $("#wordwrap").prop("checked", getUserPreference('wordwrap') === "true");
       editor.getSession().setUseWrapMode($("#wordwrap").is(':checked'));
 
-      editor.session.setUseSoftTabs(false);
+      // default to use soft tabs for backward compatability.
+      let tabs = getUserPreference('soft_tabs');
+      if(tabs === null) {
+        tabs = "true";
+      }
+      $("#soft_tabs").prop("checked", tabs === "true");
+      editor.getSession().setUseSoftTabs($("#soft_tabs").is(':checked'));
     };
 
     initializeEditor();

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -231,9 +231,10 @@
       </li>
 
       <li class="list-group-item hidden-xs px-2 form-group form-inline m-0 border-bottom-0">
-        <label class="control-label hidden-md hidden-lg navbar-text px-1" for="soft_tabs">Soft Tabs</label>
-        <div class="form-group">
-          <input type="checkbox" id="soft_tabs" value="">
+        <i class="fa fa-question-circle fa-1" data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t('dashboard.soft_tabs_info') %>"></i>
+        <label class="form-check-label hidden-md hidden-lg navbar-text px-1" for="soft_tabs"><%= t('dashboard.soft_tabs') %></label>
+        <div class="form-switch">
+          <input class="form-check-input" role="switch" type="checkbox" id="soft_tabs" value="">
         </div>
       </li>
     </ul>

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -223,10 +223,17 @@
           </optgroup>
         </select>
       </li>
-      <li class="list-group-item hidden-xs px-2 form-group form-inline m-0 border-bottom-0">
+      <li class="list-group-item hidden-xs px-2 form-group form-inline m-0">
         <label class="control-label hidden-md hidden-lg navbar-text px-1" for="wordwrap">Wrap</label>
         <div class="form-group">
           <input type="checkbox" id="wordwrap" value="">
+        </div>
+      </li>
+
+      <li class="list-group-item hidden-xs px-2 form-group form-inline m-0 border-bottom-0">
+        <label class="control-label hidden-md hidden-lg navbar-text px-1" for="soft_tabs">Soft Tabs</label>
+        <div class="form-group">
+          <input type="checkbox" id="soft_tabs" value="">
         </div>
       </li>
     </ul>

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -225,8 +225,8 @@
       </li>
       <li class="list-group-item hidden-xs px-2 form-group form-inline m-0">
         <label class="control-label hidden-md hidden-lg navbar-text px-1" for="wordwrap">Wrap</label>
-        <div class="form-group">
-          <input type="checkbox" id="wordwrap" value="">
+        <div class="form-switch">
+          <input class="form-check-input" role="switch" type="checkbox" id="wordwrap" value="">
         </div>
       </li>
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -252,6 +252,8 @@ en:
     shell_app_title: "%{cluster_title} Shell Access"
     show: Show
     skip_navigation: Skip Navigation
+    soft_tabs: Soft Tabs
+    soft_tabs_info: Soft tabs are spaces in the file instead of actual tab characters.
     support_ticket:
       creation_success: 'Support ticket email sent to: %{to}'
       generic_error: 'There was an error processing your request: %{error}'


### PR DESCRIPTION
Do not use soft tabs (spaces) in the file editor. Instead use actual tabs (`\t` characters).