### PR TITLE
added assert selectors to batch_connect_widgets_test.rb

### DIFF
--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -138,7 +138,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
 
       visit new_batch_connect_session_context_url('sys/app')
 
-      find('.alert-danger')
+      assert_selector('.alert-danger')
     end
   end
 
@@ -690,6 +690,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 
     # Span exists (HTML works).
+    assert_selector(class: 'test_form_element_header', text: 'Some text in a span')
     header_span = find(class: 'test_form_element_header', text: 'Some text in a span')
     # Markdown element exists (## => h2).
     markdown_header = header_span.find(:xpath, './/../../h2', text: 'Header using Markdown')


### PR DESCRIPTION
fixes #5249 
fixes batch_connect_widgets_test.rb

changed find  to use assert selectors.
added extra assert selector in test block that doesn't have any asserts.
tested with system/test