### PR TITLE
Apply auto_groups_filter to Project Manager groups (#5300)

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_groups.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_groups.rb
@@ -7,12 +7,7 @@ module SmartAttributes
     # @param opts [Hash] attribute's options
     # @return [Attributes::AutoGroups] the attribute object
     def self.build_auto_groups(opts = {})
-      options = begin
-        CurrentUser.group_names.grep(/#{Configuration.auto_groups_filter}/)
-      rescue RegexpError => e
-        Rails.logger.warn("auto_groups_filter does not compile, throwing this error: #{e}")
-        []
-      end
+      options = CurrentUser.filtered_group_names
 
       static_opts = {
         options: options

--- a/apps/dashboard/app/views/projects/_form.html.erb
+++ b/apps/dashboard/app/views/projects/_form.html.erb
@@ -57,7 +57,7 @@
             <div class="field">
               <% help_html = edit_project_action ? '' : form_label_tooltip(I18n.t('dashboard.jobs_project_group_help')) %>
               <%= form.select(:group_owner,
-                              CurrentUser.group_names,
+                              CurrentUser.filtered_group_names,
                               { label: "#{I18n.t('dashboard.jobs_project_group_owner')} #{help_html}".html_safe },
                               { disabled: edit_project_action })
               %>

--- a/apps/dashboard/lib/current_user.rb
+++ b/apps/dashboard/lib/current_user.rb
@@ -16,7 +16,8 @@ class CurrentUser
 
   class << self
     delegate :name, :uid, :gid, :gecos, :dir, :shell, to: :instance
-    delegate :primary_group, :primary_group_name, :group_names, :groups, to: :instance
+    delegate :primary_group, :primary_group_name, :group_names, :filtered_group_names, :groups, to: :instance
+
 
     alias_method :home, :dir
   end
@@ -40,6 +41,22 @@ class CurrentUser
     @group_names ||= groups.map(&:name)
   end
 
+  def filtered_group_names
+    return group_names unless defined?(Configuration)
+
+    filter = Configuration.auto_groups_filter
+    return group_names if filter.nil? || filter.to_s.empty?
+
+    group_names.grep(/#{filter}/)
+  rescue RegexpError => e
+    if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+      Rails.logger.warn("auto_groups_filter does not compile, throwing this error: #{e}")
+    else
+      warn("auto_groups_filter does not compile, throwing this error: #{e}")
+    end
+    []
+  end
+  
   def groups
     @groups ||= begin
 

--- a/apps/dashboard/lib/current_user.rb
+++ b/apps/dashboard/lib/current_user.rb
@@ -3,7 +3,6 @@
 require 'etc'
 require 'singleton'
 require 'active_support/core_ext/module/delegation'
-require 'active_support/core_ext/object/blank'
 
 # The CurrentUser class represents the current user on the system from Etc.
 # It has a name, a home directory, gid, uid and so on.
@@ -43,10 +42,7 @@ class CurrentUser
   end
 
   def filtered_group_names
-    filter = Configuration.auto_groups_filter
-    return group_names if filter.blank?
-
-    group_names.grep(/#{filter}/)
+    group_names.grep(/#{Configuration.auto_groups_filter}/)
   rescue RegexpError => e
     Rails.logger.warn("auto_groups_filter does not compile, throwing this error: #{e}")
     []

--- a/apps/dashboard/lib/current_user.rb
+++ b/apps/dashboard/lib/current_user.rb
@@ -3,6 +3,7 @@
 require 'etc'
 require 'singleton'
 require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/blank'
 
 # The CurrentUser class represents the current user on the system from Etc.
 # It has a name, a home directory, gid, uid and so on.
@@ -42,18 +43,12 @@ class CurrentUser
   end
 
   def filtered_group_names
-    return group_names unless defined?(Configuration)
-
     filter = Configuration.auto_groups_filter
-    return group_names if filter.nil? || filter.to_s.empty?
+    return group_names if filter.blank?
 
     group_names.grep(/#{filter}/)
   rescue RegexpError => e
-    if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
-      Rails.logger.warn("auto_groups_filter does not compile, throwing this error: #{e}")
-    else
-      warn("auto_groups_filter does not compile, throwing this error: #{e}")
-    end
+    Rails.logger.warn("auto_groups_filter does not compile, throwing this error: #{e}")
     []
   end
   

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -248,6 +248,15 @@ class ProjectManagerTest < ApplicationSystemTestCase
     assert_equal(4, icons.size)
   end
 
+  test 'project group dropdown respects auto_groups_filter' do
+    CurrentUser.instance.stubs(:group_names).returns(%w[domain_users project-a project-b other])
+    Configuration.stubs(:auto_groups_filter).returns('^project-')
+
+    visit(new_project_path)
+    options = page.all('#project_group_owner option').map(&:value)
+    assert_equal(%w[project-a project-b], options)
+  end
+
   test 'all icons show after clearing input field' do
     visit(new_project_path)
     find('#product_icon_select').set('')


### PR DESCRIPTION
Fixes #5300

Project Manager’s group selection dropdown was showing every group the user belongs to (including broad/noisy ones like domain users).

- Reuse auto_groups_filter for the Project Manager group dropdown
- Centralize the filtering logic on CurrentUser so BatchConnect + Projects stay consistent
- Add a system test to cover the filtered dropdown behavior