### PR TITLE
Fix false values 4521

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -4,6 +4,7 @@ module SmartAttributes
   # This is the base class that all other, more specific, Attributes
   # should subclass.
   class Attribute
+    include BoolReader
     # Unique identifier of attribute
     # @return [String] attribute id
     attr_reader :id
@@ -58,7 +59,7 @@ module SmartAttributes
       if opts[:cacheable].nil?
         default_value
       else
-        to_bool(opts[:cacheable])
+        read_bool(opts[:cacheable])
       end
     end
 
@@ -231,15 +232,6 @@ module SmartAttributes
         :widget, :fixed, :hide_when_empty, :options, :html_options, :checked_value, :unchecked_value,
         :required, :label, :help, :cacheable
       ]
-    end
-
-    FALSE_VALUES = [false, '', 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'].freeze
-
-    # Returns false if value is included among False_Values set
-    # @param value the value to be checked
-    # @return [Boolean]
-    def to_bool(value)
-      !FALSE_VALUES.include?(value)
     end
   end
 end

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -6,7 +6,7 @@ module BatchConnect
   class SessionContext
     include Enumerable
     include BoolReader
-    
+
     include ActiveModel::Model
     include ActiveModel::Serializers::JSON
 

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -5,7 +5,8 @@ module BatchConnect
   # available from the app and the choices made by the user.
   class SessionContext
     include Enumerable
-
+    include BoolReader
+    
     include ActiveModel::Model
     include ActiveModel::Serializers::JSON
 
@@ -86,21 +87,12 @@ module BatchConnect
 
     private
 
-    FALSE_VALUES = [false, '', 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'].freeze
-
-    # Returns false if value is among the FALSE_VALUES set
-    # @param value the value to check
-    # @return [Boolean]
-    def to_bool(value)
-      !FALSE_VALUES.include?(value)
-    end
-
     # @return [Boolean]
     def app_specific_cache_enabled?
       if @app_specific_cache_setting.nil?
         global_cache_enabled?
       else
-        to_bool(@app_specific_cache_setting)
+        read_bool(@app_specific_cache_setting)
       end
     end
 

--- a/apps/dashboard/app/models/concerns/bool_reader.rb
+++ b/apps/dashboard/app/models/concerns/bool_reader.rb
@@ -2,8 +2,9 @@ module BoolReader
   FALSE_VALUES = ['', '0', 'F', 'FALSE', 'OFF', 'NO'].freeze
 
   def read_bool(value)
-    # By converting to a string and upcasing, the size of FALSE_VALUES is less than the total readable false values,
-    # which are [nil, false, '', 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'] (as well as all other capitalization combinations)
+    # By converting to a string and upcasing, the size of FALSE_VALUES is less than the effective false values,
+    # which are [nil, false, '', 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'],
+    # as well as all other capitalization combinations
     !FALSE_VALUES.include?(value.to_s.upcase)
   end
 end

--- a/apps/dashboard/app/models/concerns/bool_reader.rb
+++ b/apps/dashboard/app/models/concerns/bool_reader.rb
@@ -1,0 +1,9 @@
+module BoolReader
+  FALSE_VALUES = ['', '0', 'F', 'FALSE', 'OFF', 'NO'].freeze
+
+  def read_bool(value)
+    # By converting to a string and upcasing, the size of FALSE_VALUES is less than the total readable false values,
+    # which are [nil, false, '', 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'] (as well as all other capitalization combinations)
+    !FALSE_VALUES.include?(value.to_s.upcase)
+  end
+end

--- a/apps/dashboard/app/models/configuration_property.rb
+++ b/apps/dashboard/app/models/configuration_property.rb
@@ -1,7 +1,6 @@
-# A generic class to map configurations to Ruby runtime objects like Intgers, Strings
+# A generic class to map configurations to Ruby runtime objects like Integers, Strings
 # and Booleans.
 class ConfigurationProperty
-
   def self.with_boolean_mapper(name:, default_value: nil, read_from_env: false, env_names: nil)
     ConfigurationProperty.new(name, default_value, read_from_env, env_names, BooleanMapper)
   end
@@ -15,7 +14,7 @@ class ConfigurationProperty
   end
 
   attr_reader :name, :default_value, :read_from_environment, :environment_names
-  alias_method :read_from_environment?, :read_from_environment
+  alias read_from_environment? read_from_environment
 
   #
   # Represents a profile based configuration property.
@@ -62,7 +61,7 @@ class ConfigurationProperty
   class BooleanMapper
     def self.map_string(string_value)
       extend BoolReader
-      
+
       string_value.nil? ? string_value : read_bool(string_value)
     end
   end

--- a/apps/dashboard/app/models/configuration_property.rb
+++ b/apps/dashboard/app/models/configuration_property.rb
@@ -61,16 +61,9 @@ class ConfigurationProperty
 
   class BooleanMapper
     def self.map_string(string_value)
-      string_value.nil? ? string_value : BooleanMapper.to_bool(string_value.to_s.upcase)
+      extend BoolReader
+      
+      string_value.nil? ? string_value : read_bool(string_value)
     end
-
-    private
-    FALSE_VALUES = ['', '0', 'F', 'FALSE', 'OFF', 'NO'].freeze
-    
-    def self.to_bool(value)
-      !FALSE_VALUES.include?(value)
-    end
-
   end
-
 end

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -1,6 +1,7 @@
 require 'pathname'
 require 'dotenv'
 require_relative '../lib/current_user'
+require_relative '../app/models/concerns/bool_reader.rb'
 
 # Dashboard app specific configuration singleton definition
 # following the first proposal in:
@@ -20,7 +21,6 @@ require_relative '../lib/current_user'
 # ConfigurationSingleton and defining it as a class method on Configuration.
 #
 class ConfigurationSingleton
-  require_relative '../app/models/concerns/bool_reader.rb'
   include BoolReader
   attr_writer :app_development_enabled
   attr_writer :app_sharing_enabled

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -20,6 +20,8 @@ require_relative '../lib/current_user'
 # ConfigurationSingleton and defining it as a class method on Configuration.
 #
 class ConfigurationSingleton
+  require_relative '../app/models/concerns/bool_reader.rb'
+  include BoolReader
   attr_writer :app_development_enabled
   attr_writer :app_sharing_enabled
 
@@ -94,7 +96,7 @@ class ConfigurationSingleton
   end
 
   def ood_bc_ssh_to_compute_node
-    to_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
+    read_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
   end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
@@ -142,7 +144,7 @@ class ConfigurationSingleton
   end
 
   def load_external_config?
-    to_bool(ENV['OOD_LOAD_EXTERNAL_CONFIG'] || (rails_env == 'production'))
+    read_bool(ENV['OOD_LOAD_EXTERNAL_CONFIG'] || (rails_env == 'production'))
   end
 
   # The root directory that holds configuration information for Batch Connect
@@ -152,7 +154,7 @@ class ConfigurationSingleton
   end
 
   def load_external_bc_config?
-    to_bool(ENV["OOD_LOAD_EXTERNAL_BC_CONFIG"] || (rails_env == "production"))
+    read_bool(ENV["OOD_LOAD_EXTERNAL_BC_CONFIG"] || (rails_env == "production"))
   end
 
   # The paths to the JSON files that store the quota information
@@ -251,18 +253,18 @@ class ConfigurationSingleton
 
   def app_development_enabled?
     return @app_development_enabled if defined? @app_development_enabled
-    to_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.directory? || DevRouter.base_path.symlink?)
+    read_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.directory? || DevRouter.base_path.symlink?)
   end
   alias_method :app_development_enabled, :app_development_enabled?
 
   def app_sharing_enabled?
     return @app_sharing_enabled if defined? @app_sharing_enabled
-    @app_sharing_enabled = to_bool(ENV['OOD_APP_SHARING'])
+    @app_sharing_enabled = read_bool(ENV['OOD_APP_SHARING'])
   end
   alias_method :app_sharing_enabled, :app_sharing_enabled?
 
   def batch_connect_global_cache_enabled?
-    to_bool(ENV["OOD_BATCH_CONNECT_CACHE_ATTR_VALUES"] || true )
+    read_bool(ENV["OOD_BATCH_CONNECT_CACHE_ATTR_VALUES"] || true )
   end
 
   def developer_docs_url
@@ -312,7 +314,7 @@ class ConfigurationSingleton
 
   # Setting terminal functionality in files app
   def files_enable_shell_button
-    can_access_shell? && to_bool(config.fetch(:files_enable_shell_button, true))
+    can_access_shell? && read_bool(config.fetch(:files_enable_shell_button, true))
   end
 
   # Report performance of activejobs table rendering
@@ -390,7 +392,7 @@ class ConfigurationSingleton
   # @return [Boolean] true if by default open apps in new window
   def open_apps_in_new_window?
     if ENV['OOD_OPEN_APPS_IN_NEW_WINDOW']
-      to_bool(ENV['OOD_OPEN_APPS_IN_NEW_WINDOW'])
+      read_bool(ENV['OOD_OPEN_APPS_IN_NEW_WINDOW'])
     else
       true
     end
@@ -507,15 +509,6 @@ class ConfigurationSingleton
     files.reverse.map {|p| p.sub(/$/, '.overload')}
   end
 
-  FALSE_VALUES = [nil, false, '', 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'].freeze
-
-  # Bool coersion pulled from ActiveRecord::Type::Boolean#cast_value
-  #
-  # @return [Boolean] false for falsy value, true for everything else
-  def to_bool(value)
-    !FALSE_VALUES.include?(value)
-  end
-
   # private method to add the boolean_config methods to this instances
   def add_boolean_configs
     boolean_configs.each do |cfg_item, default|
@@ -525,7 +518,7 @@ class ConfigurationSingleton
         if e.nil?
           config.fetch(cfg_item, default)
         else
-          to_bool(e.to_s)
+          read_bool(e.to_s)
         end
       end
     end.each do |cfg_item, _|


### PR DESCRIPTION
Fixes #4521 by adding the BoolReader module and using this whenever we need to cast a user-supplied string (such as those in config files) into a boolean. Passes all tests