### PR TITLE
Restrict Dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   # Bundler – root Gemfile (master)
   - package-ecosystem: "bundler"
     directory: "/"
-    open-pull-requests-limit: 0 // only allow essential security updates
+    open-pull-requests-limit: 0 # only allow essential security updates
     schedule:
       interval: "weekly"
     target-branch: "master"


### PR DESCRIPTION
Adds the line `open-pull-requests-limit: 0` to all Dependabot entries, which prevents PRs for non-essential updates