### PR TITLE
disable shared settings when appropriate

### DIFF
--- a/apps/dashboard/app/javascript/config.js
+++ b/apps/dashboard/app/javascript/config.js
@@ -105,3 +105,8 @@ export function appsDatatablePageLength() {
   const cfgData = configData();
   return parseInt(cfgData['appsDatatablePageLength']);
 }
+
+export function userHome() {
+  const cfgData = configData();
+  return cfgData['userHome'];
+}

--- a/apps/dashboard/app/javascript/projects_new.js
+++ b/apps/dashboard/app/javascript/projects_new.js
@@ -1,10 +1,17 @@
 'use strict';
 
 import { attachPathSelectors }  from './path_selector/path_selector';
+import { userHome } from './config';
+
+// cache this just so we don't have to keep parsing the DOM to retrieve it.
+const home = userHome();
 
 jQuery(function() {
   $("#project_template").on('change', (event) => templateChange(event));
+  $("#project_directory").on('input', (event) => toggleSharedSettings(event.target.value));
   attachPathSelectors();
+
+  toggleSharedSettings(document.getElementById('project_directory').value);
 });
 
 function templateChange(event) {
@@ -21,4 +28,13 @@ function templateChange(event) {
   $("#project_description").val(description);
   $("#product_icon_select").val(icon);
   $("#product_icon_select").trigger('change');
+}
+
+function toggleSharedSettings(value) {
+  const owner = document.getElementById('project_group_owner');
+  const setgid = document.getElementById('project_setgid');
+  const isDisabled = value.startsWith(home) || value === "";
+
+  owner.disabled = isDisabled;
+  setgid.disabled = isDisabled;
 }

--- a/apps/dashboard/app/views/layouts/_config.html.erb
+++ b/apps/dashboard/app/views/layouts/_config.html.erb
@@ -14,4 +14,5 @@
   data-status-index-url="<%= system_status_path if respond_to?(:system_status_path) %>"
   data-support-path="<%= support_path if respond_to?(:support_path) %>"
   data-apps-datatable-page-length="<%= @user_configuration.apps_datatable[:page_length] %>"
+  data-user-home="<%= CurrentUser.home %>"
 ></div>


### PR DESCRIPTION
Disable shared settings on the `projects#new` page like setgid and group ownership when the project directory is outside of the users HOME.

I know in the other PR we talked about how these are ignored if it's a private project, but even so, a little bit of reinforcement for the user I think is warranted.