### PR TITLE
specify amazonlinux e2e CI image

### DIFF
--- a/spec/e2e/nodesets/amzn2023.yml
+++ b/spec/e2e/nodesets/amzn2023.yml
@@ -4,7 +4,7 @@ HOSTS:
       - agent
     platform: el-9-x86_64
     hypervisor: docker
-    image: amazonlinux:2023
+    image: amazonlinux:2023.8.20250908.0
     docker_preserve_image: true
     docker_cmd: '/usr/sbin/init'
     docker_image_commands:


### PR DESCRIPTION
specify amazonlinux e2e CI image because of #4642 in which newer images have httpd segfaulting.