### PR TITLE
Add xz to dev container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,7 +18,7 @@ RUN dnf -y update && \
     dnf -y module enable nodejs:20 ruby:3.3 && \
     dnf install -y epel-release && \
     dnf install -y ondemand ondemand-dex && \
-    dnf install -y gcc gcc-c++ libyaml-devel nc && \
+    dnf install -y gcc gcc-c++ libyaml-devel nc xz && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
 RUN chmod 600 /etc/shadow


### PR DESCRIPTION
This PR adds xz to the dev container to fix an issue that has been occurring in my development workflow for quite some time.

The `nogokiri` gem requires `xz` to exist to be built (the PR fixes this error):
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
...
Extracting libxml2-2.13.9.tar.xz into tmp/x86_64-redhat-linux/ports/libxml2/2.13.9... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
...
/home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:558:in `xzcat_exe': xzcat not found (RuntimeError)
	from /home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:569:in `tar_command'
	from /home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:580:in `extract_file'
	from /home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:141:in `block in extract'
	from /home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:139:in `each'
	from /home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:139:in `extract'
	from /home/rkarlsso/ondemand/src/apps/dashboard/vendor/bundle/ruby/3.3.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:234:in `cook'
	from extconf.rb:550:in `block (2 levels) in process_recipe'
	from extconf.rb:329:in `chdir'
	from extconf.rb:329:in `chdir_for_build'
	from extconf.rb:550:in `block in process_recipe'
	from <internal:kernel>:90:in `tap'
	from extconf.rb:448:in `process_recipe'
	from extconf.rb:892:in `<main>'
...
An error occurred while installing nokogiri (1.18.10), and Bundler cannot continue.
```

Adding `xz` makes it possible to build the dashboard (sandbox) app inside of the dev container, which I do as building it from the host builds incompatible gems.
