### PR TITLE
Hold focus in batch connect session cards

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -119,7 +119,7 @@ module BatchConnect::SessionsHelper
     button_to(
       new_batch_connect_session_context_path(token: session.token),
       method: :get,
-      class: %w[btn px-1 py-0 btn-outline-dark full-page-spinner],
+      class: %w[btn px-1 py-0 btn-outline-dark full-page-spinner edit-session],
       form_class: %w[d-inline edit-session],
       title: title,
       'aria-label': title,

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -23,6 +23,7 @@ export function replaceHTML(id, html) {
 
 export function pollAndReplace(url, delay, id, callback, continuePolling = () => true) {
   var focusedId = null;
+  var focusedSelector = null;
   fetch(url, { headers: { Accept: "text/vnd.turbo-stream.html" } })
     .then((response) => {
       if(response.status == 200) {
@@ -37,13 +38,28 @@ export function pollAndReplace(url, delay, id, callback, continuePolling = () =>
     .then((html) => {
       const focusedElement = document.activeElement
       if (jQuery.contains(document.getElementById(id), focusedElement)) {
+        // system status ensures that focusable elements have ids
         focusedId = focusedElement.id;
+
+        // batch connect sessions use user-provided views, so use a weaker but more general approach
+
+        const parentId = $(focusedElement).closest('.session-panel').attr('id');
+        const ele = focusedElement.tagName.toLowerCase();
+        const classArray = Array.from(focusedElement.classList);
+        const text = $(focusedElement).text();
+        let classes = "";
+        if (classArray.length > 0) { // adds the leading . if classes are present
+          classes = `.${classArray.join('.')}`;
+        }
+        focusedSelector = `#${parentId} ${ele}${classes}:contains("${text}")`;
       }
       replaceHTML(id, html);
       const newFocus = document.getElementById(focusedId);
       if (newFocus) {
         newFocus.focus();
-      }	
+      }	else {
+        $(focusedSelector).focus();
+      }
     })
     .then(() => {
       if (continuePolling()) {

--- a/apps/dashboard/app/views/batch_connect/sessions/card/_id.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_id.html.erb
@@ -1,4 +1,4 @@
 <p>
   <strong><%= t('dashboard.batch_connect_sessions_stats_session_id') %></strong>
-  <%= link_to(session.id, OodAppkit.files.url(path: session.staged_root).to_s) %> 
+  <%= link_to(session.id, OodAppkit.files.url(path: session.staged_root).to_s, class:'session-id-link') %> 
 </p>

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -182,4 +182,30 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       assert_equal("Jupyter (#{get_test_job_id})\n2 nodes | 2 cores | Starting", header_text)
     end
   end
+
+  test 'session cards hold focus when replaced' do 
+    Dir.mktmpdir do |dir|
+      with_modified_env({OOD_BC_SESSIONS_POLL_DELAY: '5'}) do
+        create_test_file(dir, token: 'sys/bc_jupyter', title: 'Jupyter')
+        stub_scheduler(:running, nodes: 2, cores: 2)
+        visit(batch_connect_sessions_path)
+  
+        card_selector = "#id_#{get_test_bc_id}"
+
+        assert_selector(card_selector)
+        within(card_selector) do 
+          focusable_elements = all('a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])')
+          # since these elements are repeated on every card, they must have a unique classlist within a card
+          focusable_selectors = focusable_elements.map{ |el| "#{el.tag_name}.#{el[:class].split(' ').join('.')}" }
+
+          focusable_selectors.each do |selector|
+            assert_selector(selector)
+            execute_script("$('#{card_selector} #{selector}').focus()")
+            sleep 0.01
+            assert_equal(selector.split('.')[1..], evaluate_script('document.activeElement.classList'))
+          end
+        end
+      end
+    end
+  end
 end

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -185,7 +185,7 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
 
   test 'session cards hold focus when replaced' do 
     Dir.mktmpdir do |dir|
-      with_modified_env({OOD_BC_SESSIONS_POLL_DELAY: '5'}) do
+      with_modified_env({OOD_BC_SESSIONS_POLL_DELAY: '10'}) do
         create_test_file(dir, token: 'sys/bc_jupyter', title: 'Jupyter')
         stub_scheduler(:running, nodes: 2, cores: 2)
         visit(batch_connect_sessions_path)
@@ -200,8 +200,10 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
 
           focusable_selectors.each do |selector|
             assert_selector(selector)
+            execute_script("$('#{card_selector}').attr('data-original-marker', 'true')")
             execute_script("$('#{card_selector} #{selector}').focus()")
-            sleep 0.01
+
+            assert_no_selector("#{card_selector}[data-original-marker='true']")
             assert_equal(selector.split('.')[1..], evaluate_script('document.activeElement.classList'))
           end
         end


### PR DESCRIPTION
Fixes #4945 by customizing the turbo shim to maintain focus in batch connect session cards. This mimics the approach taken in #5079 with system status, but where there we were able to assign ids to all focusable elements, batch connect cards can be customized, so we employ a looser but more general approach, collecting 4 essential pieces of information that every element has. These 4 identifying details are
1. session card parent (has id corresponding to the session id, so is consistent through refresh)
2. element tag
3. classList (while not guaranteed to exist, this is vital for differentiating between elements without text)
4. text

Since the possibilities of what a session card could contain are endless, there is no guarantee that this will actually identify the focused element every time. What it can guarantee though, is that 
- default elements always hold focus
- even if a unique match is not found, focus will remain within the same session card

We can also document that custom view elements should be assigned ids or distinguishing classes (if it is a repeated one per session card), and this should leave us in a much better place than before, where focus returned to the start of the page.