### PR TITLE
redirect from invalid file url

### DIFF
--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -215,7 +215,7 @@ class FilesController < ApplicationController
     respond_to do |format|
 
       format.html do
-        render :index
+        redirect_to(files_path(Dir.home), alert: exception.message.to_s)
       end
       format.json do
         @files = []

--- a/apps/dashboard/test/integration/files_app_test.rb
+++ b/apps/dashboard/test/integration/files_app_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'rclone_helper'
 
 class FilesAppTest < ActionDispatch::IntegrationTest
   test 'Files app displays terminal button when configuration is set to true' do
@@ -30,21 +31,23 @@ class FilesAppTest < ActionDispatch::IntegrationTest
   end
 
   test 'breadcrumbs shows remote prefix for remotes only' do
-    get files_url(Rails.root.to_s)
-    # Select breadcrumb items that are not buttons (change dir, copy path, etc.).
-    local_breadcrumb = css_select('.breadcrumb-item')
-                       .select { |el| (el > ('.btn')).empty? }
-                       .map(&:inner_text).map(&:strip).join
-    local_expected = "/#{Rails.root.each_filename.map(&:to_s).join(' /')} /"
-
-    assert_equal local_expected, local_breadcrumb
-
-    get files_url('local_remote', Rails.root.to_s)
-    remote_breadcrumb = css_select('.breadcrumb-item')
+    with_rclone_conf(Rails.root.to_s) do
+      get files_url(Rails.root.to_s)
+      # Select breadcrumb items that are not buttons (change dir, copy path, etc.).
+      local_breadcrumb = css_select('.breadcrumb-item')
                         .select { |el| (el > ('.btn')).empty? }
                         .map(&:inner_text).map(&:strip).join
-    remote_expected = "local_remote: /#{Rails.root.each_filename.map(&:to_s).join(' /')} /"
+      local_expected = "/#{Rails.root.each_filename.map(&:to_s).join(' /')} /"
 
-    assert_equal remote_expected, remote_breadcrumb
+      assert_equal local_expected, local_breadcrumb
+
+      get files_url('local_remote', Rails.root.to_s)
+      remote_breadcrumb = css_select('.breadcrumb-item')
+                          .select { |el| (el > ('.btn')).empty? }
+                          .map(&:inner_text).map(&:strip).join
+      remote_expected = "local_remote: /#{Rails.root.each_filename.map(&:to_s).join(' /')} /"
+
+      assert_equal remote_expected, remote_breadcrumb
+    end
   end
 end

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -30,7 +30,7 @@ class FilesTest < ApplicationSystemTestCase
   end
 
   test 'visiting files app with bad directory does not duplicate errors' do
-    bad_path = Rails.root / "nonexistant"
+    bad_path = Rails.root / "nonexistent"
     visit files_url(bad_path.to_s)
     find('table')
     assert_selector '.alert-danger', count: 1

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -29,6 +29,13 @@ class FilesTest < ApplicationSystemTestCase
     assert_selector '.selected', count: 2
   end
 
+  test 'visiting files app with bad directory does not duplicate errors' do
+    bad_path = Rails.root / "nonexistant"
+    visit files_url(bad_path.to_s)
+    find('table')
+    assert_selector '.alert-danger', count: 1
+  end
+
   test 'adding new file' do
     Dir.mktmpdir do |dir|
       visit files_url(dir)
@@ -614,7 +621,7 @@ class FilesTest < ApplicationSystemTestCase
         favorites = [FavoritePath.new(allowed_dir), FavoritePath.new(not_allowed_dir)]
         OodFilesApp.stubs(:candidate_favorite_paths).returns(favorites)
 
-        visit files_url(dir)
+        visit files_url(allowed_dir)
         assert_selector('#favorites li', count: 2)
       end
     end


### PR DESCRIPTION
Fixes #4360

This error only occurred when attempting to access a nonexistent directory directly from the URL, not when using the "Change Directory" button. It also brought the user to a table that appeared to have navigated to the nonexistent directory, with the buttons to create files and directories still present but causing errors when clicked.

Instead, the user is redirected to the home directory when trying to access a nonexistent directory by URL.