### PR TITLE
Fix Quota bar display when over 100% usage in dashboard

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -175,8 +175,12 @@ small.form-text {
   max-width: 150px;
 }
 
+:where(.progress-bar[class^="w-"], .progress-bar[class*=" w-"]) {
+  width: 100%;
+}
+
 // Add width classes for every whole percentage between 0 and 100
-@for $i from 1 through 100 {
+@for $i from 0 through 100 {
   .w-#{$i} {
     width: $i * 1%;
   }

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -175,12 +175,8 @@ small.form-text {
   max-width: 150px;
 }
 
-:where(.progress-bar[class^="w-"], .progress-bar[class*=" w-"]) {
-  width: 100%;
-}
-
 // Add width classes for every whole percentage between 0 and 100
-@for $i from 0 through 100 {
+@for $i from 1 through 100 {
   .w-#{$i} {
     width: $i * 1%;
   }

--- a/apps/dashboard/app/views/widgets/_file_quotas.html.erb
+++ b/apps/dashboard/app/views/widgets/_file_quotas.html.erb
@@ -6,7 +6,7 @@
   <li class="list-group-item">
     <b><%= quota.path %></b>: <%= quota %>
     <%=
-      render(partial: "shared/variable_progress_bar", locals: { percent: quota.percent_total_usage })
+      render(partial: "shared/variable_progress_bar", locals: { percent: [quota.percent_total_usage, 100].min })
     -%>
   </li>
 


### PR DESCRIPTION
Resolves #5353

Add a catchall CSS that sets the width of any undefined class to 100%
```css
:where(.progress-bar[class^="w-"], .progress-bar[class*=" w-"]) {
  width: 100%;
}
```
Leading to this:


<img width="622" height="365" alt="image" src="https://github.com/user-attachments/assets/855a836e-0349-4d59-8a1d-e9e8afea24d9" />


However, since we don't define a class for 0% (`.w-0`)  it will also show a 100% in use bar. Then update the for loop to start at 0 rather than 1 so it's defined. With `.w-0` defined as 0% we have:


<img width="622" height="365" alt="image" src="https://github.com/user-attachments/assets/71e79e87-fb11-4c5a-9432-5d85fb59d7f5" />


I'm still unsure if this is the best way, but it seems to work. You tell me.