### PR TITLE
Fix grafana urls

### DIFF
--- a/apps/dashboard/app/helpers/active_jobs_helper.rb
+++ b/apps/dashboard/app/helpers/active_jobs_helper.rb
@@ -40,7 +40,7 @@ module ActiveJobsHelper
         jobid = jobid.split('.')[0]
         query_params["var-#{server[:labels]['jobid']}"] = jobid unless server[:labels]['jobid'].nil?
       end
-      uri = Addressable::Template.new("#{server[:host]}{/segments*}/{?query*}")
+      uri = Addressable::Template.new("#{server[:host]}{/segments*}{?query*}")
       grafana_uri = uri.expand({
         'segments' => [url_base, server[:dashboard]['uid'], server[:dashboard]['name']],
         'query'    => query_params,


### PR DESCRIPTION
Fixes #4366. The original discourse mentioned that this was required for Grafana 11.6.0, so maybe we should explicitly lay out supported grafana versions? Trusting the original poster of that discourse that this fixes the problem, as I am not sure how we would test against different grafana versions, and not even sure what version we use at OSC. 

Aside from all that, the change is small, better fits url patterns, and works for the grafana panels at OSC.