### PR TITLE
Added OOD_WORKFLOW_SYNC_KEY to synchronize all launchers in a workflow

### DIFF
--- a/apps/dashboard/app/controllers/workflows_controller.rb
+++ b/apps/dashboard/app/controllers/workflows_controller.rb
@@ -148,14 +148,14 @@ class WorkflowsController < ApplicationController
   def permit_params
     params
       .require(:workflow)
-      .permit(:name, :description, :id, launcher_ids: [])
+      .permit(:name, :description, :id, :sync_key_enabled, launcher_ids: [])
       .merge(project_dir: project_directory, metadata: session.delete(:cloned_metadata) || {})
   end
 
   def update_params
     params
       .require(:workflow)
-      .permit(:name, :description, :id, launcher_ids: [])
+      .permit(:name, :description, :id, :sync_key_enabled, launcher_ids: [])
   end
 
   def project_directory

--- a/apps/dashboard/app/helpers/projects_helper.rb
+++ b/apps/dashboard/app/helpers/projects_helper.rb
@@ -53,6 +53,6 @@ module ProjectsHelper
   end
 
   def form_label_tooltip(content)
-    "<i class='fa fa-question-circle vertical-align-middle' data-bs-toggle='tooltip' data-bs-placement='right' title='#{content}'></i>"
+    "<i class='fa fa-question-circle vertical-align-middle' data-bs-toggle='tooltip' data-bs-placement='right' data-bs-html='true' title='#{content}'></i>"
   end
 end

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -355,7 +355,8 @@ class Launcher
       # force some values for scripts like the 'workdir'. We could use auto
       # attributes, but this is not optional and not variable.
       {
-        workdir: project_dir.to_s
+        workdir: project_dir.to_s,
+        job_environment: { 'OOD_WORKFLOW_SYNC_KEY' => options[:ood_workflow_sync_key] }.compact
       }
     )
   end

--- a/apps/dashboard/app/models/launcher.rb
+++ b/apps/dashboard/app/models/launcher.rb
@@ -355,10 +355,13 @@ class Launcher
       # force some values for scripts like the 'workdir'. We could use auto
       # attributes, but this is not optional and not variable.
       {
-        workdir: project_dir.to_s,
-        job_environment: { 'OOD_WORKFLOW_SYNC_KEY' => options[:ood_workflow_sync_key] }.compact
+        workdir: project_dir.to_s
       }
-    )
+    ).tap do |opts|
+      if options[:ood_workflow_sync_key]
+        opts[:job_environment] = (opts[:job_environment] || {}).merge('OOD_WORKFLOW_SYNC_KEY' => options[:ood_workflow_sync_key])
+      end
+    end
   end
 
   def adapter(cluster_id)

--- a/apps/dashboard/app/models/workflow.rb
+++ b/apps/dashboard/app/models/workflow.rb
@@ -43,9 +43,15 @@ class Workflow
         start_launcher: meta[:start_launcher] || nil
       }
     end
+
+    # Generate sync key for entire workflow run, giving users a single synchronized 
+    # token per run that they can build shared filenames, lockfiles, etc. on top of.
+    def generate_sync_key
+      SecureRandom.alphanumeric(16)
+    end
   end
 
-  attr_accessor :id, :name, :description, :project_dir, :created_at, :launcher_ids, :metadata
+  attr_accessor :id, :name, :description, :project_dir, :created_at, :launcher_ids, :metadata, :sync_key_enabled
 
   validates :name, presence: true
   validates :launcher_ids, length: {minimum: 1}
@@ -58,6 +64,7 @@ class Workflow
     @created_at = attributes[:created_at]
     @launcher_ids = attributes[:launcher_ids] || []
     @metadata = attributes[:metadata] || {}
+    @sync_key_enabled = attributes[:sync_key_enabled] || "0"
   end
 
   def to_h
@@ -68,7 +75,8 @@ class Workflow
       :created_at => created_at,
       :project_dir => project_dir,
       :launcher_ids => launcher_ids,
-      :metadata => metadata
+      :metadata => metadata,
+      :sync_key_enabled => sync_key_enabled
     }
   end
 
@@ -119,7 +127,7 @@ class Workflow
   end
 
   def update_attrs(attributes, override = false)
-    [:name, :description, :launcher_ids, :metadata].each do |attribute|
+    [:name, :description, :launcher_ids, :metadata, :sync_key_enabled].each do |attribute|
       next unless override || attributes.key?(attribute)
       instance_variable_set("@#{attribute}".to_sym, attributes.fetch(attribute, ''))
     end
@@ -142,6 +150,7 @@ class Workflow
 
     all_launchers = Launcher.all(attributes[:project_dir])
     job_id_hash = {}  # launcher-job_id hash
+    sync_key = sync_key_enabled == "1" ? Workflow.generate_sync_key : nil
 
     for id in order
       launcher = all_launchers.find { |l| l.id == id }
@@ -153,7 +162,7 @@ class Workflow
 
       begin
         jobs = dependent_launchers.map { |id| job_id_hash.dig(id, :job_id) }.compact
-        opts = submit_launcher_params(launcher, jobs).to_h.symbolize_keys
+        opts = submit_launcher_params(launcher, jobs, sync_key).to_h.symbolize_keys
         job_id = launcher.submit(opts, write_cache: false)
         if job_id.nil?
           Rails.logger.warn("Launcher #{id} with opts #{opts} did not return a job ID.")
@@ -173,11 +182,12 @@ class Workflow
     nil
   end
 
-  def submit_launcher_params(launcher, dependent_jobs)
+  def submit_launcher_params(launcher, dependent_jobs, sync_key)
     launcher_data = launcher.cacheless_attributes.each_with_object({}) do |attr, hash|
       hash[attr.id.to_s] = attr.opts[:value]
     end
     launcher_data["afterok"] = Array(dependent_jobs)
+    launcher_data["ood_workflow_sync_key"] = sync_key if sync_key
     launcher_data
   end
 

--- a/apps/dashboard/app/views/workflows/_form.html.erb
+++ b/apps/dashboard/app/views/workflows/_form.html.erb
@@ -46,20 +46,12 @@
             <div class="form-check form-switch mt-2">
               <%= hidden_field_tag "workflow[sync_key_enabled]", "0" %>
               <%= check_box_tag "workflow[sync_key_enabled]", "1",
-                    @workflow.sync_key_enabled == "1",
-                    id: "workflow_sync_key_enabled",
-                    class: "form-check-input" %>
+                                @workflow.sync_key_enabled == "1",
+                                id: "workflow_sync_key_enabled",
+                                class: "form-check-input" %>
               <%= label_tag "workflow_sync_key_enabled",
-                    raw("Enable OOD_WORKFLOW_SYNC_KEY
-                          <i class='fa fa-info-circle text-muted ms-1'
-                            role='button'
-                            tabindex='0'
-                            data-bs-toggle='tooltip'
-                            data-bs-trigger='click'
-                            data-bs-placement='right'
-                            data-bs-html='true'
-                            title='When enabled, every launcher in this workflow receives the same <code>OOD_WORKFLOW_SYNC_KEY</code> environment variable (a random token unique to each workflow run). Useful for generating synchronized filenames, lock files, or shared identifiers across dependent jobs.'></i>"),
-                    class: "form-check-label" %>
+                            "Enable OOD_WORKFLOW_SYNC_KEY #{form_label_tooltip(I18n.t('dashboard.jobs_workflow_sync_key_help'))}".html_safe,
+                            class: "form-check-label" %>
             </div>
           </div>
         </div>

--- a/apps/dashboard/app/views/workflows/_form.html.erb
+++ b/apps/dashboard/app/views/workflows/_form.html.erb
@@ -40,6 +40,28 @@
               <%= I18n.t('dashboard.jobs_workflow_missing_launchers', count: launcher_error.options.count) %>
             </div>
           <% end %>
+
+          <div class="field mt-3">
+            <strong>Synchronization</strong><br>
+            <div class="form-check form-switch mt-2">
+              <%= hidden_field_tag "workflow[sync_key_enabled]", "0" %>
+              <%= check_box_tag "workflow[sync_key_enabled]", "1",
+                    @workflow.sync_key_enabled == "1",
+                    id: "workflow_sync_key_enabled",
+                    class: "form-check-input" %>
+              <%= label_tag "workflow_sync_key_enabled",
+                    raw("Enable OOD_WORKFLOW_SYNC_KEY
+                          <i class='fa fa-info-circle text-muted ms-1'
+                            role='button'
+                            tabindex='0'
+                            data-bs-toggle='tooltip'
+                            data-bs-trigger='click'
+                            data-bs-placement='right'
+                            data-bs-html='true'
+                            title='When enabled, every launcher in this workflow receives the same <code>OOD_WORKFLOW_SYNC_KEY</code> environment variable (a random token unique to each workflow run). Useful for generating synchronized filenames, lock files, or shared identifiers across dependent jobs.'></i>"),
+                    class: "form-check-label" %>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -242,6 +242,7 @@ en:
     jobs_workflow_show_graph: Open workflow %{name} in graph editor
     jobs_workflow_submitted: Workflow successfully submitted!
     jobs_workflow_help: Click title to select and drag. Connect by clicking two launchers with 'Connect Launchers' selected
+    jobs_workflow_sync_key_help: When enabled, every launcher in this workflow receives the same OOD_WORKFLOW_SYNC_KEY environment variable (a random token unique to each workflow run). Useful for generating synchronized filenames, lock files, or shared identifiers across dependent jobs.
     jobs_workflows: Workflows
     launch: Launch
     logo_alt_text: Welcome to Open OnDemand

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -242,7 +242,7 @@ en:
     jobs_workflow_show_graph: Open workflow %{name} in graph editor
     jobs_workflow_submitted: Workflow successfully submitted!
     jobs_workflow_help: Click title to select and drag. Connect by clicking two launchers with 'Connect Launchers' selected
-    jobs_workflow_sync_key_help: When enabled, every launcher in this workflow receives the same OOD_WORKFLOW_SYNC_KEY environment variable (a random token unique to each workflow run). Useful for generating synchronized filenames, lock files, or shared identifiers across dependent jobs.
+    jobs_workflow_sync_key_help: When enabled, every launcher in this workflow receives the same <code>OOD_WORKFLOW_SYNC_KEY</code> environment variable (a random token unique to each workflow run). Useful for generating synchronized filenames, lock files, or shared identifiers across dependent jobs.
     jobs_workflows: Workflows
     launch: Launch
     logo_alt_text: Welcome to Open OnDemand

--- a/apps/dashboard/test/models/workflow_test.rb
+++ b/apps/dashboard/test/models/workflow_test.rb
@@ -12,6 +12,7 @@ class WorkflowsTest < ActiveSupport::TestCase
     assert_nil workflow.description
     assert_nil workflow.created_at
     assert_equal [], workflow.launcher_ids
+    assert_equal '0', workflow.sync_key_enabled
   end
 
   test 'create workflow validation' do
@@ -81,7 +82,8 @@ class WorkflowsTest < ActiveSupport::TestCase
         name:         'test-workflow',
         id:           "test-#{Workflow.next_id}",
         project_dir:  project_dir,
-        launcher_ids: ['sample']
+        launcher_ids: ['sample'],
+        sync_key_enabled: '1'
       )
 
       assert workflow.errors.inspect
@@ -95,6 +97,7 @@ class WorkflowsTest < ActiveSupport::TestCase
       assert_equal "test-workflow", manifest_data["name"]
       assert_equal "description", manifest_data["description"]
       assert_equal project_dir.to_s, manifest_data["project_dir"]
+      assert_equal '1', manifest_data['sync_key_enabled']
     end
   end
 
@@ -137,7 +140,7 @@ class WorkflowsTest < ActiveSupport::TestCase
     end
   end
 
-  test 'update workflow only updates name, description, and launchers' do
+  test 'update workflow only updates name, description, launchers, and sync_key_enabled' do
     Dir.mktmpdir do |tmp|
       project_dir = Pathname.new(tmp)
       workflow = create_workflow(project_dir: project_dir, launcher_ids:['sample'])
@@ -148,7 +151,8 @@ class WorkflowsTest < ActiveSupport::TestCase
         name: 'updated',
         description: 'updated',
         project_dir: nil,
-        launcher_ids: ['sample2']
+        launcher_ids: ['sample2'],
+        sync_key_enabled: '1'
       })
       
       assert_equal 'updated',   workflow.name
@@ -156,11 +160,31 @@ class WorkflowsTest < ActiveSupport::TestCase
       assert_equal old_id,      workflow.id
       assert_equal project_dir.to_s, workflow.project_dir
       assert_equal ['sample2'], workflow.launcher_ids
+      assert_equal '1',         workflow.sync_key_enabled
     end
   end
 
-  def create_workflow(id: nil, name: 'test-workflow', description: 'description', project_dir: nil, launcher_ids: [])
-    attrs = { name: name, id: id, description: description, project_dir: project_dir, launcher_ids: launcher_ids}
+  test 'Check if submit_launcher_params injects ood_workflow_sync_key only when sync_key_enabled is true' do
+    fake_attr = Struct.new(:id, :opts)
+    launcher = Object.new
+    launcher.define_singleton_method(:cacheless_attributes) do
+      [
+        fake_attr.new('bc_num_hours', { value: '1' }),
+        fake_attr.new('auto_queues',  { value: 'batch' })
+      ]
+    end
+
+    workflow = Workflow.new
+    without_key = workflow.submit_launcher_params(launcher, ['1234'], nil)
+    assert_equal({'bc_num_hours' => '1', 'auto_queues' => 'batch', 'afterok' => ['1234'] }, without_key)
+    assert_not without_key.key?('ood_workflow_sync_key')
+
+    with_key = workflow.submit_launcher_params(launcher, ['1234'], 'abc123TOKEN')
+    assert_equal({'bc_num_hours' => '1', 'auto_queues' => 'batch', 'afterok' => ['1234'], 'ood_workflow_sync_key' => 'abc123TOKEN'}, with_key)
+  end
+
+  def create_workflow(id: nil, name: 'test-workflow', description: 'description', project_dir: nil, launcher_ids: [], sync_key_enabled: '0')
+    attrs = { name: name, id: id, description: description, project_dir: project_dir, launcher_ids: launcher_ids, sync_key_enabled: sync_key_enabled}
     workflow = Workflow.new(attrs)
     # this directory is usually created by the project
     Workflow.workflow_dir(project_dir).mkpath


### PR DESCRIPTION
Related to Issue: https://github.com/OSC/ondemand/issues/5311

- Added toggle button to enable synchronization environment variable
- One concern from Prof Sussman, "_We though of making Workflow feature as simple as possible for naive user. Does this feature going to enhance functionality or add another layer of confusion to the end user._" 
- I will try to address this under documentation, but lets think one more time if it will be absolutely necessary; or should we put it under `Advance Section` (discussion under issue 5311)

**Follow-up,** this feature will need documentation under the project manager tutorial. I will add this after the accessibility fix.