### PR TITLE
Refactor pinned app border colors using SASS loop

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
@@ -65,72 +65,40 @@
     border-radius: 10%;
   }
 /**
-  Pinned Apps border color overrides, to be used with the border_color tile property:
-  black, silver, gray, white, maroon, red, purple, fuchsia, green, lime, olive, yellow, navy, blue, teal, aqua
-  primary, secondary, success, info, warning, danger, light, and dark
+  Pinned Apps border color overrides:
+  - Any standard CSS named color
+  - Bootstrap theme colors: primary, secondary, success, info, warning, danger, light, dark
  */
-  .launcher-click.black {
-    border-color: black;
-  }
+  $css_named_colors: (
+    "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque", "black",
+    "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue", "chartreuse",
+    "chocolate", "coral", "cornflowerblue", "cornsilk", "crimson", "cyan", "darkblue",
+    "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkgrey", "darkkhaki",
+    "darkmagenta", "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon",
+    "darkseagreen", "darkslateblue", "darkslategray", "darkslategrey", "darkturquoise",
+    "darkviolet", "deeppink", "deepskyblue", "dimgray", "dimgrey", "dodgerblue", "firebrick",
+    "floralwhite", "forestgreen", "fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod",
+    "gray", "green", "greenyellow", "grey", "honeydew", "hotpink", "indianred", "indigo", "ivory",
+    "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon", "lightblue",
+    "lightcoral", "lightcyan", "lightgoldenrodyellow", "lightgray", "lightgreen",
+    "lightgrey", "lightpink", "lightsalmon", "lightseagreen", "lightskyblue",
+    "lightslategray", "lightslategrey", "lightsteelblue", "lightyellow", "lime",
+    "limegreen", "linen", "magenta", "maroon", "mediumaquamarine", "mediumblue",
+    "mediumorchid", "mediumpurple", "mediumseagreen", "mediumslateblue",
+    "mediumspringgreen", "mediumturquoise", "mediumvioletred", "midnightblue",
+    "mintcream", "mistyrose", "moccasin", "navajowhite", "navy", "oldlace", "olive",
+    "olivedrab", "orange", "orangered", "orchid", "palegoldenrod", "palegreen",
+    "paleturquoise", "palevioletred", "papayawhip", "peachpuff", "peru", "pink", "plum",
+    "powderblue", "purple", "rebeccapurple", "red", "rosybrown", "royalblue", "saddlebrown",
+    "salmon", "sandybrown", "seagreen", "seashell", "sienna", "silver", "skyblue", "slateblue",
+    "slategray", "slategrey", "snow", "springgreen", "steelblue", "tan", "teal", "thistle",
+    "tomato", "turquoise", "violet", "wheat", "white", "whitesmoke", "yellow", "yellowgreen"
+  );
 
-  .launcher-click.silver {
-    border-color: silver;
-  }
-
-  .launcher-click.gray {
-    border-color: gray;
-  }
-
-  .launcher-click.white {
-    border-color: white;
-  }
-
-  .launcher-click.maroon {
-    border-color: maroon;
-  }
-
-  .launcher-click.red {
-    border-color: red;
-  }
-
-  .launcher-click.purple {
-    border-color: purple;
-  }
-
-  .launcher-click.fuchsia {
-    border-color: fuchsia;
-  }
-
-  .launcher-click.green {
-    border-color: green;
-  }
-
-  .launcher-click.lime {
-    border-color: lime;
-  }
-
-  .launcher-click.olive {
-    border-color: olive;
-  }
-
-  .launcher-click.yellow {
-    border-color: yellow;
-  }
-
-  .launcher-click.navy {
-    border-color: navy;
-  }
-
-  .launcher-click.blue {
-    border-color: blue;
-  }
-
-  .launcher-click.teal {
-    border-color: teal;
-  }
-
-  .launcher-click.aqua {
-    border-color: aqua;
+  @each $color_name in $css_named_colors {
+    .launcher-click.#{$color_name} {
+      border-color: unquote($color_name);
+    }
   }
 
   .launcher-click.primary {


### PR DESCRIPTION
Fixes #5134

- Replaces the hardcoded border overrides with a SASS loop over standard CSS named colors
- Ensures all valid named colors are supported
- Bootstrap theme color overrides are unchanged
- No functional changes expected