### PR TITLE
Add favorites to project form path selector

### DIFF
--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -13,7 +13,7 @@
     breadcrumb_id: "#{path_selector_id}_breadcrumb",
     button_id: "#{path_selector_id}_button",
     input_field_id: 'project_directory',
-    favorites: false,
+    favorites: pathselector_favorites(nil),
     popup_title: 'Select Your Working Directory',
   }
 %>


### PR DESCRIPTION
Adds the favorites bar to the project path selector, an essential feature for navigating to shared space, and matches the import path selector.