### PR TITLE
backport shell FF fix to 4.0

### DIFF
--- a/apps/shell/public/javascripts/hterm_all_1.91.mod_1.js
+++ b/apps/shell/public/javascripts/hterm_all_1.91.mod_1.js
@@ -12401,9 +12401,18 @@ hterm.ScrollPort.prototype.decorate = function(div, callback) {
     }
   };
 
+  const agent = window.navigator.userAgent;
+  const versionMatch = agent.match(/rv:(\d+\.\d+)/);
+  let ffVersion = null;
+
+  if(versionMatch !== null && versionMatch.length == 2) {
+    ffVersion = versionMatch[1];
+  }
+
   // Insert Iframe content asynchronously in FF.  Otherwise when the frame's
   // load event fires in FF it clears out the content of the iframe.
-  if ('mozInnerScreenX' in window) { // detect a FF only property
+  // Though this only applies to gecko/FF < version '148.0'.
+  if ('mozInnerScreenX' in window && ffVersion != null && ffVersion < "148.0" ) { // detect a FF only property
     this.iframe_.addEventListener('load', () => onLoad());
   } else {
     onLoad();

--- a/apps/shell/views/index.hbs
+++ b/apps/shell/views/index.hbs
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="{{baseURI}}/stylesheets/style.css">
 
   <script src="{{baseURI}}/javascripts/lodash-4.17.21/lodash.min.js"></script>
-  <script src="{{baseURI}}/javascripts/hterm_all_1.91.mod.js"></script>
+  <script src="{{baseURI}}/javascripts/hterm_all_1.91.mod_1.js"></script>
   <script src="{{baseURI}}/javascripts/ood_shell.2.js"></script>
 </head>
 


### PR DESCRIPTION
backport #5104 to 4.0. can't cherry-pick the same commit as it's been updated in 4.1