### PR TITLE
Fix file transfer error messages

### DIFF
--- a/apps/dashboard/app/controllers/transfers_controller.rb
+++ b/apps/dashboard/app/controllers/transfers_controller.rb
@@ -36,7 +36,7 @@ class TransfersController < ApplicationController
 
     if !@transfer.valid?
       # error
-      render json: { error_message: @transfer.errors.map(&:message).join('.') }
+      render json: { error_message: @transfer.errors.map(&:message).join('. ') }
     elsif @transfer.synchronous?
       logger.info "files: executing synchronous command in directory #{@transfer.from}: #{@transfer.command_str}"
       @transfer.perform


### PR DESCRIPTION
Fixes #4957. Modifies the way file transfers report errors by only including error messages, rather than using the `full_messages` method. This means that an error like the one in #4957, which is created by the line
```rb
record.errors.add :files, "these files already exist: #{conflicts.join(', ')}" 
```
Now reads as 'these files already exist...' instead of 'Files these files already...'. This approach matches the one used by `Project` and `Workflow` classes in their `collect_errors` methods.