### PR TITLE
add aria-label to files table checkboxes

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -221,7 +221,7 @@ class DataTable {
                     orderable: false,
                     defaultContent: '<input type="checkbox">',
                     render: (data, type, row, meta) => {
-                        return `<input type='checkbox' class='file-select' data-dl-url='${row.download_url}'>`;
+                        return `<input type='checkbox' class='file-select' data-dl-url='${row.download_url}' aria-label="Select row">`;
                     }
                 },
                 { data: 'type', render: (data, type, row, meta) => data == 'd' ? '<span title="directory" class="fa fa-folder" style="color: gold"><span class="sr-only">directory</span></span>' : '<span title="file" class="fa fa-file" style="color: lightgrey"><span class="sr-only">file</span></span>' }, // type


### PR DESCRIPTION
Fixes #5178. While these checkboxes do have the header 'Select' read before them, these changes add aria-label so that there is always some text linked to the element itself (not just the position in the table). 