### PR TITLE
rm eval dbus-launch now that we have SAFE_PATH correct

### DIFF
--- a/apps/bc_desktop/template/desktops/xfce.sh
+++ b/apps/bc_desktop/template/desktops/xfce.sh
@@ -36,9 +36,5 @@ else
     "${TERM_CONFIG}"
 fi
 
-# launch dbus first through eval because it can conflict with a conda environment
-# see https://github.com/OSC/ondemand/issues/700
-eval $(dbus-launch --sh-syntax)
-
 # Start up xfce desktop (block until user logs out of desktop)
 xfce4-session


### PR DESCRIPTION
rm eval dbus-launch now that we have SAFE_PATH correct

Fixes #700 once again and hopefully forever. Now that we correctly specify SAFE_PATH without the users' HOME we can remove this as it seems to actually _cause_ issues now.