### PR TITLE
fix icons by setting x_sendfile_header

### DIFF
--- a/apps/dashboard/config/initializers/send_file_headers.rb
+++ b/apps/dashboard/config/initializers/send_file_headers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# The FilesController serves files itself by unsetting this header
+# and using 'config/initializers/validate_send_files.rb' to validate files it
+# serves.  The AppsController also uses send_file to serve icons that may not be
+# on the allowlist.  So we add this configuration to allow the AppsController
+# to serve app icons through Nginx.  No other controller should be using send_file
+# outside these 2 use cases.
+Rails.application.config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'


### PR DESCRIPTION
Fixes #5003 by setting the `Rails.application.config.action_dispatch.x_sendfile_header` to allow nginx to serve app icons.

Note that the FilesController still uses `config/initializers/validate_send_files.rb` because it unsets the header, but this will allow the AppsController to use nginx to serve icons. Also just added a large comment for when we inevitably forget why this is there at all.