### PR TITLE
Add bypass block to job composer

### DIFF
--- a/apps/myjobs/app/assets/stylesheets/application.scss
+++ b/apps/myjobs/app/assets/stylesheets/application.scss
@@ -19,6 +19,17 @@
 @import "workflows";
 @import "joyride";
 
+// styles for 'Skip Navigation' button to be hidden until focused
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip-link:focus {
+  position: static;
+  display: block;
+}
+
 // styles to make a logo fill the navbar height if using a logo for the navbar title
 .navbar-brand.navbar-brand-logo,
 .ood-appkit.navbar ul.navbar-breadcrumbs>li>a.navbar-brand-logo{

--- a/apps/myjobs/app/views/layouts/application.html.erb
+++ b/apps/myjobs/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
 
 <header>
   <!-- navbar  -->
+
+  <a href="#main_container" class="skip-link"><%= t('jobcomposer.skip_navigation') %></a>
   <nav class="ood-appkit navbar navbar-<%= ENV['OOD_NAVBAR_TYPE'].present? ? ENV['OOD_NAVBAR_TYPE'] : 'inverse' %> navbar-static-top" role="navigation">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
@@ -56,7 +58,7 @@
   </nav>
 </header>
 
-<div class="container-fluid" role="main">
+<div id="main-container" class="container-fluid" role="main">
 
   <script type="text/javascript">var selected_id = <%= @selected_id || 0 %>;</script>
 

--- a/apps/myjobs/config/locales/en.yml
+++ b/apps/myjobs/config/locales/en.yml
@@ -31,6 +31,7 @@
 
 en:
   jobcomposer:
+    skip_navigation: "Skip Navigation"
     # Site specific translations
     options_account_help:  "Account is an optional field. If not set, the account may be auto-set by the submit filter."
 


### PR DESCRIPTION
Fixes #4959. Copies the same approach from the dashboard into the job composer, including giving the main section the `main-container` id, and copying css styles to keep the skip button hidden unless it has focus.