### PR TITLE
Handle trailing slashes in OOD_SHARED_PROJECT_PATH

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -99,14 +99,14 @@ class Project
     private
 
     def importable_directories
-      Configuration.shared_projects_root.map do |root|
-        next unless File.exist?(root) && File.directory?(root) && File.readable?(root)
+      Configuration.shared_projects_root.map do |str_root|
+        root = Pathname.new(str_root)
+        next unless root.exist? && root.directory? && root.readable?
 
-        Dir.each_child(root).map do |child|
-          child_dir = "#{root}/#{child}"
-          next unless File.directory?(child_dir) && File.readable?(child_dir)
-          Dir.each_child(child_dir).map do |possible_project|
-            Project.from_directory("#{child_dir}/#{possible_project}")
+        root.children.map do |child_dir|
+          next unless child_dir.directory? && child_dir.readable?
+          child_dir.children.map do |possible_project|
+            Project.from_directory(possible_project)
           end
         end.flatten
       end.flatten.compact.reject{ |p| p.errors.any? }


### PR DESCRIPTION
Fixes #4917. While projects were already protected against user provided paths (new form, import form), it did not protect against trailing slashes in the OOD_SHARED_PROJECT_PATH variable. This causes the following output from `importable_directories`, which ends up being added to the lookup table when the import shortcut is clicked. 
```
irb(main):001> Project.importable_directories
=> 
[#<Project:0x0000150f71266048
  @description="",
  @directory=#<Pathname:/fs/ess//PZS1118/launcher_cache_test>,
  @errors=#<ActiveModel::Errors []>,
  @files="",
  @group_owner="PZS1118",
  @icon="fas://igloo",
  @id="nyqbrinl",
  @name="Launcher Cache test",
  @setgid=false,
  @template=nil>,
```
To fix this, we keep all paths in the `importable_directories` as Pathnames. This allows us to generate absolute children without doing string composition, preventing errors like this.