### PR TITLE
refactor dynamic_forms.js to be more intuitive (no `token`)

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -143,11 +143,11 @@ function makeChangeHandlers(prefix){
           if(keys.length !== 0) {
             keys.forEach((key) => {
               if(key.startsWith('optionFor')) {
-                let token = key.replace(/^optionFor/,'');
-                addOptionForHandler(idFromToken(token), element['id']);
+                let suffix = key.replace(/^optionFor/,'');
+                addOptionForHandler(idFromToken(suffix), element['id']);
               } else if (key.startsWith('exclusiveOptionFor')) {
-                let token = key.replace(/^exclusiveOptionFor/, '');
-                addExclusiveOptionForHandler(idFromToken(token), element['id']);
+                let suffix = key.replace(/^exclusiveOptionFor/, '');
+                addExclusiveOptionForHandler(idFromToken(suffix), element['id']);
               } else if(key.startsWith('max') || key.startsWith('min')) {
                 addMinMaxForHandler(element['id'], opt.value, key, data[key]);
               } else if(key.startsWith('set')) {
@@ -688,15 +688,15 @@ function parseMinMaxFor(key) {
   }
 
   //trying to parse maxNumCoresForClusterOwens
-  const tokens = k.match(/^(\w+)For(\w+)$/);
+  const groups = k.match(/^(\w+)For(\w+)$/);
 
-  if(tokens == null) {
+  if(groups == null) {
     // the key is likely just maxNumCores with no For clause
     subjectId = idFromToken(k);
 
-  } else if(tokens.length == 3) {
-    const subject = tokens[1];
-    const predicateFull = tokens[2];
+  } else if(groups.length == 3) {
+    const subject = groups[1];
+    const predicateFull = groups[2];
     subjectId = idFromToken(subject);
 
     const predicateTokens = predicateFull.split(/(?=[A-Z])/);


### PR DESCRIPTION
`parseMinMaxFor` uses the variable name `tokens` to describe regex match groups, but I think that's confusing since the word "token" already has a special meaning in this file. So I changed it to `groups`.

`makeChangeHandlers` uses the variable name `token` to describe a substring of an option-for directive, but I think that's confusing because it contains other characters as well as the token.