### PR TITLE
Render markdown properly in app popups

### DIFF
--- a/apps/dashboard/app/views/batch_connect/shared/_app_list_item.html.erb
+++ b/apps/dashboard/app/views/batch_connect/shared/_app_list_item.html.erb
@@ -6,7 +6,7 @@
       title: link.title,
       data: {
         'bs-toggle': "popover",
-        'bs-content': manifest_markdown(link.description),
+        'bs-content': content_tag(:div, manifest_markdown(link.description), class: 'ood-appkit markdown'),
         'bs-html': true,
         'bs-trigger': "hover",
         container: "body",


### PR DESCRIPTION
Fixes #4887 by giving the app popups the same classes used to render markdown in the app form. This tackles the original problem (overflowing images), while also guaranteeing consistency for other markdown elements between the popup and form