### PR TITLE
Fix project form not detecting changes from path selector (#5350)

### DIFF
--- a/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
+++ b/apps/dashboard/app/javascript/path_selector/path_selector_data_table.js
@@ -179,6 +179,7 @@ export class PathSelectorTable {
     const last = this.getLastVisited();
     const inputField = document.getElementById(this.inputFieldId);
     inputField.value = last.path;
+    inputField.dispatchEvent(new Event('input', { bubbles: true }));
     $(`#${this.modalId}`).modal('hide');
   }
 

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -118,6 +118,35 @@ class ProjectManagerTest < ApplicationSystemTestCase
     end
   end
 
+  test 'project group toggles when path selector sets directory' do
+    Dir.mktmpdir do |home_dir|
+      Dir.mktmpdir do |other_dir|
+        CurrentUser.stubs(:home).returns(home_dir)
+  
+        visit new_project_path
+  
+        owner = find('#project_group_owner', visible: :all)
+        setgid = find('#project_setgid', visible: :all)
+  
+        find('#project_directory').set(other_dir)
+        refute owner.disabled?
+        refute setgid.disabled?
+  
+        home_path = File.join(home_dir, 'projects')
+        execute_script <<~JS
+          const tableId = 'project_directory_path_selector_table';
+          const key = `${tableId}${window.location.pathname.replaceAll('/', '_')}_last_visited`;
+          localStorage.setItem(key, JSON.stringify({ path: #{home_path.to_json}, type: 'd' }));
+          document.getElementById('project_directory_path_selector_button').click();
+        JS
+  
+        assert_equal home_path, find('#project_directory').value
+        assert_selector('#project_group_owner[disabled]', visible: :all)
+        assert_selector('#project_setgid[disabled]', visible: :all)
+      end
+    end
+  end
+
   test 'delete a project from the fs and ensure no table entry' do
     Dir.mktmpdir do |dir|
       project_id = setup_project(dir)


### PR DESCRIPTION
Fixes #5350

- Selecting a path via the path selector wasn’t triggering the project form JS, so the group fields didn’t update
- Dispatch an input event after setting the value so it behaves the same as typing
- Adds a system test to cover this case