### PR TITLE
Internationalize "Home Directory"

### DIFF
--- a/apps/dashboard/app/apps/ood_app.rb
+++ b/apps/dashboard/app/apps/ood_app.rb
@@ -84,7 +84,7 @@ class OodApp
       # assumes Home Directory is primary...
       [
         OodAppLink.new(
-          title: "Home Directory",
+          title: I18n.t('dashboard.home_directory'),
           description: manifest.description,
           url: OodAppkit::Urls::Files.new(base_url: url).url(path: Dir.home),
           icon_uri: "fas://home",

--- a/apps/dashboard/app/views/files/_favorites.html.erb
+++ b/apps/dashboard/app/views/files/_favorites.html.erb
@@ -6,7 +6,7 @@
       <li role="presentation" class="nav-item">
         <%= link_to files_path(Dir.home), class: "nav-link d bg-light" do %>
           <%= fa_icon "home", classes: '' %>
-          Home Directory
+          <%= I18n.t('dashboard.home_directory') %>
         <% end %>
       </li>
       <% OodFilesApp.new.favorite_paths.each do |p| %>

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -37,7 +37,7 @@
               <div class="panel panel-default">
                 <div class="panel-heading">Favorites</div>
                 <div id="favorites" class="list-group text-nowrap">
-                  <% homedir = FavoritePath.new(Dir.home, title:'Home Directory') %>
+                  <% homedir = FavoritePath.new(Dir.home, title:I18n.t('dashboard.home_directory')) %>
                   <%= render(partial: 'batch_connect/session_contexts/favorites', collection: favorites.unshift(homedir), as: :path) %>
                 </div>
               </div>

--- a/apps/dashboard/config/locales/en-CA.yml
+++ b/apps/dashboard/config/locales/en-CA.yml
@@ -155,6 +155,7 @@ en-CA:
     files_send_to_target_title_default: Send selected files metadata to the external application
     files_shell: Open in Terminal
     files_shell_dropdown: Select Cluster to Open in Terminal
+    home_directory: Home Directory
     import: Import
     job_info: Job Info
     jobs_create_blank_project: Create a new project

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -155,6 +155,7 @@ en:
     files_shell_dropdown: Select Cluster to Open in Terminal
     files_doesnt_exist: "%{path} does not exist."
     files_not_readable: "You do not have sufficient permissions to read '%{path}'."
+    home_directory: Home Directory
     import: Import
     job_info: Job Info
     jobs_create_blank_project: Create a new project

--- a/apps/dashboard/config/locales/fr-CA.yml
+++ b/apps/dashboard/config/locales/fr-CA.yml
@@ -155,6 +155,7 @@ fr-CA:
     files_send_to_target_title_default: Envoyer les métadonnées des fichiers sélectionnés à l'application externe
     files_shell: Ouvrir dans le terminal
     files_shell_dropdown: Sélectionner le cluster à ouvrir dans le terminal
+    home_directory: Répertoire Personnel
     import: Importer
     job_info: Informations sur le travail
     jobs_create_blank_project: Créer un nouveau projet

--- a/apps/dashboard/config/locales/ja_JP.yml
+++ b/apps/dashboard/config/locales/ja_JP.yml
@@ -152,6 +152,7 @@ ja_JP:
     files_send_to_target_title_default: 選択したファイルのメタデータを外部アプリケーションに送信
     files_shell: ターミナルで開く
     files_shell_dropdown: ターミナルで開くクラスターを選択
+    home_directory: ホームディレクトリ
     import: インポート
     job_info: ジョブ情報
     jobs_create_blank_project: 新しいプロジェクトを作成

--- a/apps/dashboard/config/locales/zh-CN.yml
+++ b/apps/dashboard/config/locales/zh-CN.yml
@@ -141,6 +141,7 @@ zh-CN:
     files_send_to_target_title_default: 将选定文件的元数据发送到外部应用程序
     files_shell: 在终端中打开
     files_shell_dropdown: 选择要在终端中打开的集群
+    home_directory: 主目录
     import: 导入
     job_info: 作业信息
     jobs_create_blank_project: 创建新项目

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -42,7 +42,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     dditems = dropdown_list_items(dropdown_list('Files'))
     assert dditems.any?, 'dropdown list items not found'
     assert_equal [
-      'Home Directory',
+      I18n.t('dashboard.home_directory'),
       "Scratch #{scratch_path}",
       project_path,
       project_path2.to_s,

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -2747,7 +2747,7 @@ class BatchConnectTest < ApplicationSystemTestCase
       sleep 3
       favorites = get_favorites
       assert_equal(3, favorites.size)
-      assert_equal('Home Directory', favorites[0].text.strip)
+      assert_equal(I18n.t('dashboard.home_directory'), favorites[0].text.strip)
       assert_equal('/tmp', favorites[1].text.strip)
       assert_equal('/var', favorites[2].text.strip)
     end
@@ -2784,7 +2784,7 @@ class BatchConnectTest < ApplicationSystemTestCase
       sleep 3
       favorites = get_favorites
       assert_equal(3, favorites.size)
-      assert_equal('Home Directory', favorites[0].text.strip)
+      assert_equal(I18n.t('dashboard.home_directory'), favorites[0].text.strip)
       assert_equal('/fs/ess', favorites[1].text.strip)
       assert_equal('/fs/scratch', favorites[2].text.strip)
     end


### PR DESCRIPTION
fixes #4538

replaced hard coded "Home Directory" with internationalized variable
made a new entry in locales yaml under dashboard.home_directory
found hard coded "Home Directory" strings with grep

Manually tested by changing OOD_LOCALE to the different languages.