### PR TITLE
update system status progress bars for accessability

### DIFF
--- a/apps/dashboard/app/views/system_status/index.turbo_stream.erb
+++ b/apps/dashboard/app/views/system_status/index.turbo_stream.erb
@@ -19,8 +19,8 @@
                   <div class="progress-bar w-<%= current_status[:percent].to_i %>"></div>
                 </div>
                 <span id="component-value-<%= cindex %>-<%= subindex %>" class="text-muted" tabindex="0">
-		              <%= current_status[:percent] %> in use
-		            </span>
+                  <%= current_status[:percent] %> in use
+                </span>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
update system status progress bars for accessability. 

While reviewing the system status application for another pull request - I found that the progress bar is currently read simply as `busy indicator`. This resolves that, it's now read correctly as `progress bar N` where N is the integer of % used.