### PR TITLE
add setgid option to projects

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -236,7 +236,7 @@ class ProjectsController < ApplicationController
   def project_params
     params
       .require(:project)
-      .permit(:name, :directory, :description, :icon, :id, :template, :group_owner)
+      .permit(:name, :directory, :description, :icon, :id, :template, :group_owner, :setgid)
   end
 
   def show_project_params

--- a/apps/dashboard/app/helpers/projects_helper.rb
+++ b/apps/dashboard/app/helpers/projects_helper.rb
@@ -53,4 +53,8 @@ module ProjectsHelper
       status
     end
   end
+
+  def form_label_tooltip(content)
+    "<i class='fa fa-question-circle vertical-align-middle' data-bs-toggle='tooltip' data-bs-placement='right' title='#{content}'></i>"
+  end
 end

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -55,17 +55,19 @@
           </div>
           <% unless @project.private? && edit_project_action %>
             <div class="field">
-              <% help_html = 
-                  if edit_project_action
-                    '' 
-                  else
-                    "<i class='fa fa-question-circle vertical-align-middle' data-bs-toggle='tooltip' data-bs-placement='right' title='#{I18n.t('dashboard.jobs_project_group_help')}'></i>" 
-                  end
-              %>
+              <% help_html = edit_project_action ? '' : form_label_tooltip(I18n.t('dashboard.jobs_project_group_help')) %>
               <%= form.select(:group_owner,
                               CurrentUser.group_names,
                               { label: "#{I18n.t('dashboard.jobs_project_group_owner')} #{help_html}".html_safe },
                               { disabled: edit_project_action })
+              %>
+              <%= form.form_group(:setgid) do
+                    form.check_box(:setgid,
+                                   checked: edit_project_action ? @project.project_dataroot.setgid? : true,
+                                   switch: true,
+                                   label: "Set setgid bit? #{form_label_tooltip(I18n.t('dashboard.jobs_project_setgid_help'))}".html_safe,
+                                   disabled: edit_project_action)
+                  end
               %>
             </div>
 	        <% end %>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -187,6 +187,7 @@ en:
     jobs_project_name_validation: Project name may only contain letters, digits, dashes, underscores, and spaces
     jobs_project_not_found: Cannot find project %{project_id}
     jobs_project_save_error: Cannot save manifest to %{path}
+    jobs_project_setgid_help: Leaving setgid checked ensures project files are created with the selected group. Does not affect projects in your home directory.
     jobs_project_validation_error: Invalid Request. Please review the errors below
     jobs_select_directory_placeholder: Click on project below to import to your home page (Optional)
     jobs_workflows: Workflows


### PR DESCRIPTION
Fixes #4781 along the same lines as #4792. In addition to the basic addition of an attribute and checkbox, there were a few changes I made as well
- move the help tooltip into a helper method, as both group and setgid labels use it
- add `0o` to the start of the mode, this allows the sum arguments to correctly be read as octals
- move `chgrp_directory` to the beginning of `update_permissions`, since group changes reset the setgid bit.

This also introduces group write permissions on all shared projects (outside of home directory), so the three possible values for mode are now 
- 0750 For private projects
- 0770 For shared projects (no setgid)
- 2770 For shared projects with setgid enabled

Since most shared projects will want it enabled, I default to `checked` on new forms, and like the group setting it is disabled on the edit form and communicates the current state. Unlike the `group_owner` attribute, we do not automatically set this 'accurate' value in the model, but access it directly from the form. Because `@project.directory.setgid?` is so simple, we prefer this over @project.setgid, and so intentionally do not keep the attribute up to date with the current state, and should only ever be set during `create` actions.