### PR TITLE
Improved restricted shell messages

### DIFF
--- a/nginx_stage/lib/nginx_stage/application.rb
+++ b/nginx_stage/lib/nginx_stage/application.rb
@@ -41,7 +41,9 @@ module NginxStage
       generator.new(options).invoke if generator
     rescue
       $stderr.puts "#{$!.to_s}"
-      $stderr.puts "Run 'nginx_stage --help' to see a full list of available command line options."
+      unless NginxStage.disable_nginx_stage_help_message
+        $stderr.puts "Run 'nginx_stage --help' to see a full list of available command line options."
+      end
       exit(false)
     end
 

--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -390,6 +390,16 @@ module NginxStage
     # @return [String] user shell that is blocked
     attr_accessor :disabled_shell
 
+    # Define an error message that is displayed to users when they have a 
+    #     disabled_shell.
+    # @return [String] Error message
+    attr_accessor :disabled_shell_message
+
+    # Hide the stderr "Run 'nginx_stage --help' to see a full list of available 
+    #     command line options." message when calling nginx_stage
+    # @return [Boolean]
+    attr_accessor :disable_nginx_stage_help_message
+
     # Set BUNDLE_USER_CONFIG to /dev/null in the PUN environment
     # NB: This prevents a user's ~/.bundle/config from affecting OnDemand applications
     # @return [Boolean] set BUNDLE_USER_CONFIG to /dev/null in PUN environment
@@ -512,6 +522,8 @@ module NginxStage
       self.user_regex     = '[\w@\.\-]+'
       self.min_uid        = 1000
       self.disabled_shell = '/access/denied'
+      self.disabled_shell_message = 'user has a disabled shell: %s'
+      self.disable_nginx_stage_help_message = false
 
       self.disable_bundle_user_config = true
       self.nginx_file_upload_max = '10737420000'

--- a/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
+++ b/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
@@ -29,7 +29,7 @@ module NginxStage
 
     # Block starting up PUNs for users with disabled shells
     add_hook :block_user_with_disabled_shell do
-      raise InvalidUser, "user has disabled shell: #{user}" if user.shell == NginxStage.disabled_shell
+      raise InvalidUser, NginxStage.disabled_shell_message % user if user.shell == NginxStage.disabled_shell
     end
 
     # Accepts `skip_nginx` as an option


### PR DESCRIPTION
This PR adds two new configuration items in `/etc/ood/config/nginx_stage.yml`.
- disable_nginx_stage_help_message: true/false
- disabled_shell_message: string message that gets displayed when a user has a disabled shell

Most folks running OOD would never need to worry about this. But this is helpful for those who do need to configure `disabled_shell`.

With the current installation, and the new installation, here is what is shown when a user has a disabled_shell.
```bash
# /opt/ood/nginx_stage/sbin/nginx_stage pun --user username
user has disabled shell: username
Run 'nginx_stage --help' to see a full list of available command line options.
```
When `disable_nginx_stage_help_message: true` in `nginx_stage.yml`:
```bash
# /opt/ood/nginx_stage/sbin/nginx_stage pun --user username
user has disabled shell: username
```
Second line is hidden.

When `disabled_shell_message: 'this is a test'`:
```bash
# /opt/ood/nginx_stage/sbin/nginx_stage pun --user username
this is a test
```