### PR TITLE
Some errors occurred when compiling with ondemand.spec

### DIFF
--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -72,6 +72,7 @@ BuildRequires:   ondemand-ruby = %{runtime_version_full}
 BuildRequires:   ondemand-nodejs = %{runtime_version_full}
 BuildRequires:   rsync
 BuildRequires:   git
+BuildRequires:   rubygem-bundler rubygem-rake ruby-devel npm sqlite-devel libxslt-devel
 # Force Python 3.12 for EL8 as Python 3.6 does not work with node-gyp
 %if 0%{?rhel} == 8
 BuildRequires:   python3.12


### PR DESCRIPTION
Some errors occurred when compiling with ondemand.spec

1、+ bundle config set --global force_ruby_platform true
/var/tmp/sclCJVdy3: line 9: bundle: command not found

2、+ rake --trace -mj12 build
/var/tmp/scl5y0IqD: line 13: rake: command not found

3、Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/root/rpmbuild/BUILD/ondemand-4.1.1/gems-build/gems/bigdecimal-4.0.1/ext/bigdecimal
/usr/bin/ruby -I/usr/share/rubygems extconf.rb
mkmf.rb can't find header files for ruby at /usr/share/include/ruby.h

4、/usr/share/gems/gems/rake-13.0.6/lib/rake/file_utils.rb:67:in `block in create_shell_runner': Command failed with status (127): [npm install --production --prefix tmp yarn...] (RuntimeError)

5、conftest.c:3:10: fatal error: sqlite3.h: No such file or directory
    3 | #include <sqlite3.h>