### PR TITLE
update ood portal restart instructions

### DIFF
--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.all
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.all
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 # Listen should always be one of:

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-full
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-ldap
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.dex-no-proxy
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.maint_with_ips
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.nomaint
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
+++ b/ood-portal-generator/spec/fixtures/ood-portal.conf.oidc-ssl
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
+++ b/ood-portal-generator/spec/fixtures/ood-portal.dex-full.proxy.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/auth.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/auth_deb.conf
+++ b/ood-portal-generator/spec/fixtures/output/auth_deb.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/custom_directives.conf
+++ b/ood-portal-generator/spec/fixtures/output/custom_directives.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/custom_location_directives.conf
+++ b/ood-portal-generator/spec/fixtures/output/custom_location_directives.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/custom_vhost_directives.conf
+++ b/ood-portal-generator/spec/fixtures/output/custom_vhost_directives.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/http_redirect_host.conf
+++ b/ood-portal-generator/spec/fixtures/output/http_redirect_host.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/no_logs.conf
+++ b/ood-portal-generator/spec/fixtures/output/no_logs.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/fixtures/output/piped_logs.conf
+++ b/ood-portal-generator/spec/fixtures/output/piped_logs.conf
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 

--- a/ood-portal-generator/spec/ood_portal_generator_spec.rb
+++ b/ood-portal-generator/spec/ood_portal_generator_spec.rb
@@ -35,11 +35,11 @@ describe OodPortalGenerator do
       expect(described_class.debian?).to eq(false)
     end
 
-    it 'returns true for Ubuntu 20.04' do
+    it 'returns true for Ubuntu 24.04' do
       os_release = <<~EOS
         ID=ubuntu
         ID_LIKE=debian
-        VERSION_ID="20.04"
+        VERSION_ID="24.04"
       EOS
       File.write(os_release_file.path, os_release)
       allow(described_class).to receive(:os_release_file).and_return(os_release_file.path)

--- a/ood-portal-generator/templates/ood-portal.conf.erb
+++ b/ood-portal-generator/templates/ood-portal.conf.erb
@@ -27,15 +27,11 @@
 #
 # 3. Finally, restart Apache to have the changes take effect:
 #
-#      # For CentOS 6
-#      sudo service httpd24-httpd condrestart
-#      sudo service httpd24-htcacheclean condrestart
-#
-#      # For CentOS 7
-#      sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
-#
 #      # For CentOS 8
 #      sudo systemctl try-restart httpd.service htcacheclean.service
+#
+#      # For Ubuntu 24.04
+#      sudo systemctl try-restart apache2.service
 #
 
 <% if @listen_addr_port -%>


### PR DESCRIPTION
I have removed the now unsupported centos 6/7 instructions and added Ubuntu 24.04 from the template and tests