### PR TITLE
use longest match instead of endsWith

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -771,12 +771,10 @@ function idFromToken(str) {
 
   // you matched multiple things. For example you're searching for
   // ClusterFilesystem and matched against both 'Cluster' and 'ClusterFilesystem'.
-  // The correrct element id ends with cluster_filesystem.
+  // The correrct element id is the longer one.
   } else if(elements.length > 1) {
-    const snake_case_str = snakeCaseWords(str);
-    return elements.filter((element) => {
-      return element.endsWith(snake_case_str);
-    })[0];
+    let longest = elements.reduce((a, b) => a.length > b.length ? a : b);
+    return longest;
   }
 }
 

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -859,10 +859,12 @@ function idFromToken(str) {
 
   // you matched multiple things. For example you're searching for
   // ClusterFilesystem and matched against both 'Cluster' and 'ClusterFilesystem'.
-  // The correrct element id is the longer one.
+  // The correrct element id ends with cluster_filesystem.
   } else if(elements.length > 1) {
-    let longest = elements.reduce((a, b) => a.length > b.length ? a : b);
-    return longest;
+    const snake_case_str = snakeCaseWords(str);
+    return elements.filter((element) => {
+      return element.endsWith(snake_case_str);
+    })[0];
   }
 }
 

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -859,12 +859,10 @@ function idFromToken(str) {
 
   // you matched multiple things. For example you're searching for
   // ClusterFilesystem and matched against both 'Cluster' and 'ClusterFilesystem'.
-  // The correrct element id ends with cluster_filesystem.
+  // The correrct element id is the longer one.
   } else if(elements.length > 1) {
-    const snake_case_str = snakeCaseWords(str);
-    return elements.filter((element) => {
-      return element.endsWith(snake_case_str);
-    })[0];
+    let longest = elements.reduce((a, b) => a.length > b.length ? a : b);
+    return longest;
   }
 }
 

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -488,7 +488,7 @@ class BatchConnectTest < ApplicationSystemTestCase
         cache_json.write({ cluster: 'old' }.to_json)
       end
 
-      new_cluster = OodCore::Cluster.new({ id: :new, job: { some: 'job config' } })
+      new_cluster = OodCore::cluster.new({ id: :new, job: { some: 'job config' } })
 
       # Only new cluster exists
       BatchConnect::App.any_instance.stubs(:cfg_to_clusters).returns(new_cluster)
@@ -507,8 +507,8 @@ class BatchConnectTest < ApplicationSystemTestCase
         cache_json.write({ cluster: 'old' }.to_json)
       end
 
-      new_cluster = OodCore::Cluster.new({ id: :new, job: { some: 'job config' } })
-      old_cluster = OodCore::Cluster.new({ id: :old, job: { some: 'job config ' } })
+      new_cluster = OodCore::cluster.new({ id: :new, job: { some: 'job config' } })
+      old_cluster = OodCore::cluster.new({ id: :old, job: { some: 'job config ' } })
 
       # Both clusters exist, but only new one is valid
       BatchConnect::App.any_instance.stubs(:cfg_to_clusters).returns(new_cluster)
@@ -916,6 +916,70 @@ class BatchConnectTest < ApplicationSystemTestCase
     HEREDOC
 
     data_hide_checkbox_test(form, 'checkbox_test', 'gpus', true)
+  end
+
+  test 'hiding when form element names have a shared prefix' do
+    form = <<~HEREDOC
+      ---
+      cluster:
+        - owens
+      form:
+        - cluster
+        - cluster_file_system
+        - checkbox_hide_cluster
+        - checkbox_hide_cluster_file_system
+      attributes:
+        cluster:
+          widget: 'text_area'
+        cluster_file_system:
+          widget: 'text_area'
+        checkbox_hide_cluster:
+          widget: 'check_box'
+          html_options:
+            data:
+              hide-cluster-when-checked: true
+        checkbox_hide_cluster_file_system:
+          widget: 'check_box'
+          html_options:
+            data:
+              hide-cluster-file-system-when-checked: true
+    HEREDOC
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # defaults
+      refute(find("##{bc_ele_id("checkbox_hide_cluster")}").checked?)
+      refute(find("##{bc_ele_id("checkbox_hide_cluster_file_system")}").checked?)
+      check_visibility("cluster", true)
+      check_visibility("cluster_file_system", true)
+
+      # check the checkbox, and 'cluster' is hidden
+      check(bc_ele_id("checkbox_hide_cluster"))
+      check_visibility("cluster", false)
+      check_visibility("cluster_file_system", true)
+
+      # un-check the checkbox, and 'cluster' is back to being visible
+      uncheck(bc_ele_id("checkbox_hide_cluster"))
+      check_visibility("cluster", true)
+      check_visibility("cluster_file_system", true)
+
+      # check the checkbox, and 'cluster_file_system' is hidden
+      check(bc_ele_id("checkbox_hide_cluster_file_system"))
+      check_visibility("cluster", true)
+      check_visibility("cluster_file_system", false)
+
+      # un-check the checkbox, and 'cluster_file_system' is back to being visible
+      uncheck(bc_ele_id("checkbox_hide_cluster_file_system"))
+      check_visibility("cluster", true)
+      check_visibility("cluster_file_system", true)
+    end
   end
 
   def basic_default_hide_check_hidden(invert = false)

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -488,7 +488,7 @@ class BatchConnectTest < ApplicationSystemTestCase
         cache_json.write({ cluster: 'old' }.to_json)
       end
 
-      new_cluster = OodCore::cluster.new({ id: :new, job: { some: 'job config' } })
+      new_cluster = OodCore::Cluster.new({ id: :new, job: { some: 'job config' } })
 
       # Only new cluster exists
       BatchConnect::App.any_instance.stubs(:cfg_to_clusters).returns(new_cluster)
@@ -507,8 +507,8 @@ class BatchConnectTest < ApplicationSystemTestCase
         cache_json.write({ cluster: 'old' }.to_json)
       end
 
-      new_cluster = OodCore::cluster.new({ id: :new, job: { some: 'job config' } })
-      old_cluster = OodCore::cluster.new({ id: :old, job: { some: 'job config ' } })
+      new_cluster = OodCore::Cluster.new({ id: :new, job: { some: 'job config' } })
+      old_cluster = OodCore::Cluster.new({ id: :old, job: { some: 'job config ' } })
 
       # Both clusters exist, but only new one is valid
       BatchConnect::App.any_instance.stubs(:cfg_to_clusters).returns(new_cluster)

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -957,28 +957,28 @@ class BatchConnectTest < ApplicationSystemTestCase
       # defaults
       refute(find("##{bc_ele_id("checkbox_hide_cluster")}").checked?)
       refute(find("##{bc_ele_id("checkbox_hide_cluster_file_system")}").checked?)
-      check_visibility("cluster", true)
-      check_visibility("cluster_file_system", true)
+      check_visibility("cluster", false)
+      check_visibility("cluster_file_system", false)
 
       # check the checkbox, and 'cluster' is hidden
       check(bc_ele_id("checkbox_hide_cluster"))
-      check_visibility("cluster", false)
-      check_visibility("cluster_file_system", true)
-
-      # un-check the checkbox, and 'cluster' is back to being visible
-      uncheck(bc_ele_id("checkbox_hide_cluster"))
-      check_visibility("cluster", true)
-      check_visibility("cluster_file_system", true)
-
-      # check the checkbox, and 'cluster_file_system' is hidden
-      check(bc_ele_id("checkbox_hide_cluster_file_system"))
       check_visibility("cluster", true)
       check_visibility("cluster_file_system", false)
 
+      # un-check the checkbox, and 'cluster' is back to being visible
+      uncheck(bc_ele_id("checkbox_hide_cluster"))
+      check_visibility("cluster", false)
+      check_visibility("cluster_file_system", false)
+
+      # check the checkbox, and 'cluster_file_system' is hidden
+      check(bc_ele_id("checkbox_hide_cluster_file_system"))
+      check_visibility("cluster", false)
+      check_visibility("cluster_file_system", true)
+
       # un-check the checkbox, and 'cluster_file_system' is back to being visible
       uncheck(bc_ele_id("checkbox_hide_cluster_file_system"))
-      check_visibility("cluster", true)
-      check_visibility("cluster_file_system", true)
+      check_visibility("cluster", false)
+      check_visibility("cluster_file_system", false)
     end
   end
 


### PR DESCRIPTION
`idFromToken` expects the `token` argument to be a form element ID in MountainCase, but the argument can actually include arbitrary trailing characters:

https://github.com/OSC/ondemand/blob/87e93f63ea8cb958ea05e0f09ff39c6e855718c6/apps/dashboard/app/javascript/dynamic_forms.js#L757

But then later during an edge case, `idFromToken` expects an exact match:

https://github.com/OSC/ondemand/blob/87e93f63ea8cb958ea05e0f09ff39c6e855718c6/apps/dashboard/app/javascript/dynamic_forms.js#L778

In this case, trailing characters would result in an index-out-of-bounds error. A more reliable way to handle this edge case would be to compare the string length of the matches.

I am assuming that there is a legitimate use case for arbitrary trailing characters. If not, this is completely pedantic. A `$` could be added to the end of the regex, but it doesn't make much of a difference. The test case still might be worth keeping, though.