### PR TITLE
update hterm to deal with FF 148 (#5104)

### DIFF
--- a/apps/shell/README.md
+++ b/apps/shell/README.md
@@ -110,6 +110,7 @@ So you've updated hterm and now something is broken.  Maybe only on one platform
 changes. If you're lucky you may be able to cherry pick them, if not, hopefully we've made an issue where you can reference and you can at least see the commit. 
 
 * 0cbc84e3d53386064e278a0495c940a217f4f18b - that fixed [issue 64](https://github.com/OSC/ood-shell/issues/64)
+* <commit needed> - that fixed [issue 5101](https://github.com/OSC/ondemand/issues/5101)
 
 This commit seems to have been fixed upstream, so no need to add it. We're just leaving it here
 in the documentation for historical purposes. For completeness, this was fixed upstream in

--- a/apps/shell/public/javascripts/hterm_all_1.92.1.mod_1.js
+++ b/apps/shell/public/javascripts/hterm_all_1.92.1.mod_1.js
@@ -12645,9 +12645,18 @@ hterm.ScrollPort.prototype.decorate = function(div, callback) {
     }
   };
 
+  const agent = window.navigator.userAgent;
+  const versionMatch = agent.match(/rv:(\d+\.\d+)/);
+  let ffVersion = null;
+
+  if(versionMatch !== null && versionMatch.length == 2) {
+    ffVersion = versionMatch[1];
+  }
+
   // Insert Iframe content asynchronously in FF.  Otherwise when the frame's
   // load event fires in FF it clears out the content of the iframe.
-  if ('mozInnerScreenX' in window) { // detect a FF only property
+  // Though this only applies to gecko/FF < version '148.0'.
+  if ('mozInnerScreenX' in window && ffVersion != null && ffVersion < "148.0" ) { // detect a FF only property
     this.iframe_.addEventListener('load', () => onLoad());
   } else {
     onLoad();

--- a/apps/shell/views/index.hbs
+++ b/apps/shell/views/index.hbs
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="{{baseURI}}/stylesheets/style.css">
 
   <script src="{{baseURI}}/javascripts/lodash-4.17.21/lodash.min.js"></script>
-  <script src="{{baseURI}}/javascripts/hterm_all_1.92.1.mod.js"></script>
+  <script src="{{baseURI}}/javascripts/hterm_all_1.92.1.mod_1.js"></script>
   <script src="{{baseURI}}/javascripts/ood_shell.2.js"></script>
 </head>
 


### PR DESCRIPTION
Backport #5104 to 4.1.  Update hterm to deal with FF 148 which broken hterm unexpectedly.