### PR TITLE
Remove custom $grid-breakpoints definitions

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/_variables.scss
+++ b/apps/dashboard/app/assets/stylesheets/_variables.scss
@@ -52,14 +52,6 @@ $container-max-widths: (
   xl: 1260px,
 );
 
-$grid-breakpoints: (
-  xs: 0,
-  sm: 676px,
-  md: 850px,
-  lg: 1460px,
-  xl: 1500px
-);
-
 // Navigation bar link gutter spacing x-axis.
 $navbar-nav-link-padding-x: 0.75rem;
 

--- a/apps/dashboard/app/views/layouts/nav/_all_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_all_apps.html.erb
@@ -12,6 +12,6 @@
      <%= aria %>
     >
     <i class="fas fa-th" aria-hidden="true"></i>
-    <span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_all_apps') %></span>
+    <span class="d-md-none d-xxl-inline"> <%= t('dashboard.nav_all_apps') %></span>
   </a>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -1,7 +1,7 @@
 <% if Configuration.app_development_enabled? %>
   <li class="nav-item dropdown" role="none">
     <a role='menuitem' title="<%= t('dashboard.nav_develop_title') %>" href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <i class="fas fa-code" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_develop_title') %></span><span class="caret"></span>
+      <i class="fas fa-code" aria-hidden="true"></i><span class="d-md-none d-xxl-inline"> <%= t('dashboard.nav_develop_title') %></span><span class="caret"></span>
     </a>
 
     <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, 'dropdown-menu-end') %>" role="menu">

--- a/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_help_dropdown.html.erb
@@ -2,7 +2,7 @@
   <a href="#" title="<%= t('dashboard.nav_help_title') %>" class="nav-link dropdown-toggle"
     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
     role="menuitem">
-    <i class="fas fa-question-circle" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_help_title') %></span><span class="caret"></span>
+    <i class="fas fa-question-circle" aria-hidden="true"></i><span class="d-md-none d-xxl-inline"> <%= t('dashboard.nav_help_title') %></span><span class="caret"></span>
   </a>
 
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_alignment, 'dropdown-menu-end') %>" role="menu">

--- a/apps/dashboard/app/views/layouts/nav/_log_out.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_log_out.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item" role="none">
   <a class="nav-link" href="/logout" title="<%= t('dashboard.nav_logout') %>" role="menuitem">
     <i class="fas fa-sign-out-alt" aria-hidden="true"></i>
-    <span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_logout') %></span>
+    <span class="d-md-none d-xxl-inline"> <%= t('dashboard.nav_logout') %></span>
   </a>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_sessions.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_sessions.html.erb
@@ -12,6 +12,6 @@
      <%= aria %>
     >
     <i class="fas fa-window-restore" aria-hidden="true"></i>
-    <span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_sessions') %></span>
+    <span class="d-md-none d-xxl-inline"> <%= t('dashboard.nav_sessions') %></span>
   </a>
 </li>

--- a/apps/dashboard/app/views/layouts/nav/_user.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_user.html.erb
@@ -2,6 +2,6 @@
   data-content="<%= t('dashboard.nav_user', username: @user.name) %>" data-placement="bottom"
   role="none">
   <a class="nav-link disabled" role="menuitem" title="<%= t('dashboard.nav_user', username: @user.name) %>" href="#">
-    <i class="fas fa-user" aria-hidden="true" aria-hidden="true"></i><span class="d-sm-none d-md-none d-lg-inline"> <%= t('dashboard.nav_user', username: @user.name) %></span>
+    <i class="fas fa-user" aria-hidden="true" aria-hidden="true"></i><span class="d-md-none d-xxl-inline"> <%= t('dashboard.nav_user', username: @user.name) %></span>
   </a>
 </li>


### PR DESCRIPTION
Fixes #3390 
Removes custom $grid-breakpoints definitions to allow them to use default values instead.