### PR TITLE
used regex to ensure env is filled out

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -112,7 +112,7 @@ class LaunchersController < ApplicationController
 
   def save_launcher_params
     auto_env_params = params[:launcher].keys.select do |k|
-      k.match?('auto_environment_variable')
+      k.match?(/auto_environment_variable_\w+/)
     end
 
     allowlist = SAVE_LAUNCHER_KEYS + auto_env_params

--- a/apps/dashboard/test/controllers/launchers_controller_test.rb
+++ b/apps/dashboard/test/controllers/launchers_controller_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LaunchersControllerTest < ActionController::TestCase
+  test 'save_launcher_params allows properly named auto_environment_variable keys' do
+    @controller.params = ActionController::Parameters.new({
+      project_id: '1',
+      id:         '1',
+      launcher:   {
+        cluster:                        'ascend',
+        auto_environment_variable_PATH: '/usr/bin',
+        auto_environment_variable_HOME: '/home/user'
+      }
+    })
+
+    permitted = @controller.send(:save_launcher_params)
+    assert_equal '/usr/bin',    permitted[:launcher]['auto_environment_variable_PATH']
+    assert_equal '/home/user',  permitted[:launcher]['auto_environment_variable_HOME']
+  end
+
+  test 'save_launcher_params rejects bare auto_environment_variable key with no variable name' do
+    @controller.params = ActionController::Parameters.new({
+      project_id: '1',
+      id:         '1',
+      launcher:   {
+        cluster:                   'ascend',
+        auto_environment_variable: ''
+      }
+    })
+
+    permitted = @controller.send(:save_launcher_params)
+    assert_nil permitted[:launcher]['auto_environment_variable']
+    assert_equal 'ascend', permitted[:launcher]['cluster']
+  end
+end


### PR DESCRIPTION
fixes #5335 

changed a string lookup to only select if the param key has data after auto_environment_variable
tested by creating a new launcher and trying to reproduce the bug in the original issue.
ran project manager tests