### PR TITLE
Make "Open in Terminal" button accessible

### DIFF
--- a/apps/dashboard/app/views/files/_shell_dropdown.html.erb
+++ b/apps/dashboard/app/views/files/_shell_dropdown.html.erb
@@ -5,11 +5,12 @@
               path: @path,
               label: 'Open in Terminal',
               classes: 'btn btn-outline-dark btn-sm',
-              icon: 'fas fa-terminal'
+              icon: 'fas fa-terminal',
+              id: 'files-shell-button'
             })
   %>
   <% if Configuration.login_clusters.count > 0 %>
-    <button type="button" class="btn btn-sm btn-outline-dark dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
+    <button type="button" class="btn btn-sm btn-outline-dark dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-labelledby="files-shell-button"></button>
     <ul class="dropdown-menu" data-popper-placement="right-start" id="shell-dropdown-items">
       <% Configuration.login_clusters.each do |cluster| %>
         <li>


### PR DESCRIPTION
Fixes #2694 

The `Open in terminal` button itself was already able to be read by a screen reader, but the dropdown to select each cluster was not very specific. So, it is labeled with the text in the `Open in terminal` button.