### PR TITLE
fetch bc apps from routers that have them cached

### DIFF
--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -25,19 +25,19 @@ module BatchConnect
       # @param token [String] the token
       # @return [App] generated object
       def from_token(token)
-        type, *app = token.split('/')
-        case type
-        when 'dev'
-          name, sub_app = app
-          router = DevRouter.new(name)
-        when 'usr'
-          owner, name, sub_app = app
-          router = UsrRouter.new(name, owner)
-        else # "sys"
-          name, sub_app = app
-          router = SysRouter.new(name)
-        end
-        new(router: router, sub_app: sub_app)
+        type, = token.split('/')
+
+        # the routers have everything cached, so just find it there.
+        clazz = case type
+                when 'dev'
+                  DevRouter
+                when 'usr'
+                  UsrRouter
+                else # "sys"
+                  SysRouter
+                end
+
+        clazz.apps.find { |app| app.token == token }
       end
     end
 

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -4,6 +4,11 @@ require 'test_helper'
 
 module BatchConnect
   class SessionTest < ActiveSupport::TestCase
+
+    def setup
+      stub_sys_apps
+    end
+
     def bc_jupyter_app
       r = PathRouter.new('test/fixtures/sys_with_gateway_apps/bc_jupyter')
       BatchConnect::App.new(router: r)
@@ -261,7 +266,7 @@ module BatchConnect
       BatchConnect::SessionContext.any_instance.stubs(:cluster).returns('owens')
       BatchConnect::App.any_instance.stubs(:submit_opts).returns({})
 
-      app = BatchConnect::App.from_token('dev/test')
+      app = BatchConnect::App.from_token('sys/bc_jupyter')
       session = BatchConnect::Session.new
 
       session.save(app: app, context: BatchConnect::SessionContext.new)
@@ -273,7 +278,7 @@ module BatchConnect
       BatchConnect::Session.any_instance.stubs(:submit).returns(true)
       BatchConnect::App.any_instance.stubs(:submit_opts).returns({ :cluster => 'owens' })
 
-      app = BatchConnect::App.from_token('dev/test')
+      app = BatchConnect::App.from_token('sys/bc_jupyter')
       session = BatchConnect::Session.new
 
       session.save(app: app, context: BatchConnect::SessionContext.new)
@@ -281,7 +286,7 @@ module BatchConnect
     end
 
     test 'session throws exception when no cluster is available' do
-      app = BatchConnect::App.from_token('dev/test')
+      app = BatchConnect::App.from_token('sys/bc_jupyter')
       session = BatchConnect::Session.new
 
       save = session.save(app: app, context: BatchConnect::SessionContext.new)
@@ -437,7 +442,7 @@ module BatchConnect
 
     test 'ssh_to_compute_node? disabled globally' do
       session = BatchConnect::Session.new
-      session.stubs(:token).returns('rstudio')
+      session.stubs(:token).returns('sys/bc_jupyter')
       session.stubs(:cluster).returns(OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' } }))
       Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
       refute session.ssh_to_compute_node?
@@ -475,7 +480,7 @@ module BatchConnect
 
     test 'ssh_to_compute_node? handles non-existent cluster and disabled globally' do
       session = BatchConnect::Session.new
-      session.stubs(:token).returns('rstudio')
+      session.stubs(:token).returns('sys/bc_jupyter')
       session.stubs(:cluster).raises(BatchConnect::Session::ClusterNotFound, 'Session specifies nonexistent')
       Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
       refute session.ssh_to_compute_node?

--- a/apps/dashboard/test/models/batch_connect/settings_test.rb
+++ b/apps/dashboard/test/models/batch_connect/settings_test.rb
@@ -5,19 +5,23 @@ require 'test_helper'
 module BatchConnect
   class SettingsTest < ActionView::TestCase
 
-    test 'can set values' do
-      target = BatchConnect::Settings.new('app/token', 'settings name', { name: 'value' })
+    def setup
+      stub_sys_apps
+    end
 
-      assert_equal('app/token', target.token)
+    test 'can set values' do
+      target = BatchConnect::Settings.new('sys/bc_jupyter', 'settings name', { name: 'value' })
+
+      assert_equal('sys/bc_jupyter', target.token)
       assert_equal('settings name', target.name)
       assert_equal({ name: 'value' }, target.values)
     end
 
     test 'app returns BatchConnect::App based on token' do
-      target = BatchConnect::Settings.new('sys/token', 'settings name', { name: 'value' })
+      target = BatchConnect::Settings.new('sys/bc_jupyter', 'settings name', { name: 'value' })
 
       assert_instance_of(BatchConnect::App, target.app)
-      assert_equal('sys/token', target.app.token)
+      assert_equal('sys/bc_jupyter', target.app.token)
     end
 
     test 'outdated? returns true when settings keys do not match app attribute ids' do


### PR DESCRIPTION
Fixes #210

Fetch bc apps from routers that have them cached. This is the last spot where apps are being created every time instead of pulling from the cache.