### PR TITLE
fix navbar logo styling

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -39,10 +39,14 @@ a.navbar-brand.navbar-brand-logo {
   vertical-align: middle;
   max-width: 20em;
   overflow-x: hidden;
-}
 
-.navbar-brand.navbar-brand-logo img {
-  height: 100%;
+  img {
+    height: 100%;
+  }
+
+  span {
+    vertical-align: sub;
+  }
 }
 
 // for inverse, lets make the text slightliy darker so its

--- a/apps/dashboard/app/views/layouts/nav/_logo.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_logo.html.erb
@@ -9,6 +9,10 @@
     <img class="img-fluid" src="<%= @user_configuration.dashboard_header_img_logo %>" alt="<%= @user_configuration.dashboard_title %>">
   </a>
 <% else %>
-  <a class="navbar-brand navbar-brand-logo" <%= aria %> role='menuitem' href="<%= root_path %>"><%= @user_configuration.dashboard_title %></a>
+  <a class="navbar-brand navbar-brand-logo" <%= aria %> role='menuitem' href="<%= root_path %>">
+    <span>
+      <%= @user_configuration.dashboard_title %>
+    </span>
+  </a>
 <% end %>
 </li>


### PR DESCRIPTION
Fixes #5002. Adds a fixed height to the navbar logo, allowing images to render properly. The `2em` value for height corresponds with the previous value in the 4.0 release. Fixing the height also required us to explicitly align the text in that link element. Display should now look fine under both cases.