### PR TITLE
Improve help text in project forms

### DIFF
--- a/apps/dashboard/app/helpers/projects_helper.rb
+++ b/apps/dashboard/app/helpers/projects_helper.rb
@@ -53,6 +53,6 @@ module ProjectsHelper
   end
 
   def form_label_tooltip(content)
-    "<i class='fa fa-question-circle vertical-align-middle' data-bs-toggle='tooltip' data-bs-placement='right' title='#{content}'></i>"
+    "<i class='fa fa-question-circle vertical-align-middle' data-bs-toggle='tooltip' data-bs-placement='right' title='#{content}' tabindex='0'></i>"
   end
 end

--- a/apps/dashboard/app/javascript/projects_new.js
+++ b/apps/dashboard/app/javascript/projects_new.js
@@ -33,8 +33,10 @@ function templateChange(event) {
 function toggleSharedSettings(value) {
   const owner = document.getElementById('project_group_owner');
   const setgid = document.getElementById('project_setgid');
+  const setgidHelp = $('label[for="project_setgid"]').find('i')  
   const isDisabled = value.startsWith(home) || value === "";
 
   owner.disabled = isDisabled;
   setgid.disabled = isDisabled;
+  setgidHelp.attr('tabindex', isDisabled ? '-1' : '0');
 }


### PR DESCRIPTION
Makes some accessibility improvements to the project form help text, comprised of
- making the help text keyboard focusable
- making the setgid help text not focusable when disabled (matching visual presentation)

Note that the accessibility fixes are not vital for accessibility, as the help text is read by screenreaders when the normal label receives focus. These changes do, however, improve the experience for sighted users navigating with the keyboard. The reason that we do not disable the group selection help along with the setgid help is that the group help does not 'appear disabled' with its associated select the way that the setgid label does.