### PR TITLE
Minor fixes to files table

### DIFF
--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -4,12 +4,12 @@
       <%= render partial: 'breadcrumb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path } %>
     </ol>
 
-    <label id="select_all_label" class="sr-only">Select All</label>
+    <span id="select_all_label" class="sr-only">Select All</span>
     <table class="table table-striped table-condensed w-100" id="directory-contents">
       <thead>
         <tr>
           <th>
-            <input type="checkbox" id="select_all" aria-labelledby="select_all_label"></input>
+            <input type="checkbox" id="select_all" class="file-select" aria-labelledby="select_all_label"></input>
             <span class="sr-only">Select</span>
           </th>
           <th>Type</th>


### PR DESCRIPTION
Two simple fixes to the files table partial.
1. Change the 'Select All' label from a `<label>` to a `<span>`. 
   The current version is marked as erroneous in browsers, since the `label` element requires the `for` attribute to be set. `aria-labelledby` does not care what element is referenced, so `span` was chosen as the simplest. This matches the example provided at https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby.

2. Add the `file-select` class to the select all button
  This applies the same styles from the row checkboxes to the header checkbox, so that they all properly align