### PR TITLE
Remove close button on modules

### DIFF
--- a/apps/dashboard/app/views/module_browser/_module_list.html.erb
+++ b/apps/dashboard/app/views/module_browser/_module_list.html.erb
@@ -17,13 +17,6 @@
 
       <div id="collapse_<%= name %>" class="collapse">
         <div class="border rounded p-4">
-          <button
-            type="button"
-            class="btn-close position-absolute top-0 end-0 m-2"
-            data-bs-toggle="collapse"
-            data-bs-target="#collapse_<%= name %>"
-            aria-label="Close details for <%= name.to_s.titleize %>">
-          </button>
           <div class="mb-3">
             <div class="mb-3 h5"><strong>Available modules: </strong><span class="text-muted small">(select version)</span></div>
             <%= render 'versions_table', versions: versions, clusters: versions.map(&:cluster).uniq %>


### PR DESCRIPTION
Fixes #4992. Since positioning the button seems to be a pain point, it seems far better to me to just remove it. As mentioned in the issue, the button functionality is duplicated by the header, so there is no issue getting rid of it.