### PR TITLE
update workflow delete confirmation

### DIFF
--- a/apps/dashboard/app/views/workflows/_workflow.html.erb
+++ b/apps/dashboard/app/views/workflows/_workflow.html.erb
@@ -28,7 +28,7 @@
         <div class="col">
           <%= button_to I18n.t('dashboard.delete'), project_workflow_path(@project.id, workflow.id),
                         method: :delete,
-                        data: { confirm: t('dashboard.jobs_project_delete_project_confirmation') },
+                        data: { confirm: t('dashboard.jobs_workflow_delete_confirmation') },
                         class: "btn btn-danger launcher-button" %>
         </div>
       </div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -198,6 +198,7 @@ en:
     jobs_workflow_description_placeholder: Workflow description
     jobs_workflow_not_found: Cannot find workflow %{workflow_id}
     jobs_workflow_missing_launchers: select at least %{count}
+    jobs_workflow_delete_confirmation: Delete all contents of workflow?
     jobs_workflow_deleted: Workflow successfully deleted!
     jobs_workflow_failed: Workflow failed with error %{error}
     jobs_workflow_manifest_updated: Workflow manifest updated!


### PR DESCRIPTION
Fixes #4776. After a thorough review of our notifications, alerts, and confirmations of projects, launchers, and workflows, the only one that stood out was workflow delete, which was the original cause of the issue. It was using the project delete confirmation, so I added a new one to ask specifically about workflows. 