### PR TITLE
Apply upload download limits to files 2927

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -263,6 +263,7 @@ class FilesController < ApplicationController
     can_download, error = @path.can_download?
     if !(::Configuration.download_enabled? && can_download)
       error_message = ::Configuration.download_enabled? ? error : t('dashboard.files_download_not_enabled') 
+      @path = @path.parent
       raise(StandardError, error_message)
     end
 

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -177,7 +177,7 @@ class PosixFile
       # Handle files and directories
       elsif file?
         can_download = stat.size <= download_directory_size_limit
-        error = can_download ? nil : I18n.t('dashboard.files_directory_too_large', download_directory_size_limit: download_directory_size_limit)
+        error = can_download ? nil : I18n.t('dashboard.files_file_too_large', download_file_size_limit: download_directory_size_limit)
       elsif directory?
         # Determine the size of the directory.
         o, e, s = Open3.capture3("timeout", "#{timeout}s", "du", "-cbs", path.to_s)

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -55,6 +55,7 @@ class RemoteFile
       can_download = size <= download_directory_size_limit
       too_large_error = I18n.t('dashboard.files_directory_too_large', download_directory_size_limit: download_directory_size_limit)
       [can_download, can_download ? nil : too_large_error]
+    end
   end
 
   def editable?

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -48,8 +48,13 @@ class RemoteFile
     end.sort_by { |p| p[:directory] ? 0 : 1 }
   end
 
-  def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)
-    [false, 'Downloading remote files as zip is currently not supported']
+  def can_download?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)
+    if directory?
+      [false, 'Downloading remote files as zip is currently not supported']
+    else 
+      can_download = size <= download_directory_size_limit
+      too_large_error = I18n.t('dashboard.files_directory_too_large', download_directory_size_limit: download_directory_size_limit)
+      [can_download, can_download ? nil : too_large_error]
   end
 
   def editable?

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -136,11 +136,12 @@ en:
     edit: Edit
     file_quotas: 'File Quotas'
     files_directory_download_error_modal_title: Directory too large to download
-    files_directory_download_unauthorized: You can only download a directory as zip that you have read and execute access to
+    files_directory_download_unauthorized: You can only download a file or directory that you have read and execute access to
     files_directory_size_calculation_error: Timeout while trying to determine directory size.
     files_directory_size_calculation_timeout: Timeout while trying to determine directory size.
     files_directory_size_unknown: 'Error with status %{exit_code} when trying to determine directory size: %{error}'
     files_directory_too_large: The directory is too large to download as a zip. The directory should be less than %{download_directory_size_limit} bytes.
+    files_file_too_large: The file is too large to download. File downloads should be less than %{download_file_size_limit} bytes.
     files_download_not_enabled: Downloading files is not enabled on this server.
     files_remote_dir_not_created: Did not create directory %{path}
     files_remote_disabled: Remote file support is not enabled

--- a/apps/dashboard/test/models/files_test.rb
+++ b/apps/dashboard/test/models/files_test.rb
@@ -34,57 +34,57 @@ class FilesTest < ActiveSupport::TestCase
     end
   end
 
-  test "can_download_as_zip handles erroneous output from du" do
+  test "can_download handles erroneous output from du" do
     Dir.mktmpdir do |dir|
       error_msg = 'some failure message'
       Open3.stubs(:capture3).returns(["blarg \n 28d", error_msg, exit_failure])
-      result = PosixFile.new(dir).can_download_as_zip?
+      result = PosixFile.new(dir).can_download?
       error = I18n.t('dashboard.files_directory_size_unknown', exit_code: '1', error: error_msg)
 
       assert_equal [false, error], result
     end 
   end
 
-  test "can_download_as_zip handles unauthorized directory" do
+  test "can_download handles unauthorized directory" do
     Dir.mktmpdir do |dir|
       FileUtils.chmod(0400, dir)  # Read-only permission
-      result = PosixFile.new(dir).can_download_as_zip?
+      result = PosixFile.new(dir).can_download?
       error = I18n.t('dashboard.files_directory_download_unauthorized')
   
       assert_equal [false, error], result
     end
   end
 
-  test "can_download_as_zip handles directory size calculation timeout" do
+  test "can_download handles directory size calculation timeout" do
     Dir.mktmpdir do |dir|
       Open3.stubs(:capture3).returns(["", "Timeout", exit_failure(124)])
-      result = PosixFile.new(dir).can_download_as_zip?
+      result = PosixFile.new(dir).can_download?
       error = I18n.t('dashboard.files_directory_size_calculation_timeout')
 
       assert_equal [false, error], result
     end
   end
 
-  test "can_download_as_zip handles directory size calculation error" do
+  test "can_download handles directory size calculation error" do
     Dir.mktmpdir do |dir|
       Open3.stubs(:capture3).returns(["", "", exit_success])
-      result = PosixFile.new(dir).can_download_as_zip?
+      result = PosixFile.new(dir).can_download?
       error = I18n.t('dashboard.files_directory_size_calculation_error')
 
       assert_equal [false, error], result
     end
   end
 
-  test "can_download_as_zip handles files sizes of 0" do
+  test "can_download handles files sizes of 0" do
     Dir.mktmpdir do |dir|
       Open3.stubs(:capture3).returns(["0 /dev
         0 total", "", exit_success])
 
-      assert_equal [true, nil], PosixFile.new(dir).can_download_as_zip?
+      assert_equal [true, nil], PosixFile.new(dir).can_download?
     end 
   end
 
-  test "can_download_as_zip handles directory size exceeding limit" do
+  test "can_download handles directory size exceeding limit" do
     download_directory_size_limit = Configuration.file_download_dir_max
     Dir.mktmpdir do |dir|
       dir_size = download_directory_size_limit + 1
@@ -92,7 +92,7 @@ class FilesTest < ActiveSupport::TestCase
         .returns(download_directory_size_limit + 1)
       Open3.stubs(:capture3).returns(["#{dir_size} #{dir} 
         \n #{dir_size} total", "", exit_success])
-      result = PosixFile.new(dir).can_download_as_zip?
+      result = PosixFile.new(dir).can_download?
       error = I18n.t('dashboard.files_directory_too_large', download_directory_size_limit: download_directory_size_limit)
 
       assert_equal([false, error], result)


### PR DESCRIPTION
Fixes #2927. There will be a few more commits trickling in before this is done, but I wanted to get this out there. This PR modifies the can_download_as_zip? method so that any PosixFile instance can be passed in, and handles the directory and file download qualifications separately. It also modifies the `FilesController` to respond to json requests (checking download compliance) on file paths, as well as adds the `can_download?` check to the `show_file` method. It also adds an error message in `locales/en.yml` for file_too_large errors, and updates the testing. Interestingly, there is still an error in testing from `integrations/files_test.rb` on multiple methods reading 
```sh
Error:
FilesIntegrationTest#test_can_download_file_as_image/png:
NoMethodError: undefined method `close' for an instance of ActionDispatch::Response::FileBody
    test/integration/files_test.rb:42:in `block in download_and_test'
    test/integration/files_test.rb:36:in `download_and_test'
    test/integration/files_test.rb:53:in `block in <class:FilesIntegrationTest>'
```
This error is encountered three times by various tests in that file. Upon inspection, it seems to stem from the line https://github.com/OSC/ondemand/blob/f0213d6543e055bf63e240b3e559a7bab8bb7200/apps/dashboard/test/integration/files_test.rb#L42
Although I can't tell exactly what `close` is being called on or how any of the changes affected that test.

Before merging, I would still like to modify the frontend code to route the file downloads currently taking place purely on the client through the json check, fix the testing, and modify certain variables in `can_download?` to reflect the fact that it has expanded to include files as well. We will also need an issue to update the other language locales with the additional message. 

On a minor note, I strongly considered adding a concern for the directory size computation to simplify the logic of `can_download?`, since that process takes up a lot of space and seems like it could be useful. A `directory_size` function could also be a private method of PosixFile if it is not necessarily going to be used anywhere else. 