### PR TITLE
permit directory links with downloads disabled

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -388,7 +388,7 @@ class DataTable {
     renderNameColumn(data, type, row, meta) {
         let element = undefined;
 
-        if(!downloadEnabled() || row.url === undefined || this.isInvalidURL(row.url)) {
+        if(row.type == 'f' && (!downloadEnabled() || row.url === undefined || this.isInvalidURL(row.url))) {
             element = document.createElement('span');
         } else {
             element = document.createElement('a');

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -11,7 +11,7 @@ json.files @files do |f|
   json.type f[:directory] ? 'd' : 'f'
   json.name f[:name]
 
-  json.url files_path(@filesystem, @path.join(f[:name]).to_s) if f[:downloadable]
+  json.url files_path(@filesystem, @path.join(f[:name]).to_s) if (f[:directory] || f[:downloadable])
   json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') if f[:downloadable]
   json.edit_url OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s
 


### PR DESCRIPTION
Fixes #5106. Checks path type and ensures that navigational links for directories are served even when downloads are disabled. 