### PR TITLE
add gpu panel to job stats

### DIFF
--- a/apps/dashboard/app/helpers/active_jobs_helper.rb
+++ b/apps/dashboard/app/helpers/active_jobs_helper.rb
@@ -60,6 +60,16 @@ module ActiveJobsHelper
     OODClusters[host].try { |cluster| cluster.custom_allow?(:grafana) } || false
   end
 
+  def supports_grafana_panel?(cluster, panel)
+    begin 
+      config = OODClusters[cluster].custom_config(:grafana)
+      panel_config = config[:dashboard]['panels'][panel]
+      panel_config.instance_of?(Integer)
+    rescue
+      false
+    end
+  end
+
   def status_label(status)
     "<span class='badge #{status_class(status)}'>#{status_text(status)}</span>".html_safe
   end

--- a/apps/dashboard/app/helpers/active_jobs_helper.rb
+++ b/apps/dashboard/app/helpers/active_jobs_helper.rb
@@ -30,7 +30,7 @@ module ActiveJobsHelper
         "var-#{server[:labels]['cluster']}": cluster,
         "var-#{server[:labels]['host']}": node_num.split('.')[0],
       }
-      if ['cpu','memory'].include?(report_type)
+      if ['cpu','memory','gpu-util','gpu-memory'].include?(report_type)
         url_base = 'd-solo'
         query_params[:panelId] = server[:dashboard]['panels'][report_type]
       else

--- a/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
+++ b/apps/dashboard/app/models/active_jobs/jobstatusdata.rb
@@ -7,7 +7,7 @@ module ActiveJobs
   # @author Brian L. McMichael
   # @version 0.0.1
   class Jobstatusdata
-    attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
+    attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :gpus, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
 
     Attribute = Struct.new(:name, :value)
 
@@ -32,6 +32,7 @@ module ActiveJobs
       self.cluster_title = cluster.metadata.title ||  cluster.id.to_s.titleize
       self.walltime_used = info.wallclock_time.to_i > 0 ? pretty_time(info.wallclock_time) : ''
       self.queue = info.queue_name
+      self.gpus = info.gpus
       if info.status == :running || info.status == :completed
         self.nodes = node_array(info.allocated_nodes).reject(&:blank?)
         self.starttime = info.dispatch_time.to_i
@@ -355,7 +356,7 @@ module ActiveJobs
         node_info_array.map { |n| n.name }
       end
 
-      attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
+      attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :gpus, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
 
   end
 end

--- a/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
@@ -24,6 +24,11 @@
           <div class="card-body">
             <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'cpu', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
             <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'memory', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
+            
+            <% if data.gpus.positive? || data.jobname == 'interactive' %>
+              <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'gpu-util', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
+              <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'gpu-memory', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
+            <% end %>
           </div>
          
         <% end %>

--- a/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
@@ -21,18 +21,14 @@
               </a>
             </span>
           </div>
+          <% grafana_panels = %w( cpu memory ) %>
+          <% grafana_panels.push(*%w( gpu-util gpu-memory )) if data.gpus.positive? %>
           <div class="card-body">
-            <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'cpu', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
-            <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'memory', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
-            
-            <% if data.gpus.positive? || data.jobname == 'interactive' %>
-              <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'gpu-util', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
-              <iframe src="<%= build_grafana_link(data.cluster, data.starttime, 'gpu-memory', node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
-            <% end %>
-          </div>
-         
+            <% grafana_panels.each do |name| %>
+              <iframe src="<%= build_grafana_link(data.cluster, data.starttime, name, node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
+            <% end%>
+          </div>       
         <% end %>
-  
 </div>
        
 

--- a/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_job_details_node_view.html.erb
@@ -21,11 +21,15 @@
               </a>
             </span>
           </div>
-          <% grafana_panels = %w( cpu memory ) %>
-          <% grafana_panels.push(*%w( gpu-util gpu-memory )) if data.gpus.positive? %>
+          <% grafana_panels = %w[ cpu memory ] %>
+          <% grafana_panels.push(*%w[ gpu-util gpu-memory ]) if data.gpus.positive? %>
           <div class="card-body">
             <% grafana_panels.each do |name| %>
-              <iframe src="<%= build_grafana_link(data.cluster, data.starttime, name, node, data.pbsid) %>" width="450" height="200" frameborder="0"></iframe>
+              <% if supports_grafana_panel?(data.cluster, name) %>
+                <iframe src="<%= build_grafana_link(data.cluster, data.starttime, name, node, data.pbsid) %>" 
+                  width="450" height="200" frameborder="0">
+                </iframe>
+              <% end %>
             <% end%>
           </div>       
         <% end %>


### PR DESCRIPTION
Fixes #3622. Adds two new parameters to cluster's custom attribute, `gpu-util` and `gpu-memory`, and conditionally adds the grafana tiles for interactive jobs or jobs that require gpus. (Interactive jobs seem to have 0 gpus but grafana still records gpu stats). Because cluster configurations are difficult to access for testing, I used the following snippet in active_jobs_helper.rb to simulate supplied values (starting from committed changes)
```rb
      if ['cpu','memory','gpu-util','gpu-memory'].include?(report_type)
        gpuvals = {'gpu-util' => 16, 'gpu-memory' => 18}
        url_base = 'd-solo'
        query_params[:panelId] = server[:dashboard]['panels'].merge(gpuvals)[report_type]
      else
        url_base = 'd'
      end
```
Interactive jobs are detected by title, which is not ideal and may not catch all of them. However the discovery that some jobs use GPU resources while having `@gpus == 0` is likely a bug itself and should be investigated. Once this detection is accurate we could remove the exception for interactive.