### PR TITLE
write a file instead of using Tempfile

### DIFF
--- a/lib/tasks/rake_helper.rb
+++ b/lib/tasks/rake_helper.rb
@@ -4,6 +4,8 @@ require 'pathname'
 require 'erb'
 require 'dotenv'
 require 'tempfile'
+require 'tmpdir'
+require 'securerandom'
 
 module RakeHelper
   def proj_root
@@ -110,13 +112,10 @@ module RakeHelper
     return src unless File.extname(name) == '.erb'
 
     content = ERB.new(File.read(src), trim_mode: '-').result(binding)
-    begin
-      t = Tempfile.new(name)
-      t.write(content)
-      t.path
-    ensure
-      t.close
-    end
+    fname = "#{Dir.tmpdir}/#{name}_#{SecureRandom.hex(4)}"
+    File.open(fname, 'w') { |file| file.write(content) }
+
+    fname
   end
 
   def ood_image_tag


### PR DESCRIPTION
Our CI is failing kind of consistently in EL9 with this error trying to copy the `sudo.erb` file. I believe it's because this is from a `Tempfile` that is removed when the object is finalized (garbage collected). I suspect EL9 is just running faster than other distros. I.e., finalizing this object quicker. 

```
mkdir -p /work/el9-x86_64/BUILDROOT/ondemand-4.0.0-1.el9.x86_64/etc/sudoers.d
cp /tmp/sudo.erb20251020-8226-23yux8 /work/el9-x86_64/BUILDROOT/ondemand-4.0.0-1.el9.x86_64/etc/sudoers.d/ood
error: Bad exit status from /var/tmp/rpm-tmp.RmBX8p (%install)
    Macro expanded in comment on line 54: %{nil}

    Bad exit status from /var/tmp/rpm-tmp.RmBX8p (%install)
```

Instead, I'm thinking we just generate a random filename and use `File.write` instead so that the underlying file persists.