### PR TITLE
block `password_field`s from app popup

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -103,7 +103,7 @@ module SmartAttributes
     end
 
     def display?
-      !!opts[:display]
+      !!opts[:display] && widget != 'password_field'
     end
 
     # Submission hash describing how to submit this attribute


### PR DESCRIPTION
Fixes #4848 by filtering displayable settings with an additional check of `widget == 'password_field'`. That check is borrowed from 
https://github.com/OSC/ondemand/blob/01972e482f3fa90478355446ec0ac5da78cd16da/apps/dashboard/app/models/concerns/encrypted_cache.rb#L18

and both these checks may be simpler if we create a `sensitive?` flag on attributes. I can make a ticket if others agree