### PR TITLE
add loop for resource widgets

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_card_header.html.erb
@@ -2,10 +2,11 @@
   session_class = status_context(session)
   badge_class = "bg-#{session_class}"
   alert_class = "alert-#{session_class}"
-  num_nodes = session.info.allocated_nodes.size
-  num_cores = session.info.procs.to_i
-  num_gpus = session.info.gpus
-  info_labels = { 'node' => num_nodes, 'core' => num_cores, 'gpu' => num_gpus }
+  info_labels = { 
+                  'node' => session.info.allocated_nodes.size, 
+                  'core' => session.info.procs.to_i, 
+                  'gpu' => session.info.gpus 
+                }
 -%>
 
 <div class="card-heading">


### PR DESCRIPTION
Fixes #4554. Simplifies view logic in the sessions card header partial and makes it easy to add additional widgets in the future.