### PR TITLE
New versions of KDE use startplasma-x11

### DIFF
--- a/apps/bc_desktop/template/desktops/kde.sh
+++ b/apps/bc_desktop/template/desktops/kde.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if command -v startplasma-x11 > /dev/null 2>&1; then
     exec startplasma-x11
 elif command -v startkde > /dev/null 2>&1; then


### PR DESCRIPTION
This is a simple change to the KDE desktop template file in the system bc_desktop app that updates it to work with modern versions of KDE where startkde has been deprecated and removed. 
I am not aware of any testing frameworks for interactive apps so I haven't included any formal unit testing, but I have tested this on our system and it works fine there. 

Fixes #5152 