### PR TITLE
Make footer 'Powered by Open OnDemand' more prominent (#1986)

### DIFF
--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer d-flex m-0 mt-4 justify-content-between align-items-center px-4 py-3">
+<footer class="footer d-flex flex-column flex-md-row flex-wrap m-0 mt-4 justify-content-between align-items-start align-items-md-center px-4 py-3 gap-2">
   <div class="d-flex flex-column align-items-start">
     <%= link_to "https://openondemand.org" do %>
       <%=

--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <div class="text-muted small mt-1">
       Open source software.
-      <%= link_to "Contribute on GitHub", "https://github.com/OSC/ondemand/issues", class: "text-decoration-underline" %>
+      <%= link_to "Contribute on GitHub", "https://github.com/OSC/ondemand", class: "text-decoration-underline" %>
     </div>
   </div>
   <span id="ood_version">OnDemand version: <%= Configuration.ood_version %><br><a href="https://openondemand.org/licensing">Software License Notice</a></span>

--- a/apps/dashboard/app/views/layouts/_footer.html.erb
+++ b/apps/dashboard/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
-<footer class="d-flex m-0 mt-4 justify-content-between align-items-center p-4">
-  <div class="me-2">
+<footer class="footer d-flex m-0 mt-4 justify-content-between align-items-center px-4 py-3">
+  <div class="d-flex flex-column align-items-start">
     <%= link_to "https://openondemand.org" do %>
       <%=
         image_tag(
@@ -10,6 +10,10 @@
         )
       %>
     <% end %>
+    <div class="text-muted small mt-1">
+      Open source software.
+      <%= link_to "Contribute on GitHub", "https://github.com/OSC/ondemand/issues", class: "text-decoration-underline" %>
+    </div>
   </div>
   <span id="ood_version">OnDemand version: <%= Configuration.ood_version %><br><a href="https://openondemand.org/licensing">Software License Notice</a></span>
 </footer>

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -165,11 +165,16 @@ class ProjectManagerTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       project_id = setup_project(dir)
 
-      click_on 'Edit'
+      within(:css, "[id='#{project_id}']") do
+        click_on 'Edit'
+      end
+      assert_selector 'h1', text: 'Editing: Test Project'
       find('#project_name').set('my-test-project', clear: :backspace)
       click_on 'Save'
       assert_selector "[href='/projects/#{project_id}']", text: 'My Test Project'
-      click_on 'Edit'
+      within(:css, "[id='#{project_id}']") do
+        click_on 'Edit'
+      end
       assert_selector 'h1', text: 'Editing: My Test Project'
       assert_equal 'my-test-project', find('#project_name').value
       assert_equal "#{dir}/projects/#{project_id}", find('#project_directory').value
@@ -191,7 +196,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       click_on 'Save'
 
       assert_text I18n.t('dashboard.jobs_project_validation_error')
-      assert_selector '.alert-danger', wait: 10
+      assert_selector '.alert-danger'
     end
   end
 
@@ -203,7 +208,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       click_on 'Save'
 
       assert_text I18n.t('dashboard.jobs_project_validation_error')
-      assert_selector '.alert-danger', wait: 10
+      assert_selector '.alert-danger'
     end
   end
 
@@ -446,7 +451,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       assert_selector("#{tframe_selector} strong", text: "#{project_dir}")
 
       # just check count since the previous test checks the same header text
-      assert_equal 7, all("#{tframe_selector} th").length
+      assert_selector "#{tframe_selector} th", count: 7
 
       rows = all("#{tframe_selector} tbody tr")
       assert_equal 8, rows.length

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -190,7 +190,8 @@ class ProjectManagerTest < ApplicationSystemTestCase
       find('#product_icon_select').set(icon)
       click_on 'Save'
 
-      assert_selector '.alert-danger', text: I18n.t('dashboard.jobs_project_validation_error')
+      assert_text I18n.t('dashboard.jobs_project_validation_error')
+      assert_selector '.alert-danger', wait: 10
     end
   end
 
@@ -201,7 +202,8 @@ class ProjectManagerTest < ApplicationSystemTestCase
       find('#product_icon_select').set('fas://bad&icon')
       click_on 'Save'
 
-      assert_selector '.alert-danger', text: I18n.t('dashboard.jobs_project_validation_error')
+      assert_text I18n.t('dashboard.jobs_project_validation_error')
+      assert_selector '.alert-danger', wait: 10
     end
   end
 

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -165,16 +165,11 @@ class ProjectManagerTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       project_id = setup_project(dir)
 
-      within(:css, "[id='#{project_id}']") do
-        click_on 'Edit'
-      end
-      assert_selector 'h1', text: 'Editing: Test Project'
+      click_on 'Edit'
       find('#project_name').set('my-test-project', clear: :backspace)
       click_on 'Save'
       assert_selector "[href='/projects/#{project_id}']", text: 'My Test Project'
-      within(:css, "[id='#{project_id}']") do
-        click_on 'Edit'
-      end
+      click_on 'Edit'
       assert_selector 'h1', text: 'Editing: My Test Project'
       assert_equal 'my-test-project', find('#project_name').value
       assert_equal "#{dir}/projects/#{project_id}", find('#project_directory').value
@@ -195,8 +190,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       find('#product_icon_select').set(icon)
       click_on 'Save'
 
-      assert_text I18n.t('dashboard.jobs_project_validation_error')
-      assert_selector '.alert-danger'
+      assert_selector '.alert-danger', text: I18n.t('dashboard.jobs_project_validation_error')
     end
   end
 
@@ -207,8 +201,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       find('#product_icon_select').set('fas://bad&icon')
       click_on 'Save'
 
-      assert_text I18n.t('dashboard.jobs_project_validation_error')
-      assert_selector '.alert-danger'
+      assert_selector '.alert-danger', text: I18n.t('dashboard.jobs_project_validation_error')
     end
   end
 
@@ -451,7 +444,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       assert_selector("#{tframe_selector} strong", text: "#{project_dir}")
 
       # just check count since the previous test checks the same header text
-      assert_selector "#{tframe_selector} th", count: 7
+      assert_equal 7, all("#{tframe_selector} th").length
 
       rows = all("#{tframe_selector} tbody tr")
       assert_equal 8, rows.length


### PR DESCRIPTION
Fixes #1986

- Made the “Powered by Open OnDemand” footer more prominent so that folks know that this is an open source project
- Added a link encouraging users to learn more and contribute on GitHub.

Visual change only. No functional impact.