### PR TITLE
Add S3-Specific Directory Check

### DIFF
--- a/apps/dashboard/lib/rclone_util.rb
+++ b/apps/dashboard/lib/rclone_util.rb
@@ -78,7 +78,7 @@ class RcloneUtil
       end
       
       # Fall back if lsjson fails
-      if (remote_type(remote) == "s3") && path.to_s.match(/^\/[^\/]*[\/]?$/)
+      if (remote_type(remote) == "s3") && path.each_filename.count <= 1
         o, e, s = rclone( "lsf", "--low-level-retries=1", full_path)
 
         if s.success?


### PR DESCRIPTION
## What problem this PR solves

This PR is primarily to fix a bug associated with Open Storage Network (OSN) S3 buckets. On OSN, users can't enumerate buckets in the root of the remote, so it leads to OOD believing that a bucket doesn't exist. For example, the bucket `georgia-osn` exists on my remote, but it doesn't register as valid since `lsf` on the parent is empty:

<img width="1307" height="256" alt="image" src="https://github.com/user-attachments/assets/18244262-6ff5-4dfc-9e0a-4536b7b284a7" />

But navigating to a "subdirectory" works fine since the parent returns a file listing on `lsf`:

<img width="971" height="294" alt="image" src="https://github.com/user-attachments/assets/3b44198c-fe83-47c2-8b8b-6e0b2a282f22" />

## How this PR solves the problem

This PR simply adds an alternative route to verifying a bucket exists for S3 remotes. Instead of using `lsf` to enumerate the parent, it uses `rclone test info --check-length` and approves any match with an entry that's not `maxFileLength = -1`.

This has an unexpected side benefit of correctly rejecting an s3 file (not directory) for file browser navigation. Previously, it threw vague JSON error: 

<img width="1298" height="94" alt="image" src="https://github.com/user-attachments/assets/7186d3e9-b5ee-470e-aa8b-72fe89fe5119" />

Now, it correctly identifies the file as not being a directory: 

<img width="1291" height="82" alt="image" src="https://github.com/user-attachments/assets/32b2bfc9-a1c5-4ec1-8771-a792d97927aa" />

## Improvements needed

I'm no Ruby expert, so this can probably be cleaned up. I went the straightforward route and duplicated the whole if-statement since efforts to reduce redundancy got more convoluted, somehow...