### PR TITLE
Fix select all headers bug in files table

### DIFF
--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -4,7 +4,7 @@
       <%= render partial: 'breadcrumb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path } %>
     </ol>
 
-    <span id="select_all_label" class="sr-only">Select All</span>
+    <label id="select_all_label" class="sr-only">Select All</label>
     <table class="table table-striped table-condensed w-100" id="directory-contents">
       <thead>
         <tr>


### PR DESCRIPTION
Fixes #4637 using an approach that could be generalized to the rest of the table columns. 

To prevent the issue of the checkbox title in the header row being mistaken for the title of the column, we use `aria-labelledby` to move the 'Select All' label outside the `<th>` element, and moving the header title 'Select' to a `span.sr-only` inside the `<th>`.

This produces the intended behavior, reading 'Select All' for the header, and then 'Select' for all subsequent checkboxes. 

I may extend this to handle #4650 with the same strategy, but those titles are set in javascript so will be a bit different to change.

