### PR TITLE
use cluster title or id.titleize

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -475,7 +475,9 @@ module BatchConnect
                                {
                                  widget:  'select',
                                  label:   'Cluster',
-                                 options: clusters.map(&:id)
+                                 options: clusters.map do |c|
+                                            [c.metadata.title || c.id.to_s.titleize, c.id]                         
+                                          end
                                }.merge(defined_cluster_attr)
                              else
                                {


### PR DESCRIPTION
Mimics the approach taken in https://github.com/OSC/ondemand/blob/ee4d3e7fe078e80208b52bf44fb19f40c6b535e6/apps/dashboard/app/apps/ood_app.rb#L131
for accessing cluster title but defaulting to id.titleize. While this hurts the style, we will be able to get our terseness back when we implement #4613 