### PR TITLE
Added supports for args in Launchers

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -114,8 +114,11 @@ class LaunchersController < ApplicationController
     auto_env_params = params[:launcher].keys.select do |k|
       k.match?('auto_environment_variable')
     end
+    auto_args_params = params[:launcher].keys.select do |k|
+      k.match?('auto_args')
+    end
 
-    allowlist = SAVE_LAUNCHER_KEYS + auto_env_params
+    allowlist = SAVE_LAUNCHER_KEYS + auto_env_params + auto_args_params
 
     params.permit({ launcher: allowlist }, :project_id, :id)
   end

--- a/apps/dashboard/app/helpers/launchers_helper.rb
+++ b/apps/dashboard/app/helpers/launchers_helper.rb
@@ -74,6 +74,12 @@ module LaunchersHelper
     attrib = SmartAttributes::AttributeFactory.build_auto_log_location
     create_editable_widget(script_form_double, attrib)
   end
+
+  def auto_args_template
+    attrib = SmartAttributes::AttributeFactory.build_auto_args
+    create_editable_widget(script_form_double, attrib)
+  end
+
   # We need a form builder to build the template divs. These are
   # templates so that they are not a part of the _actual_ form (yet).
   # Otherwise you'd have required fields that you cannot actually edit

--- a/apps/dashboard/app/javascript/launcher_edit.js
+++ b/apps/dashboard/app/javascript/launcher_edit.js
@@ -34,6 +34,10 @@ const newFieldData = {
   auto_cores: {
     label: 'Cores',
     help: 'How many cores the job will run on.'
+  },
+  auto_args: {
+    label: 'Args',
+    help: 'Add an arg field and value'
   }
 }
 
@@ -162,6 +166,9 @@ function addInProgressField(event) {
   justAdded.find('[data-auto-environment-variable="name"]')
            .on('keyup', (event) => { updateAutoEnvironmentVariable(event) });
 
+  justAdded.find('[data-auto-args="name"]')
+           .on('keyup', (event) => { updateAutoArgs(event) });
+
   const entireDiv = event.target.parentElement.parentElement.parentElement;
   entireDiv.remove();
   enableNewFieldButton();
@@ -189,6 +196,42 @@ function updateAutoEnvironmentVariable(event) {
   let checkbox = fixedBoxGroup.children[0];
   checkbox.id = `${idString}_fixed`;
   checkbox.name = `launcher[auto_environment_variable_${aev_name}_fixed]`;
+  checkbox.setAttribute('data-fixed-toggler', idString);
+
+  // Update hidden field if attribute is already fixed, otherwise just update label
+  let labelIndex = 2;
+  if(fixedBoxGroup.children.length == 3) {
+    let hiddenField = fixedBoxGroup.children[1];
+    hiddenField.name = nameString;
+  } else {
+    labelIndex = 1;
+  }
+
+  let fixedLabel = fixedBoxGroup.children[labelIndex];
+  fixedLabel.setAttribute('for', `${idString}_fixed`);
+}
+
+function updateAutoArgs(event) {
+  const arg_name = event.target.value;
+  const labelString = event.target.dataset.labelString;
+  const idString = `launcher_auto_args_${arg_name}`;
+  const nameString = `launcher[auto_args_${arg_name}]`;
+  var input_field = event.target.parentElement.children[2].children[0].children[1];
+
+  input_field.removeAttribute('readonly');
+  input_field.id = idString;
+  input_field.name = nameString;
+
+  if (labelString.match(/Args/)) {
+    const label_field = event.target.parentElement.children[2].children[0].children[0];
+    label_field.innerHTML = `Args: ${arg_name}`;
+  }
+
+  let fixedBoxGroup = event.target.parentElement.children[3].children[0].children[0];
+
+  let checkbox = fixedBoxGroup.children[0];
+  checkbox.id = `${idString}_fixed`;
+  checkbox.name = `launcher[auto_args_${arg_name}_fixed]`;
   checkbox.setAttribute('data-fixed-toggler', idString);
 
   // Update hidden field if attribute is already fixed, otherwise just update label
@@ -410,6 +453,9 @@ jQuery(() => {
 
   $('[data-auto-environment-variable="name"]')
       .on('keyup', (event) => { updateAutoEnvironmentVariable(event) });
+  
+  $('[data-auto-args="name"]')
+      .on('keyup', (event) => { updateAutoArgs(event) });
 
   initSelectFields();
   initFixedFields();

--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -26,4 +26,5 @@ module SmartAttributes
   require 'smart_attributes/attributes/auto_environment_variable'
   require 'smart_attributes/attributes/auto_cores'
   require 'smart_attributes/attributes/global_attribute'
+  require 'smart_attributes/attributes/auto_args'
 end

--- a/apps/dashboard/app/lib/smart_attributes/attribute_factory.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute_factory.rb
@@ -3,6 +3,7 @@ module SmartAttributes
 
     AUTO_MODULES_REX = /\Aauto_modules_([\w\-\/]+)\z/.freeze
     AUTO_ENVIRONMENT_VARIABLE_REX = /\Aauto_environment_variable_([\w-]+)\z/.freeze
+    AUTO_ARGS_REX = /\Aauto_args_([\w-]+)\z/.freeze
     GLOBAL_ATTRIBUTE_REX = /\Aglobal_([\w-]+)\z/.freeze
 
     class << self
@@ -26,6 +27,10 @@ module SmartAttributes
           sub_id = id.match(GLOBAL_ATTRIBUTE_REX)[1]
           id = 'global_attribute'
           opts = opts.merge({ 'key' => real_id, 'sub_id' => sub_id })
+        elsif id.match?(AUTO_ARGS_REX)
+          args = id.match(AUTO_ARGS_REX)[1]
+          id = 'auto_args'
+          opts = opts.merge({'key' => args})
         end
 
         build_method = "build_#{id}"

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_args.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_args.rb
@@ -1,0 +1,46 @@
+module SmartAttributes
+    class AttributeFactory
+      extend AccountCache
+  
+      def self.build_auto_args(opts = {})
+        Attributes::AutoArgs.new('auto_args', opts)
+      end
+    end
+  
+    module Attributes
+      class AutoArgs < Attribute
+        def initialize(id, opts = {})
+          super
+  
+          @key = @opts.delete(:key)
+          # reset the id to be unique from other auto_args_*
+          @id = @key ? "#{id}_#{normalize_key(@key)}" : id
+        end
+
+        def widget
+          'text_field'
+        end
+
+        def original_label
+          return 'Args' if !@opts[:label] || opts[:label].match('Args')
+          @opts[:label].to_s
+        end
+
+        def label(*)
+          (opts[:label] || "Args: #{@key}").to_s
+        end
+
+        def field_options(fmt: nil)
+          @key.blank? ? super.merge({readonly: true}) : super
+        end
+
+        def normalize_key(key_name)
+          key_name.to_s.gsub('-', '_')
+        end
+
+        def submit(*)
+          { script: { args: ["--#{@key.to_s}", value.to_s ] }}
+        end
+      end
+    end
+  end

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -351,7 +351,15 @@ class Launcher
       sm
     end.map do |sm|
       sm.submit(fmt: render_format)
-    end.reduce(&:deep_merge)[:script].merge(
+    end.reduce do |merged, current|
+      merged.deep_merge(current) do |key, old_val, new_val|
+        if old_val.is_a?(Array) && new_val.is_a?(Array)
+          old_val + new_val  # concatenate arg arrays
+        else
+          new_val
+        end
+      end
+    end[:script].merge(
       # force some values for scripts like the 'workdir'. We could use auto
       # attributes, but this is not optional and not variable.
       {

--- a/apps/dashboard/app/views/launchers/edit.html.erb
+++ b/apps/dashboard/app/views/launchers/edit.html.erb
@@ -46,3 +46,7 @@
 <template id="auto_log_location_template">
   <%= auto_log_location_template %>
 </template>
+
+<template id="auto_args_template">
+  <%= auto_args_template %>
+</template>

--- a/apps/dashboard/app/views/launchers/editable_form_fields/_editable_text_field.erb
+++ b/apps/dashboard/app/views/launchers/editable_form_fields/_editable_text_field.erb
@@ -11,6 +11,14 @@
        data-label-string=<%= attrib.original_label.gsub(' ', '&#32;').force_encoding('utf-8') %>
        value=<%= attrib.id.gsub(/auto_environment_variable_?/, '') %>
   >
+<% elsif field_id.match?('auto_args') %>
+  <label>Name</label>
+  <input class="form-control edit-field"
+       type="text"
+       data-auto-args="name"
+       data-label-string=<%= attrib.original_label.gsub(' ', '&#32;').force_encoding('utf-8') %>
+       value=<%= attrib.id.gsub(/auto_args_?/, '') %>
+  >
 <% end %>
   <%=  create_widget(form, attrib, format: format, hide_fixed: false) %>
 


### PR DESCRIPTION
Epic Link - https://github.com/OSC/ondemand/issues/4993

If a script support args then you can specify with the help of args field in Launchers

`SmartAttribute` implementation is done similar to existing `auto_environment_variable`

**NOTE:** I wasn't able to test with scheduler due to Slurm not supporting args in ood-core https://github.com/OSC/ood_core/blob/master/lib/ood_core/job/adapters/slurm.rb#L628