### PR TITLE
Add html form structure to input modal

### DIFF
--- a/apps/dashboard/app/views/files/_input_modal.html.erb
+++ b/apps/dashboard/app/views/files/_input_modal.html.erb
@@ -3,6 +3,7 @@
 <div class="modal" id="files_input_modal" tabindex="-1" aria-labelledby="files_input_modal_title" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
+      <form method="dialog">
       <div class="modal-header">
         <div class="modal-title justify-text-center" id="files_input_modal_title"></div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t('dashboard.close') %>"></button>
@@ -16,8 +17,9 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><%= t('dashboard.close') %></button>
-        <button type="button" class="btn btn-primary" id="files_input_modal_ok_button"><%= t('dashboard.ok') %></button>
+        <button type="submit" class="btn btn-primary" id="files_input_modal_ok_button"><%= t('dashboard.ok') %></button>
       </div>
+      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #5014. Adds an html form element and `type='submit'` to use native browser shortcuts with enter. As far as I can tell this is the only form like this in the files app, but this approach could easily be repeated anywhere else it is needed