### PR TITLE
Test path selector hides spinner

### DIFF
--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -2404,6 +2404,8 @@ class BatchConnectTest < ApplicationSystemTestCase
 
       find('span', text: 'test').click
       sleep 3 # make sure the table has time to refresh
+      assert_no_selector("##{base_id}_path_selector_table_spinner", visible: true)
+
       find("##{base_id}_path_selector_button").click
 
       text_field = find("##{base_id}")


### PR DESCRIPTION
Fixes #4927 

I assumed the issue is referring to the spinner is referring to the path selector rather than icon picker, but I'll revise it if that's not the case.