### PR TITLE
Add help to resolution fields

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attributes/bc_vnc_resolution.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/bc_vnc_resolution.rb
@@ -22,11 +22,11 @@ module SmartAttributes
       # @param fmt [String, nil] formatting of form label
       # @return [String] form label
       def label(fmt: nil)
-        (opts[:label] || I18n.t('dashboard.batch_connect_form_resolution_label')).to_s
+        (opts[:label] || 'Resolution').to_s
       end
 
       def help(fmt: nil)
-        (opts[:help] || I18n.t('dashboard.batch_connect_form_resolution_help')).to_s
+        (opts[:help] || 'Resolution is only used by native VNC connections').to_s
       end
 
       # Submission hash describing how to submit this attribute

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -45,8 +45,6 @@ en:
     batch_connect_form_launch: Launch
     batch_connect_form_prefill: Use saved settings
     batch_connect_form_prefill_error: Oops... Something is wrong with your template
-    batch_connect_form_resolution_label: Resolution
-    batch_connect_form_resolution_help: Resolution setting is only used by native VNC connections
     batch_connect_form_reset_resolution: Reset Resolution
     batch_connect_form_save: Save settings
     batch_connect_form_save_new_template: save new settings


### PR DESCRIPTION
Fixes #4248 by adding internationalized help text to resolution fields explaining that they are only used for native VNC connections. Also revamps the resolution field helper method to more closely match the patterns used by bootstrap form including
1. Moving the main widget id to a wrapping div instead of the width input
2. Modifying the help element to match other widgets
3. Moving the label to be adjacent to the element it describes and adding `form-label` class
4. Moving the 'Reset Resolution' button inside the main div to prevent extra vertical padding pushing it down