### PR TITLE
Add dependabot scanning on release_4.x branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,21 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "master"
-  
+
+  # Bundler - ood_portal_generator (master)
+  - package-ecosystem: "bundler"
+    directory: "/ood_portal_generator"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    
+  # Bundler - nginx_stage (master)
+  - package-ecosystem: "bundler"
+    directory: "/nginx_stage"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+
   # Bundler – root Gemfile (release_4.x)
   - package-ecosystem: "bundler"
     directory: "/"
@@ -66,6 +80,20 @@ updates:
   # Bundler - apps/myjobs (release_4.x)
   - package-ecosystem: "bundler"
     directory: "/apps/myjobs"
+    schedule:
+      interval: "weekly"
+    target-branch: "release_4.*"
+
+  # Bundler - ood_portal_generator (release_4.x)
+  - package-ecosystem: "bundler"
+    directory: "/ood_portal_generator"
+    schedule:
+      interval: "weekly"
+    target-branch: "release_4.*"
+    
+  # Bundler - nginx_stage (release_4.x)
+  - package-ecosystem: "bundler"
+    directory: "/nginx_stage"
     schedule:
       interval: "weekly"
     target-branch: "release_4.*"


### PR DESCRIPTION
Adds a dependabot config file based on the docs at https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file. This is currently efficient because the only two supported releases are 4.0 and 4.1 (and soon to have 4.2 as well), so this file should work without modification for a while.

Rather than configure different automation for branches that receive backports vs receive an announcement, this should open PRs on all branches, and if we get any to `release_4.0` we can close them and note the warning for a discourse announcement (which will be a good way to encourage upgrades).