### PR TITLE
Announce files table updates

### DIFF
--- a/apps/dashboard/app/javascript/files/data_table.js
+++ b/apps/dashboard/app/javascript/files/data_table.js
@@ -3,7 +3,7 @@ import { getGlobusLink, updateGlobusLink } from './globus.js';
 import { downloadEnabled } from '../config.js';
 export { CONTENTID, EVENTNAME };
 import { OODAlertError } from '../alert.js';
-import { toHumanSize } from '../utils.js';
+import { toHumanSize, ariaNotify } from '../utils.js';
 
 const EVENTNAME = {
     getJsonResponse: 'getJsonResponse',
@@ -302,6 +302,9 @@ class DataTable {
             if ($('#select_all').is(':checked')) {
                 $('#select_all').trigger();
             }
+
+	    $(`${CONTENTID}_caption`).text(`Contents of directory ${data.path}`);
+	    ariaNotify(`navigated to ${data.path}`);
 
             let result = await Promise.resolve(data);
             $('td input[type=checkbox]').on('keypress', function(event) {

--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -6,6 +6,7 @@
 
     <span id="select_all_label" class="sr-only">Select All</span>
     <table class="table table-striped table-condensed w-100" id="directory-contents">
+      <caption id="directory-contents_caption" class="sr-only" aria-live='polite'> <%= "Contents of directory #{@path}" %> </caption>
       <thead>
         <tr>
           <th>


### PR DESCRIPTION
Fixes #2080. Adds a caption to the files table, mentioning the current directory. When a subdirectory link is selected, focus jumps to the top of the table. Since focus never leaves the table, the caption is not read, and so we have to send an `ariaNotify` alert  stating that we have navigated to a a new path.