### PR TITLE
Updated UI for workflows

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -178,6 +178,7 @@ small.form-text {
 @import "support_ticket";
 @import "data_tables";
 @import "projects";
+@import "workflows";
 @import "scripts";
 @import "common";
 @import "module_browser";

--- a/apps/dashboard/app/assets/stylesheets/workflows.scss
+++ b/apps/dashboard/app/assets/stylesheets/workflows.scss
@@ -1,0 +1,206 @@
+$cols: 16;
+$rows: 16;
+// Now we can increse grid size in 1:1 ratio to keep workspace wrapper size same
+$cell_w: 204; // (204+20) * 4 = 900px width for workspace wrapper
+$cell_h: 130; // (130+20) * 4 = 600px height for workspace wrapper
+$gap: 20;
+
+:root {
+  --bg: #f7f7fb;
+  --ink: #222;
+  --ink-muted: #666;
+  --accent: #2266ff;
+  --accent-weak: #cfe0ff;
+  --danger: #b71c1c;
+  --danger-weak: #c628285c;
+  --box-selected: #ffecb3;
+  // To pass on the variable to javascript
+  --grid_cols: #{$cols};
+  --grid_rows: #{$rows};
+  --cell_w: #{$cell_w};
+  --cell_h: #{$cell_h};
+  --gap: #{$gap};
+}
+
+html, body {
+  height: 100%;
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--ink);
+}
+
+.app {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  background: var(--bg);
+}
+
+.toolbar {
+  display: flex;
+  gap: .5rem;
+  align-items: center;
+  padding: .5rem .75rem;
+  border-bottom: 1px solid #e6e8ee;
+  background: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.toolbar button {
+  border: 1.5px solid #d5d8e0;
+  background: #fff;
+  border-radius: 10px;
+  padding: .35rem .7rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.15s ease-in-out;
+}
+
+.toolbar button.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-weak);
+  transform: scale(0.98);
+}
+
+.toolbar .danger:active {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 4px var(--danger-weak);
+  transform: scale(0.98);
+}
+
+.hint {
+  margin-left: auto;
+  color: var(--ink-muted);
+  font-size: .9rem;
+}
+
+.workspace-wrapper {
+  position: relative;
+  width: 100%;
+  height: 600px;
+  overflow: hidden;
+  border: 1px solid #ddd;
+}
+
+.zoom-controls {
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 20;
+  user-select: none;
+}
+
+.zoom-controls button {
+  width: 45px;
+  height: 30px;
+  border-radius: 8px;
+  border: 1px solid #d5d8e0;
+  background: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zoom-controls button:active { 
+  transform: translateY(1px); 
+}
+
+.zoom-controls button[aria-pressed="true"] { 
+  box-shadow: 0 0 0 3px var(--accent-weak); 
+  border-color: var(--accent); 
+}
+
+.workspace {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: auto;
+  background: var(--bg);
+}
+
+.stage-zoom {
+  width: 100%;
+  height: 100%;
+  transform-origin: top left;
+  will-change: transform;
+}
+
+.stage {
+  display: grid;
+  grid-template-columns: repeat(#{$cols}, #{$cell_w});
+  grid-template-rows: repeat(#{$rows}, #{$cell_h});
+  gap: #{$gap};
+  background: repeating-conic-gradient(#fafbff 0% 25%, #f5f7ff 0% 50%) 50%/20px 20px;
+  padding: 20px;
+  // count * width + (count-1) * gap
+  min-width: calc(#{$cols} * #{$cell_w}px + (#{$cols} - 1) * #{$gap}px);
+  min-height: calc(#{$rows} * #{$cell_h}px + (#{$rows} - 1) * #{$gap}px);
+  position: relative;
+}
+
+svg.edges {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.edge {
+  stroke: var(--accent);
+  stroke-width: 2;
+  marker-end: url(#arrow);
+  pointer-events: none;
+}
+
+.edge.click-area {
+  stroke: transparent;
+  stroke-width: 20px;
+  pointer-events: stroke;
+  cursor: pointer;
+  marker-end: none; 
+}
+
+.edge.selected {
+  stroke: var(--danger);
+  stroke-width: 3;
+  filter: drop-shadow(0 0 4px var(--danger-weak));
+}
+
+.launcher-box {
+  position: absolute;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  user-select: none;
+  padding: 0.5rem;
+  transform-origin: top left;
+  transition: transform 0.15s;
+  will-change: transform;
+}
+
+.launcher-title-grab {
+  font-size: 1em;
+  font-weight: bold;
+  cursor: grab;
+  user-select: none;  
+}
+
+.launcher-box.selected {
+  outline: 3px solid var(--accent-weak);
+  background: var(--box-selected);
+}
+
+.launcher-box.connect-queued {
+  outline: 3px dashed var(--accent);
+}

--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -75,6 +75,14 @@ class LaunchersController < ApplicationController
     end
   end
 
+  # GET /projects/:project_id/launchers/:id/render_button
+  def render_button
+    launcher = Launcher.find(show_launcher_params[:id], @project.directory)
+    @valid_project = Launcher.clusters?
+    @remove_delete_button = true
+    render(partial: 'projects/launcher_buttons', locals: { launcher: launcher })
+  end
+
   private
 
   def find_launcher

--- a/apps/dashboard/app/javascript/dag.js
+++ b/apps/dashboard/app/javascript/dag.js
@@ -1,0 +1,78 @@
+// This class will help us to detect if any new edge can lead to cycle or not
+// Thus we can alert user to avoid that edge thus resolving cycle issue on UI
+
+// Directed Acyclic Graph
+export class DAG {
+  #launcher_list;
+  #adjacency_list;
+  #visited;
+  #stack;
+  #has_cycle;
+
+  constructor() {
+    this.#launcher_list = new Set();
+    this.#adjacency_list = {};
+  }
+
+  addEdge(fromId, toId) {
+    if (!this.#launcher_list.has(fromId)) {
+      this.#launcher_list.add(fromId);
+    }
+
+    if (!this.#launcher_list.has(toId)) {
+      this.#launcher_list.add(toId);
+    }
+
+    if (!this.#adjacency_list[fromId]) {
+      this.#adjacency_list[fromId] = [];
+    }
+    this.#adjacency_list[fromId].push(toId);
+
+    this.#has_cycle = false;
+    this.#visited = new Set();
+    this.#stack = new Set();
+    this.#launcher_list.forEach(l => this.#detectCycle(l));
+
+    // Remove the added edge from the adjacency list if cycle detected
+    if (this.#has_cycle === true) {
+      this.#adjacency_list[fromId].pop();
+    }
+  }
+
+  removeEdge(fromId, toId) {
+    if (!this.#adjacency_list[fromId]) return;
+
+    if (this.#adjacency_list[fromId].includes(toId)) {
+      this.#adjacency_list[fromId] = this.#adjacency_list[fromId].filter(x => x !== toId);
+    }
+  }
+
+  removeLauncher(id) {
+    this.#launcher_list.delete(id);
+    delete this.#adjacency_list[id];
+
+    for (const from in this.#adjacency_list) {
+      this.#adjacency_list[from] = this.#adjacency_list[from].filter(x => x !== id);
+    }
+  }
+
+  hasCycle() {
+    return this.#has_cycle;
+  }
+
+  // Basic dfs on graph to find a cycle
+  #detectCycle(id) {
+    if (this.#stack.has(id)) {
+      this.#has_cycle = true;
+      return;
+    }
+    if (this.#visited.has(id)) return;
+
+    this.#stack.add(id);
+    this.#visited.add(id);
+    for (const l of this.#adjacency_list[id] || []) {
+      this.#detectCycle(l);
+    }
+    this.#stack.delete(id);
+  }
+}

--- a/apps/dashboard/app/javascript/workflows.js
+++ b/apps/dashboard/app/javascript/workflows.js
@@ -1,0 +1,528 @@
+import { DAG } from './dag.js';
+
+/*
+ * Helper Classes to support Drag and Drop UI 
+ */
+
+// Box represents a draggable launcher box
+class Box {
+  constructor(id, el, row, col, w, h) {
+    this.id = id;
+    this.el = el;
+    this.row = row;
+    this.col = col;
+    this.x = 0;
+    this.y = 0;
+    this.w = w;
+    this.h = h;
+  }
+
+  moveTo(x, y) {
+    this.x = x;
+    this.y = y;
+    this.el.style.transform = `translate(${x}px, ${y}px)`;
+  }
+}
+
+// Edge represents a connection between two launcher boxes
+class Edge {
+  constructor(fromBox, toBox, el, clickEl) {
+    this.fromBox = fromBox;
+    this.toBox = toBox;
+    this.el = el;
+    this.clickEl = clickEl
+  }
+
+  intersectRect(cx, cy, w, h, dx, dy) {
+    const absDx = Math.abs(dx);
+    const absDy = Math.abs(dy);
+    let scale = 0.5 / Math.max(absDx / w, absDy / h);
+    scale = Math.min(scale, 1);
+    return { x: cx + dx * scale, y: cy + dy * scale };
+  }
+
+  update() {
+    const { fromBox, toBox } = this;
+    const cx1 = fromBox.x + fromBox.w / 2, cy1 = fromBox.y + fromBox.h / 2;
+    const cx2 = toBox.x + toBox.w / 2, cy2 = toBox.y + toBox.h / 2;
+    const dx = cx2 - cx1, dy = cy2 - cy1;
+    const start = this.intersectRect(cx1, cy1, fromBox.w, fromBox.h, dx, dy);
+    const end = this.intersectRect(cx2, cy2, toBox.w, toBox.h, -dx, -dy);
+
+    this.el.setAttribute('x1', start.x);
+    this.el.setAttribute('y1', start.y);
+    this.el.setAttribute('x2', end.x);
+    this.el.setAttribute('y2', end.y);
+    this.clickEl.setAttribute('x1', start.x);
+    this.clickEl.setAttribute('y1', start.y);
+    this.clickEl.setAttribute('x2', end.x);
+    this.clickEl.setAttribute('y2', end.y);
+  }
+}
+
+// Pointer tracks mouse on screen and translates to stage coordinates
+class Pointer {
+  constructor(stage, zoomRef, step, max, min, applyZoomCb) {
+    this.stage = stage;
+    this.zoomRef = zoomRef;
+    this.step = step;
+    this.max = max;
+    this.min = min;
+    this.applyZoomCb = applyZoomCb;
+    this.x = 0;
+    this.y = 0;
+  }
+
+  update(e) {
+    const r = this.stage.getBoundingClientRect();
+    const clientX = e.clientX ?? e.touches?.[0].clientX;
+    const clientY = e.clientY ?? e.touches?.[0].clientY;
+    this.x = (clientX - r.left) / this.zoomRef.value;
+    this.y = (clientY - r.top) / this.zoomRef.value;
+  }
+
+  pos() {
+    return { x: this.x, y: this.y };
+  }
+
+  zoomIn() {
+    this.zoomRef.value = Math.min(this.zoomRef.value + this.step, this.max);
+    this.applyZoomCb();
+  }
+
+  zoomOut() {
+    this.zoomRef.value = Math.max(this.zoomRef.value - this.step, this.min);
+    this.applyZoomCb();
+  }
+
+  resetZoom() {
+    this.zoomRef.value = 1;
+    this.applyZoomCb();
+  }
+
+  handleWheel(e) {
+    if (e.ctrlKey) {
+      e.preventDefault();
+      if (e.deltaY < 0) {
+        this.zoomIn();
+      } else {
+        this.zoomOut();
+      }
+    }
+  }
+}
+
+// DragController manages dragging of launcher boxes
+class DragController {
+  constructor(pointer, boxes, edges, gridCols, gridRows, cell_w, cell_h, halfGap) {
+    this.pointer = pointer;
+    this.boxes = boxes;
+    this.edges = edges;
+    this.gridCols = gridCols;
+    this.gridRows = gridRows;
+    this.cell_w = cell_w;
+    this.cell_h = cell_h;
+    this.halfGap = halfGap;
+    this.dragging = null;
+    this.start = null;
+
+    document.addEventListener('pointermove', e => this.onMove(e));
+    document.addEventListener('pointerup', e => this.onUp(e));
+  }
+
+  update(gridCols, gridRows) {
+    this.gridCols = gridCols;
+    this.gridRows = gridRows;
+  }
+
+  beginDrag(box) {
+    this.start = {
+      px: this.pointer.x,
+      py: this.pointer.y,
+      x: box.x,
+      y: box.y
+    };
+    this.dragging = box;
+  }
+
+  onMove(e) {
+    if (!this.dragging) return;
+    this.pointer.update(e);
+    const dx = this.pointer.x - this.start.px;
+    const dy = this.pointer.y - this.start.py;
+    this.updateBoxPosition(this.dragging, this.start.x + dx, this.start.y + dy);
+  }
+
+  onUp(e) {
+    if (!this.dragging) return;
+    const box = this.dragging;
+    const snapped = this.snapToGrid(box.x, box.y);
+
+    if (this.isCellOccupied(snapped.row, snapped.col, box.id)) {
+      const revertPos = this.cellToXY(box.row, box.col);
+      this.updateBoxPosition(box, revertPos.x, revertPos.y);
+    } else {
+      box.row = snapped.row;
+      box.col = snapped.col;
+      const finalPos = this.cellToXY(snapped.row, snapped.col);
+      this.updateBoxPosition(box, finalPos.x, finalPos.y);
+      box.el.setAttribute('data-row', snapped.row);
+      box.el.setAttribute('data-col', snapped.col);
+    }
+
+    this.dragging = null;
+    this.start = null;
+  }
+
+  snapToGrid(x, y) {
+    const col = Math.max(1, Math.min(this.gridCols, Math.round((x - this.halfGap) / this.cell_w) + 1));
+    const row = Math.max(1, Math.min(this.gridRows, Math.round((y - this.halfGap) / this.cell_h) + 1));
+    return { row, col };
+  }
+
+  cellToXY(row, col) {
+    return {
+      x: (col - 1) * this.cell_w + this.halfGap,
+      y: (row - 1) * this.cell_h + this.halfGap
+    };
+  }
+
+  isCellOccupied(row, col, excludeId = null) {
+    for (const [id, box] of this.boxes.entries()) {
+      if (id !== excludeId && box.row === row && box.col === col) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  updateBoxPosition(box, x, y) {
+    box.moveTo(x, y);
+    this.edges.forEach(edge => {
+      if (edge.fromBox === box || edge.toBox === box) {
+        edge.update();
+      }
+    });
+  }
+}
+
+/*
+ * Immediately Invoked Function Expression (IIFE) to encapsulate the workflow logic
+*/
+(() => {
+  // Document elements
+  const workspace = document.getElementById('workspace');
+  const stage = document.getElementById('stage');
+  const edgesSvg = document.getElementById('edges');
+  const addLauncherButton = document.getElementById('btn-add');
+  const connectLauncherButton = document.getElementById('btn-connect');
+  const deleteLauncherButton = document.getElementById('btn-delete-launcher');
+  const deleteEdgeButton = document.getElementById('btn-delete-edge');
+  const zoomInButton = document.getElementById('zoom-in');
+  const zoomOutButton = document.getElementById('zoom-out');
+  const zoomResetButton = document.getElementById('zoom-reset');
+  const selectedLauncher = document.getElementById('select_launcher');
+  const baseLauncherUrl = document.getElementById('base-launcher-url').value;
+  const styles = getComputedStyle(document.documentElement);
+  const stageZoom = document.getElementById('stage-zoom');
+
+  // State variables and constants
+  const zoomState = {value: 1};
+  const cell_w = parseInt(styles.getPropertyValue('--cell_w')) + parseInt(styles.getPropertyValue('--gap'));
+  const cell_h = parseInt(styles.getPropertyValue('--cell_h')) + parseInt(styles.getPropertyValue('--gap'));
+  const halfGap = parseInt(styles.getPropertyValue('--gap')) / 2;
+  const zoomMax = 2.0;
+  const zoomMin = 0.1; // 0.125 needed for 32x32 grid to fit
+  const zoomStep = 0.1;
+  const fillRatioExpand = 0.40;
+  const fillRatioShrink = 0.1; // 8x smaller than expand ratio
+  let selectedLauncherId = null;
+  let selectedEdge = null;
+  let connectMode = false;
+  let connectQueue = null;
+  let gridExpanded = false;
+  let gridCols = parseInt(styles.getPropertyValue('--grid_cols'));
+  let gridRows = parseInt(styles.getPropertyValue('--grid_rows'));
+
+  // Class instances
+  const dag = new DAG();
+  const boxes = new Map();
+  const edges = [];
+  const pointer = new Pointer(stage, zoomState, zoomStep, zoomMax, zoomMin, applyZoom);
+  const drag = new DragController(pointer, boxes, edges, gridCols, gridRows, cell_w, cell_h, halfGap);
+
+  function applyZoom() {
+    stageZoom.style.transform = `scale(${zoomState.value})`;
+    edges.forEach(edge => edge.update());
+    zoomResetButton.textContent = `${Math.round(zoomState.value * 100)}%`;
+  }
+
+  function gridSpawn() {
+    for (let r = 1; r <= gridRows; r++) {
+      for (let c = 1; c <= gridCols; c++) {
+        let occupied = false;
+        for (let box of boxes.values()) {
+          if (box.row === r && box.col === c) {
+            occupied = true;
+            break;
+          }
+        }
+        if (!occupied) return { row: r, col: c };
+      }
+    }
+    alert('No empty grid cells available!');
+    return null;
+  }
+
+  // No launcher box should be outside [1...row][1..col] to resize
+  // else will lead to launchers left outisde the workflow-stage
+  function checkIfBoxOutside(newRows, newCols) {
+    for (const box of boxes.values()) {
+      if (box.row > newRows || box.col > newCols) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Maximum we support 1024 launchers (32x32 grid)
+  function changeGridIfNeeded() {
+    const totalCells = gridCols * gridRows;
+    const usedCells = boxes.size;
+    const fillRatio = usedCells / totalCells;
+
+    if (fillRatio >= fillRatioExpand && !gridExpanded) {
+      gridCols *= 2;
+      gridRows *= 2;
+      drag.update(gridCols, gridRows);
+
+      stage.style.gridTemplateColumns = `repeat(${gridCols}, ${cell_w}px)`;
+      stage.style.gridTemplateRows = `repeat(${gridRows}, ${cell_h}px)`;
+      stage.style.minWidth = `${gridCols * cell_w}px`;
+      stage.style.minHeight = `${gridRows * cell_h}px`;
+
+      edges.forEach(edge => edge.update());
+      gridExpanded = true;
+    } else if (fillRatio < fillRatioShrink && gridExpanded) { 
+      if (checkIfBoxOutside(gridRows/2, gridCols/2)) return;
+      gridCols = Math.floor(gridCols / 2);
+      gridRows = Math.floor(gridRows / 2);
+      drag.update(gridCols, gridRows);
+
+      stage.style.gridTemplateColumns = `repeat(${gridCols}, ${cell_w}px)`;
+      stage.style.gridTemplateRows = `repeat(${gridRows}, ${cell_h}px)`;
+      stage.style.minWidth = `${gridCols * cell_w}px`;
+      stage.style.minHeight = `${gridRows * cell_h}px`;
+
+      edges.forEach(edge => edge.update());
+      gridExpanded = false;
+    }
+  }
+
+  function createEdge(fromId, toId) {
+    console.log(  `Creating edge from ${fromId} to ${toId}`);
+    if (fromId === toId) return;
+    if (!boxes.has(fromId) || !boxes.has(toId)) return;
+
+    const existingEdge = edges.find(e => e.fromBox.id === fromId && e.toBox.id === toId);
+    if (existingEdge) return;
+
+    const reverseEdge = edges.find(e => e.fromBox.id === toId && e.toBox.id === fromId);
+    if (reverseEdge) {
+      alert('Bidirectional edges are not allowed.');
+      return;
+    }
+
+    dag.addEdge(fromId, toId);
+    if (dag.hasCycle()) {
+      dag.removeEdge(fromId, toId);
+      alert('Adding this edge will create a cyclic dependency among the launchers.');
+      return;
+    }
+
+    const clickArea = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    clickArea.classList.add('edge', 'click-area');
+    edgesSvg.appendChild(clickArea);
+
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.classList.add('edge');
+    edgesSvg.appendChild(line);
+    
+    const edge = new Edge(boxes.get(fromId), boxes.get(toId), line, clickArea);
+    edges.push(edge);
+    edge.update();
+
+    clickArea.addEventListener('click', (e) => {
+      e.stopPropagation();
+      document.querySelectorAll('.edge.selected').forEach(el => el.classList.remove('selected'));
+      document.querySelectorAll('.launcher-box.selected').forEach(el => el.classList.remove('selected'));
+      selectedLauncherId = null;
+
+      line.classList.add('selected');
+      selectedEdge = edge;
+    });
+  }
+
+  function makeLauncher(row, col, id, title) {
+    const url = `${baseLauncherUrl}/${id}/render_button`;
+    $.get(url, function(html) {
+      const $launcher = $(`
+        <div class='launcher-box' id='launcher_${id}' data-row='${row}' data-col='${col}'>
+          <div class='row'>
+            <div class='col launcher-title-grab'>${title}</div>
+          </div>
+          ${html}
+        </div>
+      `);
+
+      $('#stage').append($launcher);
+      const pos = drag.cellToXY(row, col);
+      $launcher.css({ transform: `translate(${pos.x}px, ${pos.y}px)` });
+      const box = new Box(id, $launcher[0], row, col, $launcher.outerWidth(), $launcher.outerHeight());
+      boxes.set(id, box);
+      drag.updateBoxPosition(box, pos.x, pos.y);
+
+      // Pointer / drag events
+      $launcher.on('pointerdown', function(e) {
+        e.stopPropagation();
+        selectedLauncherId = id;
+        $('.launcher-box.selected').removeClass('selected');
+        $launcher.addClass('selected');
+        pointer.update(e);
+        drag.beginDrag(box);
+      });
+
+      // Connect mode click
+      $launcher.on('click', function(e) {
+        if (!connectMode) return;
+        e.stopPropagation();
+        if (!connectQueue) {
+          connectQueue = id;
+          $launcher.addClass('connect-queued');
+        } else {
+          const fromId = connectQueue;
+          const toId = id;
+          $(`#launcher_${fromId}`).removeClass('connect-queued');
+          connectQueue = null;
+          createEdge(fromId, toId);
+        }
+      });
+    }).fail(function() {
+      alert('Failed to load launcher HTML. Please try again.');
+    });
+  }
+
+  function deleteSelectedLauncher() {
+    if (!selectedLauncherId) return;
+    dag.removeLauncher(selectedLauncherId);
+    for (let i = edges.length - 1; i >= 0; i--) {
+      const e = edges[i];
+      if (e.fromBox.id === selectedLauncherId || e.toBox.id === selectedLauncherId) {
+        e.el.remove();
+        edges.splice(i, 1);
+      }
+    }
+    boxes.get(selectedLauncherId)?.el.remove();
+    boxes.delete(selectedLauncherId);
+    selectedLauncherId = null;
+    changeGridIfNeeded();
+  }
+
+  function deleteSelectedEdge() {
+    if (!selectedEdge) return;
+    selectedEdge.el.remove();
+    dag.removeEdge(selectedEdge.fromBox.id, selectedEdge.toBox.id);
+    edges.splice(edges.indexOf(selectedEdge), 1);
+    selectedEdge = null;
+  }
+
+  // This helps to bounce rapid button clicks ie. accidental double clicks
+  function debounce(fn, delay = 300) {
+    let timeout;
+    return function (...args) {
+      if (timeout) return;
+      fn.apply(this, args);
+      timeout = setTimeout(() => (timeout = null), delay);
+    };
+  }
+
+  async function handleAddLauncherClick() {
+    if(addLauncherButton.disabled) return;
+    addLauncherButton.disabled = true;
+    addLauncherButton.classList.add('active');
+    setTimeout(() => addLauncherButton.classList.remove('active'), 150);
+
+    try {
+      const launcherId = selectedLauncher.value;
+      if (!launcherId) return alert('Please select a launcher');
+      const launcherExists = document.getElementById(`launcher_${launcherId}`);
+      if (launcherExists) return alert('Launcher already exists, please select a different launcher');
+
+      const title = selectedLauncher.options[selectedLauncher.selectedIndex].text;
+      const spawn = gridSpawn();
+      if (spawn) {
+        await makeLauncher(spawn.row, spawn.col, launcherId, title);
+        changeGridIfNeeded(); 
+      }
+    } finally {
+      addLauncherButton.disabled = false;
+    }
+  }
+
+  addLauncherButton.addEventListener('click', debounce(handleAddLauncherClick, 300));
+
+  connectLauncherButton.addEventListener('click', () => {
+    connectMode = !connectMode;
+    connectLauncherButton.classList.toggle('active', connectMode);
+    connectLauncherButton.setAttribute('aria-pressed', String(connectMode));
+    if (!connectMode && connectQueue) {
+      document.querySelector(`#launcher_${connectQueue}`)?.classList.remove('connect-queued');
+      connectQueue = null;
+    }
+  });
+
+  deleteLauncherButton.addEventListener('click', deleteSelectedLauncher);
+  deleteEdgeButton.addEventListener('click', deleteSelectedEdge);
+
+  zoomInButton.addEventListener('click', () => { pointer.zoomIn(); });
+  zoomOutButton.addEventListener('click', () => { pointer.zoomOut(); });
+  zoomResetButton.addEventListener('click', () => { pointer.resetZoom();});
+
+  workspace.addEventListener('pointermove', e => pointer.update(e));
+  workspace.addEventListener('touchmove', e => pointer.update(e));
+  workspace.addEventListener('wheel', e => pointer.handleWheel(e), { passive: false });
+
+  stage.addEventListener('pointerdown', (e) => {
+    if (!e.target.closest('.launcher-box')) {
+      selectedLauncherId = null;
+      document.querySelectorAll('.launcher-box.selected').forEach(el => el.classList.remove('selected'));
+      selectedEdge = null;
+      document.querySelectorAll('.edge.selected').forEach(el => el.classList.remove('selected'));
+    }
+  });
+
+  stage.addEventListener('keydown', (e) => {
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault();
+      if (selectedLauncherId) {
+        deleteSelectedLauncher();
+      } else if (selectedEdge) {
+        deleteSelectedEdge();
+      }
+    }
+    if (e.key === 'Escape' && connectMode) connectLauncherButton.click();
+  });
+
+  const resizeObserver = new ResizeObserver(() => {
+    edgesSvg.setAttribute('width', stage.offsetWidth);
+    edgesSvg.setAttribute('height', stage.offsetHeight);
+    edges.forEach(edge => edge.update());
+  });
+  resizeObserver.observe(stage);
+
+  function init() {
+    edgesSvg.setAttribute('width', stage.offsetWidth);
+    edgesSvg.setAttribute('height', stage.offsetHeight);
+  }
+  init();
+})();

--- a/apps/dashboard/app/views/projects/_launcher_buttons.html.erb
+++ b/apps/dashboard/app/views/projects/_launcher_buttons.html.erb
@@ -3,6 +3,7 @@
   disabled_class = disabled ? 'disabled' : ''
   edit_title = "#{t('dashboard.edit')} launcher #{launcher.title}"
   delete_title = "#{t('dashboard.delete')} launcher #{launcher.title}"
+  remove_delete_button = @remove_delete_button
 -%>
 
 <div class="row">
@@ -44,16 +45,18 @@
     <%- end %>
   </div>
 
-  <div class="col">
-    <%= button_to(
-      project_launcher_path(@project.id, launcher.id),
-      id: "delete_#{launcher.id}",
-      class: "btn btn-danger launcher-button",
-      title: delete_title,
-      data: { confirm: I18n.t('dashboard.jobs_launchers_delete_script_confirmation') },
-      method: :delete) do
-    %>
-      <%= I18n.t('dashboard.delete') %>
-    <%- end -%>
-  </div>
+  <% unless remove_delete_button %>
+    <div class="col">
+      <%= button_to(
+        project_launcher_path(@project.id, launcher.id),
+        id: "delete_#{launcher.id}",
+        class: "btn btn-danger launcher-button",
+        title: delete_title,
+        data: { confirm: I18n.t('dashboard.jobs_launchers_delete_script_confirmation') },
+        method: :delete) do
+      %>
+        <%= I18n.t('dashboard.delete') %>
+      <%- end -%>
+    </div>
+  <% end %>
 </div>

--- a/apps/dashboard/app/views/workflows/show.html.erb
+++ b/apps/dashboard/app/views/workflows/show.html.erb
@@ -1,56 +1,37 @@
-<%# TODO Add support to describe relationship among launchers via two drop down menu to select "To-Fro" edge %>
-<%# This will act as way to describe the DAG until we figure out which JS UI library to use %>
+<%= javascript_include_tag 'workflows', nonce: true, defer: true %>
 
-<div class='page-header text-center'>
-  <h1 class="my-2 h3"><%= @workflow.name %></h1>
+<input type="hidden" id="base-launcher-url" value="<%= project_launchers_path(@project.id) %>">
 
-  <small class="text-muted"><%= @workflow.description %></small>
-</div>
+<div class="app" id="app">
+  <div class="toolbar" aria-label="toolbar">
+    <%= select_tag "select_launcher", options_from_collection_for_select(@launchers, :id, :title), include_blank: true, class: 'form-control mb-2 w-50' %>
+    <button id="btn-add">Add Launcher</button>
+    <button id="btn-connect" aria-pressed="false">Connect Launchers</button>
+    <button id="btn-delete-launcher" class="danger" title="Delete selected launcher (Del/Backspace)">Delete Launcher</button>
+    <button id="btn-delete-edge" class="danger" title="Delete selected edge (Del/Backspace)">Delete Edge</button>
+    <span class="hint">Click title to select and drag. Connect via clicking two launchers.</span>
+  </div>
 
-<br>
+  <div class="workspace-wrapper">
+    <div class="zoom-controls" id="zoom-controls" aria-label="Zoom controls">
+      <button id="zoom-in" title="Zoom in" aria-label="Zoom in">+</button>
+      <button id="zoom-reset" title="Reset zoom" aria-label="Reset zoom">100%</button>
+      <button id="zoom-out" title="Zoom out" aria-label="Zoom out">−</button>
+    </div>
 
-<%= bootstrap_form_for(@workflow, url: submit_project_workflow_path(@project.id, @workflow.id), method: :post) do |form| %>
-  <%# This is a hidden field to store launcher ids for this workflow used inside the submit method %>
-  <% @workflow.launcher_ids.each do |id| %>
-    <%= hidden_field_tag "workflow[launcher_ids][]", id %>
-  <% end %>
-
-  <% num_test_edges = 7 %>
-  <div class='card'>
-    <div class='card-group'>
-      <div class="card">
-        <div class='card-body'>
-          <div class="field mt-3">
-            <strong>Source Launcher (To)</strong><br>
-
-            <% num_test_edges.times do %>
-              <%= select_tag "workflow[source_ids][]", 
-                    options_from_collection_for_select(@launchers, :id, :title),
-                    include_blank: true, class: 'form-control mb-2' %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class='card-body'>
-          <div class="field mt-3">
-            <strong>Target Launcher (Fro)</strong><br>
-
-            <% num_test_edges.times do %>
-              <%= select_tag "workflow[target_ids][]", 
-                    options_from_collection_for_select(@launchers, :id, :title),
-                    include_blank: true, class: 'form-control mb-2' %>
-            <% end %>
-          </div>
+    <div class="workspace" id="workspace">
+      <div class="stage-zoom" id="stage-zoom">
+        <div class="stage" id="stage" tabindex="0" aria-label="canvas">
+          <svg class="edges" id="edges" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+                <polygon points="0 0, 10 3.5, 0 7"></polygon>
+              </marker>
+            </defs>
+          </svg>
         </div>
       </div>
     </div>
   </div>
-  <br>
-  <p>
-    <%= form.submit I18n.t('dashboard.jobs_workflow_submit'), class: 'btn btn-primary', title: 'Save project' %>
-    <%= form.button I18n.t('dashboard.reset'), type: :reset, class: 'btn btn-default', title: 'Clear form fields' %>
-    <%= link_to I18n.t('dashboard.back'), project_path(params[:project_id]), class: 'btn btn-default', title: 'Return to projects page' %>
-  </p>
-<% end %>
+
+</div>

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       resources :launchers do
         post 'submit', on: :member
         post 'save', on: :member
+        get 'render_button', on: :member
       end
     end
   end


### PR DESCRIPTION
Workflows Epic Link - https://github.com/OSC/ondemand/issues/4338
UI Discussion and feature demo - https://github.com/OSC/ondemand/issues/4625 

Just UI changes, no stitching with the backend. 

Todo tasks required:
1) Save the edge and launcher position in backend, save the dependency graph and allow submitting workflow. Add workflow submit buttons.
2) Visually show whether or not a launcher was successful(green), failure(red) or didn't get launcher (greyed-out) due to pre-requisite unsatisfied
3) Allow mechanism to have more than one instance of launchers, backend code change needed to support.
4) Edges can still overlap ex. 1->2, 2->3, 1->3 in linear fashion. Maybe we detect this and add some vertical space between to prevent?

This is how new UI looks like:
![New_UI](https://github.com/user-attachments/assets/68f204c2-b263-445f-a693-96fd7fdc1680)
