### PR TITLE
allow lowercasing usernames via user_map_match

### DIFF
--- a/mod_ood_proxy/lib/ood/user_map.lua
+++ b/mod_ood_proxy/lib/ood/user_map.lua
@@ -41,7 +41,14 @@ function map(r, user_map_match, user_map_cmd, remote_user)
   local sys_user = ""
   -- match string
   if user_map_match ~= nil then
-    sys_user = string.match(remote_user, user_map_match)
+    -- if match string ends in :lower, lowercase the username
+    local pat = string.match(user_map_match, "^(.*):lower$")
+    if pat then
+        sys_user = string.match(remote_user, pat)
+        sys_user = string.lower(sys_user)
+    else
+        sys_user = string.match(remote_user, user_map_match)
+    end
   -- run user_map_cmd and read in stdout
   elseif user_map_cmd ~= nil then
     local handle = io.popen(user_map_cmd .. " '" .. r:escape(remote_user) .. "'")


### PR DESCRIPTION
See #3802 

This keeps the old behavior, but makes it relatively easy to "fix" incoming usernames that may contain uppercase characters. Using `:lower` as flag-suffix to the pattern is ok because `:` cannot occur in posix usernames.

Just the lowercase function should catch most cases where currently a map command is necessary. 