### PR TITLE
simplify workflow to get i18n-tools on the PATH

### DIFF
--- a/.github/workflows/localizations.yml
+++ b/.github/workflows/localizations.yml
@@ -35,10 +35,14 @@ jobs:
           bundle install
 
       - name: Remove unused 
-        run: bundle exec i18n-tools remove-unused
+        run: |
+          cd apps/dashboard
+          bundle exec i18n-tools remove-unused
 
       - name: Update translations
-        run: bundle exec i18n-tools translate-missing
+        run: |
+          cd apps/dashboard
+          bundle exec i18n-tools translate-missing
         env:
           OPENAI_API_TOKEN: ${{ secrets.CHATGPT_API_KEY }}
 


### PR DESCRIPTION
This workflow is broken right now with `i18n-tools` not being in the PATH. This is an attempt to simplify the workflow to get i18n-tools on the PATH.
