### PR TITLE
adds oidc_redirect_uri variable

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -7,7 +7,7 @@ module OodPortalGenerator
   class View
     attr_reader :ssl, :protocol, :proxy_server, :port, :dex_uri
     attr_accessor :user_map_match, :user_map_cmd, :logout_redirect, :dex_http_port, :dex_enabled
-    attr_accessor :oidc_uri, :oidc_client_secret, :oidc_remote_user_claim, :oidc_client_id, :oidc_provider_metadata_url
+    attr_accessor :oidc_uri, :oidc_client_secret, :oidc_remote_user_claim, :oidc_client_id, :oidc_provider_metadata_url, :oidc_redirect_uri
 
     # let the application set the auth if it needs to
     attr_writer :auth
@@ -105,6 +105,7 @@ module OodPortalGenerator
       @oidc_provider_metadata_url       = opts.fetch(:oidc_provider_metadata_url, nil)
       @oidc_client_id                   = opts.fetch(:oidc_client_id, nil)
       @oidc_client_secret               = opts.fetch(:oidc_client_secret, nil)
+      @oidc_redirect_uri                = opts.fetch(:oidc_redirect_uri, "#{protocol}#{servername}#{@oidc_uri}")
       @oidc_remote_user_claim           = opts.fetch(:oidc_remote_user_claim, 'preferred_username')
       @oidc_scope                       = opts.fetch(:oidc_scope, "openid profile email")
       @oidc_crypto_passphrase           = opts.fetch(:oidc_crypto_passphrase, Digest::SHA1.hexdigest(servername))

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -134,7 +134,7 @@ Listen <%= addr_port %>
   <%- if @oidc_client_secret -%>
   OIDCClientSecret <%= @oidc_client_secret %>
   <%- end -%>
-  OIDCRedirectURI <%= @oidc_uri %>
+  OIDCRedirectURI <%= @oidc_redirect_uri %>
   OIDCRemoteUserClaim <%= @oidc_remote_user_claim %>
   OIDCScope "<%= @oidc_scope %>"
   OIDCCryptoPassphrase <%= @oidc_crypto_passphrase %>


### PR DESCRIPTION
Introduce a variable to configure `oidc_redirect_uri `. If nothing is set, `#{protocol}#{servername}#{@oidc_uri}` will be used as `oidc_redirect_uri`, as it is currently.