### PR TITLE
Fix template icons

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -227,7 +227,7 @@ class ProjectsController < ApplicationController
       label = project.title
       data = {
         'data-description' => project.description,
-        'data-icon'        => project.icon
+        'data-icon'        => project.icon_class
       }
       [label, project.directory, data]
     end


### PR DESCRIPTION
Fixes #4177. A very simple fix since we already have the `icon_class` method on Project that gives us the proper value for the form. This mirrors the pattern used to fill out the form for the edit page.