### PR TITLE
Fix workflows show styling

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/workflows.scss
+++ b/apps/dashboard/app/assets/stylesheets/workflows.scss
@@ -72,9 +72,12 @@ $gap: 20;
 }
 
 .hint {
-  margin-left: auto;
+  margin-left: 2rem;;
   color: var(--ink-muted);
   font-size: .9rem;
+  align-content: center;
+  max-height: 4rem;
+  overflow: clip;
 }
 
 .workspace-wrapper {

--- a/apps/dashboard/app/views/workflows/show.html.erb
+++ b/apps/dashboard/app/views/workflows/show.html.erb
@@ -18,8 +18,8 @@
       <button id="btn-restore-workflow" class="<%= hidden_class %>"><%= I18n.t('dashboard.restore') %></button>
       <button id="btn-clear-workflow" class="<%= hidden_class %>"><%= I18n.t('dashboard.clear') %></button>
       <button id="btn-save-workflow" class="<%= hidden_class %>"><%= I18n.t('dashboard.save') %></button>
-      <%= link_to I18n.t('dashboard.back'), project_path(params[:project_id]), class: 'btn btn-default', title: 'Return to projects page' %>
-      <span class="hint <%= hidden_class %>">Click title to select and drag. Connect via clicking two launchers.</span>
+      <%= link_to I18n.t('dashboard.back'), project_path(params[:project_id]), class: 'btn btn-default align-content-center', title: 'Return to projects page' %>
+      <span class="hint <%= hidden_class %>"><%= I18n.t('dashboard.jobs_workflow_help')%></span>
     </div>
   </div>
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -208,6 +208,7 @@ en:
     jobs_workflow_name_validation: Workflow name may only contain letters, digits, dashes, underscores, and spaces
     jobs_workflow_not_found: Cannot find workflow %{workflow_id}
     jobs_workflow_submitted: Workflow successfully submitted!
+    jobs_workflow_help: Click title to select and drag. Connect by clicking two launchers with 'Connect Launchers' selected
     jobs_workflows: Workflows
     launch: Launch
     logo_alt_text: Welcome to Open OnDemand


### PR DESCRIPTION
Fixes the scaling behavior to prioritize buttons over help text, and internationalize the help text content. When the screen width shrinks, the help text will now wrap to 3 lines maximum before clipping