### PR TITLE
Fixing PUN management of config home

### DIFF
--- a/packaging/rpm/ondemand-selinux.fc
+++ b/packaging/rpm/ondemand-selinux.fc
@@ -17,3 +17,4 @@
 /opt/ood/apps/[^/]+/public(/.*)? gen_context(system_u:object_r:ood_apps_public_t,s0)
 /var/www/ood/apps/sys/[^/]+/bin/.+ gen_context(system_u:object_r:ood_pun_exec_t,s0)
 /opt/ood/apps/[^/]+/bin/.+ gen_context(system_u:object_r:ood_pun_exec_t,s0)
+HOME_DIR/\.config/ondemand(/.*)? gen_context(system_u:object_r:ood_pun_config_t,s0)

--- a/packaging/rpm/ondemand-selinux.te
+++ b/packaging/rpm/ondemand-selinux.te
@@ -99,21 +99,13 @@ read_lnk_files_pattern(ood_pun_t, ood_apps_public_t, ood_apps_public_t)
 read_files_pattern(httpd_t, ood_apps_public_t, ood_apps_public_t)
 read_lnk_files_pattern(httpd_t, ood_apps_public_t, ood_apps_public_t)
 
-## <desc>
-## <p>
-## Allow OnDemand to manage user .config directories labelled with config_home_t
-## </p>
-## </desc>
-gen_tunable(ondemand_manage_config_dir, false)
-tunable_policy(`ondemand_manage_config_dir',`
-  ifdef(`config_home_t',`
-    type ood_pun_config_t;
-    allow ood_pun_t config_home_t:dir { add_name write create };
-    manage_files_pattern(ood_pun_t, ood_pun_config_t, ood_pun_config_t)
-    manage_dirs_pattern(ood_pun_t, ood_pun_config_t, ood_pun_config_t)
-    filetrans_pattern(ood_pun_t, config_home_t, ood_pun_config_t, dir, "ondemand")
-  ')
-')
+# user-specific config files
+type ood_pun_config_t;
+files_type(ood_pun_config_t)
+gnome_config_filetrans(ood_pun_t, ood_pun_config_t, dir, "ondemand")
+gnome_create_home_config_dirs(ood_pun_t)
+manage_files_pattern(ood_pun_t, ood_pun_config_t, ood_pun_config_t)
+manage_dirs_pattern(ood_pun_t, ood_pun_config_t, ood_pun_config_t)
 
 ## <desc>
 ## <p>


### PR DESCRIPTION
Suggested fix for #5132, incorporating interfaces from [policy/modules/contrib/gnome.if](https://github.com/fedora-selinux/selinux-policy/blob/rawhide/policy/modules/contrib/gnome.if)

I've tested this successfully on our RHEL 9 instance of OOD.

Regarding https://github.com/OSC/ondemand/pull/4651#issuecomment-3374079201: `config_home_t` is not specific to local $HOME. NFS-mounted home will use all standard labels assuming fcontext rules are set (examples in the `semanage-fcontext` man page show a simple way to do this). Possibly the `webdev02` example shown is using the `context=` mount option to set `nfs_t`? Mount option would override the label in **ondemand-selinux.fc**, so containing it in a boolean should not be necessary.