### PR TITLE
This will always set the HSTS header for security purposes

### DIFF
--- a/mod_ood_proxy/lib/nginx.lua
+++ b/mod_ood_proxy/lib/nginx.lua
@@ -11,7 +11,7 @@ local nginx_stage = require 'ood.nginx_stage'
     2. 'stop'  = send `stop` signal to PUN process
 --]]
 function nginx_handler(r)
-  -- Always set the Strinv Transport Security
+  -- Always set the Strict Transport Security
   r.err_headers_out['Strict-Transport-Security'] = "max-age=31536000"
   -- read in OOD specific settings defined in Apache config
   local user_map_match = r.subprocess_env['OOD_USER_MAP_MATCH']

--- a/mod_ood_proxy/lib/nginx.lua
+++ b/mod_ood_proxy/lib/nginx.lua
@@ -11,6 +11,8 @@ local nginx_stage = require 'ood.nginx_stage'
     2. 'stop'  = send `stop` signal to PUN process
 --]]
 function nginx_handler(r)
+  -- Always set the Strinv Transport Security
+  r.err_headers_out['Strict-Transport-Security'] = "max-age=31536000"
   -- read in OOD specific settings defined in Apache config
   local user_map_match = r.subprocess_env['OOD_USER_MAP_MATCH']
   local user_map_cmd   = r.subprocess_env['OOD_USER_MAP_CMD']


### PR DESCRIPTION
In a security scan of our implementation the /nginx/stop url came up as not setting the proper HSTS headers even though we are setting it everywhere else.  

I tried forcing it with the `custom_location_directives` but that was also not working.  

It seems the lua directly returning the reponse bypasses the apache header handling.. This was my work around so that it will always set them.

If there is a better way to handle this let me know.