### PR TITLE
Use cluster title in modbrowser versions table

### DIFF
--- a/apps/dashboard/app/views/module_browser/_versions_table.html.erb
+++ b/apps/dashboard/app/views/module_browser/_versions_table.html.erb
@@ -12,7 +12,7 @@
       <% clusters.each do |cluster| %>
         <% cluster_versions = versions_by_cluster[cluster] || [] %>
         <tr>
-          <td><%= cluster.to_s.titleize %></td>
+          <td><%= Configuration.job_clusters[cluster].title %></td>
           <td>
             <% if cluster_versions.any? %>
               <% cluster_versions.uniq { |v| v.version }.sort_by(&:version).reverse.each do |mod| %>


### PR DESCRIPTION
Cluster column value in versions table should use the cluster title to match the toolbar cluster filter menu values