### PR TITLE
serve icons through rails render

### DIFF
--- a/apps/dashboard/app/controllers/apps_controller.rb
+++ b/apps/dashboard/app/controllers/apps_controller.rb
@@ -46,13 +46,18 @@ class AppsController < ApplicationController
     set_app
     expires_in 365.days, public: true
 
-    if @app.svg_icon? 
-      send_file @app.icon_path, :type => 'image/svg+xml', :disposition => 'inline'
+    if @app.svg_icon?
+      content_type = 'image/svg+xml'
+      dispostion_header = 'inline; filename="icon.svg"; filename*=UTF-8\'\'icon.svg'
     elsif @app.png_icon?
-      send_file @app.icon_path, :type => 'image/png', :disposition => 'inline'
+      content_type = 'image/png'
+      dispostion_header = 'inline; filename="icon.png"; filename*=UTF-8\'\'icon.png'
     else
-      raise ActionController::RoutingError.new('Not Found')
+      raise(ActionController::RoutingError, 'Not Found')
     end
+
+    response.headers['content-disposition'] = dispostion_header
+    render(file: @app.icon_path, layout: false, content_type: content_type)
   end
 
   private


### PR DESCRIPTION
related to #5028 and the PR that it's reverting.

Instead of having nginx serve these files through `send_file` that generates extra log messages, instead we'll use rails' utility to `render` any file without a layout.

This means it's done purely in ruby which has a performance hit, but I believe enabling the `x-accel-mapping` header may have security issues. I'm not 100% sure how a specially crafted request may get `send_file` coupled with a `x-accel-mapping` header  to access files outside of the ALLOWLIST, but I figure this can turn a 1 in a million chance to 0, so that's the trade I'm willing to make. 