### PR TITLE
Submit a subset of the workflow with launcher 'Launch' button 

### DIFF
--- a/apps/dashboard/app/controllers/workflows_controller.rb
+++ b/apps/dashboard/app/controllers/workflows_controller.rb
@@ -163,7 +163,7 @@ class WorkflowsController < ApplicationController
   end
 
   def permit_json_data
-    params.permit(:project_id, :id, :zoom, :saved_at, boxes: [:id, :title, :row, :col], edges: [:from, :to]).to_h
+    params.permit(:project_id, :id, :zoom, :saved_at, :start_launcher, boxes: [:id, :title, :row, :col], edges: [:from, :to]).to_h
   end
 
   def metadata_params(json)
@@ -174,7 +174,8 @@ class WorkflowsController < ApplicationController
         edges: json["edges"] || [], 
         zoom: json["zoom"] || 1.0,
         job_hash: json["job_hash"] || {},
-        saved_at: json["saved_at"] || Time.now.to_i
+        saved_at: json["saved_at"] || Time.now.to_i,
+        start_launcher: json["start_launcher"] || nil
       } 
     }
   end

--- a/apps/dashboard/app/models/workflow.rb
+++ b/apps/dashboard/app/models/workflow.rb
@@ -39,7 +39,8 @@ class Workflow
         launcher_ids: meta[:boxes].map { |b| b["id"] },
         source_ids: meta[:edges].map { |e| e["from"] },
         target_ids: meta[:edges].map { |e| e["to"] },
-        project_dir: project_dir
+        project_dir: project_dir,
+        start_launcher: meta[:start_launcher] || nil
       }
     end
   end


### PR DESCRIPTION
Related to Epic https://github.com/OSC/ondemand/issues/4338

Support to process subgraph in DAG class was added in PR https://github.com/OSC/ondemand/pull/4918

If you click on `Launch`, then only the current launcher and everything that depends on it will be launched.

This will become crucial for cases such as 
- You have one failure node and want to relaunch it; but that should also relaunch the subsequent dependencies in the DAG.
- You have disjoint subgraphs and only want to run one; also don't want to create a separate workflow to do so.