### PR TITLE
Make SAFE_PATH restrictive rather than prescriptive

### DIFF
--- a/apps/bc_desktop/template/script.sh.erb
+++ b/apps/bc_desktop/template/script.sh.erb
@@ -12,7 +12,7 @@ export SHELL="$(getent passwd $USER | cut -d: -f7)"
 # use a safe PATH to boot the desktop because dbus-launch can be
 # in another location from a python/conda installation and that will
 # conflict and cause issues. See https://github.com/OSC/ondemand/issues/700 for more.
-SAFE_PATH="/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin"
+SAFE_PATH=$(echo -n "$PATH" | tr : '\0' | grep -zvE ^"$HOME"'($|/)' | tr '\0' : | head -c -1)
 
 # Start up desktop
 echo "Launching desktop '<%= context.desktop %>'..."


### PR DESCRIPTION
Fixes #4424 by allowing custom paths to be present in SAFE_PATH as long as those paths lie outside the users home directory. Before these changes SAFE_PATH was fixed to 5 common locations, but now it will interact with the $PATH variable, only filtering out the $HOME variable and any descendants. The expression successfully filtered $PATH both on OSC systems and on an ubuntu WSL instance. The only backwards-compatibility issue I see is if the presets from before these changes are not included in $PATH, so I could see this being an opt-in feature instead. Open to other thoughts, and thanks to @twhitehead for the expression.