### PR TITLE
Disable compression level 0 as it breaks the clipboard

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -6,7 +6,7 @@
 
  <div class="row">
   <div class="col-sm-6">
-   <%= f.number_field(:compression, class: 'custom-range', type: 'range', min: 0, max: 9, value: Configuration.novnc_default_compression.to_i, label: "Compression", help: "0 (low) to 9 (high)") %>
+   <%= f.number_field(:compression, class: 'custom-range', type: 'range', min: 1, max: 9, value: Configuration.novnc_default_compression.to_i, label: "Compression", help: "1 (low) to 9 (high)") %>
   </div>
   <div class="col-sm-6">
    <%= f.number_field(:quality, class: 'custom-range', type: 'range', min: 0, max: 9, value: Configuration.novnc_default_quality.to_i, label: "Image Quality", help: "0 (low) to 9 (high)") %>


### PR DESCRIPTION
As was [figured out here](https://discourse.openondemand.org/t/novnc-error-incomplete-zlib-block-for-interactive-desktop-sessions/2895), any use of the clipboard generates the error message _incomplete zlib block_ when the compression level is 0.

I would guess it is a bug in the noVNC library whereby it is still trying to decompress something that isn't compressed. This avoids the issue from happening by making it not possible to specify a level of less than 1.