### PR TITLE
Test file transfer failure behavior

### DIFF
--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -975,7 +975,7 @@ class FilesTest < ApplicationSystemTestCase
       alert_text = "Error occurred when attempting to rename file: these files already exist: #{dir}/foo"
       assert_selector '.alert-danger span', text: alert_text
 
-      # close alert modal
+      # Close alert modal
       find('.alert-danger button').click
 
       assert_no_selector '.alert-danger', visible: true


### PR DESCRIPTION
Fixes #4928

Checks that the alert is generated and the full page spinner is closed when a file transfer fails. The alert scrolls into view but doesn't actually "focus" (and I think that's the intended behavior), so it's hard to reliably test that.