### PR TITLE
dashboard: noVNC: Handle newline representation mismatch

### DIFF
--- a/apps/dashboard/public/noVNC-1.3.0/app/ui.js
+++ b/apps/dashboard/public/noVNC-1.3.0/app/ui.js
@@ -955,7 +955,8 @@ const UI = {
             .then(() => navigator.clipboard.readText())
             .then((clipboardText) => {
                 const text = document.getElementById('noVNC_clipboard_text').value;
-                if (clipboardText !== text) {
+                const nlClipboardText = clipboardText.replace(/\r\n/g, "\n");
+                if (clipboardText !== text && nlClipboardText !== text) {
                     document.getElementById('noVNC_clipboard_text').value = clipboardText;
                     UI.clipboardSend();
                 }

--- a/apps/dashboard/public/noVNC-1.3.0/app/ui.js
+++ b/apps/dashboard/public/noVNC-1.3.0/app/ui.js
@@ -954,9 +954,9 @@ const UI = {
             navigator.permissions.query({name: 'clipboard-read'})
             .then(() => navigator.clipboard.readText())
             .then((clipboardText) => {
+                clipboardText = clipboardText.replace(/\r\n/g, "\n");
                 const text = document.getElementById('noVNC_clipboard_text').value;
-                const nlClipboardText = clipboardText.replace(/\r\n/g, "\n");
-                if (clipboardText !== text && nlClipboardText !== text) {
+                if (clipboardText !== text) {
                     document.getElementById('noVNC_clipboard_text').value = clipboardText;
                     UI.clipboardSend();
                 }


### PR DESCRIPTION
Do not sync back the clipboard text if it only differs in newline representation (nl vs. crnl).

Fixes: #3839