### PR TITLE
add disclaimer about dynamic form actions

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -3,6 +3,9 @@
 
 <%= render "prefill_templates" if Configuration.bc_saved_settings? %>
 
+<% if Configuration.bc_dynamic_js? %>
+  <span class='sr-only' tabindex='0'> The following form may change dynamically as options are selected. All changes will be announced and are reversible </span>
+<% end %>
 <%= bootstrap_form_for(@session_context, html: { autocomplete: "off", }) do |f| %>
   <% f.object.each do |attrib| %>
     <%= create_widget(f, attrib, format: @render_format) %>


### PR DESCRIPTION
Fixes #2075 by alerting screen reader users that forms could change as they fill it out. As noted in the issue, we should also verify that all actions are truly reversible before closing it for good.