### PR TITLE
Fix contrast issues in main pages

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -27,20 +27,9 @@
 
 
 * { // Contrast fixes. Do not edit without re-checking accessibility
-  --bs-link-color: rgb(31, 110, 178);
-  --bs-link-color-rgb: 31, 110, 178;
-  --bs-danger: rgb(218, 52, 67);
-  --bs-danger-rbg: 218, 52, 67;
-}
-
-.btn-danger {
-  --bs-btn-bg: rgb(218, 52, 67);
-  --bs-btn-border-color: rgb(218, 52, 67);
-}
-
-.btn-secondary {
-  --bs-btn-bg: rgb(107 117 128);
-  --bs-btn-border-color: rgb(107 117 128);
+  $bs-link-color: rgb(31, 110, 178);
+  $bs-danger: rgb(218, 52, 67);
+  $bs-secondary: rgb(107 117 128);
 }
 
 .bg-white {

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -48,6 +48,13 @@
   --bs-info-rgb: 9, 128, 151;
 }
 
+.badge {
+  --bs-success: rgb(66, 130, 66);
+  --bs-success-rgb: 66, 130, 66;
+  --bs-info: rgb(9, 128, 151);
+  --bs-info-rgb: 9, 128, 151;
+}
+
 nav.navbar {
   padding: 0.5rem 1rem;
 }

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -24,6 +24,30 @@
 // get in the way
 // $navbar-height: 20px;
 
+
+
+* { // Contrast fixes. Do not edit without re-checking accessibility
+  --bs-link-color: rgb(31, 110, 178);
+  --bs-link-color-rgb: 31, 110, 178;
+  --bs-danger: rgb(218, 52, 67);
+  --bs-danger-rbg: 218, 52, 67;
+}
+
+.btn-danger {
+  --bs-btn-bg: rgb(218, 52, 67);
+  --bs-btn-border-color: rgb(218, 52, 67);
+}
+
+.btn-secondary {
+  --bs-btn-bg: rgb(107 117 128);
+  --bs-btn-border-color: rgb(107 117 128);
+}
+
+.bg-white {
+  --bs-info: rgb(9, 128, 151);
+  --bs-info-rgb: 9, 128, 151;
+}
+
 nav.navbar {
   padding: 0.5rem 1rem;
 }

--- a/apps/dashboard/app/assets/stylesheets/batch_connect/sessions.scss
+++ b/apps/dashboard/app/assets/stylesheets/batch_connect/sessions.scss
@@ -26,7 +26,7 @@
 .list-group-item.header {
   padding-top: 3px;
   padding-bottom: 3px;
-  color: #777;
+  color: #6f6f6f;
   font-size: 12px;
   background-color: #f5f5f5;
 }

--- a/apps/dashboard/app/assets/stylesheets/projects.scss
+++ b/apps/dashboard/app/assets/stylesheets/projects.scss
@@ -134,6 +134,20 @@ div#directory_browser td a {
   text-wrap:nowrap;
 }
 
+.btn-success.launcher-button {
+  --bs-btn-bg: rgb(66, 130, 66);
+  --bs-btn-border-color: rgb(66, 130, 66);
+  --bs-btn-hover-bg: rgb(76, 154, 76);
+  --bs-btn-hover-border-color: rgb(76, 154, 76);
+}
+
+.btn-info.launcher-button {
+  --bs-btn-bg: rgb(9, 128, 151);
+  --bs-btn-border-color: rgb(9, 128, 151);
+  --bs-btn-hover-bg: rgb(12, 154, 183);
+  --bs-btn-hover-border-color: rgb(12, 154, 183);
+}
+
 .workflow-item {
   justify-content: right;
 }
@@ -168,6 +182,10 @@ div#directory_browser td a {
 
     button.badge.collapsed {
       color: var(--bs-badge-color);
+      --bs-success: rgb(66, 130, 66);
+      --bs-success-rgb: 66, 130, 66;
+      --bs-info: rgb(9, 128, 151);
+      --bs-info-rgb: 9, 128, 151;
       &:hover, &:focus-within {
         color: var(--bs-btn-hover-color);
       }


### PR DESCRIPTION
Contributes to #5169. Fixes contrast issues on all main pages. Does not fix widgets, as those are customizable by the centers (though they can be fixed in future patches). With the exception of disabled buttons (see https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast on 'Incidental'), every piece of visible text meets the AA guideline of 4.5+ contrast ratio. 

CSS changes were applied at the smallest scope possible, and the global ones are only for cases where the bootstrap default is quite close to the 4.5 number, but not quite there. More drastic changes like the ones seen in the project manager are due to us forcing white text where the bootstrap default is black, and so the associated color variables had to be shifted to the other side of the spectrum. 