### PR TITLE
Add per user caching to launchers

### DIFF
--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -258,7 +258,6 @@ class Launcher
     with_proper_umask(project_dir) do
       dir_path = Launcher.path(project_dir, id)
       dir_path.mkpath unless dir_path.exist?
-      FileUtils.touch(cache_file_path) unless cache_file_path.exist?
     end
   end
 
@@ -309,7 +308,7 @@ class Launcher
   end
 
   def cache_file_path
-    Pathname.new(File.join(Launcher.path(project_dir, id), "cache.json"))
+    Pathname.new(File.join(Launcher.path(project_dir, id), "#{CurrentUser.name}-cache.json"))
   end
 
   def cache_file_exists?
@@ -318,7 +317,6 @@ class Launcher
 
   def cached_values
     @cached_values ||= begin
-      cache_file_path = OodAppkit.dataroot.join(Launcher.launchers_dir("#{project_dir}"), "#{id}_opts.json")
       cache_file_content = File.read(cache_file_path) if cache_file_path.exist?
       
       File.exist?(cache_file_path) ? JSON.parse(cache_file_content) : {}


### PR DESCRIPTION
Fixes #4925. Makes launcher caches user-specific by adding the current user's username into the file title. Also removes a line that was breaking launcher caches altogether by redefining `cache_file_path` outside the same-named method. Currently difficult to test as jobs are not running very quickly, but should be double checked anyway during final Project Manager testing.