### PR TITLE
Prevent caching on batch connect forms

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -7,6 +7,8 @@ module BatchConnect
     include UserSettingStore
     include EncryptedCache
 
+    before_action :set_no_cache_headers, only: [:new]
+
     # GET /batch_connect/<app_token>/session_contexts/new
     def new
       set_app
@@ -112,6 +114,10 @@ module BatchConnect
     end
 
     private
+
+    def set_no_cache_headers
+      response.headers['Cache-Control'] = 'private, no-store'
+    end
 
     # Set the app from the token
     def set_app


### PR DESCRIPTION
Fixes #2749. Replaces default headers with "private, no-store", which are the strongest no-cache directives. Attempted to include all of `max-age=0, no-cache, no-store, must-revalidate, private` but rails filtered these to `private, no-store` and after some research it looks like the only browser that would need no-cache as well as no-store is internet explorer. While we could leave these all in the setting in case Rails changes this in the future, trimming it down ourselves help keep this simple and concise. The changes were only made to `BatchConnectSessionsContextsController#new`, although I did notice `dynamic_forms.js` being called from LaunchersController#show as well, not sure if that means we should include this there as well.
