### PR TITLE
Fix path selector allow list 4264

### DIFF
--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -101,9 +101,10 @@ export class PathSelectorTable {
       this.resetTable();
     } catch (err) {
       this.resetTable();
-      if (err.message.match("Permission denied")) {
+      if (err.message) {
         $('#forbidden-warning').removeClass('d-none')
-        $('#forbidden-warning').trigger('focus');
+          .text(err.message)
+          .trigger('focus');
       }
       console.log(err);
     }

--- a/apps/dashboard/app/models/allowlist_policy.rb
+++ b/apps/dashboard/app/models/allowlist_policy.rb
@@ -34,7 +34,7 @@ class AllowlistPolicy
   def validate!(path)
     return if permitted?(path.to_s)
 
-    msg = "#{path} does not have an ancestor directory specified in ALLOWLIST_PATH"
+    msg = "Permission denied: '#{path}' does not have an ancestor directory specified in ALLOWLIST_PATH"
     Rails.logger.warn(msg)
     raise AllowlistPolicy::Forbidden, msg
   end

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -42,7 +42,7 @@
               <ol id="<%= breadcrumb_id %>" class="breadcrumb breadcrumb-no-delimiter rounded">
               </ol>
 
-              <div class="d-none alert alert-warning" role="alert" id="forbidden-warning">
+              <div class="d-none alert alert-danger" role="alert" id="forbidden-warning" aria-live="assertive">
                 <%= t('dashboard.batch_connect_sessions_path_selector_forbidden_error') %>
               </div>
 

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1765,6 +1765,58 @@ class BatchConnectTest < ApplicationSystemTestCase
     # puts favorites.map{|i| i['innerHTML']}.join('')
   end
 
+  test 'path_selector respects allowlist' do
+    Dir.mktmpdir do |dir|
+      allowed_dir = "#{dir}/allowed"
+      with_modified_env({OOD_ALLOWLIST_PATH: allowed_dir}) do
+        `mkdir -p #{allowed_dir}/real_directory`
+        `touch #{allowed_dir}/real_file`
+        `touch #{allowed_dir}/real_directory/other_real_file`
+        `mkdir -p #{dir}/not_allowed`
+        `touch #{dir}/not_allowed/bad_file`
+
+        form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - path
+        attributes:
+          path:
+            widget: 'path_selector'
+            directory: '#{allowed_dir}/real_directory'
+        HEREDOC
+
+        make_bc_app(dir, form)
+        visit new_batch_connect_session_context_url('sys/app')
+
+        click_on 'Select Path'
+
+        # await load
+        assert_selector("##{bc_ele_id('path_path_selector_table_wrapper')}")
+        # verify location
+        assert_text('other_real_file')
+
+        find('span.fa-arrow-up').click
+        assert_text('real_file')
+        assert_text('real_directory')
+
+        find('span.fa-arrow-up').click
+        error_text = "Permission denied: '#{dir}' does not have an ancestor directory specified in ALLOWLIST_PATH"
+        assert_selector('#forbidden-warning', text: error_text)
+
+        # reset
+        find('tr.clickable td span', text: 'real_directory').click
+        assert_text('other_real_file')
+        assert_selector('#forbidden-warning', visible: :hidden)
+
+        find_all('span.clickable', text: '/').first.click
+        error_text_root = "Permission denied: '/' does not have an ancestor directory specified in ALLOWLIST_PATH"
+        assert_selector('#forbidden-warning', text: error_text_root)
+      end
+    end
+  end
+
   test 'launches and saves settings as a template' do
     with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SAVED_SETTINGS: 'true' }) do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
Fixes #4264, the error reporting existed before, but attempted to match text in the error message that had since been removed. These changes remove that check, reporting any errors that are encountered, and move the added description "Permission denied" to the source of the error message rather than be specific to path selector. It also changes the error modal from warning to danger (color), to be consistent with the modal in the files app. 

This PR does not address the second point brought up in the issue, that you are unable to navigate across the allowlist since this would always require visiting a directory not on the allowlist. The files app gives an out for this by allowing you to manually type a path, but given the limited size of the path selector modal I think that would add too much clutter (and is a poor solution for users anyway). I think the best solution for that would be to add the allowlist to the favorites, checking for duplicates in the supplied favorites. This could be restricted to the path selector or extend to the files app as well, but ought to be its own issue. 

A system test was added that attempts to violate the allowlist and checks that errors are being reported properly. It tests two methods of leaving the allowlist, by clicking the up arrow in the modal, and by clicking the breadcrumb elements. As far as I can tell this is the only way to leave the allowlist, but I would be happy to add more if I am missing something. Either way, the checks for the allowlist happen outside of the path selector, so the errors should be the same regardless of the method of reaching them. 

I did discover one latent bug due to the reporting, when you click the breadcrumb for  the current directory (which lacks the 'clickable' class), it makes an incomplete request to the server and produces a generic "Not Acceptable" error. This was fine when errors were unreported, because you stay in the same directory and never notice that a request was made. We should either ignore these errors at the path selector or truly disable the breadcrumb, the former approach would likely fit well in this PR while the other could be its own. 