### PR TITLE
Fix workflows widget issue in Projects#show

### DIFF
--- a/apps/dashboard/app/views/projects/show.html.erb
+++ b/apps/dashboard/app/views/projects/show.html.erb
@@ -56,6 +56,7 @@
         <%= t('dashboard.jobs_new_launcher') %>
       </a>
     </div>
+    <%= render partial: 'workflows/workflow', locals: { project: @project, workflows: @workflows } %>
   </div>
   
   <div class="col-md-4">
@@ -94,9 +95,6 @@
         </div>
       <%- end -%>
     </div>
-  </div>
-  <div class="col-md-2">
-    <%= render partial: 'workflows/workflow', locals: { project: @project, workflows: @workflows } %>
   </div>
 </div>
 

--- a/apps/dashboard/app/views/workflows/_workflow.html.erb
+++ b/apps/dashboard/app/views/workflows/_workflow.html.erb
@@ -1,4 +1,4 @@
-<div class="list-group bg-white rounded">
+<div class="list-group bg-white rounded mt-4">
   <a class="list-group-item list-group-item-action bg-light font-weight-bold list-toggler"
       data-bs-toggle="collapse" data-bs-target="#workflow_list"
       aria-expanded="true" aria-controls="workflow_list">


### PR DESCRIPTION
Fixes #4753. A minor change but with a big improvement to the project show page, as it prevents workflows from moving down the page as jobs and outfiles accumulate. Instead keeps the workflows widget 1.5rem from the launchers widget, matching the spacing between the other widgets on the page. 