### PR TITLE
Test ActiveJobs models

### DIFF
--- a/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
+++ b/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
@@ -3,7 +3,9 @@
 module ActiveJobs
   module ActiveJobsTestHelper
     Node = Struct.new(:name)
-    Status = Struct.new(:state)
+    
+    # Status is a freestanding structure, so we simply alias it
+    Status = OodCore::Job::Status
 
     Metadata = Struct.new(:title)
 
@@ -31,6 +33,14 @@ module ActiveJobs
 
       def job_adapter
         FakeJobAdapter.new
+      end
+
+      def ==(other)
+        (other) ? id == other.to_sym : false
+      end
+
+      def to_sym
+        id
       end
     end
   end

--- a/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
+++ b/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
@@ -1,0 +1,37 @@
+# Shared dummy classes for ActiveJobs
+
+module ActiveJobs
+  module ActiveJobsTestHelper
+    Node = Struct.new(:name)
+    Status = Struct.new(:state)
+
+    Metadata = Struct.new(:title)
+
+    class FakeJobAdapter
+      def supports_job_arrays?
+        true
+      end
+    end
+
+    class FakeCluster
+      attr_reader :id, :metadata
+
+      def initialize(id:, title:)
+        @id = id
+        @metadata = Metadata.new(title)
+      end
+
+      def self.set_adapter(setting)
+        @adapter = setting
+      end
+
+      def job_config
+        { adapter: @adapter || 'slurm' }
+      end
+
+      def job_adapter
+        FakeJobAdapter.new
+      end
+    end
+  end
+end

--- a/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
+++ b/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
@@ -22,7 +22,7 @@ module ActiveJobs
         @metadata = Metadata.new(title)
       end
 
-      def self.set_adapter(setting)
+      def set_adapter(setting)
         @adapter = setting
       end
 
@@ -32,6 +32,10 @@ module ActiveJobs
 
       def job_adapter
         FakeJobAdapter.new
+      end
+
+      def login_allow?
+        false
       end
 
       def ==(other)

--- a/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
+++ b/apps/dashboard/test/models/active_jobs/active_jobs_test_helper.rb
@@ -2,10 +2,9 @@
 
 module ActiveJobs
   module ActiveJobsTestHelper
-    Node = Struct.new(:name)
-    
-    # Status is a freestanding structure, so we simply alias it
+    # Status and NodeInfo are freestanding structures, so we simply alias
     Status = OodCore::Job::Status
+    NodeInfo = OodCore::Job::NodeInfo
 
     Metadata = Struct.new(:title)
 

--- a/apps/dashboard/test/models/active_jobs/filter_test.rb
+++ b/apps/dashboard/test/models/active_jobs/filter_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ActiveJobs
+  class FilterTest < ActiveSupport::TestCase
+  end
+end

--- a/apps/dashboard/test/models/active_jobs/filter_test.rb
+++ b/apps/dashboard/test/models/active_jobs/filter_test.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require 'test_helper'
-
-module ActiveJobs
-  class FilterTest < ActiveSupport::TestCase
-  end
-end

--- a/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
@@ -2,9 +2,12 @@ require 'test_helper'
 require 'json'
 require 'stringio'
 require 'logger'
+require Rails.application.root.join('test','models','active_jobs','active_jobs_test_helper.rb')
 
 module ActiveJobs
   class JobsJsonRequestHandlerTest < ActiveSupport::TestCase
+    include ActiveJobsTestHelper
+    
     FakeStream = Struct.new(:buffer, :closed, keyword_init: true) do
       def write(str)
         self.buffer ||= ''
@@ -32,9 +35,6 @@ module ActiveJobs
       end
     end
 
-    Node = Struct.new(:name)
-    Status = Struct.new(:state)
-
     class FakeJob
       attr_reader :id, :job_name, :accounting_id, :queue_name, :wallclock_time, :job_owner, :allocated_nodes, :status
 
@@ -47,31 +47,6 @@ module ActiveJobs
         @job_owner = job_owner
         @allocated_nodes = nodes
         @status = status
-      end
-    end
-
-    Metadata = Struct.new(:title)
-
-    class FakeJobAdapter
-      def supports_job_arrays?
-        true
-      end
-    end
-
-    class FakeCluster
-      attr_reader :id, :metadata
-
-      def initialize(id:, title:)
-        @id = id
-        @metadata = Metadata.new(title)
-      end
-
-      def job_config
-        { adapter: 'slurm' }
-      end
-
-      def job_adapter
-        FakeJobAdapter.new
       end
     end
 

--- a/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
@@ -76,7 +76,7 @@ module ActiveJobs
           wallclock_time: 3600,
           job_owner:      "not_#{ENV['USER']}",
           nodes:          [Node.new('node001'), Node.new('node002')],
-          status:         Status.new(:running)
+          status:         Status.new(state: :running)
         ),
         FakeJob.new(
           id:             '67890',
@@ -86,7 +86,7 @@ module ActiveJobs
           wallclock_time: 120,
           job_owner:      "not_#{ENV['USER']}",
           nodes:          [Node.new('node003')],
-          status:         Status.new(:queued)
+          status:         Status.new(state: :queued)
         )
       ]
 
@@ -177,7 +177,7 @@ module ActiveJobs
             wallclock_time: 3600,
             job_owner:      "not_#{ENV['USER']}",
             nodes:          [Node.new('node001'), Node.new('node002')],
-            status:         Status.new(:running)
+            status:         Status.new(state: :running)
           ),
           FakeJob.new(
             id:             '345',
@@ -187,7 +187,7 @@ module ActiveJobs
             wallclock_time: 120,
             job_owner:      "#{ENV['USER']}",
             nodes:          [Node.new('node003')],
-            status:         Status.new(:queued)
+            status:         Status.new(state: :queued)
           ),
           FakeJob.new(
             id:             '567',
@@ -197,7 +197,7 @@ module ActiveJobs
             wallclock_time: 120,
             job_owner:      "#{ENV['USER']}",
             nodes:          [Node.new('node001'), Node.new('node002')],
-            status:         Status.new(:queued)
+            status:         Status.new(state: :queued)
           ),
           FakeJob.new(
             id:             '789',
@@ -207,7 +207,7 @@ module ActiveJobs
             wallclock_time: 120,
             job_owner:      "not_#{ENV['USER']}",
             nodes:          [Node.new('node003')],
-            status:         Status.new(:queued)
+            status:         Status.new(state: :queued)
           )
         ]
 

--- a/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
@@ -35,21 +35,6 @@ module ActiveJobs
       end
     end
 
-    class FakeJob
-      attr_reader :id, :job_name, :accounting_id, :queue_name, :wallclock_time, :job_owner, :allocated_nodes, :status
-
-      def initialize(id:, job_name:, accounting_id:, queue_name:, wallclock_time:, job_owner:, nodes:, status:)
-        @id = id
-        @job_name = job_name
-        @accounting_id = accounting_id
-        @queue_name = queue_name
-        @wallclock_time = wallclock_time
-        @job_owner = job_owner
-        @allocated_nodes = nodes
-        @status = status
-      end
-    end
-
     test 'render writes successful json for all jobs' do
       # Build fake controller/response/stream
       stream = FakeStream.new(buffer: '', closed: false)
@@ -68,25 +53,25 @@ module ActiveJobs
       # Prepare fake cluster and jobs
       cluster = FakeCluster.new(id: :test, title: 'Test Cluster')
       jobs = [
-        FakeJob.new(
-          id:             '12345',
-          job_name:       'Sample',
-          accounting_id:  'account1',
-          queue_name:     'normal',
-          wallclock_time: 3600,
-          job_owner:      "not_#{ENV['USER']}",
-          nodes:          [Node.new('node001'), Node.new('node002')],
-          status:         Status.new(state: :running)
+        OodCore::Job::Info.new(
+          id:              '12345',
+          job_name:        'Sample',
+          accounting_id:   'account1',
+          queue_name:      'normal',
+          wallclock_time:  3600,
+          job_owner:       "not_#{ENV['USER']}",
+          allocated_nodes: [NodeInfo.new(name: 'node001'), NodeInfo.new(name: 'node002')],
+          status:          :running
         ),
-        FakeJob.new(
-          id:             '67890',
-          job_name:       'Example',
-          accounting_id:  'account2',
-          queue_name:     'short',
-          wallclock_time: 120,
-          job_owner:      "not_#{ENV['USER']}",
-          nodes:          [Node.new('node003')],
-          status:         Status.new(state: :queued)
+        OodCore::Job::Info.new(
+          id:              '67890',
+          job_name:        'Example',
+          accounting_id:   'account2',
+          queue_name:      'short',
+          wallclock_time:  120,
+          job_owner:       "not_#{ENV['USER']}",
+          allocated_nodes: [NodeInfo.new(name: 'node003')],
+          status:          :queued
         )
       ]
 
@@ -169,45 +154,45 @@ module ActiveJobs
         # Prepare fake cluster and jobs
         cluster = FakeCluster.new(id: :test, title: 'Test Cluster')
         jobs = [
-          FakeJob.new(
-            id:             '123',
-            job_name:       'Sample',
-            accounting_id:  'account1',
-            queue_name:     'normal',
-            wallclock_time: 3600,
-            job_owner:      "not_#{ENV['USER']}",
-            nodes:          [Node.new('node001'), Node.new('node002')],
-            status:         Status.new(state: :running)
+          OodCore::Job::Info.new(
+            id:              '123',
+            job_name:        'Sample',
+            accounting_id:   'account1',
+            queue_name:      'normal',
+            wallclock_time:  3600,
+            job_owner:       "not_#{ENV['USER']}",
+            allocated_nodes: [NodeInfo.new(name: 'node001'), NodeInfo.new(name: 'node002')],
+            status:          :running
           ),
-          FakeJob.new(
-            id:             '345',
-            job_name:       'Example',
-            accounting_id:  'account2',
-            queue_name:     'short',
-            wallclock_time: 120,
-            job_owner:      "#{ENV['USER']}",
-            nodes:          [Node.new('node003')],
-            status:         Status.new(state: :queued)
+          OodCore::Job::Info.new(
+            id:              '345',
+            job_name:        'Example',
+            accounting_id:   'account2',
+            queue_name:      'short',
+            wallclock_time:  120,
+            job_owner:       "#{ENV['USER']}",
+            allocated_nodes: [NodeInfo.new(name: 'node003')],
+            status:          :queued
           ),
-          FakeJob.new(
-            id:             '567',
-            job_name:       'Example',
-            accounting_id:  'account2',
-            queue_name:     'short',
-            wallclock_time: 120,
-            job_owner:      "#{ENV['USER']}",
-            nodes:          [Node.new('node001'), Node.new('node002')],
-            status:         Status.new(state: :queued)
+          OodCore::Job::Info.new(
+            id:              '567',
+            job_name:        'Example',
+            accounting_id:   'account2',
+            queue_name:      'short',
+            wallclock_time:  120,
+            job_owner:       "#{ENV['USER']}",
+            allocated_nodes: [NodeInfo.new(name: 'node001'), NodeInfo.new(name: 'node002')],
+            status:          :queued
           ),
-          FakeJob.new(
-            id:             '789',
-            job_name:       'Example',
-            accounting_id:  'account2',
-            queue_name:     'short',
-            wallclock_time: 120,
-            job_owner:      "not_#{ENV['USER']}",
-            nodes:          [Node.new('node003')],
-            status:         Status.new(state: :queued)
+          OodCore::Job::Info.new(
+            id:              '789',
+            job_name:        'Example',
+            accounting_id:   'account2',
+            queue_name:      'short',
+            wallclock_time:  120,
+            job_owner:       "not_#{ENV['USER']}",
+            allocated_nodes: [NodeInfo.new(name: 'node003')],
+            status:          :queued
           )
         ]
 

--- a/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ActiveJobs
+  class JobsJsonRequestHandlerTest < ActiveSupport::TestCase
+  end
+end

--- a/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobs_json_request_handler_test.rb
@@ -1,8 +1,304 @@
-# frozen_string_literal: true
-
 require 'test_helper'
+require 'json'
+require 'stringio'
+require 'logger'
 
 module ActiveJobs
   class JobsJsonRequestHandlerTest < ActiveSupport::TestCase
+    FakeStream = Struct.new(:buffer, :closed, keyword_init: true) do
+      def write(str)
+        self.buffer ||= ''
+        self.buffer << str.to_s
+      end
+
+      def close
+        self.closed = true
+      end
+    end
+
+    class FakeResponse
+      attr_accessor :content_type, :stream
+
+      def initialize(stream)
+        @stream = stream
+      end
+    end
+
+    class FakeController
+      attr_reader :logger
+
+      def initialize
+        @logger = Logger.new(StringIO.new)
+      end
+    end
+
+    Node = Struct.new(:name)
+    Status = Struct.new(:state)
+
+    class FakeJob
+      attr_reader :id, :job_name, :accounting_id, :queue_name, :wallclock_time, :job_owner, :allocated_nodes, :status
+
+      def initialize(id:, job_name:, accounting_id:, queue_name:, wallclock_time:, job_owner:, nodes:, status:)
+        @id = id
+        @job_name = job_name
+        @accounting_id = accounting_id
+        @queue_name = queue_name
+        @wallclock_time = wallclock_time
+        @job_owner = job_owner
+        @allocated_nodes = nodes
+        @status = status
+      end
+    end
+
+    Metadata = Struct.new(:title)
+
+    class FakeJobAdapter
+      def supports_job_arrays?
+        true
+      end
+    end
+
+    class FakeCluster
+      attr_reader :id, :metadata
+
+      def initialize(id:, title:)
+        @id = id
+        @metadata = Metadata.new(title)
+      end
+
+      def job_config
+        { adapter: 'slurm' }
+      end
+
+      def job_adapter
+        FakeJobAdapter.new
+      end
+    end
+
+    test 'render writes successful json for all jobs' do
+      # Build fake controller/response/stream
+      stream = FakeStream.new(buffer: '', closed: false)
+      response = FakeResponse.new(stream)
+      controller = FakeController.new
+
+      # Build handler under test
+      handler = JobsJsonRequestHandler.new(
+        filter_id:  'all',
+        cluster_id: 'test',
+        controller: controller,
+        params:     {},
+        response:   response
+      )
+
+      # Prepare fake cluster and jobs
+      cluster = FakeCluster.new(id: :test, title: 'Test Cluster')
+      jobs = [
+        FakeJob.new(
+          id:             '12345',
+          job_name:       'Sample',
+          accounting_id:  'account1',
+          queue_name:     'normal',
+          wallclock_time: 3600,
+          job_owner:      "not_#{ENV['USER']}",
+          nodes:          [Node.new('node001'), Node.new('node002')],
+          status:         Status.new(:running)
+        ),
+        FakeJob.new(
+          id:             '67890',
+          job_name:       'Example',
+          accounting_id:  'account2',
+          queue_name:     'short',
+          wallclock_time: 120,
+          job_owner:      "not_#{ENV['USER']}",
+          nodes:          [Node.new('node003')],
+          status:         Status.new(:queued)
+        )
+      ]
+
+      # Stub internal collaborators to isolate test
+      filter = Object.new
+      def filter.user?
+        false
+      end
+
+      def filter.apply(jobs)
+        jobs
+      end
+
+      handler.define_singleton_method(:clusters) { [cluster] }
+      handler.define_singleton_method(:filter) { filter }
+      handler.define_singleton_method(:job_info_enumerator) { |_cluster| jobs }
+
+      # Exercise
+      handler.render
+
+      # Verify content type set
+      assert_equal Mime[:json], response.content_type
+
+      # Verify stream closed
+      assert_equal true, stream.closed
+
+      # Verify JSON payload shape and values
+      payload = JSON.parse(stream.buffer)
+
+      assert_equal [], payload['errors']
+      assert payload['data'].is_a?(Array), 'data should be an array'
+      assert_equal 1, payload['data'].size, 'data should contain one slice'
+      slice = payload['data'].first
+      assert_equal 2, slice.size
+
+      first = slice.first
+      assert_equal 'Test Cluster',         first['cluster_title']
+      assert_equal 'running',              first['status']
+      assert_equal 'test',                 first['cluster']
+      assert_equal '12345',                first['pbsid']
+      assert_equal 'Sample',               first['jobname']
+      assert_equal 'account1',             first['account']
+      assert_equal 'normal',               first['queue']
+      assert_equal 3600,                   first['walltime_used']
+      assert_equal "not_#{ENV['USER']}",   first['username']
+      assert_equal true,                   first['extended_available']
+      assert_equal ['node001', 'node002'], first['nodes']
+      assert_equal '',                     first['delete_path']
+
+      second = slice.last
+      assert_equal 'Test Cluster',       second['cluster_title']
+      assert_equal 'queued',             second['status']
+      assert_equal 'test',               second['cluster']
+      assert_equal '67890',              second['pbsid']
+      assert_equal 'Example',            second['jobname']
+      assert_equal 'account2',           second['account']
+      assert_equal 'short',              second['queue']
+      assert_equal 120,                  second['walltime_used']
+      assert_equal "not_#{ENV['USER']}", second['username']
+      assert_equal true,                 second['extended_available']
+      assert_equal ['node003'],          second['nodes']
+      assert_equal '',                   second['delete_path']
+    end
+
+    test "render writes successful json for user's jobs" do
+      with_modified_env(USER: 'FakeUser') do
+        stream = FakeStream.new(buffer: '', closed: false)
+        response = FakeResponse.new(stream)
+        controller = FakeController.new
+
+        # Build handler under test
+        handler = JobsJsonRequestHandler.new(
+          filter_id:  'user',
+          cluster_id: 'test',
+          controller: controller,
+          params:     {},
+          response:   response
+        )
+
+        # Prepare fake cluster and jobs
+        cluster = FakeCluster.new(id: :test, title: 'Test Cluster')
+        jobs = [
+          FakeJob.new(
+            id:             '123',
+            job_name:       'Sample',
+            accounting_id:  'account1',
+            queue_name:     'normal',
+            wallclock_time: 3600,
+            job_owner:      "not_#{ENV['USER']}",
+            nodes:          [Node.new('node001'), Node.new('node002')],
+            status:         Status.new(:running)
+          ),
+          FakeJob.new(
+            id:             '345',
+            job_name:       'Example',
+            accounting_id:  'account2',
+            queue_name:     'short',
+            wallclock_time: 120,
+            job_owner:      "#{ENV['USER']}",
+            nodes:          [Node.new('node003')],
+            status:         Status.new(:queued)
+          ),
+          FakeJob.new(
+            id:             '567',
+            job_name:       'Example',
+            accounting_id:  'account2',
+            queue_name:     'short',
+            wallclock_time: 120,
+            job_owner:      "#{ENV['USER']}",
+            nodes:          [Node.new('node001'), Node.new('node002')],
+            status:         Status.new(:queued)
+          ),
+          FakeJob.new(
+            id:             '789',
+            job_name:       'Example',
+            accounting_id:  'account2',
+            queue_name:     'short',
+            wallclock_time: 120,
+            job_owner:      "not_#{ENV['USER']}",
+            nodes:          [Node.new('node003')],
+            status:         Status.new(:queued)
+          )
+        ]
+
+        # Stub internal collaborators
+        filter = Object.new
+        def filter.user?
+          true
+        end
+
+        def filter.apply(jobs)
+          jobs
+        end
+
+        handler.define_singleton_method(:clusters) { [cluster] }
+        handler.define_singleton_method(:filter) { filter }
+        # Simulate ood_core operation
+        handler.define_singleton_method(:job_info_enumerator) do |_cluster|
+          jobs.select do |job|
+            job.job_owner == ENV['USER']
+          end
+        end
+
+        # Exercise
+        handler.render
+
+        # Verify content type set
+        assert_equal Mime[:json], response.content_type
+        # Verify stream closed
+        assert_equal true, stream.closed
+        # Verify JSON payload shape and values
+        payload = JSON.parse(stream.buffer)
+
+        assert_equal [], payload['errors']
+        assert payload['data'].is_a?(Array), 'data should be an array'
+        assert_equal 1, payload['data'].size, 'data should contain one slice'
+        slice = payload['data'].first
+        assert_equal 2, slice.size
+
+        first = slice.first
+        assert_equal 'Test Cluster',                       first['cluster_title']
+        assert_equal 'queued',                             first['status']
+        assert_equal 'test',                               first['cluster']
+        assert_equal '345',                                first['pbsid']
+        assert_equal 'Example',                            first['jobname']
+        assert_equal 'account2',                           first['account']
+        assert_equal 'short',                              first['queue']
+        assert_equal 120,                                  first['walltime_used']
+        assert_equal 'FakeUser',                           first['username']
+        assert_equal true,                                 first['extended_available']
+        assert_equal ['node003'],                          first['nodes']
+        assert_equal '/activejobs?cluster=test&pbsid=345', first['delete_path']
+
+        second = slice.second
+        assert_equal 'Test Cluster',                       second['cluster_title']
+        assert_equal 'queued',                             second['status']
+        assert_equal 'test',                               second['cluster']
+        assert_equal '567',                                second['pbsid']
+        assert_equal 'Example',                            second['jobname']
+        assert_equal 'account2',                           second['account']
+        assert_equal 'short',                              second['queue']
+        assert_equal 120,                                  second['walltime_used']
+        assert_equal 'FakeUser',                           second['username']
+        assert_equal true,                                 second['extended_available']
+        assert_equal ['node001', 'node002'],               second['nodes']
+        assert_equal '/activejobs?cluster=test&pbsid=567', second['delete_path']
+      end
+    end
   end
 end

--- a/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
@@ -1,8 +1,88 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require Rails.application.root.join('test','models','active_jobs','active_jobs_test_helper.rb')
 
 module ActiveJobs
   class JobstatusdataTest < ActiveSupport::TestCase
+    include ActiveJobsTestHelper
+
+    # Dummy object for OodCore::Job::Info
+    FakeJobInfo = Struct.new(
+      :id,
+      :status,
+      :allocated_nodes,
+      :submit_host,
+      :job_name,
+      :job_owner,
+      :accounting_id,
+      :procs,
+      :queue_name,
+      :wallclock_time,
+      :wallclock_limit,
+      :cpu_time,
+      :submission_time,
+      :dispatch_time,
+      :native,
+      :gpus,
+      :tasks,
+      keyword_init: true
+    )
+
+    # Dummy class for OodCore::Clusters
+    class FakeClusters
+      include Enumerable
+
+      def initialize(clusters)
+        @clusters = clusters
+      end
+
+      def [](id)
+        @clusters.detect { |cluster| cluster == id }
+      end
+
+      def each(&block)
+        @clusters.each(&block)
+      end
+    end
+    
+    # Redefine OODClusters constant to use dummy clusters
+    Object.send(:remove_const, :OODClusters) 
+
+    ActiveJobs::Jobstatusdata::OODClusters = FakeClusters.new([
+      FakeCluster.new(id: :test, title: 'Test Cluster'),
+      FakeCluster.new(id: :sample, title: 'Sample Cluster')
+    ])
+
+    # Alias constant for easy reference inside tests
+    OODClusters = ActiveJobs::Jobstatusdata::OODClusters
+
+    test 'default no extensions' do 
+      info = FakeJobInfo.new(
+        id:             12,
+        job_name:       'test_job',
+        job_owner:      'Fake User',
+        accounting_id:  123,
+        status:         Status.new(:running),
+        wallclock_time: 120,
+        queue_name:     'regular'
+      )
+      
+      data = Jobstatusdata.new(info)
+      
+      # Test supplied data
+      assert_equal 12,          data.pbsid
+      assert_equal 'test_job',  data.jobname
+      assert_equal 'Fake User', data.username
+      assert_equal 123,         data.account
+      assert_equal 'running',   data.status
+      assert_equal '00:02:00',  data.walltime_used
+      assert_equal 'regular',   data.queue
+
+      # Test defaults
+      assert data.extended_available
+      assert_equal OODClusters.first.id.to_s,        data.cluster
+      assert_equal OODClusters.first.metadata.title, data.cluster_title
+    end
   end
 end

--- a/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
@@ -1,42 +1,19 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require Rails.application.root.join('test','models','active_jobs','active_jobs_test_helper.rb')
+require Rails.application.root.join('test', 'models', 'active_jobs', 'active_jobs_test_helper.rb')
 
 module ActiveJobs
   class JobstatusdataTest < ActiveSupport::TestCase
     include ActiveJobsTestHelper
 
-    # Dummy class for OodCore::Clusters
-    class FakeClusters
-      include Enumerable
-
-      def initialize(clusters)
-        @clusters = clusters
-      end
-
-      def [](id)
-        @clusters.detect { |cluster| cluster == id }
-      end
-
-      def each(&block)
-        @clusters.each(&block)
-      end
-    end
-    
-    # def clusters
-    #   OodCore::Clusters.load_file('test/fixtures/config/clusters.d')
-    # end
-  
     def setup
       OODClusters.stubs(:[]).with('owens').returns(FakeCluster.new(id: :owens, title: 'Owens'))
       OODClusters.stubs(:[]).with('oakley').returns(FakeCluster.new(id: :oakley, title: 'Oakley Cluster'))
-      OODClusters.stubs(:[]).with(nil).returns(nil)
-      OODClusters.stubs(:[]).with('').returns(nil)
       OODClusters.stubs(:first).returns(OODClusters['owens'])
     end
 
-    test 'default no extensions' do 
+    test 'default no extensions' do
       info = OodCore::Job::Info.new(
         id:             12,
         job_name:       'test_job',
@@ -46,14 +23,14 @@ module ActiveJobs
         wallclock_time: 120,
         queue_name:     'regular'
       )
-      
+
       data = Jobstatusdata.new(info)
-      
+
       # Test supplied data
-      assert_equal '12',          data.pbsid
+      assert_equal '12',        data.pbsid
       assert_equal 'test_job',  data.jobname
       assert_equal 'Fake User', data.username
-      assert_equal '123',         data.account
+      assert_equal '123',       data.account
       assert_equal 'running',   data.status
       assert_equal '00:02:00',  data.walltime_used
       assert_equal 'regular',   data.queue
@@ -66,7 +43,7 @@ module ActiveJobs
       assert_equal exp, data.cluster_title
     end
 
-    test 'default with cluster supplied' do 
+    test 'default with cluster supplied' do
       info = OodCore::Job::Info.new(
         id:             12,
         job_name:       'test_job',
@@ -78,12 +55,12 @@ module ActiveJobs
       )
 
       data = Jobstatusdata.new(info, 'oakley')
-      
+
       # Test supplied data
-      assert_equal '12',          data.pbsid
+      assert_equal '12',        data.pbsid
       assert_equal 'test_job',  data.jobname
       assert_equal 'Fake User', data.username
-      assert_equal '123',         data.account
+      assert_equal '123',       data.account
       assert_equal 'running',   data.status
       assert_equal '00:02:00',  data.walltime_used
       assert_equal 'regular',   data.queue
@@ -101,11 +78,11 @@ module ActiveJobs
       def initialize(data)
         @data = data
       end
-      
+
       def fetch(key, default = nil)
         @data.fetch(key, default)
       end
-    
+
       def [](key)
         @data[key]
       end
@@ -121,28 +98,28 @@ module ActiveJobs
 
       # Create job
       samplejob = OodCore::Job::Info.new(
-        id: "123450",
-        status: :queued,
+        id:              '123450',
+        status:          :queued,
         allocated_nodes: [NodeInfo.new(name: 'node001')],
-        submit_host: "submit01.cluster",
-        job_name: "TestJob1",
-        job_owner: "user1",
-        accounting_id: "acct123",
-        procs: 4,
-        queue_name: "batch",
-        wallclock_time: 3600,
+        submit_host:     'submit01.cluster',
+        job_name:        'TestJob1',
+        job_owner:       'user1',
+        accounting_id:   'acct123',
+        procs:           4,
+        queue_name:      'batch',
+        wallclock_time:  3600,
         wallclock_limit: 7200,
-        cpu_time: 1800,
+        cpu_time:        1800,
         submission_time: Time.now.to_i - 3600,
-        dispatch_time: Time.now.to_i - 1800,
-        gpus: 1,
-        native: native,
-        tasks: [{ id: "12345.1", status: :running }]
+        dispatch_time:   Time.now.to_i - 1800,
+        gpus:            1,
+        native:          native,
+        tasks:           [{ id: '12345.1', status: :running }]
       )
-      
+
       # Run test
-      data = Jobstatusdata.new(samplejob, 'oakley', true)
-    end  
+      Jobstatusdata.new(samplejob, 'oakley', true)
+    end
 
     # Helper method to access native_attribs
     def get_native_value(data, name)
@@ -163,19 +140,19 @@ module ActiveJobs
     test 'use torque extensions' do
       # Set up native
       torque_data = {
-        Resource_List: {
-          walltime: "02:00:00",
-          nodect: 4,
-          nodes: "node01+node02+node03+node04:ppn=8"
+        Resource_List:  {
+          walltime: '02:00:00',
+          nodect:   4,
+          nodes:    'node01+node02+node03+node04:ppn=8'
         },
         resources_used: {
-          cput: "01:30:00",
-          mem: "4gb",
-          vmem: "6gb"
+          cput: '01:30:00',
+          mem:  '4gb',
+          vmem: '6gb'
         },
-        comment: "Test job",
-        submit_args: "--test-args",
-        Output_Path: "server:/home/user/output.log"
+        comment:        'Test job',
+        submit_args:    '--test-args',
+        Output_Path:    'server:/home/user/output.log'
       }
 
       # Execute test
@@ -183,7 +160,7 @@ module ActiveJobs
 
       # Check basic attributes
       assert_shared_attributes(data)
-      
+
       # Check extended attributes
       assert_equal '02:00:00',    get_native_value(data, 'Walltime')
       assert_equal 4,             get_native_value(data, 'Node Count')
@@ -203,18 +180,18 @@ module ActiveJobs
 
     test 'use slurm extensions' do
       slurm_data = {
-        array_job_id: "12345",
-        array_task_id: "1",
-        state: "running",
-        reason: "None",
-        nodes: 2,
-        cpus: 64,
-        time_limit: "01:00:00",
-        start_time: "2025-08-28T14:00:00",
-        end_time: "2025-08-28T15:00:00",
-        min_memory: "128GB",
-        gres: "gres:gpu:2",
-        work_dir: "/home/user/slurm_job"
+        array_job_id:  '12345',
+        array_task_id: '1',
+        state:         'running',
+        reason:        'None',
+        nodes:         2,
+        cpus:          64,
+        time_limit:    '01:00:00',
+        start_time:    '2025-08-28T14:00:00',
+        end_time:      '2025-08-28T15:00:00',
+        min_memory:    '128GB',
+        gres:          'gres:gpu:2',
+        work_dir:      '/home/user/slurm_job'
       }
 
       # Execute test
@@ -257,13 +234,13 @@ module ActiveJobs
         start_time:  '2025-08-28 12:00:00',
         finish_time: '2025-08-28 13:10:00'
       }
-    
+
       # Execute test
       data = extensions_test_setup('lsf', lsf_data)
-    
+
       # Check basic/shared attributes (same helper used by torque/slurm tests)
       assert_shared_attributes(data)
-    
+
       # Check extended/native attributes specific to LSF
       assert_equal 'submit01',            get_native_value(data, 'From Host')
       assert_equal 'exec01',              get_native_value(data, 'Exec Host')
@@ -277,19 +254,18 @@ module ActiveJobs
       assert_equal '2025-08-28 12:00:00', get_native_value(data, 'Start Time')
       assert_equal '2025-08-28 13:10:00', get_native_value(data, 'Finish Time')
     end
-    
 
     test 'use pbspro extensions' do
       # Set up native PBS Pro data
       pbspro_data = {
-        Resource_List: {
+        Resource_List:    {
           walltime: '02:00:00',
           nodect:   4,
           ncpus:    '32',
           select:   '2:ncpus=16:mem=64gb:ngpus=2'
         },
-        resources_used: {
-          cput: '5400',  # seconds => pretty_time => "01:30:00"
+        resources_used:   {
+          cput: '5400', # seconds => pretty_time => "01:30:00"
           mem:  '4gb',
           vmem: '6gb'
         },
@@ -298,13 +274,13 @@ module ActiveJobs
         Submit_arguments: '--pbspro-args',
         Output_Path:      'server:/home/user/output.log'
       }
-    
+
       # Execute test
       data = extensions_test_setup('pbspro', pbspro_data)
-    
+
       # Check basic attributes
       assert_shared_attributes(data)
-    
+
       # Check extended/native attributes specific to PBS Pro
       assert_equal '02:00:00',                    get_native_value(data, 'Walltime')
       assert_equal '01:00:00',                    get_native_value(data, 'Walltime Used')
@@ -317,44 +293,44 @@ module ActiveJobs
       assert_equal '2:ncpus=16:mem=64gb:ngpus=2', get_native_value(data, 'Select')
       assert_equal 'PBSPro test job',             get_native_value(data, 'Comment')
       assert_equal 'groupA,groupB',               get_native_value(data, 'Group List')
-    
+
       assert_equal '--pbspro-args',               data.submit_args
       assert_equal '/home/user',                  Pathname.new(data.output_path).dirname.to_s
     end
-    
+
     test 'use sge extensions' do
       # Set up native SGE data
       sge_data = {
-        JB_version:               '8.6.12',
-        JB_exec_file:             '/opt/sge/bin/lx-amd64/sge_shepherd',
-        JB_script_file:           '/home/user/job.sh',
-        JB_script_size:           2048,
-        JB_execution_time:        '00:45:00',
-        JB_deadline:              '2025-08-28 16:00:00',
-        JB_uid:                   1001,
-        JB_group:                 'users',
-        JB_gid:                   1001,
-        JB_account:               'projectA',
-        JB_cwd:                   '/home/user/work',
-        JB_notify:                'n',
-        JB_type:                  'binary',
-        JB_reserve:               'y',
-        JB_priority:              '0.5',
-        JB_jobshare:              0,
-        JB_verify:                'false',
-        JB_checkpoint_attr:       'cwhen',
-        JB_checkpoint_interval:   '00:10:00',
-        JB_restart:               'y',
-        ST_name:                  '--sge-args',
-        PN_path:                  '/home/user/sge_job/output.log'
+        JB_version:             '8.6.12',
+        JB_exec_file:           '/opt/sge/bin/lx-amd64/sge_shepherd',
+        JB_script_file:         '/home/user/job.sh',
+        JB_script_size:         2048,
+        JB_execution_time:      '00:45:00',
+        JB_deadline:            '2025-08-28 16:00:00',
+        JB_uid:                 1001,
+        JB_group:               'users',
+        JB_gid:                 1001,
+        JB_account:             'projectA',
+        JB_cwd:                 '/home/user/work',
+        JB_notify:              'n',
+        JB_type:                'binary',
+        JB_reserve:             'y',
+        JB_priority:            '0.5',
+        JB_jobshare:            0,
+        JB_verify:              'false',
+        JB_checkpoint_attr:     'cwhen',
+        JB_checkpoint_interval: '00:10:00',
+        JB_restart:             'y',
+        ST_name:                '--sge-args',
+        PN_path:                '/home/user/sge_job/output.log'
       }
-    
+
       # Execute test
       data = extensions_test_setup('sge', sge_data)
-    
+
       # Check basic/shared attributes
       assert_shared_attributes(data)
-    
+
       # Check SGE-native mapped attributes
       assert_equal '8.6.12',                             get_native_value(data, 'Job Version')
       assert_equal '/opt/sge/bin/lx-amd64/sge_shepherd', get_native_value(data, 'Job Exec File')
@@ -386,23 +362,22 @@ module ActiveJobs
         START_DATE: '2025-08-28 12:05:00',                    # Start Time
         STD:        '/home/user/fj_job/std.out'               # used to build URLs
       }
-    
+
       # Execute test
       data = extensions_test_setup('fujitsu_tcs', fujitsu_data)
-    
+
       # Check basic/shared attributes
       assert_shared_attributes(data)
-    
+
       # Check extended/native attributes specific to Fujitsu TCS
       assert_equal '2',                         get_native_value(data, 'Nodes')
       assert_equal '02:00:00',                  get_native_value(data, 'Time Limit')
       assert_equal '2025-08-28 12:00:00',       get_native_value(data, 'Submission Time')
       assert_equal '2025-08-28 12:05:00',       get_native_value(data, 'Start Time')
-    
+
       # It does build file_explorer_url and shell_url from dirname(STD); ensure they were set
       assert_not_nil data.file_explorer_url
       assert_not_nil data.shell_url
     end
-    
   end
 end

--- a/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ActiveJobs
+  class JobstatusdataTest < ActiveSupport::TestCase
+  end
+end

--- a/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
+++ b/apps/dashboard/test/models/active_jobs/jobstatusdata_test.rb
@@ -7,28 +7,6 @@ module ActiveJobs
   class JobstatusdataTest < ActiveSupport::TestCase
     include ActiveJobsTestHelper
 
-    # Dummy object for OodCore::Job::Info
-    FakeJobInfo = Struct.new(
-      :id,
-      :status,
-      :allocated_nodes,
-      :submit_host,
-      :job_name,
-      :job_owner,
-      :accounting_id,
-      :procs,
-      :queue_name,
-      :wallclock_time,
-      :wallclock_limit,
-      :cpu_time,
-      :submission_time,
-      :dispatch_time,
-      :native,
-      :gpus,
-      :tasks,
-      keyword_init: true
-    )
-
     # Dummy class for OodCore::Clusters
     class FakeClusters
       include Enumerable
@@ -58,12 +36,12 @@ module ActiveJobs
     OODClusters = ActiveJobs::Jobstatusdata::OODClusters
 
     test 'default no extensions' do 
-      info = FakeJobInfo.new(
+      info = OodCore::Job::Info.new(
         id:             12,
         job_name:       'test_job',
         job_owner:      'Fake User',
         accounting_id:  123,
-        status:         Status.new(:running),
+        status:         :running,
         wallclock_time: 120,
         queue_name:     'regular'
       )
@@ -71,10 +49,10 @@ module ActiveJobs
       data = Jobstatusdata.new(info)
       
       # Test supplied data
-      assert_equal 12,          data.pbsid
+      assert_equal '12',          data.pbsid
       assert_equal 'test_job',  data.jobname
       assert_equal 'Fake User', data.username
-      assert_equal 123,         data.account
+      assert_equal '123',         data.account
       assert_equal 'running',   data.status
       assert_equal '00:02:00',  data.walltime_used
       assert_equal 'regular',   data.queue
@@ -84,5 +62,344 @@ module ActiveJobs
       assert_equal OODClusters.first.id.to_s,        data.cluster
       assert_equal OODClusters.first.metadata.title, data.cluster_title
     end
+
+    test 'default with cluster supplied' do 
+      info = OodCore::Job::Info.new(
+        id:             12,
+        job_name:       'test_job',
+        job_owner:      'Fake User',
+        accounting_id:  123,
+        status:         :running,
+        wallclock_time: 120,
+        queue_name:     'regular'
+      )
+
+      data = Jobstatusdata.new(info, 'sample')
+      
+      # Test supplied data
+      assert_equal '12',          data.pbsid
+      assert_equal 'test_job',  data.jobname
+      assert_equal 'Fake User', data.username
+      assert_equal '123',         data.account
+      assert_equal 'running',   data.status
+      assert_equal '00:02:00',  data.walltime_used
+      assert_equal 'regular',   data.queue
+
+      # Test defaults
+      assert data.extended_available
+
+      # Test cluster data
+      assert_equal 'sample',         data.cluster
+      assert_equal 'Sample Cluster', data.cluster_title
+    end
+
+    # To test native extensions, we define a plausible native class for each scheduler
+    class DummyNative
+      def initialize(data)
+        @data = data
+      end
+      
+      def fetch(key, default = nil)
+        @data.fetch(key, default)
+      end
+    
+      def [](key)
+        @data[key]
+      end
+    end
+
+    # Special setup method to keep extension tests consistent
+    def extensions_test_setup(adapter, native_data)
+      # Set scheduler on cluster
+      OODClusters['sample'].set_adapter(adapter)
+
+      # Define native
+      native = DummyNative.new(native_data)
+
+      # Create job
+      samplejob = OodCore::Job::Info.new(
+        id: "123450",
+        status: :queued,
+        allocated_nodes: [NodeInfo.new(name: 'node001')],
+        submit_host: "submit01.cluster",
+        job_name: "TestJob1",
+        job_owner: "user1",
+        accounting_id: "acct123",
+        procs: 4,
+        queue_name: "batch",
+        wallclock_time: 3600,
+        wallclock_limit: 7200,
+        cpu_time: 1800,
+        submission_time: Time.now.to_i - 3600,
+        dispatch_time: Time.now.to_i - 1800,
+        gpus: 1,
+        native: native,
+        tasks: [{ id: "12345.1", status: :running }]
+      )
+      
+      # Run test
+      data = Jobstatusdata.new(samplejob, 'sample', true)
+    end  
+
+    # Helper method to access native_attribs
+    def get_native_value(data, name)
+      data.native_attribs.find { |a| a.name == name }.value
+    end
+
+    # To consistently check attributes unaffected by extensions
+    def assert_shared_attributes(data)
+      assert_equal 'Sample Cluster', data.cluster_title
+      assert_equal '123450',         data.pbsid
+      assert_equal 'TestJob1',       data.jobname
+      assert_equal 'user1',          data.username
+      assert_equal 'acct123',        data.account
+      assert_equal 'batch',          data.queue
+      assert_equal '01:00:00',       data.walltime_used
+    end
+
+    test 'use torque extensions' do
+      # Set up native
+      torque_data = {
+        Resource_List: {
+          walltime: "02:00:00",
+          nodect: 4,
+          nodes: "node01+node02+node03+node04:ppn=8"
+        },
+        resources_used: {
+          cput: "01:30:00",
+          mem: "4gb",
+          vmem: "6gb"
+        },
+        comment: "Test job",
+        submit_args: "--test-args",
+        Output_Path: "server:/home/user/output.log"
+      }
+
+      # Execute test
+      data = extensions_test_setup('torque', torque_data)
+
+      # Check basic attributes
+      assert_shared_attributes(data)
+      
+      # Check extended attributes
+      assert_equal '02:00:00',    get_native_value(data, 'Walltime')
+      assert_equal 4,             get_native_value(data, 'Node Count')
+      assert_equal 'node001',     get_native_value(data, 'Node List')
+      assert_equal '8',           get_native_value(data, 'PPN')
+      assert_equal 32,            get_native_value(data, 'Total CPUs')
+      assert_equal '01:30:00',    get_native_value(data, 'CPU Time')
+      assert_equal '4gb',         get_native_value(data, 'Memory')
+      assert_equal '6gb',         get_native_value(data, 'Virtual Memory')
+      assert_equal 'Test job',    get_native_value(data, 'Comment')
+      assert_equal '--test-args', data.submit_args
+      assert_equal '/home/user',  Pathname.new(data.output_path).dirname.to_s
+
+      assert_not_nil data.file_explorer_url
+      assert_not_nil data.shell_url
+    end
+
+    test 'use slurm extensions' do
+      slurm_data = {
+        array_job_id: "12345",
+        array_task_id: "1",
+        state: "running",
+        reason: "None",
+        nodes: 2,
+        cpus: 64,
+        time_limit: "01:00:00",
+        start_time: "2025-08-28T14:00:00",
+        end_time: "2025-08-28T15:00:00",
+        min_memory: "128GB",
+        gres: "gres:gpu:2",
+        work_dir: "/home/user/slurm_job"
+      }
+
+      # Execute test
+      data = extensions_test_setup('slurm', slurm_data)
+
+      # Check basic attributes
+      assert_shared_attributes(data)
+
+      # Check extensions
+      assert_equal '12345',                get_native_value(data, 'Array Job Id')
+      assert_equal '1',                    get_native_value(data, 'Array Task Id')
+      assert_equal 'running',              get_native_value(data, 'State')
+      assert_equal 'None',                 get_native_value(data, 'Reason')
+      assert_equal 2,                      get_native_value(data, 'Total Nodes')
+      assert_equal 'node001',              get_native_value(data, 'Node List')
+      assert_equal 64,                     get_native_value(data, 'Total CPUs')
+      assert_equal '01:00:00',             get_native_value(data, 'Time Limit')
+      assert_equal '01:00:00',             get_native_value(data, 'Time Used')
+      assert_equal '2025-08-28 14:00:00',  get_native_value(data, 'Start Time')
+      assert_equal '2025-08-28 15:00:00',  get_native_value(data, 'End Time')
+      assert_equal '128GB',                get_native_value(data, 'Memory')
+      assert_equal 'gpu:2',                get_native_value(data, 'GRES')
+      assert_equal '/home/user/slurm_job', data.output_path
+
+      assert_not_nil data.file_explorer_url
+      assert_not_nil data.shell_url
+    end
+
+    test 'use lsf extensions' do
+      # Set up native LSF data
+      lsf_data = {
+        from_host:   'submit01',
+        exec_host:   'exec01',
+        submit_time: '2025-08-28 11:50:00',
+        project:     'test-project',
+        cpu_used:    '01:10:30',
+        mem:         '2048MB',
+        swap:        '4096MB',
+        pids:        '12345,12346',
+        start_time:  '2025-08-28 12:00:00',
+        finish_time: '2025-08-28 13:10:00'
+      }
+    
+      # Execute test
+      data = extensions_test_setup('lsf', lsf_data)
+    
+      # Check basic/shared attributes (same helper used by torque/slurm tests)
+      assert_shared_attributes(data)
+    
+      # Check extended/native attributes specific to LSF
+      assert_equal 'submit01',            get_native_value(data, 'From Host')
+      assert_equal 'exec01',              get_native_value(data, 'Exec Host')
+      assert_equal 'test-project',        get_native_value(data, 'Project Name')
+      assert_equal 'node001',             get_native_value(data, 'Node List')
+      assert_equal '01:10:30',            get_native_value(data, 'CPU Used')
+      assert_equal '2048MB',              get_native_value(data, 'Mem')
+      assert_equal '4096MB',              get_native_value(data, 'Swap')
+      assert_equal '12345,12346',         get_native_value(data, 'PIDs')
+      assert_equal '2025-08-28 11:50:00', get_native_value(data, 'Submit Time')
+      assert_equal '2025-08-28 12:00:00', get_native_value(data, 'Start Time')
+      assert_equal '2025-08-28 13:10:00', get_native_value(data, 'Finish Time')
+    end
+    
+
+    test 'use pbspro extensions' do
+      # Set up native PBS Pro data
+      pbspro_data = {
+        Resource_List: {
+          walltime: '02:00:00',
+          nodect:   4,
+          ncpus:    '32',
+          select:   '2:ncpus=16:mem=64gb:ngpus=2'
+        },
+        resources_used: {
+          cput: '5400',  # seconds => pretty_time => "01:30:00"
+          mem:  '4gb',
+          vmem: '6gb'
+        },
+        group_list:       'groupA,groupB',
+        comment:          'PBSPro test job',
+        Submit_arguments: '--pbspro-args',
+        Output_Path:      'server:/home/user/output.log'
+      }
+    
+      # Execute test
+      data = extensions_test_setup('pbspro', pbspro_data)
+    
+      # Check basic attributes
+      assert_shared_attributes(data)
+    
+      # Check extended/native attributes specific to PBS Pro
+      assert_equal '02:00:00',                    get_native_value(data, 'Walltime')
+      assert_equal '01:00:00',                    get_native_value(data, 'Walltime Used')
+      assert_equal '4',                           get_native_value(data, 'Node Count')
+      assert_equal 'node001',                     get_native_value(data, 'Node List')
+      assert_equal '32',                          get_native_value(data, 'Total CPUs')
+      assert_equal '01:30:00',                    get_native_value(data, 'CPU Time')
+      assert_equal '4gb',                         get_native_value(data, 'Memory')
+      assert_equal '6gb',                         get_native_value(data, 'Virtual Memory')
+      assert_equal '2:ncpus=16:mem=64gb:ngpus=2', get_native_value(data, 'Select')
+      assert_equal 'PBSPro test job',             get_native_value(data, 'Comment')
+      assert_equal 'groupA,groupB',               get_native_value(data, 'Group List')
+    
+      assert_equal '--pbspro-args',               data.submit_args
+      assert_equal '/home/user',                  Pathname.new(data.output_path).dirname.to_s
+    end
+    
+    test 'use sge extensions' do
+      # Set up native SGE data
+      sge_data = {
+        JB_version:               '8.6.12',
+        JB_exec_file:             '/opt/sge/bin/lx-amd64/sge_shepherd',
+        JB_script_file:           '/home/user/job.sh',
+        JB_script_size:           2048,
+        JB_execution_time:        '00:45:00',
+        JB_deadline:              '2025-08-28 16:00:00',
+        JB_uid:                   1001,
+        JB_group:                 'users',
+        JB_gid:                   1001,
+        JB_account:               'projectA',
+        JB_cwd:                   '/home/user/work',
+        JB_notify:                'n',
+        JB_type:                  'binary',
+        JB_reserve:               'y',
+        JB_priority:              '0.5',
+        JB_jobshare:              0,
+        JB_verify:                'false',
+        JB_checkpoint_attr:       'cwhen',
+        JB_checkpoint_interval:   '00:10:00',
+        JB_restart:               'y',
+        ST_name:                  '--sge-args',
+        PN_path:                  '/home/user/sge_job/output.log'
+      }
+    
+      # Execute test
+      data = extensions_test_setup('sge', sge_data)
+    
+      # Check basic/shared attributes
+      assert_shared_attributes(data)
+    
+      # Check SGE-native mapped attributes
+      assert_equal '8.6.12',                             get_native_value(data, 'Job Version')
+      assert_equal '/opt/sge/bin/lx-amd64/sge_shepherd', get_native_value(data, 'Job Exec File')
+      assert_equal '/home/user/job.sh',                  get_native_value(data, 'Job Script File')
+      assert_equal 2048,                                 get_native_value(data, 'Job Script Size')
+      assert_equal '00:45:00',                           get_native_value(data, 'Job Execution Time')
+      assert_equal '2025-08-28 16:00:00',                get_native_value(data, 'Job Deadline')
+      assert_equal 1001,                                 get_native_value(data, 'Job UID')
+      assert_equal 'users',                              get_native_value(data, 'Job Group')
+      assert_equal 1001,                                 get_native_value(data, 'Job GID')
+      assert_equal 'projectA',                           get_native_value(data, 'Job Account')
+      assert_equal '/home/user/work',                    get_native_value(data, 'Current Working Directory')
+      assert_equal 'n',                                  get_native_value(data, 'Notifications')
+      assert_equal 'binary',                             get_native_value(data, 'Job Type')
+      assert_equal 'y',                                  get_native_value(data, 'Reserve')
+      assert_equal '0.5',                                get_native_value(data, 'Job Priority')
+      assert_equal 0,                                    get_native_value(data, 'Job Share')
+      assert_equal 'false',                              get_native_value(data, 'Job Verify')
+      assert_equal 'cwhen',                              get_native_value(data, 'Job Checkpoint Attr')
+      assert_equal '00:10:00',                           get_native_value(data, 'Job Checkpoint Interval')
+      assert_equal 'y',                                  get_native_value(data, 'Job Restart')
+    end
+
+    test 'use fujitsu tcs extensions' do
+      # Set up native Fujitsu TCS data
+      fujitsu_data = {
+        NODES:      '2',                                      # echoed as-is
+        ACCEPT:     '2025-08-28 12:00:00',                    # Submission Time
+        START_DATE: '2025-08-28 12:05:00',                    # Start Time
+        STD:        '/home/user/fj_job/std.out'               # used to build URLs
+      }
+    
+      # Execute test
+      data = extensions_test_setup('fujitsu_tcs', fujitsu_data)
+    
+      # Check basic/shared attributes
+      assert_shared_attributes(data)
+    
+      # Check extended/native attributes specific to Fujitsu TCS
+      assert_equal '2',                         get_native_value(data, 'Nodes')
+      assert_equal '02:00:00',                  get_native_value(data, 'Time Limit')
+      assert_equal '2025-08-28 12:00:00',       get_native_value(data, 'Submission Time')
+      assert_equal '2025-08-28 12:05:00',       get_native_value(data, 'Start Time')
+    
+      # It does build file_explorer_url and shell_url from dirname(STD); ensure they were set
+      assert_not_nil data.file_explorer_url
+      assert_not_nil data.shell_url
+    end
+    
   end
 end


### PR DESCRIPTION
Contributes to #375. Adds unit tests for Jobstatusdata and JobsJsonRequestHandler, excludes Filter since the majority of filter functionality has been moved to job adapters.