### PR TITLE
Escape option values for CSS selectors

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -895,7 +895,7 @@ function sharedToggleOptionsFor(_event, targetId, optionForType) {
   // be the current selected value.
   // if you've hidden what _was_ selected.
   if(hideSelectedValue !== undefined) {
-    let others = [...document.querySelectorAll(`#${targetId} option[value='${hideSelectedValue}']`)];
+    let others = [...document.querySelectorAll(`#${targetId} option[value='${CSS.escape(hideSelectedValue)}']`)];
     let newSelectedOption = undefined;
 
     // You have hidden what _was_ selected, so try to find a duplicate option that is visible

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -990,4 +990,60 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     all('form select').first.hover.click
     refute_selector("div##{popover_id}")
   end
+
+  test 'apps with spaces' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+      ---
+      cluster:  
+      - oakley
+      form:
+        - software
+        - node_type
+        - gpu_type
+      attributes:
+        software:
+          widget: select
+          options:
+            - ruby
+            - python
+        node_type:
+          widget: select
+          options:
+            - regular
+            - [ "broken option '", broken, data-exclusive-option-for-software-python: true ]
+        gpu_type:
+          widget: select
+          options:
+            - good
+            - [ better, better, data-exclusive-option-for-node-type-broken: true ]
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # defaults
+      assert_equal('ruby', find_value('software'))
+      assert_equal('regular', find_value('node_type'))
+      assert_equal('good', find_value('gpu_type'))
+      assert_equal('display: none;', find_option_style('node_type', 'broken'))
+      assert_equal('display: none;', find_option_style('gpu_type', 'better'))
+
+      # select python and broken node type is available
+      select('python', from: bc_ele_id('software'))
+      assert_equal('', find_option_style('node_type', 'broken'))
+
+      # select broken node and better gpu type is available
+      select('broken option \'', from: bc_ele_id('node_type'))
+      assert_equal('', find_option_style('gpu_type', 'better'))
+
+      # flip back to ruby and get defaults back
+      select('ruby', from: bc_ele_id('software'))
+      assert_equal('ruby', find_value('software'))
+      assert_equal('regular', find_value('node_type'))
+      assert_equal('good', find_value('gpu_type'))
+      assert_equal('display: none;', find_option_style('node_type', 'broken'))
+      assert_equal('display: none;', find_option_style('gpu_type', 'better'))
+    end
+  end
 end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -991,7 +991,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     refute_selector("div##{popover_id}")
   end
 
-  test 'apps with spaces' do
+  test 'app that needs escape sequences' do
     Dir.mktmpdir do |dir|
       form = <<~HEREDOC
       ---


### PR DESCRIPTION
Fixes #5344 by escaping the option value for the CSS selector.

I haven't yet added test cases for this, but it would probably be good to have.