### PR TITLE
Added unit testing for directed acyclic graph

### DIFF
--- a/apps/dashboard/test/models/dag_test.rb
+++ b/apps/dashboard/test/models/dag_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WorkflowTest < ActiveSupport::TestCase
+  def setup
+    stub_sinfo
+  end
+
+  # a -> b -> c
+  test 'test linear graph' do
+    attributes = {
+      launcher_ids: ["a", "b", "c"],
+      source_ids:   ["a", "b"],
+      target_ids:   ["b", "c"]
+    }
+    dependency =   { "b"=>["a"], "c"=>["b"] }
+    order = ["a", "b", "c"]
+    
+    graph = Dag.new(attributes)
+    refute graph.has_cycle
+
+    assert_equal(dependency, graph.dependency)
+    assert_equal(order, graph.order)
+  end
+
+  # b; a -> a
+  test 'test self loop failure' do
+    attributes = {
+      launcher_ids: ["a", "b"],
+      source_ids:   ["a"],
+      target_ids:   ["a"]
+    }
+    graph = Dag.new(attributes)
+    assert graph.has_cycle
+  end
+
+  # a -> b -> c -> a
+  test 'test cycle failure' do
+    attributes = {
+      launcher_ids: ["a", "b", "c"],
+      source_ids:   ["a", "b", "c"],
+      target_ids:   ["b", "c", "a"]
+    }
+    graph = Dag.new(attributes)
+    assert graph.has_cycle
+  end
+
+  # a -> b -> c
+  #  \       /
+  #   d -> e
+  test 'test cross edge' do
+    attributes = {
+      launcher_ids: ["a", "b", "c", "d", "e"],
+      source_ids:   ["a", "b", "a", "d", "e"],
+      target_ids:   ["b", "c", "d", "e", "c"]
+    }
+    dependency =   { "b"=>["a"], "c"=>["b", "e"], "d"=>["a"], "e"=>["d"] }
+    order = ["a", "d", "e", "b", "c"]
+    
+    graph = Dag.new(attributes)
+    refute graph.has_cycle
+
+    assert_equal(dependency, graph.dependency)
+    assert_equal(order, graph.order)
+  end
+
+  # a -> b
+  #  \ /  \   *all pointing down
+  #   c -> d
+  test 'test forward edge' do
+    attributes = {
+      launcher_ids: ["a", "b", "c", "d"],
+      source_ids:   ["a", "a", "b", "b", "c"],
+      target_ids:   ["b", "c", "c", "d", "d"]
+    }
+    dependency =   { "b"=>["a"], "c"=>["a", "b"], "d"=>["b", "c"] }
+    order = ["a", "b", "c", "d"]
+    
+    graph = Dag.new(attributes)
+    refute graph.has_cycle
+
+    assert_equal(dependency, graph.dependency)
+    assert_equal(order, graph.order)
+  end
+
+end


### PR DESCRIPTION
Workflows Epic Link - https://github.com/OSC/ondemand/issues/4338

PR where model DAG was added - https://github.com/OSC/ondemand/pull/4505

```
Singularity> cd dashboard/
Singularity> ./bin/rails test test/models/dag_test.rb
# Running:  .....
Finished in 0.020909s, 239.1281 runs/s, 526.0819 assertions/s.
5 runs, 11 assertions, 0 failures, 0 errors, 0 skips
```
