### PR TITLE
Remove deleted projects from lookup

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -31,7 +31,9 @@ class Project
 
     def lookup_table
       f = File.read(lookup_file)
-      YAML.safe_load(f).to_h
+      YAML.safe_load(f).to_h.reject do |_, dir|
+        from_directory(dir).errors.present?
+      end
     rescue StandardError, Exception => e
       Rails.logger.warn("cannot read #{dataroot}/.project_lookup due to error #{e}")
       {}


### PR DESCRIPTION
Fixes #4754 by adding a `load` parameter to `Project#intialize` to signal that the object is expected to already exist. If it does not, we remove it from the lookup table so that it is not called next time. We also filter the returned list in `Project#all` so that these nonexistent records do not appear that first time (after which they will be removed from the table). 