### PR TITLE
Remove action from import error reports

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -113,10 +113,10 @@ class ProjectsController < ApplicationController
       if Project.import_to_lookup(@project)
         redirect_to projects_path, notice: I18n.t('dashboard.jobs_project_imported')
       else
-        redirect_to project_import_path, alert: @project.errors.map{ |e| e.message }.join('. ')
+        redirect_to project_import_path, alert: @project.collect_errors
       end
     else
-      redirect_to project_import_path, alert: @project.errorsmap{ |e| e.message }.join('. ')
+      redirect_to project_import_path, alert: @project.collect_errors
     end
   end
 


### PR DESCRIPTION
Fixes #4265. Uses the built in method `collect_errors` in place of manually collecting and separating `full_messages`, which included the action that spawned the error. This aligns with the rest of the actions in `ProjectsController`, none of which use the `full_messages` approach