### PR TITLE
Improve importable project search

### DIFF
--- a/apps/dashboard/app/models/project.rb
+++ b/apps/dashboard/app/models/project.rb
@@ -104,7 +104,7 @@ class Project
         next unless root.exist? && root.directory? && root.readable?
 
         root.children.map do |child_dir|
-          next unless child_dir.directory? && child_dir.readable?
+          next unless child_dir.directory? && child_dir.writable?
           child_dir.children.map do |possible_project|
             Project.from_directory(possible_project)
           end


### PR DESCRIPTION
Fixes #4892 using the assumption that project-level directories will be writable by all potential collaborators, greatly improving load times (see the issue for a comparison)