### PR TITLE
exclude owned/imported projects from import list

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -91,7 +91,7 @@ class Project
     def possible_imports
       Rails.cache.fetch('possible_imports', expires_in: 1.hour) do
         importable_directories
-      end
+      end.reject{ |p| lookup_table.include?(p.id) }
     end
 
     private


### PR DESCRIPTION
Contributes to #4120. Adds a filter on the discovered projects so that only projects owned by other users are presented as options. These changes do not fix the issue of the card pane for discovered projects still being visible when empty, but this will be fixed in a future PR reformatting the import views.