### PR TITLE
Fix accessibility for file/folder icons (#4889)

### DIFF
--- a/apps/dashboard/app/javascript/files/clip_board.js
+++ b/apps/dashboard/app/javascript/files/clip_board.js
@@ -133,11 +133,18 @@ class ClipBoard {
         listItem.className = 'list-group-item';
 
         const icon = document.createElement('span');
-        icon.title = file.directory ? 'directory' : 'file';
+        const typeLabel = file.directory ? 'directory' : 'file';
+        icon.title = typeLabel;
         icon.className = file.directory
           ? 'fa fa-folder color-gold'
           : 'fa fa-file color-lightgrey';
+        icon.setAttribute('aria-hidden', 'true');
         listItem.appendChild(icon);
+
+        const srOnly = document.createElement('span');
+        srOnly.className = 'sr-only';
+        srOnly.textContent = typeLabel;
+        listItem.appendChild(srOnly);
 
         const fileName = document.createTextNode(` ${file.name}`);
         listItem.appendChild(fileName);

--- a/apps/dashboard/app/views/files/turbo_frames/_file.html.erb
+++ b/apps/dashboard/app/views/files/turbo_frames/_file.html.erb
@@ -18,7 +18,12 @@
   <hr>
   <div class="row content-justied-center col-6 mx-auto">
     <div class="btn btn-sm btn-primary">
-      <span><i class="fa fa-folder-open"></i>&nbsp<%= files_button(path) %></span>
+      <% dir_label = I18n.t('dashboard.directory') %>
+      <span>
+        <i class="fa fa-folder-open" aria-hidden="true"></i>
+        <span class="sr-only"><%= dir_label %></span>
+        &nbsp<%= files_button(path) %>
+      </span>
     </div>
   </div>
 <%- end -%>

--- a/apps/dashboard/app/views/files/turbo_frames/_files.html.erb
+++ b/apps/dashboard/app/views/files/turbo_frames/_files.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td>
     <% dir_type = I18n.t('dashboard.directory') %>
-    <i class="fa fa-folder" title="<%= dir_type %>">
-    <span class="sr-only"> <%= dir_type %> </span>
+    <i class="fa fa-folder" title="<%= dir_type %>" aria-hidden="true"></i>
+    <span class="sr-only"><%= dir_type %></span>
   </td>
   <td>
     <strong>
@@ -32,7 +32,7 @@
   <tr>
     <td>
       <% type = I18n.t("dashboard.#{file[:directory] ? 'directory' : 'file'}") %>
-      <i class="fa fa-<%= file[:directory] ? 'folder' : 'file' %>" title="<%= type %>">
+      <i class="fa fa-<%= file[:directory] ? 'folder' : 'file' %>" title="<%= type %>" aria-hidden="true"></i>
       <span class="sr-only"> <%= type %> </span>
     </td>
     <%- if file[:directory] && readable-%>

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -255,10 +255,11 @@ class ProjectManagerTest < ApplicationSystemTestCase
     assert_equal(990, icons.size)
   end
 
-  def check_icon(icon, type)
+  def check_icon(cell, type)
     iclass = type == :file ? 'fa-file' : 'fa-folder'
+    icon = cell.find('i')
     assert_equal "fa #{iclass}",       icon[:class]
-    assert_equal type.to_s.capitalize, icon.find('.sr-only').text
+    assert_equal type.to_s.capitalize, cell.find('.sr-only').text
   end
 
   def check_link(link, text, path)
@@ -268,7 +269,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
   end
 
   def check_top_directory_row(row_data, tmpdir)
-    check_icon(row_data[0].find('i'), :directory)
+    check_icon(row_data[0], :directory)
     link = row_data[1].find('a')
     check_link(link, '..', directory_frame_path(path: "#{tmpdir}/projects"))
     assert_equal 0, row_data[2].all('*').length
@@ -277,7 +278,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
   end
 
   def check_files(name, size, project_dir, row_data)
-    check_icon(row_data[0].find('i'), :file)
+    check_icon(row_data[0], :file)
     link = row_data[1].find('a')
     check_link(link, name, files_path("#{project_dir}/#{name}"))
 
@@ -351,7 +352,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       check_top_directory_row(rows[0].all('td'), dir)
 
       row_2_data = rows[1].all('td')
-      check_icon(row_2_data[0].find('i'), :directory)
+      check_icon(row_2_data[0], :directory)
       row_2_link = row_2_data[1].find('a')
       check_link(row_2_link, '.ondemand', directory_frame_path(path: "#{project_dir}/.ondemand"))
       assert_equal 0,  row_2_data[2].all('*').length
@@ -408,7 +409,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       check_top_directory_row(rows[0].all('td'), dir)
 
       row_2_data = rows[1].all('td')
-      check_icon(row_2_data[0].find('i'), :directory)
+      check_icon(row_2_data[0], :directory)
       row_2_link = row_2_data[1].find('a')
       check_link(row_2_link, '.ondemand', directory_frame_path(path: "#{project_dir}/.ondemand"))
       assert_equal 0,  row_2_data[2].all('*').length


### PR DESCRIPTION
Fixes #4889

Screen readers weren’t consistently announcing the file/folder type icons in the Files app because some spots relied on the icon title attribute.

- Make the file/folder icons in the turbo frame table purely decorative (aria-hidden) and rely on the existing sr-only text label
- Add the same sr-only type label to the Copy/Move clipboard list (so it reads reliably there too)