### PR TITLE
added file download limits

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -287,6 +287,8 @@ class FilesController < ApplicationController
 
   def show_file
     raise(StandardError, t('dashboard.files_download_not_enabled')) unless ::Configuration.download_enabled?
+    can_download, error = @path.can_download_file?
+    raise(StandardError, error) unless can_download
 
     if html_file? && ::Configuration.unsafe_render_html
       render(file: @path.realpath, layout: false)

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -203,7 +203,7 @@ class PosixFile
   end
 
   # This serves the same function as can_download_as_zip?, but for files
-  def can_download_file?(download_file_size_limit: Configuration.file_download_dir_max)
+  def can_download_file?(download_file_size_limit: Configuration.file_download_max)
     if !(file? && readable?)
       error = I18n.t('dashboard.files_directory_download_unauthorized')
       return [false, error]

--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -202,6 +202,17 @@ class PosixFile
     return can_download, error
   end
 
+  # This serves the same function as can_download_as_zip?, but for files
+  def can_download_file?(download_file_size_limit: Configuration.file_download_dir_max)
+    if !(file? && readable?)
+      error = I18n.t('dashboard.files_directory_download_unauthorized')
+      return [false, error]
+    end
+    can_download = stat.size <= download_file_size_limit
+    error = can_download ? nil : I18n.t('dashboard.files_file_too_large', download_file_size_limit: download_file_size_limit)
+    [can_download, error]
+  end
+
   def mime_type
     type = %x[ file -b --mime-type #{path.to_s.shellescape} ].strip
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -52,7 +52,7 @@ class RemoteFile
     [false, 'Downloading remote files as zip is currently not supported']
   end
 
-  def can_download_file?(download_file_size_limit: Configuration.file_download_dir_max)
+  def can_download_file?(download_file_size_limit: Configuration.file_download_max)
     can_download = size <= download_file_size_limit
     error = can_download ? nil : I18n.t('dashboard.files_file_too_large', download_file_size_limit: download_file_size_limit)
     [can_download, error]

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -52,6 +52,12 @@ class RemoteFile
     [false, 'Downloading remote files as zip is currently not supported']
   end
 
+  def can_download_file?(download_file_size_limit: Configuration.file_download_dir_max)
+    can_download = size <= download_file_size_limit
+    error = can_download ? nil : I18n.t('dashboard.files_file_too_large', download_file_size_limit: download_file_size_limit)
+    [can_download, error]
+  end
+
   def editable?
     # Assume file is editable if it exists and isn't a directory even though it
     # might not actually be (e.g. permissions)

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -363,6 +363,13 @@ class ConfigurationSingleton
     ENV['OOD_DOWNLOAD_DIR_TIMEOUT_SECONDS']&.to_i || 5
   end
 
+  # The maximum size of a file that can be downloaded.
+  #
+  # Default for OOD_DOWNLOAD_FILE_MAX is 10*1024*1024*1024 bytes.
+  # @return [Integer]
+  def file_download_max
+    ENV['OOD_DOWNLOAD_FILE_MAX']&.to_i || 10737418240
+  end
   # The maximum size of a .zip file that can be downloaded.
   #
   # Default for OOD_DOWNLOAD_DIR_MAX is 10*1024*1024*1024 bytes.

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -136,11 +136,12 @@ en:
     edit: Edit
     file_quotas: 'File Quotas'
     files_directory_download_error_modal_title: Directory too large to download
-    files_directory_download_unauthorized: You can only download a directory as zip that you have read and execute access to
+    files_directory_download_unauthorized: You can only download a file or directory that you have read and execute access to
     files_directory_size_calculation_error: Timeout while trying to determine directory size.
     files_directory_size_calculation_timeout: Timeout while trying to determine directory size.
     files_directory_size_unknown: 'Error with status %{exit_code} when trying to determine directory size: %{error}'
     files_directory_too_large: The directory is too large to download as a zip. The directory should be less than %{download_directory_size_limit} bytes.
+    files_file_too_large: The file is too large to download. File downloads should be less than %{download_file_size_limit} bytes.
     files_download_not_enabled: Downloading files is not enabled on this server.
     files_remote_dir_not_created: Did not create directory %{path}
     files_remote_disabled: Remote file support is not enabled


### PR DESCRIPTION
Fixes #2927 with minimal changes. Adds a check before file display or download that checks size against the OOD_DOWNLOAD_DIR_MAX configuration and throws an error in `show_file` that is then caught by the `FilesController#fs` action. There are several additional changes we may want to make later, such as:

1. Cleaning up error behavior 
    - selecting download from the individual file's dropdown fails silently
    - attempting to open a file that is too large will render an error notification above a rendering of that file as an empty directory
2. Add international error messages
    - the locales/en.yml file was updated, the other ones will also need to be
3. Add separate environment variable for files
    - Adding a OOD_DOWNLOAD_FILE_MAX would allow users to opt out or customize this feature, and it would be back-compatible as long as it defaults to the DOWNLOAD_DIR_MAX