### PR TITLE
Fix missing activejobs sorting chevrons 

### DIFF
--- a/apps/dashboard/app/views/active_jobs/index.html.erb
+++ b/apps/dashboard/app/views/active_jobs/index.html.erb
@@ -42,15 +42,15 @@
       <thead>
       <tr>
         <th></th>
-        <th><span>ID</span></th>
-        <th><span>Name</span></th>
-        <th><span>User</span></th>
-        <th><span>Account</span></th>
-        <th><span>Time Used</span></th>
-        <th><span>Queue</span></th>
-        <th><span>Status</span></th>
-        <th><span>Cluster</span></th>
-        <th><span>Actions</span></th>
+        <th>ID<span aria-hidden="true"></span></th>
+        <th>Name<span aria-hidden="true"></span></th>
+        <th>User<span aria-hidden="true"></span></th>
+        <th>Account<span aria-hidden="true"></span></th>
+        <th>Time Used<span aria-hidden="true"></span></th>
+        <th>Queue<span aria-hidden="true"></span></th>
+        <th>Status<span aria-hidden="true"></span></th>
+        <th>Cluster<span aria-hidden="true"></span></th>
+        <th>Actions<span aria-hidden="true"></span></th>
       </tr>
       </thead>
     </table>


### PR DESCRIPTION
Wraps activejobs table header text in span tags to apply sorting icons - fixes #4658