### PR TITLE
lock @uppy/dashboard to 4.3.4

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,7 +6,7 @@
     "@popperjs/core": "^2.11.8",
     "@rails/ujs": "^7.0.1",
     "@uppy/core": "^4.0",
-    "@uppy/dashboard": "^4.0",
+    "@uppy/dashboard": "4.3.4",
     "@uppy/xhr-upload": "^4.0",
     "ace-code": "^1.35.0",
     "bootstrap": "^5.0.2",

--- a/apps/dashboard/yarn.lock
+++ b/apps/dashboard/yarn.lock
@@ -205,7 +205,7 @@
     nanoid "^5.0.9"
     preact "^10.5.13"
 
-"@uppy/dashboard@^4.0":
+"@uppy/dashboard@4.3.4":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@uppy/dashboard/-/dashboard-4.3.4.tgz#2b63c5424833cf311a396d4b35d6cc0dfab43c45"
   integrity sha512-SMPa5K3jZ2qNf110Hf8adN/cEAQLdpvXGjgl+R9c8AnUdpKE5f4XxaWSukdW6N7YYWmoBrLGesFvwRSPKZzCOw==


### PR DESCRIPTION
lock @uppy/dashboard to 4.3.4 because upgrading to `4.4.x` has errors that I just need to defer right now.