### PR TITLE
Revert "fix icons by setting x_sendfile_header"

### DIFF
--- a/apps/dashboard/config/initializers/send_file_headers.rb
+++ b/apps/dashboard/config/initializers/send_file_headers.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# The FilesController serves files itself by unsetting this header
-# and using 'config/initializers/validate_send_files.rb' to validate files it
-# serves.  The AppsController also uses send_file to serve icons that may not be
-# on the allowlist.  So we add this configuration to allow the AppsController
-# to serve app icons through Nginx.  No other controller should be using send_file
-# outside these 2 use cases.
-Rails.application.config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'


### PR DESCRIPTION
Reverts OSC/ondemand#5007

I think we need to revert this because of #5025. #5025 mentions it's outputting during tests, but this is also the case when the app is running and I know that folks are not going to like these messages being printed all the time in the logs.

I'm working on a solution to actually just read the file and serve it while setting all the headers manually. 