### PR TITLE
Dereference symlink for directory size check

### DIFF
--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -170,7 +170,7 @@ class PosixFile
       error = I18n.t('dashboard.files_directory_download_unauthorized')
     else
       # Determine the size of the directory.
-      o, e, s = Open3.capture3("timeout", "#{timeout}s", "du", "-cbs", path.to_s)
+      o, e, s = Open3.capture3("timeout", "#{timeout}s", "du", "-cbLs", path.to_s)
 
       # Catch SIGTERM.
       if s.exitstatus == 124


### PR DESCRIPTION
Fixes #4713.

This would be the simplest solution, which solves the problem, but it might be better to dereference the symlink in the Ruby code instead, i.e. using `path.realpath` as target for `du`.