### PR TITLE
Data-hide hides files attachments

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_file_attachments.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_file_attachments.html.erb
@@ -1,7 +1,10 @@
 <% has_error = !form.object.errors[attrib.id].empty? %>
-<div class="form-group">
-  <label class="form-label" for="<%= "#{form.object.class.name.underscore}_#{attrib.id}" %>"><%= attrib.label %></label>
-  <p class="<%= has_error ? 'is-invalid' : '' %>" data-bs-toggle="attachments-error" id="<%= "#{form.object.class.name.underscore}_#{attrib.id}" %>">Click the box to attach a file. Screenshots or other files can help troubleshoot your problem.</p>
+<% widget_id = [form.object.class.name.underscore.gsub('/','_'), attrib.id].join('_') %>
+<div class="mb-3">
+  <label class="form-label" for="<%= widget_id %>"><%= attrib.label %></label>
+  <p id="<%= widget_id %>" class="<%= has_error ? 'is-invalid' : '' %>" data-bs-toggle="attachments-error">
+    Click the box to attach a file. Screenshots or other files can help troubleshoot your problem.
+  </p>
   <% if has_error %>
     <div class="invalid-feedback">
       <p><%= form.object.errors[attrib.id].join(", ") %></p>

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -758,6 +758,48 @@ class BatchConnectTest < ApplicationSystemTestCase
     data_hide_checkbox_test(form, 'checkbox_test', 'gpus_1', true)
   end
 
+  test 'hiding file attachments using check boxes based on when checked' do
+    form = <<~HEREDOC
+      ---
+      cluster:
+        - owens
+      form:
+        - seeds
+        - checkbox_test
+      attributes:
+        seeds:
+          widget: 'file_attachments'
+          label: 'Seed Files'
+        checkbox_test:
+          widget: 'check_box'
+          html_options:
+            data:
+              hide-seeds-when-checked: true
+    HEREDOC
+    data_hide_checkbox_test(form, 'checkbox_test', 'seeds', false)
+  end
+
+  test 'hiding file attachments using check boxes based on when unchecked' do
+    form = <<~HEREDOC
+    ---
+    cluster:
+      - owens
+    form:
+      - seeds
+      - checkbox_test
+    attributes:
+      seeds:
+        widget: 'file_attachments'
+        label: 'Seed Files'
+      checkbox_test:
+        widget: 'check_box'
+        html_options:
+          data:
+            hide-seeds-when-not-checked: true
+  HEREDOC
+  data_hide_checkbox_test(form, 'checkbox_test', 'seeds', true)
+  end
+
   test 'hiding path selector using check boxes based on when checked' do
     form = <<~HEREDOC
       ---


### PR DESCRIPTION
Fixes #3463. Enabled data-hide action by replacing the `.form-group` wrapper with `.mb-3` to match bootstrap 5 behavior (see #3461), and adjusted the id composition to replace '/' with '_'. Previous behavior produced ids like `batch_connect/sessions_context_{widget name}` but now produces `batch_connect_sessions_contexts_{widget name}`. There are several other things here that raise questions but are not relevant to data-hide such as 
1. Why is the id mentioned being given to the `<p>` element instead of the actual file attachment div? This seems to contradict some of the assumptions/precedents in other dynamic form widgets
2. There seems to be text specific to support ticket uses
https://github.com/OSC/ondemand/blob/5cde830b5384b33879c08d360ee94b1fd85a958f/apps/dashboard/app/views/batch_connect/session_contexts/_file_attachments.html.erb#L6
that is being included with it every time it is used. Shouldn't something in `support_tickets.js` handle this text?

These could each be issues of their own, but it seems good to discuss them here first while we have our eyes on it.