### PR TITLE
Add link to Software License page in dashboard footer

### DIFF
--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -11,5 +11,5 @@
       %>
     <% end %>
   </div>
-  <span id="ood_version">OnDemand version: <%= Configuration.ood_version %></span>
+  <span id="ood_version">OnDemand version: <%= Configuration.ood_version %><br><a href="https://openondemand.org/licensing">Software License Notice</a></span>
 </footer>


### PR DESCRIPTION
Per some recommendations on Open Source Software best practices, we should link to our software license info in the footer of the dashboard.

I've tested this on the live OSC OnDemand site by editing the page and it looks like this:
<img width="1173" height="357" alt="image" src="https://github.com/user-attachments/assets/b505ec03-6b63-40f8-bff3-130651ac3313" />
