### PR TITLE
4.1 backport - This will always set the HSTS header for security purposes (#5323)

### DIFF
--- a/mod_ood_proxy/lib/nginx.lua
+++ b/mod_ood_proxy/lib/nginx.lua
@@ -11,6 +11,8 @@ local nginx_stage = require 'ood.nginx_stage'
     2. 'stop'  = send `stop` signal to PUN process
 --]]
 function nginx_handler(r)
+  -- Always set the Strict Transport Security
+  r.err_headers_out['Strict-Transport-Security'] = "max-age=31536000"
   -- read in OOD specific settings defined in Apache config
   local user_map_match = r.subprocess_env['OOD_USER_MAP_MATCH']
   local user_map_cmd   = r.subprocess_env['OOD_USER_MAP_CMD']


### PR DESCRIPTION
backport to 4.1 - This will always set the HSTS header in nginx actions.

---------