### PR TITLE
Populate int_configs

### DIFF
--- a/apps/dashboard/app/models/posix_file.rb
+++ b/apps/dashboard/app/models/posix_file.rb
@@ -164,7 +164,7 @@ class PosixFile
     nil
   end
 
-  def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)
+  def can_download_as_zip?(timeout: Configuration.download_dir_timeout_seconds, download_directory_size_limit: Configuration.download_dir_max)
     can_download = false
     error = nil
 

--- a/apps/dashboard/app/models/remote_file.rb
+++ b/apps/dashboard/app/models/remote_file.rb
@@ -48,7 +48,7 @@ class RemoteFile
     end.sort_by { |p| p[:directory] ? 0 : 1 }
   end
 
-  def can_download_as_zip?(timeout: Configuration.file_download_dir_timeout, download_directory_size_limit: Configuration.file_download_dir_max)
+  def can_download_as_zip?(timeout: Configuration.download_dir_timeout_seconds, download_directory_size_limit: Configuration.download_dir_max)
     [false, 'Downloading remote files as zip is currently not supported']
   end
 

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -6,10 +6,10 @@
 
  <div class="row">
   <div class="col-sm-6">
-   <%= f.number_field(:compression, class: 'custom-range', type: 'range', min: 1, max: 9, value: Configuration.novnc_default_compression.to_i, label: "Compression", help: "1 (low) to 9 (high)") %>
+   <%= f.number_field(:compression, class: 'custom-range', type: 'range', min: 1, max: 9, value: Configuration.novnc_default_compression, label: "Compression", help: "1 (low) to 9 (high)") %>
   </div>
   <div class="col-sm-6">
-   <%= f.number_field(:quality, class: 'custom-range', type: 'range', min: 0, max: 9, value: Configuration.novnc_default_quality.to_i, label: "Image Quality", help: "0 (low) to 9 (high)") %>
+   <%= f.number_field(:quality, class: 'custom-range', type: 'range', min: 0, max: 9, value: Configuration.novnc_default_quality, label: "Image Quality", help: "0 (low) to 9 (high)") %>
   </div>
  </div>
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -88,11 +88,14 @@ class ConfigurationSingleton
   # @return [Hash] key/value pairs of defaults
   def int_configs
     {
-      :bc_clean_old_dirs_days    => 30,
-      :file_download_max         => 10_737_418_240,
-      :project_size_timeout      => 15,
-      :novnc_default_compression => 6,
-      :novnc_default_quality     => 2,
+      :bc_clean_old_dirs_days       => 30,
+      :download_dir_timeout_seconds => 5,
+      :download_dir_max             => 10_737_418_240, # 10*1024*1024*1024 bytes
+      :file_editor_max_size         => 12_582_912,     # 12*1024*1024 bytes
+      :file_download_max            => 10_737_418_240, # 10*1024*1024*1024 bytes
+      :project_size_timeout         => 15,
+      :novnc_default_compression    => 6,
+      :novnc_default_quality        => 2,
     }.freeze
   end
 
@@ -366,30 +369,6 @@ class ConfigurationSingleton
   # @return [String] Maximum upload size for nginx.
   def file_upload_max
     [ENV['FILE_UPLOAD_MAX']&.to_i, ENV['NGINX_FILE_UPLOAD_MAX']&.to_i].compact.min || 10737420000
-  end
-
-  # The timeout (seconds) for "generating" a .zip from a directory.
-  #
-  # Default for OOD_DOWNLOAD_DIR_TIMEOUT_SECONDS is "5" (seconds).
-  # @return [Integer]
-  def file_download_dir_timeout
-    ENV['OOD_DOWNLOAD_DIR_TIMEOUT_SECONDS']&.to_i || 5
-  end
-
-  # The maximum size of a .zip file that can be downloaded.
-  #
-  # Default for OOD_DOWNLOAD_DIR_MAX is 10*1024*1024*1024 bytes.
-  # @return [Integer]
-  def file_download_dir_max
-    ENV['OOD_DOWNLOAD_DIR_MAX']&.to_i || 10737418240
-  end
-
-  # The maximum size of a file that can be opened in the file editor.
-  #
-  # Default for OOD_FILE_EDITOR_MAX_SIZE is 12*1024*1024 bytes.
-  # @return [Integer]
-  def file_editor_max_size
-    ENV['OOD_FILE_EDITOR_MAX_SIZE']&.to_i || 12582912 
   end
 
   def allowlist_paths

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -74,14 +74,10 @@ class ConfigurationSingleton
       :user_settings_file             => Pathname.new("~/.config/#{ood_portal}/settings.yml").expand_path.to_s,
       :facl_domain                    => nil,
       :auto_groups_filter             => nil,
-      :bc_clean_old_dirs_days         => '30',
       :google_analytics_tag_id        => nil,
       :project_template_dir           => "#{config_root}/projects",
       :rclone_extra_config            => nil,
       :default_profile                => nil,
-      :project_size_timeout           => '15',
-      :novnc_default_compression      => '6',
-      :novnc_default_quality          => '2',
       :plugins_directory              => '/etc/ood/config/plugins'
     }.freeze
   end
@@ -92,7 +88,11 @@ class ConfigurationSingleton
   # @return [Hash] key/value pairs of defaults
   def int_configs
     {
-      :file_download_max => 10_737_418_240
+      :bc_clean_old_dirs_days    => 30,
+      :file_download_max         => 10_737_418_240,
+      :project_size_timeout      => 15,
+      :novnc_default_compression => 6,
+      :novnc_default_quality     => 2,
     }.freeze
   end
 

--- a/apps/dashboard/config/initializers/bc_cleanup.rb
+++ b/apps/dashboard/config/initializers/bc_cleanup.rb
@@ -3,7 +3,7 @@
 Rails.application.config.after_initialize do
   next unless Configuration.bc_clean_old_dirs?
 
-  config_days = Configuration.bc_clean_old_dirs_days.to_i
+  config_days = Configuration.bc_clean_old_dirs_days
   config_days = 30 if config_days.zero? || config_days.negative?
 
   thirty_day_seconds = config_days * 24 * 60 * 60

--- a/apps/dashboard/test/models/files_test.rb
+++ b/apps/dashboard/test/models/files_test.rb
@@ -92,7 +92,7 @@ class FilesTest < ActiveSupport::TestCase
   end
 
   test "can_download_as_zip handles directory size exceeding limit" do
-    download_directory_size_limit = Configuration.file_download_dir_max
+    download_directory_size_limit = Configuration.download_dir_max
     Dir.mktmpdir do |dir|
       dir_size = download_directory_size_limit + 1
       PosixFile.any_instance.stubs(:calculate_directory_size)


### PR DESCRIPTION
Fixes #4657. Using the `int_configs` method introduced in #4535, we populate the hash with string configs that are cast to ints (removing the casting from the references). We also move random int configs that were never included in the `string_configs` hash, which appear to only be these three
https://github.com/OSC/ondemand/blob/1463cc81a22452abe84c872279f32df830c2f327/apps/dashboard/config/configuration_singleton.rb#L360-L394

some which have deviated from the naming convention required by `int_configs`, so all the references to these methods were updated to match the (existing) associated environment variable. This does violate the codebase convention of starting the config with the app it concerns itself with, (`files_download_dir_timeout`, eg.) but is much less disruptive than changing existing environment variables. I would be okay with reverting those changes though if it seems better to just leave them alone.