### PR TITLE
Fix forever spinners in edit BC sessions

### DIFF
--- a/apps/dashboard/app/javascript/utils.js
+++ b/apps/dashboard/app/javascript/utils.js
@@ -42,11 +42,7 @@ export function today() {
   return `${now.getFullYear()}-${now.getMonth()+1}-${now.getDate()}`;
 }
 
-function showSpinner() {
-  $('body').addClass('modal-open');
-  $('#full-page-spinner').removeClass('d-none');
-}
-
+// the next two functions, using #full_page_spinner, are only used in sweet_alert.js
 export function pageSpin() {
   const ele = document.getElementById('full_page_spinner');
   ele.classList.remove('d-none');
@@ -59,6 +55,17 @@ export function stopPageSpin() {
   ariaNotify('Loading complete.');
 }
 
+// The next three functions use #full-page-spinner, and are used more widely
+function showSpinner() {
+  $('body').addClass('modal-open');
+  $('#full-page-spinner').removeClass('d-none');
+}
+
+function hideSpinner() {
+  $('body').removeClass('modal-open');
+  $('#full-page-spinner').addClass('d-none');
+}
+
 export function bindFullPageSpinnerEvent() {
   $('.full-page-spinner').each((index, element) => {
     const $element = $(element);
@@ -68,6 +75,9 @@ export function bindFullPageSpinnerEvent() {
       $element.closest('form').on('submit', showSpinner);
     }
   });
+  window.addEventListener('pageshow', (event) => {
+    if (event.persisted) hideSpinner();
+  })
 }
 
 // open links in javascript and display an alert


### PR DESCRIPTION
Fixes #4692 by adding a listener for window `pageshow` event and then checking `event.persisted` to make sure the page is being pulled from the browser cache and not reloaded. This may be unnecessary (we may want to remove the spinners every time the sessions index is opened) but this solves the original issue of the browser back button breaking spinners. Because these changes were added to `bindFullPageSpinnerEvent`, this will also fix this behavior on all the other pages that use this functionality. 

In doing this update, I did notice a second spinner div, `#full_page_spinner` (cf. `#full-page-spinner` used here) which is exclusively used by sweet alert, and IIRC we have a ticket to refactor. In the mean time, I added some comments and grouped the different sets of spinner functions together to reduce confusion.