### PR TITLE
Pinned app icons respond to focus

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
@@ -196,6 +196,6 @@
   }
 }
 
-.app-launcher-hover:hover {
+.app-launcher-hover:hover, .app-launcher-hover:focus-within {
   transform: scale(0.98);
 }


### PR DESCRIPTION
Fixes #4514 by including `focus-within` to `hover` in the stylesheet. Since it will likely come up for other components, this was necessary because the focused element is the submit button, but the element responding to `:hover` is the wrapping div. 