### PR TITLE
rm bundler version requirement for nginx_stage

### DIFF
--- a/nginx_stage/nginx_stage.gemspec
+++ b/nginx_stage/nginx_stage.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "syslog", "~> 0.1.0"
   spec.add_dependency 'dotenv', '~> 2.1'
 
-  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0.1"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "climate_control"


### PR DESCRIPTION
rm bundler version requirement for nginx_stage as the CI is currently failing to meet this dependency.