### PR TITLE
Add issue template config for Discourse

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://discourse.openondemand.org
+    about: Have a question? Ask it on our Discourse forum instead.


### PR DESCRIPTION
Direct folks to Discourse as an option when they start to open an issue in this repo