### PR TITLE
Align breadcrumbs in files table

### DIFF
--- a/apps/dashboard/app/views/files/_files_table.html.erb
+++ b/apps/dashboard/app/views/files/_files_table.html.erb
@@ -1,6 +1,6 @@
 <div class="col-md-9">
   <%# TODO put search box ABOVE the breadcrumbs %>
-    <ol id="path-breadcrumbs" class="breadcrumb breadcrumb-no-delimiter rounded" role="region" aria-label="Path breadcrumbs">
+    <ol id="path-breadcrumbs" class="breadcrumb breadcrumb-no-delimiter rounded align-items-center" role="region" aria-label="Path breadcrumbs">
       <%= render partial: 'breadcrumb', collection: @path.descend, as: :file, locals: { file_count: @path.descend.count, full_path: @path } %>
     </ol>
 


### PR DESCRIPTION
It's a bit of nitpicking, but using the bootstrap class an easy fix :)

Before:

<img width="1080" height="583" alt="Screenshot 2026-05-05 at 17 53 54" src="https://github.com/user-attachments/assets/d3cf726f-ceb2-4f80-a074-272cc046bf59" />

After

<img width="1080" height="583" alt="Screenshot 2026-05-05 at 17 54 20" src="https://github.com/user-attachments/assets/866e9ab6-1ba4-4481-ae05-4b1db9ff955f" />
