### PR TITLE
Do not install e2e gems during Gitlab package build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ before_script:
   - MAJOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f1)
   - MINOR_VERSION=$(echo "${CI_COMMIT_TAG#v}" | cut -d'.' -f2)
   - '[ "x$CI_COMMIT_TAG" != "x" ] && OOD_PACKAGING_RELEASE="${MAJOR_VERSION}.${MINOR_VERSION}" || OOD_PACKAGING_RELEASE=main'
-  - bundle install --path vendor/bundle --without test
+  - bundle install --path vendor/bundle --without test e2e
 stages:
   - build
   - deploy


### PR DESCRIPTION
Beaker requires Ruby 3.2+ but our Gitlab runner uses Ruby 3.0 still