### PR TITLE
Depend on ondemand-runtime 4.1.0-3 to fix Amazon 2023 npm dependency (release 4.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rake'
 gem 'dotenv', '~> 2.1'
 
 group :package do
-  gem 'ood_packaging', '~> 0.19.0'
+  gem 'ood_packaging', '~> 0.19.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.3.0)
     net-telnet (0.2.0)
-    ood_packaging (0.19.0)
+    ood_packaging (0.19.2)
       rake (~> 13.0.1)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -137,7 +137,7 @@ DEPENDENCIES
   beaker-docker (~> 2.2.0)
   beaker-rspec
   dotenv (~> 2.1)
-  ood_packaging (~> 0.19.0)
+  ood_packaging (~> 0.19.2)
   rake
   rspec
   rubocop

--- a/packaging/rpm/ondemand.spec
+++ b/packaging/rpm/ondemand.spec
@@ -6,7 +6,7 @@
 %define major_version %(echo %{git_tag_minus_v} | cut -d. -f1)
 %define minor_version %(echo %{git_tag_minus_v} | cut -d. -f2)
 %define runtime_version %{major_version}.%{minor_version}.0
-%define runtime_release 2
+%define runtime_release 3
 %define runtime_version_full %{runtime_version}-%{runtime_release}%{?dist}
 # Use hardcoded RHEL 9.5 for a short period while downstream RHEL clones get RHEL 9.6 release
 %if 0%{?rhel} == 9


### PR DESCRIPTION
Back port #5127

* Depend on ondemand-runtime 4.1.0-3 to fix Amazon 2023 npm dependency

* Bump ood_packaging to version that should fix Amazon builds