### PR TITLE
only use time limit if it is positive

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -38,12 +38,12 @@ module BatchConnect::SessionsHelper
     time_limit = session.info.wallclock_limit
     time_used  = session.info.wallclock_time
     if session.starting? || session.running?
-      if time_limit.positive? && time_used
+      if time_limit.to_i.positive? && time_used
         [t('dashboard.batch_connect_sessions_stats_time_remaining'), distance_of_time_in_words(time_limit - time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)] 
       elsif time_used
         [t('dashboard.batch_connect_sessions_stats_time_used'), distance_of_time_in_words(time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)] 
       end
-    elsif time_limit.positive?
+    elsif time_limit.to_i.positive?
       [t('dashboard.batch_connect_sessions_stats_time_requested'), distance_of_time_in_words(time_limit, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)]
     end
   end


### PR DESCRIPTION
Fixes #4425 by checking for positive (> 0) time limit to account for jobs with unlimited time.