### PR TITLE
Prevent bad requests in path selector

### DIFF
--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -135,6 +135,9 @@ export class PathSelectorTable {
   clickRow(event) {
     const row = $(event.target).closest('tr').get(0) || event.target;
     const url = row.dataset['apiUrl'];
+    if (url === undefined) {
+      return;
+    }
     const pathType = row.dataset['pathType'];
     this.activateFavorite(row);
 
@@ -159,7 +162,10 @@ export class PathSelectorTable {
   }
 
   clickBreadcrumb(event) {
-    const path = event.target.id;
+    const path = event.target.id || undefined;
+    if (path === undefined) {
+      return;
+    }
     this.activateFavorite(event.target);
     this.reloadTable(path);
   }


### PR DESCRIPTION
Fixes #4689 

The issue says that the bad request (`406 response`) occurs when using the keyboard, but that doesn't seem to be the case. Instead, it looks like the bug happens when the user clicks on the active directory, which has no `id` and passes an empty string for the path. A similar case happens when the table has no items and the user clicks the "No data available" row, which has no `url`.