### PR TITLE
Install NodeJS 22 in dev container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN cp /etc/yum.repos.d/ondemand-web.repo /etc/yum.repos.d/ondemand-nightly-web.
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled powertools && \
-    dnf -y module enable nodejs:20 ruby:3.3 && \
+    dnf -y module enable nodejs:22 ruby:3.3 && \
     dnf install -y epel-release && \
     dnf install -y ondemand ondemand-dex && \
     dnf install -y gcc gcc-c++ libyaml-devel nc && \


### PR DESCRIPTION
This PR upgrade the NodeJS version in the dev container to 22, which seems to be required by the current nighly RPMs.

When rebuilding the dev container today I noticed it fails due to the NodeJS version being too old:
```
Error: 
 Problem: package ondemand-4.1.20251114-246559.8b6f69f.nightly.el8.x86_64 from ondemand-web-nightly requires ondemand-nodejs = 4.1.0-1.el8, but none of the providers can be installed
  - package ondemand-nodejs-4.1.0-1.el8.x86_64 from ondemand-web requires nodejs >= 1:22.0, but none of the providers can be installed
  - cannot install the best candidate for the job
  - package nodejs-1:22.11.0-1.module+el8.10.0+1924+614dc87f.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:22.13.1-1.module+el8.10.0+1935+d3cbe60f.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:22.13.1-2.module+el8.10.0+1956+804687b6.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:22.15.0-1.module+el8.10.0+1971+0bb08ece.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:22.16.0-1.module+el8.10.0+1989+e60144d9.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:22.16.0-2.module+el8.10.0+2012+fb8b67c7.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:22.19.0-2.module+el8.10.0+2069+07c7cb32.x86_64 from appstream is filtered out by modular filtering
  - package nodejs-1:24.4.1-1.module+el8.10.0+2084+ab509703.x86_64 from appstream is filtered out by modular filtering
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
Error: building at STEP "RUN dnf -y update &&     dnf install -y dnf-utils &&     dnf config-manager --set-enabled powertools &&     dnf -y module enable nodejs:20 ruby:3.3 &&     dnf install -y epel-release &&     dnf install -y ondemand ondemand-dex &&     dnf install -y gcc gcc-c++ libyaml-devel nc xz &&     dnf clean all && rm -rf /var/cache/dnf/*": while running runtime: exit status 1
rake aborted!
Command failed with status (1): [buildah bud --build-arg VERSION=v4.1.0-0.1...]
```