### PR TITLE
Add toggle behavior tests

### DIFF
--- a/apps/dashboard/test/system/toggle_behavior_test.rb
+++ b/apps/dashboard/test/system/toggle_behavior_test.rb
@@ -141,7 +141,7 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
 
       toggle_button.click
       refute_selector('#workflow_list.show')
-      assert_selector('#workflow_list.collapse')
+      assert_selector('#workflow_list.collapse', visible: false)
       assert_not workflow_list.visible?, 'Workflow list should be hidden after toggle'
 
       toggle_button.click


### PR DESCRIPTION
Fixes #4929 

Tests toggle behavior throughout the dashboard. This is probably not comprehensive but should be a decent starting point.