### PR TITLE
Add aria labels to nav elements for accessibility

### DIFF
--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
       <a href="#main_container" class="skip-link"><%= t('dashboard.skip_navigation') %></a>
     </span>
 
-    <nav class="navbar navbar-expand-md shadow-sm navbar-color navbar-<%= @user_configuration.navbar_type %>">
+    <nav class="navbar navbar-expand-md shadow-sm navbar-color navbar-<%= @user_configuration.navbar_type %>" aria-label="Main Menu">
       <ul class="navbar-nav w-100 align-items-center" role="menubar">
         <%= render partial: 'layouts/nav/logo' %>
       

--- a/apps/dashboard/app/views/shared/_path_selector_table.html.erb
+++ b/apps/dashboard/app/views/shared/_path_selector_table.html.erb
@@ -45,7 +45,7 @@
           <% end %>
 
             <div class="<%= favorites ? 'col-sm-7' : 'col-sm-12' %>">
-              <nav>
+              <nav aria-label="<%= "#{popup_title} Breadcrumb" %>">
                 <ol id="<%= breadcrumb_id %>" class="breadcrumb breadcrumb-no-delimiter rounded">
                 </ol>
               </nav>

--- a/apps/myjobs/app/views/layouts/application.html.erb
+++ b/apps/myjobs/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   <!-- navbar  -->
 
   <a href="#main_container" class="skip-link"><%= t('jobcomposer.skip_navigation') %></a>
-  <nav class="ood-appkit navbar navbar-<%= ENV['OOD_NAVBAR_TYPE'].present? ? ENV['OOD_NAVBAR_TYPE'] : 'inverse' %> navbar-static-top" role="navigation">
+  <nav class="ood-appkit navbar navbar-<%= ENV['OOD_NAVBAR_TYPE'].present? ? ENV['OOD_NAVBAR_TYPE'] : 'inverse' %> navbar-static-top" role="navigation" aria-label="Job Composer Menu">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">

--- a/apps/shell/views/index.hbs
+++ b/apps/shell/views/index.hbs
@@ -18,7 +18,7 @@
 <body>
   <div id="terminal">
 
-    <nav class="navbar navbar-inverse navbar-static-top navbar-expand" role="navigation">
+    <nav class="navbar navbar-inverse navbar-static-top navbar-expand" role="navigation" aria-label="Shell Menu">
       <div class="container-fluid" >
       <ul class="navbar-nav left-padding-none">
             <li class="nav-item custom-host">


### PR DESCRIPTION
Fixes #4255

- Adds `aria-label` to `<nav>` elements that were missing accessible names to improve screen reader support
- No UI or behavior changes