### PR TITLE
Fix project file permissions

### DIFF
--- a/apps/dashboard/app/models/concerns/project_permissions.rb
+++ b/apps/dashboard/app/models/concerns/project_permissions.rb
@@ -1,0 +1,22 @@
+module ProjectPermissions
+  def with_proper_umask(path)
+    with_umask(get_umask(path)) do
+      yield
+    end
+  end
+
+  def with_umask(mask)
+    old = File.umask(mask)
+    yield
+  ensure
+    File.umask(old)
+  end
+
+  def get_umask(path)
+    shared?(path) ? 0o007 : 0o077
+  end
+
+  def shared?(path)
+    !path.to_s.start_with?(CurrentUser.home)
+  end
+end

--- a/apps/dashboard/app/models/workflow.rb
+++ b/apps/dashboard/app/models/workflow.rb
@@ -2,6 +2,7 @@
 
 class Workflow
   include ActiveModel::Model
+  include ProjectPermissions
 
   class << self
     def workflow_dir(project_dir)
@@ -85,7 +86,9 @@ class Workflow
 
   def save_manifest(operation)
     FileUtils.touch(manifest_file) unless manifest_file.exist?
-    Pathname(manifest_file).write(to_h.as_json.compact.to_yaml)
+    if editable?
+      Pathname(manifest_file).write(to_h.as_json.compact.to_yaml)
+    end
 
     true
   rescue StandardError => e
@@ -119,6 +122,10 @@ class Workflow
       next unless override || attributes.key?(attribute)
       instance_variable_set("@#{attribute}".to_sym, attributes.fetch(attribute, ''))
     end
+  end
+
+  def editable?
+    manifest_file.writable? || !shared?(manifest_file)
   end
 
   def submit(attributes = {})


### PR DESCRIPTION
Fixes #4121. We first add a new `ProjectPermissions` module to help keep project permission logic consistent across Projects, Launchers, and Workflows. This gives us two important methods, `with_proper_umask` and `shared?` (opposite of Project#private?). 

Using these permissions, we do the following with shared project files (with shared implying write access)
- Project
  - .ondemand (shared)
  - .ondemand/launchers (shared)
  - .ondemand/workflows (shared)
  - job_log.yml (shared)
  - manifest.yml (not shared)

- Launcher
  - id (launcher dir) (shared)
  - id/cache.json (shared)
  - id/form.yml (not shared)

- Workflow
  - manifest (not shared)
 
The files marked 'not shared' just means they do not enforce sharing, instead taking the default mode using the user's umask. This allows people to toggle which project objects are editable by their group members, but ensures that all collaborators can at least read and launch anything they can see.

Finally, we add an `editable?` method to Workflows to toggle whether we raise an error on a failed update. This appears because workflows must save before they are submitted, and ensures that we don't fail by trying to rewrite the manifest. `editable?` will return true unless the project is shared, ensuring that errors with private projects are reported to the user.

To test, two users should be able to
- launch each other's launchers
- create workflows with owned and unowned launchers
- run workflows, regardless of workflow or launcher ownership