### PR TITLE
Add owner name to shared projects

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/projects.scss
+++ b/apps/dashboard/app/assets/stylesheets/projects.scss
@@ -40,6 +40,19 @@
   }
 }
 
+.project-icon.shared {
+  padding: 1.75rem 2rem;
+
+  .project-title {
+    margin: .5rem 0rem;
+  }
+
+  small {
+    display: block;
+    font-size: 1rem;
+  }
+}
+
 .thin-outline {
   outline: 0.15em solid rgb(36, 36, 36);
 }

--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -206,6 +206,10 @@ class Project
     false
   end
 
+  def mine?
+    directory.stat.uid == CurrentUser.uid
+  end
+
   def private?
     directory.to_s.start_with?(CurrentUser.home)
   end

--- a/apps/dashboard/app/views/projects/_possible_imports.html.erb
+++ b/apps/dashboard/app/views/projects/_possible_imports.html.erb
@@ -17,9 +17,9 @@
                 <strong>
                   <%= icon_tag(URI.parse(project.icon)) %>
                   <div class="project-title mt-2 mb-0">
-		    <%= project.title %>
-		    <%= content_tag(:small, PosixFile.username_from_cache(project.directory.stat.uid), class:'text-muted d-block') %>
-		  </div>
+                    <%= project.title %>
+                    <%= content_tag(:small, PosixFile.username_from_cache(project.directory.stat.uid), class:'text-muted d-block') %>
+                  </div>
                 </strong>
               </div>
             <% end %>

--- a/apps/dashboard/app/views/projects/_possible_imports.html.erb
+++ b/apps/dashboard/app/views/projects/_possible_imports.html.erb
@@ -16,7 +16,10 @@
               <div class="text-center d-flex justify-content-center">
                 <strong>
                   <%= icon_tag(URI.parse(project.icon)) %>
-                  <%= content_tag(:div, project.title, class:'project-title my-2') %>
+                  <div class="project-title mt-2 mb-0">
+		    <%= project.title %>
+		    <%= content_tag(:small, PosixFile.username_from_cache(project.directory.stat.uid), class:'text-muted d-block') %>
+		  </div>
                 </strong>
               </div>
             <% end %>

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -10,11 +10,17 @@
     <div class="row">
       <% @projects.each do |project| %>
         <div id="<%= project.id %>" class="project-card">
-          <%= link_to(project_path(project.id), class: 'text-dark project-icon') do %>
+          <% owned = project.directory.stat.uid == CurrentUser.uid %>
+          <%= link_to(project_path(project.id), class: "text-dark project-icon #{owned ? '' : 'shared'}") do %>
             <div class="text-center d-flex justify-content-center">
               <strong>
                 <%= icon_tag(URI.parse(project.icon)) %>
-                <%= content_tag(:div, project.title, class: 'project-title') %>
+                <%= content_tag(:div, class: 'project-title') do %>
+                  <%= project.title %>
+		  <small class="text-muted">
+		    <%= PosixFile.username_from_cache(project.directory.stat.uid) unless owned %>
+		  </small>
+		<% end %>
               </strong>
             </div>
             <div class="row">

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -10,15 +10,14 @@
     <div class="row">
       <% @projects.each do |project| %>
         <div id="<%= project.id %>" class="project-card">
-          <% owned = project.directory.stat.uid == CurrentUser.uid %>
-          <%= link_to(project_path(project.id), class: "text-dark project-icon #{owned ? '' : 'shared'}") do %>
+          <%= link_to(project_path(project.id), class: "text-dark project-icon #{project.mine? ? '' : 'shared'}") do %>
             <div class="text-center d-flex justify-content-center">
               <strong>
                 <%= icon_tag(URI.parse(project.icon)) %>
                 <%= content_tag(:div, class: 'project-title') do %>
                   <%= project.title %>
                   <small class="text-muted">
-                    <%= PosixFile.username_from_cache(project.directory.stat.uid) unless owned %>
+                    <%= PosixFile.username_from_cache(project.directory.stat.uid) unless project.mine? %>
                   </small>
                 <% end %>
               </strong>

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -17,10 +17,10 @@
                 <%= icon_tag(URI.parse(project.icon)) %>
                 <%= content_tag(:div, class: 'project-title') do %>
                   <%= project.title %>
-		  <small class="text-muted">
-		    <%= PosixFile.username_from_cache(project.directory.stat.uid) unless owned %>
-		  </small>
-		<% end %>
+                  <small class="text-muted">
+                    <%= PosixFile.username_from_cache(project.directory.stat.uid) unless owned %>
+                  </small>
+                <% end %>
               </strong>
             </div>
             <div class="row">


### PR DESCRIPTION
Fixes #4854 by adding a `small` element with the project owners username (provided it is not you). We add this in two places, the project index list, and the importable projects list. For the index list, we do some css math to ensure that the project card remains the same height, by 
- fixing the font-size of the `small` to `1rem`, giving the element a height of 1.5 rem
- changing the vertical margin of the title to .5rem from 1rem (saving 1rem)
- changing the vertical padding of the card from 2rem to 1.75rem (saving 1.5 rem)

The importable project cards need less styling because they are always owned by someone else, so naturally share the same height as one another. We do slightly adjust the margins to make sure the title block (title and owner) remains centered in the same place as before.