### PR TITLE
add gpus to session card info

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
@@ -4,6 +4,7 @@
   alert_class = "alert-#{session_class}"
   num_nodes = session.info.allocated_nodes.size
   num_cores = session.info.procs.to_i
+  num_gpus = session.info.gpus
 -%>
 
 <div class="card-heading">
@@ -20,6 +21,10 @@
       <%- end -%>
       <%- if num_cores.positive? -%>
       <span class="badge <%= badge_class %> rounded-pill"><%= pluralize(num_cores, "core") %></span>
+      <span class="card-text"> | </span>
+      <%- end -%>
+      <%- if num_gpus.positive? -%>
+      <span class="badge <%= badge_class %> rounded-pill"><%= pluralize(num_gpus, "gpu") %></span>
       <span class="card-text"> | </span>
       <%- end -%>
       <%- end -%>


### PR DESCRIPTION
Fixes #3910. The gpus data was already being collected in the session.info object, this just displays it in the session card along with the cores and time. Considering #1007, there is a good case for refactoring this partial so that we could define a hash at the top and loop through this to render each of the pill widgets, given the parallel handling of each one. These changes have been tested with bc_osc_mathematica (0 gpus) and bc_osc_blender (max 1 gpu) and worked as expected.