### PR TITLE
HTCondor Adapater also supports account info.

### DIFF
--- a/apps/dashboard/app/lib/account_cache.rb
+++ b/apps/dashboard/app/lib/account_cache.rb
@@ -9,10 +9,10 @@ module AccountCache
   # @return [Array<AccountInfo>] - the account info objects
   def accounts
     Rails.cache.fetch('account_info', expires_in: 4.hours) do
-      # only Slurm support in ood_core
+      # only Slurm & HTCondor support in ood_core
       # job_clusters: not to be confused with clusters
-      slurm_job_clusters = Configuration.job_clusters.select(&:slurm?)
-      slurm_job_clusters.empty? ? [] : slurm_job_clusters.map(&:job_adapter).flat_map(&:accounts).uniq
+      job_clusters = Configuration.job_clusters.select { |c| c.slurm? || c.htcondor? }
+      job_clusters.empty? ? [] : job_clusters.map(&:job_adapter).flat_map(&:accounts).uniq
     rescue StandardError => e
       Rails.logger.warn("Did not get accounts from system with error #{e}")
       Rails.logger.warn(e.backtrace.join("\n"))


### PR DESCRIPTION
Add HTCondor as an option for the account_cache.
We do want users to be able to select which account (quota group in HTCondor), they want to use for a OOD job.
For that, we need to communicate this information outward.
For Slurm the account_cache is used for this - we should also just allow HTCondor as an accounts provider.

This change has been deployed locally (on an older master) for a while (since July?).
I hope nothing has changed about the meaning of this since then? :)
I'd love to get this upstream as well, to enable other people to use the full functionality of the HTCondor backend (and to reduce the complexity of our setup :))
