### PR TITLE
internationalize dynamic form disclaimer

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -4,7 +4,7 @@
 <%= render "prefill_templates" if Configuration.bc_saved_settings? %>
 
 <% if Configuration.bc_dynamic_js? %>
-  <span class='sr-only' tabindex='0'> <%=t('dashboard.batch_connect_form_dynamic_disclaimer') %></span>
+  <span class='sr-only' tabindex='0'><%= t('dashboard.batch_connect_form_dynamic_disclaimer') %></span>
 <% end %>
 <%= bootstrap_form_for(@session_context, html: { autocomplete: "off", }) do |f| %>
   <% f.object.each do |attrib| %>

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -4,7 +4,7 @@
 <%= render "prefill_templates" if Configuration.bc_saved_settings? %>
 
 <% if Configuration.bc_dynamic_js? %>
-  <span class='sr-only' tabindex='0'> The following form may change dynamically as options are selected. All changes will be announced and are reversible </span>
+  <span class='sr-only' tabindex='0'> <%=t('dashboard.batch_connect_form_dynamic_disclaimer') %></span>
 <% end %>
 <%= bootstrap_form_for(@session_context, html: { autocomplete: "off", }) do |f| %>
   <% f.object.each do |attrib| %>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
     batch_connect_form_attr_cache_error: Unable to use previously cached values, using defaults instead. (%{error_message})
     batch_connect_form_choose_template_name: Choose a template name
     batch_connect_form_data_root: data root directory
+    batch_connect_form_dynamic_disclaimer: The following form may change dynamically as options are selected. All changes will be announced and are reversible.
     batch_connect_form_invalid: The form.yml has missing options in the %{id} form field.
     batch_connect_form_launch: Launch
     batch_connect_form_prefill: Use saved settings


### PR DESCRIPTION
Came across a large text segment I forgot to internationalize as part of #5126. This internationalizes that string so that it can be made available in other languages.