### PR TITLE
fix scss variables for contrast

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/_variables.scss
+++ b/apps/dashboard/app/assets/stylesheets/_variables.scss
@@ -63,3 +63,6 @@ $breadcrumb-padding-x: 1rem;
 
 // files get copied during 'yarn build' in esbuild.config.js
 $fa-font-path: "../builds";
+
+// accessibility variables
+$link-color: rgb(31, 110, 178);

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -26,11 +26,7 @@
 
 
 
-* { // Contrast fixes. Do not edit without re-checking accessibility
-  $bs-link-color: rgb(31, 110, 178);
-  $bs-danger: rgb(218, 52, 67);
-  $bs-secondary: rgb(107 117 128);
-}
+// Contrast fixes. Do not edit without re-checking accessibility
 
 .bg-white {
   --bs-info: rgb(9, 128, 151);

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -28,6 +28,10 @@
 
 // Contrast fixes. Do not edit without re-checking accessibility
 
+.alert-danger a {
+  color: rgb(43, 102, 153);;
+}
+
 .bg-white {
   --bs-info: rgb(9, 128, 151);
   --bs-info-rgb: 9, 128, 151;

--- a/apps/dashboard/app/assets/stylesheets/files.scss
+++ b/apps/dashboard/app/assets/stylesheets/files.scss
@@ -1,6 +1,10 @@
 #directory-contents .selected {
   color: white;
   background-color: rgb(0, 136, 204);
+
+  .dropdown-menu a {
+    color: var(--bs-dropdown-link-color);
+  }
 }
 
 #directory-contents .selected a.name {
@@ -32,3 +36,4 @@ div.datatables-status, div.transfers-status {
 .z-index-999 {
   z-index: 999;
 }
+

--- a/apps/dashboard/app/assets/stylesheets/module_browser.scss
+++ b/apps/dashboard/app/assets/stylesheets/module_browser.scss
@@ -17,3 +17,7 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
 }
+
+.bg-light .btn-outline-secondary {
+  --bs-btn-color: #515558;
+}


### PR DESCRIPTION
Contributes to #5169. Glad I checked in on this, as the link color variable was not correct. Fixing that, adding an extra rule for .btn-outline-secondary inside .bg-light (from module browser), and correcting a visual bug with file action links in selected rows completes the contrast fixes on the main pages