### PR TITLE
add alt text to welcome logo

### DIFF
--- a/apps/dashboard/app/helpers/dashboard_helper.rb
+++ b/apps/dashboard/app/helpers/dashboard_helper.rb
@@ -11,7 +11,7 @@ module DashboardHelper
     if url
       uri = Addressable::URI.parse(url)
       uri.query_values = (uri.query_values || {}).merge({timestamp: Time.now.to_i})
-      tag.img(src: uri, alt: "logo", height: @user_configuration.dashboard_logo_height, class: 'py-2')
+      tag.img(src: uri, alt: I18n.t('dashboard.logo_alt_text'), height: @user_configuration.dashboard_logo_height, class: 'py-2')
     else # default logo image
       image_tag("OpenOnDemand_stack_RGB.svg", alt: "logo", height: "85", class: 'py-2')
     end

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -299,6 +299,7 @@ en:
     welcome_html: |
       %{logo_img_tag}
       <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
+    logo_alt_text: Welcome to Open OnDemand
     unknown: "Unknown"
     save: "Save"
     add: "Add"


### PR DESCRIPTION
Fixes #2067 by adding a localization for the logo alt text, which was previously fixed to 'logo'