### PR TITLE
Remove hidden class from workflow submit button

### DIFF
--- a/apps/dashboard/app/views/workflows/show.html.erb
+++ b/apps/dashboard/app/views/workflows/show.html.erb
@@ -8,7 +8,7 @@
 <div id="workflows_app">
   <div class="toolbar" aria-label="toolbar">
     <% hidden_class = @workflow.editable? ? '' : 'd-none' %>
-    <%= select_tag "select_launcher", options_from_collection_for_select(@launchers, :id, :title), include_blank: false, class: "form-control mb-2 w-25 #{hidden_class}" %>
+    <%= select_tag "select_launcher", options_from_collection_for_select(@launchers, :id, :title), include_blank: false, class: "form-control w-25 #{hidden_class}" %>
     <button id="btn-add" class="<%= hidden_class %>">Add Launcher</button>
     <button id="btn-connect" class="<%= hidden_class %>" aria-pressed="false">Connect Launchers</button>
     <button id="btn-delete-launcher" class="danger <%= hidden_class %>" title="Delete selected launcher (Del/Backspace)">Delete Launcher</button>


### PR DESCRIPTION
In testing the workflows, I realized I accidentally hid the submit button on uneditable projects. This reverses that and ensures that the submit button is always displayed (since you should always be able to submit a readable workflow). Also removes the margin-bottom from the launcher selection, which keeps the top row of control buttons aligned