### PR TITLE
fix file editor overflows

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/editor.scss
+++ b/apps/dashboard/app/assets/stylesheets/editor.scss
@@ -11,6 +11,10 @@
   margin-bottom: auto !important;
 }
 
+.editor-controls {
+  min-width: 7rem;
+}
+
 .glyphicon-spin {
   -webkit-animation: spin 1000ms infinite linear;
   animation: spin 1000ms infinite linear;

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -2,7 +2,7 @@
 <div id="editor-filename" class="text-center mb-2"><%= @path %></div>
 
 <div class="d-flex flex-row flex-grow-1">
-  <div class="flex-column col-sm-1 card mx-2 text-center">
+  <div class="editor-controls flex-column col-sm-1 card mx-2 text-center">
 
     <div class="card-header">
       <div class="d-grid gap-2">


### PR DESCRIPTION
Fixes #4886 by adding a class for the controls sidebar and setting a width min of 7rem.