### PR TITLE
Change default value of show_all_apps_link to true

### DIFF
--- a/apps/dashboard/app/models/user_configuration.rb
+++ b/apps/dashboard/app/models/user_configuration.rb
@@ -66,7 +66,7 @@ class UserConfiguration
     ConfigurationProperty.property(name: :dashboard_title, default_value: 'Open OnDemand', read_from_env: true),
 
     # Navigation properties
-    ConfigurationProperty.with_boolean_mapper(name: :show_all_apps_link, default_value: false, read_from_env: true,
+    ConfigurationProperty.with_boolean_mapper(name: :show_all_apps_link, default_value: true, read_from_env: true,
                                               env_names: ['SHOW_ALL_APPS_LINK']),
     # New navigation definition properties
     ConfigurationProperty.property(name: :nav_bar, default_value: []),

--- a/apps/dashboard/test/models/user_configuration_test.rb
+++ b/apps/dashboard/test/models/user_configuration_test.rb
@@ -72,7 +72,7 @@ class UserConfigurationTest < ActiveSupport::TestCase
       navbar_type:                       'dark',
       pinned_apps_group_by:              nil,
 
-      show_all_apps_link:                false,
+      show_all_apps_link:                true,
       filter_nav_categories?:            false,
       nav_categories:                    ['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps'],
       nav_bar:                           [],


### PR DESCRIPTION
Change the default value so that guideline [2.4.5 Multiple Ways](http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc) is met by default. This should be included in the next patch of 4.2