### PR TITLE
Hardcode home dir button in path selector favorites

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_favorites.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_favorites.html.erb
@@ -1,5 +1,6 @@
 <li role='button'
   class='clickable text-wrap list-group-item list-group-item-action'
   data-api-url=<%= files_path(path.to_s, fs: path.filesystem) %>>
-  <span class='fa fa-folder'>&nbsp;</span><%= path %>
+  <%= fa_icon (path.title.to_s.downcase.include?('home') ? 'home' : path.icon), classes: ''%>
+  <%= path.title || path %>
 </li>

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -26,19 +26,17 @@
       
         <div class="container-fluid">
           <div class="row">
-          <% if favorites %>
             <div class="col-sm-5">
               <div class="panel panel-default">
                 <div class="panel-heading">Favorites</div>
                 <ol id="favorites" class="list-group text-nowrap">
-                  <%= render partial: 'favorites', collection: favorites, as: :path %>
+                  <% homedir = FavoritePath.new Dir.home, title:'Home Directory' %>
+                  <%= render partial: 'favorites', collection: favorites.unshift(homedir), as: :path %>
                 </ol>
               </div>
             </div>
-          <% end %>
-        
-      
-            <div class="<%= favorites ? 'col-sm-7' : 'col-sm-12' %>">
+
+            <div class="col-sm-7">
               <ol id="<%= breadcrumb_id %>" class="breadcrumb breadcrumb-no-delimiter rounded">
               </ol>
 


### PR DESCRIPTION
Could take or leave this one. There is already a small home button at the beginning of the breadcrumbs showing the current location, but a larger one is accessible. This would remove the function of the right column growing to fill the path selector when no favorites are present (although this behavior was broken because an empty favorites array is still truthy). It also determines when to use the home icon by detecting 'home' in the path title, which is only safe because the normal favorites are passed through the following helper method 

https://github.com/OSC/ondemand/blob/e881d48d918055fce0054717e67df973d8fedf18/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb#L143-#L150

and the FavoritePath objects are initialized without the title option. This could be an issue in and of itself, as the documentation gives the example 
```rb
    # Hash of base paths to check for additional directories with titles
    # location => Title
    base_paths = {
      '/home/share/' => 'Shared home',
      '/srv/scratch/shares/' => 'Shared scratch',
      '/srv/scratch/groups/' => 'Group scratch',
      '/srv/fast/users/' => 'Fast user'
      # Add more paths and titles here if needed
    }
``` 
for setting the favorites, and these titles do not get displayed in the path selector. The changes here fulfil the original issue with minimal changes, and the question is really whether it is effective to solve any of these other issues in this PR or if they deserve their own.