### PR TITLE
test back-button functionality in files

### DIFF
--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -401,6 +401,24 @@ class FilesTest < ApplicationSystemTestCase
     find('tbody a', exact_text: 'config')
   end
 
+  test 'window.onpopstate does not overwrite browser state' do
+    visit files_url(Rails.root.to_s)
+    find('tbody a', exact_text: 'app').click
+    find('tbody a', exact_text: 'apps').click
+    find('tbody a', exact_text: 'ood_app.rb')
+
+    page.driver.go_back
+    find('tbody a', exact_text: 'assets')
+
+    page.driver.go_back
+    find('tbody a', exact_text: 'app')
+    find('tbody a', exact_text: 'config')
+
+    page.driver.go_forward
+    find('tbody a', exact_text: 'apps')
+    find('tbody a', exact_text: 'assets')
+  end
+
   test 'edit file' do
     OodAppkit.stubs(:files).returns(OodAppkit::Urls::Files.new(title: 'Files', base_url: '/files'))
     OodAppkit.stubs(:editor).returns(OodAppkit::Urls::Editor.new(title: 'Editor', base_url: '/files'))


### PR DESCRIPTION
Fixes #3226

There was an issue with the _forward_ button when navigating in our main and test environments, however it doesn't seem to be present in dev and I cannot seem to recreate the issues in tests. With that in mind, I wrote a test making sure that navigating back and forth works properly in the files app.