### PR TITLE
apply bug fixes to ActiveJobs

### DIFF
--- a/apps/dashboard/app/javascript/active_jobs.js
+++ b/apps/dashboard/app/javascript/active_jobs.js
@@ -39,6 +39,13 @@ function human_time(seconds_total) {
   return hours_str + ":" + minutes_str + ":" + seconds_str;
 }
 
+function clean_options(options) {
+  if (!options) options = {};
+  if (!options.doneCallback) options.doneCallback = null;
+  if (!options.base_uri) options.base_uri = window.location.pathname.replace('/activejobs','');
+  return options;
+}
+
 function fetch_job_data(tr, row, options) {
   let btn = tr.find('button.details-control');
   if (row.child.isShown()) {
@@ -89,9 +96,7 @@ function fetch_job_data(tr, row, options) {
 }
 
 function fetch_table_data(table, options){
-  if (!options) options = {};
-  if (!options.doneCallback) options.doneCallback = null;
-  if (!options.base_uri) options.base_uri = window.location.pathname;
+  options = clean_options(options);
 
   oboe({
     url: options.base_uri + '/activejobs.json?'+get_request_params(),
@@ -147,9 +152,7 @@ function status_label(status){
 }
 
 function create_datatable(options){
-    if (!options) options = {};
-    if (!options.drawCallback) options.drawCallback = null;
-    if (!options.base_uri) options.base_uri = window.location.pathname;
+    options = clean_options(options)
 
     $("#selected-filter-label").text($("#filter-id-"+filter_id).text());
     $("#selected-cluster-label").text($("#cluster-id-"+cluster_id).text());

--- a/apps/dashboard/app/views/active_jobs/index.html.erb
+++ b/apps/dashboard/app/views/active_jobs/index.html.erb
@@ -59,12 +59,12 @@
 
 <div hidden=true
   id="active_jobs_config"
-  data-filter-id=<%= @jobfilter ? "#{@jobfilter}" : "null" %>
-  data-default-filter-id=<%= default_filter_id %> 
+  data-filter-id='<%= @jobfilter ? "#{@jobfilter}" : "null" %>'
+  data-default-filter-id='<%= default_filter_id %>'
   data-cluster-id=<%= @jobcluster ? "#{@jobcluster}" : "null" %> 
-  data-console-log-performance-report=<%= Configuration.console_log_performance_report? %>
-  data-base-uri=<%= controller.relative_url_root %>
-  data-ood-version=<%= Configuration.ood_version %>
+  data-console-log-performance-report='<%= Configuration.console_log_performance_report? %>'
+  data-base-uri='<%= controller.relative_url_root %>'
+  data-ood-version='<%= Configuration.ood_version %>'
 >
 </div>
 

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -104,7 +104,7 @@ Rails.application.routes.draw do
 
   # ActiveJobs which can be disabled in production
   if Configuration.can_access_activejobs?
-    get '/activejobs' => 'active_jobs#index'
+    get '/activejobs' => 'active_jobs#index', :as => 'active_jobs'
     get '/activejobs/json' => 'active_jobs#json', :defaults => { :format => 'json' }
     delete '/activejobs' => 'active_jobs#delete_job', :as => 'delete_job'
   end


### PR DESCRIPTION
Contributes to #375, system tests revealed several latent bugs that had easy fixes, the rest of the system tests will depend on this PR being merged. 
1. Simplify javascript and fix paths
  - the same processing of `options` was in two different places, so they were collected into a single method
  - the default to `window.location.pathname` had errors because it would contain "/activejobs" at the end causing us to request `ROOTURL/activejobs/activejobs.json` which gave a routingerror. `String#replace` takes care of this if it is there but leaves it alone if not.
2. Options passed in view
  - The options were passed in the view using ERB without quotes, leading to the bug that when `controller.relative_url_root` was nil the url passed was "data-ood-version=Unknown" which led to routingerrors. Placing single quotes around these options allows nil values to be passed as empty strings without picking up the next variable.
3. Route alias
 - Not a bug fix per se, but having an alias for the activejobs route makes it much cleaner to `visit` in the system test