### PR TITLE
Change `submit` to `cancel` and block any `launch button` in case workflow is already running

### DIFF
--- a/apps/dashboard/app/controllers/projects_controller.rb
+++ b/apps/dashboard/app/controllers/projects_controller.rb
@@ -156,6 +156,7 @@ class ProjectsController < ApplicationController
     render(partial: 'job_details', locals: { job: hpc_job, project: @project })
   end
 
+  # TODO: Refactor it to `?from_workflow=true`
   # DELETE /projects/:project_id/jobs/:cluster/:jobid
   def delete_job
     @project = Project.find(job_details_params[:project_id])
@@ -177,6 +178,7 @@ class ProjectsController < ApplicationController
     end
   end
 
+  # TODO: Refactor it to `?from_workflow=true`
   # POST /projects/:project_id/jobs/:cluster/:jobid/stop
   def stop_job
     @project = Project.find(job_details_params[:project_id])
@@ -189,10 +191,14 @@ class ProjectsController < ApplicationController
 
     begin
       cluster.job_adapter.delete(jobid.to_s) unless hpc_job.status.to_s == 'completed'
-      redirect_to(
-        project_path(job_details_params[:project_id]),
-        notice: I18n.t('dashboard.jobs_project_job_stopped', job_id: jobid)
-      )
+      if request.format.html?
+        redirect_to(
+          project_path(job_details_params[:project_id]),
+          notice: I18n.t('dashboard.jobs_project_job_stopped', job_id: jobid)
+        )
+      else
+        render json: { message: I18n.t('dashboard.jobs_project_job_stopped', job_id: jobid) }
+      end
     rescue StandardError => e
       redirect_to(
         project_path(job_details_params[:project_id]),


### PR DESCRIPTION
Related to Epic https://github.com/OSC/ondemand/issues/4338

- Added a `workflow_state` in metadata, that switch between `running` and `completed`
- Support for `cancel` button in workflow that will `STOP` all the running jobs
- Blocked all `Launch` button when a workflow is running. Only way to submit another workflow is cancelling the current or will reset the buttons when it is completed.
- Job Hash was not saved in the backend upon retuning from the `submit` function. Fixed that.