### PR TITLE
Files app external integration

### DIFF
--- a/apps/dashboard/app/helpers/application_helper.rb
+++ b/apps/dashboard/app/helpers/application_helper.rb
@@ -77,6 +77,7 @@ module ApplicationHelper
   end
 
   def icon_tag(icon_uri, classes: ['app-icon'])
+    icon_uri = URI(icon_uri) if icon_uri.is_a?(String)
     if ['fa', 'fas', 'far', 'fab', 'fal'].include?(icon_uri.scheme)
       fa_icon(icon_uri.host, fa_style: icon_uri.scheme, classes: classes)
     elsif icon_uri.to_s.starts_with?(@user_configuration.public_url.to_s)

--- a/apps/dashboard/app/javascript/alert.js
+++ b/apps/dashboard/app/javascript/alert.js
@@ -1,17 +1,24 @@
 
 export function OODAlert(message) {
-  const div = alertDiv(message);
+  const div = alertDiv(message, 'danger');
   const main = document.getElementById('main_container');
   main.prepend(div);
   div.scrollIntoView({ behavior: 'smooth' });
 }
 
-function alertDiv(message) {
+export function OODAlertSuccess(message) {
+  const div = alertDiv(message, 'success');
+  const main = document.getElementById('main_container');
+  main.prepend(div);
+  div.scrollIntoView({ behavior: 'smooth' });
+}
+
+function alertDiv(message, type) {
   const span = document.createElement('span');
   span.innerText = message;
 
   const div = document.createElement('div');
-  div.classList.add('alert', 'alert-danger', 'alert-dismissible');
+  div.classList.add('alert', `alert-${type}`, 'alert-dismissible');
   div.setAttribute('role', 'alert');
   div.appendChild(span);
   div.appendChild(closeButton());

--- a/apps/dashboard/app/javascript/alert.js
+++ b/apps/dashboard/app/javascript/alert.js
@@ -1,13 +1,14 @@
 
-export function OODAlert(message) {
-  const div = alertDiv(message, 'danger');
-  const main = document.getElementById('main_container');
-  main.prepend(div);
-  div.scrollIntoView({ behavior: 'smooth' });
+export function OODAlertError(message) {
+  OODAlert(message, 'danger');
 }
 
 export function OODAlertSuccess(message) {
-  const div = alertDiv(message, 'success');
+  OODAlert(message, 'success');
+}
+
+function OODAlert(message, type) {
+  const div = alertDiv(message, type);
   const main = document.getElementById('main_container');
   main.prepend(div);
   div.scrollIntoView({ behavior: 'smooth' });

--- a/apps/dashboard/app/javascript/batch_connect/bc_notifications.js
+++ b/apps/dashboard/app/javascript/batch_connect/bc_notifications.js
@@ -1,5 +1,5 @@
 import { getBoolean, storeBoolean } from '../utils';
-import { OODAlert } from '../alert';
+import { OODAlertError } from '../alert';
 
 const NOTIFICATIONS_ENABLED_KEY = 'ood_notifications_enabled';
 const EXPIRATION_NOTIFIED_KEY = 'ood_expiration_notified';
@@ -45,10 +45,10 @@ export function setupNotificationToggle(toggleElementId) {
         const permission = await Notification.requestPermission();
         if (permission !== 'granted') {
           event.target.checked = false;
-          OODAlert('Please allow notification permissions in your browser to enable session alerts.');
+          OODAlertError('Please allow notification permissions in your browser to enable session alerts.');
         }
       } catch (error) {
-        OODAlert('Error requesting notification permission:', error);
+        OODAlertError('Error requesting notification permission:', error);
       }
     }
     storeBoolean(NOTIFICATIONS_ENABLED_KEY, event.target.checked);

--- a/apps/dashboard/app/javascript/files/index.js
+++ b/apps/dashboard/app/javascript/files/index.js
@@ -4,7 +4,9 @@ import {} from './file_ops.js';
 import {} from './sweet_alert.js';
 import {} from './uppy_ops.js';
 import { setPageLoadState } from './page_load';
+import { initSendToTarget } from './send_to_target';
 
 addEventListener("DOMContentLoaded", (_event) => {
   setPageLoadState();
+  initSendToTarget();
 });

--- a/apps/dashboard/app/javascript/files/send_to_target.js
+++ b/apps/dashboard/app/javascript/files/send_to_target.js
@@ -1,5 +1,5 @@
 import { CONTENTID } from './data_table.js';
-import { OODAlert, OODAlertSuccess } from '../alert';
+import { OODAlertError, OODAlertSuccess } from '../alert';
 
 export function initSendToTarget() {
   const button = document.getElementById('send-to-target-btn');
@@ -20,7 +20,7 @@ function handleSend(button, endpoint) {
   const selection = table.rows({ selected: true }).data().toArray();
 
   if (selection.length === 0) {
-    OODAlert('Select at least one file or directory to send.');
+    OODAlertError('Select at least one file or directory to send.');
     return;
   }
 
@@ -44,7 +44,7 @@ function handleSend(button, endpoint) {
       OODAlertSuccess('Files sent successfully.');
     })
     .catch(() => {
-      OODAlert('Failed to send files.');
+      OODAlertError('Failed to send files.');
     })
     .finally(() => {
       button.removeAttribute('disabled');

--- a/apps/dashboard/app/javascript/files/send_to_target.js
+++ b/apps/dashboard/app/javascript/files/send_to_target.js
@@ -1,0 +1,95 @@
+import { CONTENTID } from './data_table.js';
+import { OODAlert, OODAlertSuccess } from '../alert';
+
+export function initSendToTarget() {
+  const button = document.getElementById('send-to-target-btn');
+  if (!button) {
+    return;
+  }
+
+  const endpoint = button.dataset.filesSelectTargetEndpoint;
+  if (!endpoint) {
+    return;
+  }
+
+  button.addEventListener('click', () => handleSend(button, endpoint));
+}
+
+function handleSend(button, endpoint) {
+  const table = $(CONTENTID).DataTable();
+  const selection = table.rows({ selected: true }).data().toArray();
+
+  if (selection.length === 0) {
+    OODAlert('Select at least one file or directory to send.');
+    return;
+  }
+
+  button.setAttribute('disabled', 'disabled');
+
+  const payload = buildPayload(selection);
+
+  fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    credentials: 'same-origin',
+    body: JSON.stringify(payload)
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error();
+      }
+
+      OODAlertSuccess('Files sent successfully.');
+    })
+    .catch(() => {
+      OODAlert('Failed to send files.');
+    })
+    .finally(() => {
+      button.removeAttribute('disabled');
+    });
+}
+
+function buildPayload(selection) {
+  const baseDirectory = history.state.currentDirectory;
+  const directoryUrl = history.state.currentDirectoryUrl;
+  const filesystem = history.state.currentFilesystem;
+
+  const files = selection.map((row) => {
+    const name = row.name;
+    const filePath = joinPath(baseDirectory, name);
+
+    return {
+      file_path: filePath,
+      id: row.id,
+      name: name,
+      type: row.type,
+      directory: row.type === 'd',
+      size: row.size,
+      human_size: row.human_size,
+      modified_at: row.modified_at,
+      owner: row.owner,
+      mode: row.mode,
+      url: row.url,
+      download_url: row.download_url,
+      edit_url: row.edit_url
+    };
+  });
+
+  return {
+    filesystem: filesystem,
+    directory: baseDirectory,
+    directory_url: directoryUrl,
+    files: files
+  };
+}
+
+function joinPath(base, name) {
+  if (!base || base === '/') {
+    return `/${name}`;
+  }
+
+  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  return `${sanitizedBase}/${name}`;
+}

--- a/apps/dashboard/app/javascript/files/send_to_target.js
+++ b/apps/dashboard/app/javascript/files/send_to_target.js
@@ -12,10 +12,10 @@ export function initSendToTarget() {
     return;
   }
 
-  button.addEventListener('click', () => handleSend(button, endpoint));
+  button.addEventListener('click', () => handleSendToTarget(button, endpoint));
 }
 
-function handleSend(button, endpoint) {
+function handleSendToTarget(button, endpoint) {
   const table = $(CONTENTID).DataTable();
   const selection = table.rows({ selected: true }).data().toArray();
 
@@ -41,7 +41,7 @@ function handleSend(button, endpoint) {
         throw new Error();
       }
 
-      OODAlertSuccess('Files sent successfully.');
+      OODAlertSuccess('Selected file information sent successfully.');
     })
     .catch(() => {
       OODAlertError('Failed to send files.');

--- a/apps/dashboard/app/javascript/files/send_to_target.js
+++ b/apps/dashboard/app/javascript/files/send_to_target.js
@@ -1,6 +1,8 @@
 import { CONTENTID } from './data_table.js';
 import { OODAlertError, OODAlertSuccess } from '../alert';
 
+const TOKEN_KEY = 'files_select_target_token';
+
 export function initSendToTarget() {
   const button = document.getElementById('send-to-target-btn');
   if (!button) {
@@ -8,14 +10,40 @@ export function initSendToTarget() {
   }
 
   const endpoint = button.dataset.filesSelectTargetEndpoint;
-  if (!endpoint) {
+  const expirationMinutes = parseInt(button.dataset.tokenExpiration);
+  if (!endpoint || !expirationMinutes) {
     return;
   }
 
-  button.addEventListener('click', () => handleSendToTarget(button, endpoint));
+  const tokenFromUrl = getUrlToken();
+  const storedToken = getStoredToken(expirationMinutes);
+
+  // If token in URL, store it
+  if (tokenFromUrl) {
+    storeToken(tokenFromUrl);
+  }
+
+  const effectiveToken = tokenFromUrl || storedToken;
+
+  // Disable if no token
+  if (!effectiveToken) {
+    disableButton(button);
+  }
+
+  button.addEventListener('click', () =>
+      handleSendToTarget(button, endpoint, expirationMinutes)
+  );
 }
 
-function handleSendToTarget(button, endpoint) {
+function handleSendToTarget(button, endpoint, expirationMinutes) {
+  const targetToken = getStoredToken(expirationMinutes);
+
+  if (!targetToken) {
+    disableButton(button);
+    OODAlertError('Application token is missing or expired. Start again');
+    return;
+  }
+
   const table = $(CONTENTID).DataTable();
   const selection = table.rows({ selected: true }).data().toArray();
 
@@ -24,9 +52,9 @@ function handleSendToTarget(button, endpoint) {
     return;
   }
 
-  button.setAttribute('disabled', 'disabled');
+  disableButton(button);
 
-  const payload = buildPayload(selection);
+  const payload = buildPayload(selection, targetToken);
 
   fetch(endpoint, {
     method: 'POST',
@@ -36,22 +64,22 @@ function handleSendToTarget(button, endpoint) {
     credentials: 'same-origin',
     body: JSON.stringify(payload)
   })
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error();
-      }
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error();
+        }
 
-      OODAlertSuccess('Selected file information sent successfully.');
-    })
-    .catch(() => {
-      OODAlertError('Failed to send files.');
-    })
-    .finally(() => {
-      button.removeAttribute('disabled');
-    });
+        OODAlertSuccess('Selected file information sent successfully.');
+      })
+      .catch(() => {
+        OODAlertError('Failed to send file information.');
+      })
+      .finally(() => {
+        button.removeAttribute('disabled');
+      });
 }
 
-function buildPayload(selection) {
+function buildPayload(selection, token) {
   const baseDirectory = history.state.currentDirectory;
   const directoryUrl = history.state.currentDirectoryUrl;
   const filesystem = history.state.currentFilesystem;
@@ -78,11 +106,46 @@ function buildPayload(selection) {
   });
 
   return {
+    token: token,
     filesystem: filesystem,
     directory: baseDirectory,
     directory_url: directoryUrl,
     files: files
   };
+}
+
+function getUrlToken() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(TOKEN_KEY);
+}
+
+function storeToken(token) {
+  const data = {
+    value: token,
+    stored_at: Date.now()
+  };
+  sessionStorage.setItem(TOKEN_KEY, JSON.stringify(data));
+}
+
+function getStoredToken(expirationMinutes) {
+  const raw = sessionStorage.getItem(TOKEN_KEY);
+  if (!raw) return null;
+  try {
+    const tokenData = JSON.parse(raw);
+    const ageMinutes = (Date.now() - tokenData.stored_at) / 1000 / 60;
+    if (ageMinutes > expirationMinutes) {
+      sessionStorage.removeItem(TOKEN_KEY);
+      return null;
+    }
+    return tokenData.value;
+  } catch {
+    sessionStorage.removeItem(TOKEN_KEY);
+    return null;
+  }
+}
+
+function disableButton(button) {
+  button.setAttribute('disabled', 'disabled');
 }
 
 function joinPath(base, name) {

--- a/apps/dashboard/app/javascript/files/sweet_alert.js
+++ b/apps/dashboard/app/javascript/files/sweet_alert.js
@@ -1,4 +1,4 @@
-import { OODAlert } from '../alert';
+import { OODAlertError } from '../alert';
 import {CONTENTID, EVENTNAME as DATATABLE_EVENTNAME} from './data_table.js';
 import { pageSpin, stopPageSpin } from '../utils';
 
@@ -64,7 +64,7 @@ function attachOKHandler(options) {
     }
 
     if(error) {
-      OODAlert(error);
+      OODAlertError(error);
     } else {
       $(CONTENTID).trigger(options.action, eventData);
     }
@@ -77,7 +77,7 @@ function attachOKHandler(options) {
 jQuery(function() {
 
   $(CONTENTID).on(EVENTNAME.showError, function(e,options) {
-    OODAlert(options.message);
+    OODAlertError(options.message);
   });
 
   $(CONTENTID).on(EVENTNAME.showInput, function(e, options) {

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -1,4 +1,4 @@
-import { OODAlert } from '../alert';
+import { OODAlertError } from '../alert';
 import { hide, show } from "../utils";
 
 export class PathSelectorTable {
@@ -220,7 +220,7 @@ export class PathSelectorTable {
         regex = RegExp(this.filePattern);
       }
     } catch {
-      OODAlert("The regular expression provided for this path selector did not compile");
+      OODAlertError("The regular expression provided for this path selector did not compile");
     }
 
     const filteredFiles = data.files.filter((file) => {

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -6,7 +6,7 @@
 */
 
 import { setInnerHTML } from './utils';
-import { OODAlert } from './alert';
+import { OODAlertError } from './alert';
 
 export function replaceHTML(id, html) {
   const ele = document.getElementById(id);
@@ -45,9 +45,9 @@ export function pollAndReplace(url, delay, id, callback, continuePolling = () =>
     })
     .catch((err) => {
       if (typeof err == 'string') {
-        OODAlert(err);
+        OODAlertError(err);
       } else {
-        OODAlert('This page has encountered an unexpected error. Please refresh the page.');
+        OODAlertError('This page has encountered an unexpected error. Please refresh the page.');
       }
       console.log(err);
     });

--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -80,7 +80,10 @@ class UserConfiguration
     ConfigurationProperty.property(name: :support_ticket, default_value: {}),
 
     # Datatables configuration for the apps pages
-    ConfigurationProperty.property(name: :apps_datatable, default_value: { page_length: 10 })
+    ConfigurationProperty.property(name: :apps_datatable, default_value: { page_length: 10 }),
+
+    # Files app integration button configuration
+    ConfigurationProperty.property(name: :files_select_target)
   ].freeze
 
   def initialize(request_hostname: nil)

--- a/apps/dashboard/app/views/files/_send_to_target_button.html.erb
+++ b/apps/dashboard/app/views/files/_send_to_target_button.html.erb
@@ -1,6 +1,7 @@
-<span id="loop-wrapper">
+<span id="loop-wrapper" data-bs-toggle="tooltip" title="<%= @user_configuration.files_select_target[:title] || 'Send selected files to the external application' %>">
   <button id="send-to-target-btn" type="button" class="btn btn-primary btn-sm align-middle"
-          data-files-select-target-endpoint="<%= @user_configuration.files_select_target[:endpoint] %>">
+          data-files-select-target-endpoint="<%= @user_configuration.files_select_target[:endpoint] %>"
+          data-token-expiration="<%= @user_configuration.files_select_target[:expiration] || 10 %>">
     <%= icon_tag(@user_configuration.files_select_target[:icon] || 'fas://paper-plane', classes: nil) %>
     <%= @user_configuration.files_select_target[:label] %>
   </button>

--- a/apps/dashboard/app/views/files/_send_to_target_button.html.erb
+++ b/apps/dashboard/app/views/files/_send_to_target_button.html.erb
@@ -1,0 +1,7 @@
+<span id="loop-wrapper">
+  <button id="send-to-target-btn" type="button" class="btn btn-primary btn-sm align-middle"
+          data-files-select-target-endpoint="<%= @user_configuration.files_select_target[:endpoint] %>">
+    <%= icon_tag(@user_configuration.files_select_target[:icon] || 'fas://paper-plane', classes: nil) %>
+    <%= @user_configuration.files_select_target[:label] %>
+  </button>
+</span>

--- a/apps/dashboard/app/views/files/index.html.erb
+++ b/apps/dashboard/app/views/files/index.html.erb
@@ -14,6 +14,9 @@
     <% if Configuration.globus_endpoints %>
       <%= render partial: 'globus' %>
     <% end %>
+    <% if @user_configuration.files_select_target %>
+      <%= render partial: 'send_to_target_button' %>
+    <% end %>
     <button id="copy-move-btn" type="button" class="btn btn-outline-dark btn-sm"><i class="fas fa-copy" aria-hidden="true"></i> Copy/Move</button>
     <button id="delete-btn" type="button" class="btn btn-danger btn-sm"><i class="fas fa-trash" aria-hidden="true"></i> Delete</button>
 </div>

--- a/apps/dashboard/test/helpers/application_helper_test.rb
+++ b/apps/dashboard/test/helpers/application_helper_test.rb
@@ -152,6 +152,19 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal image_uri.to_s, image_html['src']
   end
 
+  test 'icon_tag should convert string icon_uri to URI and render correct icon' do
+    @user_configuration = stub({ public_url: Pathname.new('/public') })
+
+    # Pass a plain string instead of a URI
+    icon_string = 'fas://paper-plane'
+    html = Nokogiri::HTML(icon_tag(icon_string))
+
+    icon_html = html.at_css('i')
+    assert_not_nil icon_html, 'Expected <i> element for FontAwesome icon'
+    assert_includes icon_html['class'], 'fas'
+    assert_includes icon_html['class'], 'paper-plane'
+  end
+
   test 'favicon tag should use public asset uri in production mode' do
     Rails.stubs(:env).returns(stub('production?', production?: true))
 


### PR DESCRIPTION
Adds a configurable button to the files app to submit a post request to a URL with the selected files metadata.
This is to leverage the Files App functionality in the dashboard with other applications deployed as passenger apps.

fixes: #4656 