### PR TITLE
Fix filename URL encoding for # in Files app (#5202)

### DIFF
--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -40,9 +40,9 @@ module FilesHelper
     path.to_s.split('/').map { |seg| ERB::Util.url_encode(seg.to_s) }.join('/')
   end
 
-  def files_editor_api_url(path:, filesystem:)
-    api_url = OodAppkit.files.api(path: '/', fs: filesystem).to_s
-    base = api_url.chomp('/')
-    "#{controller.relative_url_root}#{base.match(%r{(/files/api/v1/fs).*})[1]}#{url_encode_path(path.to_s)}"
+  def url_encode_url_path(url)
+    path, query = url.to_s.split('?', 2)
+    encoded = url_encode_path(path)
+    query ? "#{encoded}?#{query}" : encoded
   end
 end

--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -35,5 +35,13 @@ module FilesHelper
   def frame_path(path)
     path.to_s
   end
+
+  def url_encode_segment(segment)
+    ERB::Util.url_encode(segment.to_s)
+  end
+
+  def url_encode_path(path)
+    path.to_s.split('/').map { |seg| url_encode_segment(seg) }.join('/')
+  end
 end
 

--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -36,12 +36,13 @@ module FilesHelper
     path.to_s
   end
 
-  def url_encode_segment(segment)
-    ERB::Util.url_encode(segment.to_s)
+  def url_encode_path(path)
+    path.to_s.split('/').map { |seg| ERB::Util.url_encode(seg.to_s) }.join('/')
   end
 
-  def url_encode_path(path)
-    path.to_s.split('/').map { |seg| url_encode_segment(seg) }.join('/')
+  def files_editor_api_url(path:, filesystem:)
+    api_url = OodAppkit.files.api(path: '/', fs: filesystem).to_s
+    base = api_url.chomp('/')
+    "#{controller.relative_url_root}#{base.match(%r{(/files/api/v1/fs).*})[1]}#{url_encode_path(path.to_s)}"
   end
 end
-

--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -1,4 +1,7 @@
 # Helper for /files pages.
+
+require 'uri'
+
 module FilesHelper
   include ApplicationHelper
   

--- a/apps/dashboard/app/javascript/files/file_ops.js
+++ b/apps/dashboard/app/javascript/files/file_ops.js
@@ -350,7 +350,7 @@ class FileOps {
 
   newFile(filename) {
     let myFileOp = new FileOps();
-    fetch(`${history.state.currentDirectoryUrl}/${encodeURI(filename)}?touch=true`, { method: 'put', headers: { 'X-CSRF-Token': csrfToken() } })
+    fetch(`${history.state.currentDirectoryUrl}/${encodeURIComponent(filename)}?touch=true`, { method: 'put', headers: { 'X-CSRF-Token': csrfToken() } })
       .then(response => this.dataFromJsonResponse(response))
       .then(function () {
         myFileOp.reloadTable();
@@ -384,7 +384,7 @@ class FileOps {
 
   newDirectory(filename) {
     let myFileOp = new FileOps();
-    fetch(`${history.state.currentDirectoryUrl}/${encodeURI(filename)}?dir=true`, {method: 'put', headers: { 'X-CSRF-Token': csrfToken() }})
+    fetch(`${history.state.currentDirectoryUrl}/${encodeURIComponent(filename)}?dir=true`, {method: 'put', headers: { 'X-CSRF-Token': csrfToken() }})
       .then(response => this.dataFromJsonResponse(response))
       .then(function () {
         myFileOp.reloadTable();
@@ -406,7 +406,7 @@ class FileOps {
 
   downloadDirectory(file) {
     let filename = $($.parseHTML(file.name)).text(),
-        canDownloadReq = `${history.state.currentDirectoryUrl}/${encodeURI(filename)}?can_download=${Date.now().toString()}`
+        canDownloadReq = `${history.state.currentDirectoryUrl}/${encodeURIComponent(filename)}?can_download=${Date.now().toString()}`
 
     this.showSwalLoading('preparing to download directory: ' + file.name);
   
@@ -439,7 +439,7 @@ class FileOps {
     // so this just repeats the status quo
   
     let filename = $($.parseHTML(file.name)).text(),
-        downloadUrl = `${history.state.currentDirectoryUrl}/${encodeURI(filename)}?download=${Date.now().toString()}`,
+        downloadUrl = `${history.state.currentDirectoryUrl}/${encodeURIComponent(filename)}?download=${Date.now().toString()}`,
         iframe = document.createElement('iframe'),
         TIME = 30 * 1000;
   

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -50,8 +50,9 @@ jQuery(function() {
         return Promise.all(this.empty_dirs.map((d) => {
           // "fullPath" should actually be the path relative to the current directory
           let filename = _.trimStart(d.fullPath, '/');
+          let encoded = filename.split('/').map(encodeURIComponent).join('/');
 
-          return fetch(`${history.state.currentDirectoryUrl}/${encodeURI(filename)}?dir=true`, {method: 'put', headers: { 'X-CSRF-Token': csrfToken() }})
+          return fetch(`${history.state.currentDirectoryUrl}/${encoded}?dir=true`, {method: 'put', headers: { 'X-CSRF-Token': csrfToken() }})
           //TODO: parse json response verify if there was an error creating directory and handle error
 
         })).then(() => this.empty_dirs = []);

--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -3,6 +3,7 @@ import { ariaNotify, hide, show } from "../utils";
 
 export class PathSelectorTable {
   _table = null;
+  _currentListPath = undefined;
 
   // input data that should be passed into the constructor
   tableId             = undefined;
@@ -97,6 +98,7 @@ export class PathSelectorTable {
       ariaNotify('Loading directory contents');
       const response = await fetch(url, { headers: { 'Accept': 'application/json' }, cache: 'no-store' });
       const data = await this.dataFromJsonResponse(response);
+      this._currentListPath = data.path;
       $(`#${this.breadcrumbId}`).html(data.path_selector_breadcrumbs_html);
       this._table.clear();
       this._table.rows.add(data.files);
@@ -149,8 +151,18 @@ export class PathSelectorTable {
     // only reload table for directories. and correct last visited
     // if it's a file.
     if(pathType == 'f') {
-      const path = url.replace(this.filesPath, '').replaceAll('//','/');
-      this.setLastVisited(path, pathType);
+      // Use JSON path + name instead of URL since URLs are encoded and can break filenames like + or #
+      const $tr = $(event.target).closest('tr');
+      const inMainTable = $tr.length && $tr.closest(`#${this.tableId}`).length > 0;
+      const rowData = inMainTable ? this._table.row($tr).data() : null;
+      let fsPath;
+      if (this._currentListPath && rowData && rowData.name) {
+        const base = this._currentListPath.replace(/\/$/, '');
+        fsPath = `${base}/${rowData.name}`;
+      } else {
+        fsPath = url.replace(this.filesPath, '').replaceAll('//','/');
+      }
+      this.setLastVisited(fsPath, pathType);
     } else {
       this.reloadTable(url);
     }

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -242,5 +242,5 @@
     <div class="card-body border-0"></div>
 
   </div>
-  <pre class="flex-grow-1" id="editor" data-path="<%= @path %>" data-api="<%= OodAppkit.files.api(path: @path, fs: @filesystem) %>"><%= @content %></pre>
+  <pre class="flex-grow-1" id="editor" data-path="<%= @path %>" data-api="<%= "#{controller.relative_url_root}/files/#{@filesystem}#{url_encode_path(@path)}" %>"><%= @content %></pre>
 </div>

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -242,5 +242,5 @@
     <div class="card-body border-0"></div>
 
   </div>
-  <pre class="flex-grow-1" id="editor" data-path="<%= @path %>" data-api="<%= "#{controller.relative_url_root}/files/#{@filesystem}#{url_encode_path(@path)}" %>"><%= @content %></pre>
+  <pre class="flex-grow-1" id="editor" data-path="<%= @path %>" data-api="<%= files_editor_api_url(path: @path, filesystem: @filesystem) %>"><%= @content %></pre>
 </div>

--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -242,5 +242,5 @@
     <div class="card-body border-0"></div>
 
   </div>
-  <pre class="flex-grow-1" id="editor" data-path="<%= @path %>" data-api="<%= files_editor_api_url(path: @path, filesystem: @filesystem) %>"><%= @content %></pre>
+  <pre class="flex-grow-1" id="editor" data-path="<%= @path %>" data-api="<%= url_encode_url_path(OodAppkit.files.api(path: @path, fs: @filesystem)) %>"><%= @content %></pre>
 </div>

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -12,9 +12,12 @@ json.files @files do |f|
   json.type f[:directory] ? 'd' : 'f'
   json.name f[:name]
 
-  json.url files_path(@filesystem, @path.join(f[:name]).to_s) if (f[:directory] || f[:downloadable])
-  json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') if f[:downloadable]
-  json.edit_url OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s if f[:downloadable]
+  encoded_name = url_encode_segment(f[:name])
+  encoded_filepath = url_encode_path(@path.join(f[:name]))
+
+  json.url "#{files_path(@filesystem, @path)}/#{encoded_name}" if (f[:directory] || f[:downloadable])
+  json.download_url "#{files_path(@filesystem, @path)}/#{encoded_name}?download=1" if f[:downloadable]
+  json.edit_url "#{controller.relative_url_root}/files/edit/#{@filesystem}#{encoded_filepath}" if f[:downloadable]
 
   json.size f[:size]
   json.human_size f[:human_size]

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -13,7 +13,7 @@ json.files @files do |f|
   json.name f[:name]
 
   json.url files_path(@filesystem, @path.join(f[:name]).to_s) if (f[:directory] || f[:downloadable])
-  json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') if f[:downloadable]
+  json.download_url url_encode_url_path(files_path(@filesystem, @path.join(f[:name]).to_s, download: '1').to_s) if f[:downloadable]
   json.edit_url url_encode_url_path(OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s) if f[:downloadable]
 
   json.size f[:size]

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -12,12 +12,9 @@ json.files @files do |f|
   json.type f[:directory] ? 'd' : 'f'
   json.name f[:name]
 
-  encoded_name = url_encode_path(f[:name])
-  encoded_filepath = url_encode_path(@path.join(f[:name]))
-
-  json.url "#{files_path(@filesystem, @path)}/#{encoded_name}" if (f[:directory] || f[:downloadable])
-  json.download_url "#{files_path(@filesystem, @path)}/#{encoded_name}?download=1" if f[:downloadable]
-  json.edit_url "#{controller.relative_url_root}/files/edit/#{@filesystem}#{encoded_filepath}" if f[:downloadable]
+  json.url files_path(@filesystem, @path.join(f[:name]).to_s) if (f[:directory] || f[:downloadable])
+  json.download_url files_path(@filesystem, @path.join(f[:name]).to_s, download: '1') if f[:downloadable]
+  json.edit_url url_encode_url_path(OodAppkit.editor.edit(path: @path.join(f[:name]).to_s, fs: @filesystem).to_s) if f[:downloadable]
 
   json.size f[:size]
   json.human_size f[:human_size]

--- a/apps/dashboard/app/views/files/index.json.jbuilder
+++ b/apps/dashboard/app/views/files/index.json.jbuilder
@@ -12,7 +12,7 @@ json.files @files do |f|
   json.type f[:directory] ? 'd' : 'f'
   json.name f[:name]
 
-  encoded_name = url_encode_segment(f[:name])
+  encoded_name = url_encode_path(f[:name])
   encoded_filepath = url_encode_path(@path.join(f[:name]))
 
   json.url "#{files_path(@filesystem, @path)}/#{encoded_name}" if (f[:directory] || f[:downloadable])

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -220,6 +220,44 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'path_selector handles filenames with # and +' do
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+      base_id = 'batch_connect_session_context_path'
+      name = '#foo+bar.txt#'
+      filename = "#{Rails.root}/tmp/#{name}"
+      FileUtils.touch(filename)
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - path
+        attributes:
+          path:
+            widget: 'path_selector'
+            directory: "#{Rails.root}/tmp"
+      HEREDOC
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+
+      visit new_batch_connect_session_context_url('sys/app')
+
+      click_on 'Select Path'
+      sleep 0.5
+
+      find('span', exact_text: name).click
+      find("##{base_id}_path_selector_button").click
+
+      assert_equal(filename, find("##{base_id}").value)
+    end
+  end
+
   test 'path_selector retains URL encodes if they are present' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -228,33 +228,35 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       stub_sacctmgr
       stub_git("#{dir}/app")
       base_id = 'batch_connect_session_context_path'
-      name = '#foo+bar.txt#'
-      filename = "#{Rails.root}/tmp/#{name}"
-      FileUtils.touch(filename)
+      Dir.mktmpdir do |tmpdir|
+        name = '#foo+bar.txt#'
+        filename = "#{tmpdir}/#{name}"
+        FileUtils.touch(filename)
 
-      form = <<~HEREDOC
-        ---
-        cluster:
-          - owens
-        form:
-          - path
-        attributes:
-          path:
-            widget: 'path_selector'
-            directory: "#{Rails.root}/tmp"
-      HEREDOC
+        form = <<~HEREDOC
+          ---
+          cluster:
+            - owens
+          form:
+            - path
+          attributes:
+            path:
+              widget: 'path_selector'
+              directory: "#{tmpdir}"
+        HEREDOC
 
-      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+        Pathname.new("#{dir}/app/").join('form.yml').write(form)
 
-      visit new_batch_connect_session_context_url('sys/app')
+        visit new_batch_connect_session_context_url('sys/app')
 
-      click_on 'Select Path'
-      sleep 0.5
+        click_on 'Select Path'
+        sleep 0.5
 
-      find('span', exact_text: name).click
-      find("##{base_id}_path_selector_button").click
+        find('span', exact_text: name).click
+        find("##{base_id}_path_selector_button").click
 
-      assert_equal(filename, find("##{base_id}").value)
+        assert_equal(filename, find("##{base_id}").value)
+      end
     end
   end
 

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -874,6 +874,26 @@ class FilesTest < ApplicationSystemTestCase
     assert_equal('&lt;img src=1 onerror=alert("hello")&gt;', actual_text)
   end
 
+  test 'filenames with # are url-escaped' do
+    OodAppkit.stubs(:files).returns(OodAppkit::Urls::Files.new(title: 'Files', base_url: '/files'))
+    OodAppkit.stubs(:editor).returns(OodAppkit::Urls::Editor.new(title: 'Editor', base_url: '/files'))
+
+    Dir.mktmpdir do |dir|
+      name = '#foo.txt#'
+      FileUtils.touch(File.join(dir, name))
+
+      visit files_url(dir)
+
+      row = find('tbody a', exact_text: name).ancestor('tr')
+
+      row.find('button.dropdown-toggle').click
+      href = row.find('a.edit-file')[:href]
+
+      assert_includes href, '%23'
+      refute_includes href, '#'
+    end
+  end
+
   test 'will not render HTML files by default' do
     data = <<-HEREDOC
     <html>


### PR DESCRIPTION
Fixes #5202

- Properly URL encodes file paths so filenames containing # no longer break edit and download links (i.e. '#foo.txt#')
- Includes a system test for filenames with #

Also manually tested in the dashboard by creating, editing, and downloading files containing # in the name.