### PR TITLE
Added logic for temporary directory in Workflows

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -337,7 +337,7 @@ class Launcher
       # force some values for scripts like the 'workdir'. We could use auto
       # attributes, but this is not optional and not variable.
       {
-        workdir: project_dir.to_s
+        workdir: options[:workflow_run_dir] || project_dir.to_s
       }
     )
   end


### PR DESCRIPTION
Related to Epic https://github.com/OSC/ondemand/issues/4338

Currently, in launchers we force set the `workdir` to Project Directory

From now on if a launcher is run as part of workflow then the `workdir` will be set to a new temporary directory named as `workflow_name + current date and time`