### PR TITLE
Fix interactive app menu border hover issue (#5343)

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/batch_connect/sessions.scss
+++ b/apps/dashboard/app/assets/stylesheets/batch_connect/sessions.scss
@@ -17,10 +17,6 @@
   }
 }
 
-.system-and-shared-apps-header.card, .sandbox-apps-header.card {
-  overflow: hidden;
-}
-
 .list-group .app-icon{
   width: 14px;
   height: 14px;
@@ -44,4 +40,11 @@
 .session-buttons-list {
   display: flex;
   align-items: center;
+}
+
+nav[aria-label="Interactive Apps Menu"] {
+  .list-group-flush > a.list-group-item-action:last-of-type {
+    border-bottom-left-radius: var(--bs-card-border-radius);
+    border-bottom-right-radius: var(--bs-card-border-radius);
+  }
 }

--- a/apps/dashboard/app/assets/stylesheets/batch_connect/sessions.scss
+++ b/apps/dashboard/app/assets/stylesheets/batch_connect/sessions.scss
@@ -17,6 +17,10 @@
   }
 }
 
+.system-and-shared-apps-header.card, .sandbox-apps-header.card {
+  overflow: hidden;
+}
+
 .list-group .app-icon{
   width: 14px;
   height: 14px;

--- a/apps/dashboard/app/assets/stylesheets/custom.scss
+++ b/apps/dashboard/app/assets/stylesheets/custom.scss
@@ -1,11 +1,28 @@
 // Bootstrap custom CSS
 
-.sr-only, .sr-only * {
-  @extend .visually-hidden;
+.sr-only * {
+  @extend .sr-only;
 }
 
 .sr-only.focusable, .sr-only.focusable * {
-  @extend .visually-hidden-focusable;
+  position: initial;
+}
+
+.sr-only.focusable.popover-hidden-clone,
+.sr-only.focusable.popover-hidden-clone * {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+  pointer-events: none !important;
 }
 
 .card {

--- a/apps/dashboard/app/assets/stylesheets/custom.scss
+++ b/apps/dashboard/app/assets/stylesheets/custom.scss
@@ -1,11 +1,11 @@
 // Bootstrap custom CSS
 
-.sr-only * {
-    @extend .sr-only;
+.sr-only, .sr-only * {
+  @extend .visually-hidden;
 }
 
 .sr-only.focusable, .sr-only.focusable * {
-    position: initial;
+  @extend .visually-hidden-focusable;
 }
 
 .card {

--- a/apps/dashboard/app/javascript/popovers.js
+++ b/apps/dashboard/app/javascript/popovers.js
@@ -89,7 +89,7 @@ function customizePopoverTriggers() {
       // duplicate content (not required but practically necessary to follow links)
       if (!hiddenClone) {
         hiddenClone = popoverEl.cloneNode(true);
-        hiddenClone.classList.add('sr-only','focusable');
+        hiddenClone.classList.add('visually-hidden', 'visually-hidden-focusable');
         hiddenClone.id = '';
         hiddenClone.style = '';
         trigger.insertAdjacentElement('afterend', hiddenClone);

--- a/apps/dashboard/app/javascript/popovers.js
+++ b/apps/dashboard/app/javascript/popovers.js
@@ -89,7 +89,7 @@ function customizePopoverTriggers() {
       // duplicate content (not required but practically necessary to follow links)
       if (!hiddenClone) {
         hiddenClone = popoverEl.cloneNode(true);
-        hiddenClone.classList.add('visually-hidden', 'visually-hidden-focusable');
+        hiddenClone.classList.add('sr-only', 'focusable', 'popover-hidden-clone');
         hiddenClone.id = '';
         hiddenClone.style = '';
         trigger.insertAdjacentElement('afterend', hiddenClone);


### PR DESCRIPTION
Fixes #5343

Hovering over apps caused a small shift that made the bottom border disappear (mostly noticeable on the last item). This seemed to be triggered when the tooltip/popover appeared.

- Add `overflow: hidden` to header cards to keep the border in place
- Clean up `.sr-only` styles to use Bootstrap’s visually hidden classes
- Update popover hidden clone classes accordingly