### PR TITLE
add `newLineMode("unix")` option to editor

### DIFF
--- a/apps/dashboard/app/javascript/editor.js
+++ b/apps/dashboard/app/javascript/editor.js
@@ -72,6 +72,9 @@ jQuery(function () {
 
       // Set the caret at inside the editor on load.
       editor.focus();
+
+      // Set the edtor to unix style new lines (stops the `CRLF` or `\r\n` problem which Slurm can't parse)
+      editor.newLineMode("unix");
     };
 
     function setSaveButtonState() {


### PR DESCRIPTION
Hi, I don't know if this has already been discussed, I couldn't find anything but some of our users are having issues with the text editor and writing job scripts for Slurm if they copy and paste from a Windows environment. It looks like a simple fix is to add a setting to the editor.

**Problem**
Slurm cannot parse text copied and pasted from a Windows machine if the text contains `CRLF` or `\r\n` at the end of a line. So creating job scripts using the OOD editor can cause issues when submitting jobs.

**Solution**
The text editor has a [NewLineMode](https://ace.c9.io/api/types/ace.Ace.NewLineMode.html) setting which allows it to be set to `unix` mode and will convert the EOL chars.