### PR TITLE
Make session directory link text more descriptive (#5438)

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_id.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_id.html.erb
@@ -1,8 +1,7 @@
 <p>
   <strong><%= t('dashboard.batch_connect_sessions_stats_session_id') %></strong>
-  <span class="text-muted"><%= "#{session.id} —" %></span>
   <%= link_to(
-        t('dashboard.batch_connect_sessions_stats_session_dir_link_text'),
+        session.id,
         OodAppkit.files.url(path: session.staged_root).to_s,
         class: 'session-id-link',
         title: t('dashboard.batch_connect_sessions_stats_session_dir_link_title', session_id: session.id),

--- a/apps/dashboard/app/views/batch_connect/sessions/card/_id.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_id.html.erb
@@ -1,4 +1,11 @@
 <p>
   <strong><%= t('dashboard.batch_connect_sessions_stats_session_id') %></strong>
-  <%= link_to(session.id, OodAppkit.files.url(path: session.staged_root).to_s, class:'session-id-link') %> 
+  <span class="text-muted"><%= "#{session.id} —" %></span>
+  <%= link_to(
+        t('dashboard.batch_connect_sessions_stats_session_dir_link_text'),
+        OodAppkit.files.url(path: session.staged_root).to_s,
+        class: 'session-id-link',
+        title: t('dashboard.batch_connect_sessions_stats_session_dir_link_title', session_id: session.id),
+        aria: { label: t('dashboard.batch_connect_sessions_stats_session_dir_link_title', session_id: session.id) }
+      ) %>
 </p>

--- a/apps/dashboard/config/locales/en-CA.yml
+++ b/apps/dashboard/config/locales/en-CA.yml
@@ -91,6 +91,8 @@ en-CA:
     batch_connect_sessions_stats_created_at: 'Created at:'
     batch_connect_sessions_stats_host: 'Host:'
     batch_connect_sessions_stats_session_id: 'Session ID:'
+    batch_connect_sessions_stats_session_dir_link_text: 'Open session directory'
+    batch_connect_sessions_stats_session_dir_link_title: 'Open session directory for %{session_id}'
     batch_connect_sessions_stats_support_ticket: Problems with this session?
     batch_connect_sessions_stats_support_ticket_link_text: Submit support ticket
     batch_connect_sessions_stats_time_remaining: 'Time Remaining:'

--- a/apps/dashboard/config/locales/en-CA.yml
+++ b/apps/dashboard/config/locales/en-CA.yml
@@ -91,7 +91,6 @@ en-CA:
     batch_connect_sessions_stats_created_at: 'Created at:'
     batch_connect_sessions_stats_host: 'Host:'
     batch_connect_sessions_stats_session_id: 'Session ID:'
-    batch_connect_sessions_stats_session_dir_link_text: 'Open session directory'
     batch_connect_sessions_stats_session_dir_link_title: 'Open session directory for %{session_id}'
     batch_connect_sessions_stats_support_ticket: Problems with this session?
     batch_connect_sessions_stats_support_ticket_link_text: Submit support ticket

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -91,7 +91,6 @@ en:
     batch_connect_sessions_stats_created_at: 'Created at:'
     batch_connect_sessions_stats_host: 'Host:'
     batch_connect_sessions_stats_session_id: 'Session ID:'
-    batch_connect_sessions_stats_session_dir_link_text: 'Open session directory'
     batch_connect_sessions_stats_session_dir_link_title: 'Open session directory for %{session_id}'
     batch_connect_sessions_stats_support_ticket: Problems with this session?
     batch_connect_sessions_stats_support_ticket_link_text: Submit support ticket

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -91,6 +91,8 @@ en:
     batch_connect_sessions_stats_created_at: 'Created at:'
     batch_connect_sessions_stats_host: 'Host:'
     batch_connect_sessions_stats_session_id: 'Session ID:'
+    batch_connect_sessions_stats_session_dir_link_text: 'Open session directory'
+    batch_connect_sessions_stats_session_dir_link_title: 'Open session directory for %{session_id}'
     batch_connect_sessions_stats_support_ticket: Problems with this session?
     batch_connect_sessions_stats_support_ticket_link_text: Submit support ticket
     batch_connect_sessions_stats_time_remaining: 'Time Remaining:'

--- a/apps/dashboard/config/locales/fr-CA.yml
+++ b/apps/dashboard/config/locales/fr-CA.yml
@@ -91,7 +91,6 @@ fr-CA:
     batch_connect_sessions_stats_created_at: 'Créé le :'
     batch_connect_sessions_stats_host: 'Hôte :'
     batch_connect_sessions_stats_session_id: 'ID de session :'
-    batch_connect_sessions_stats_session_dir_link_text: Ouvrir le répertoire de la session
     batch_connect_sessions_stats_session_dir_link_title: "Ouvrir le répertoire de la session pour %{session_id}"
     batch_connect_sessions_stats_support_ticket: Problèmes avec cette session ?
     batch_connect_sessions_stats_support_ticket_link_text: Soumettre un billet de soutien

--- a/apps/dashboard/config/locales/fr-CA.yml
+++ b/apps/dashboard/config/locales/fr-CA.yml
@@ -91,6 +91,8 @@ fr-CA:
     batch_connect_sessions_stats_created_at: 'Créé le :'
     batch_connect_sessions_stats_host: 'Hôte :'
     batch_connect_sessions_stats_session_id: 'ID de session :'
+    batch_connect_sessions_stats_session_dir_link_text: Ouvrir le répertoire de la session
+    batch_connect_sessions_stats_session_dir_link_title: "Ouvrir le répertoire de la session pour %{session_id}"
     batch_connect_sessions_stats_support_ticket: Problèmes avec cette session ?
     batch_connect_sessions_stats_support_ticket_link_text: Soumettre un billet de soutien
     batch_connect_sessions_stats_time_remaining: 'Temps restant :'

--- a/apps/dashboard/config/locales/ja_JP.yml
+++ b/apps/dashboard/config/locales/ja_JP.yml
@@ -88,6 +88,8 @@ ja_JP:
     batch_connect_sessions_stats_created_at: 作成日時：
     batch_connect_sessions_stats_host: ホスト：
     batch_connect_sessions_stats_session_id: セッションID：
+    batch_connect_sessions_stats_session_dir_link_text: セッションディレクトリを開く
+    batch_connect_sessions_stats_session_dir_link_title: "%{session_id} のセッションディレクトリを開く"
     batch_connect_sessions_stats_support_ticket: このセッションに問題がありますか？
     batch_connect_sessions_stats_support_ticket_link_text: サポートチケットを提出する
     batch_connect_sessions_stats_time_remaining: 残り時間：

--- a/apps/dashboard/config/locales/ja_JP.yml
+++ b/apps/dashboard/config/locales/ja_JP.yml
@@ -88,7 +88,6 @@ ja_JP:
     batch_connect_sessions_stats_created_at: 作成日時：
     batch_connect_sessions_stats_host: ホスト：
     batch_connect_sessions_stats_session_id: セッションID：
-    batch_connect_sessions_stats_session_dir_link_text: セッションディレクトリを開く
     batch_connect_sessions_stats_session_dir_link_title: "%{session_id} のセッションディレクトリを開く"
     batch_connect_sessions_stats_support_ticket: このセッションに問題がありますか？
     batch_connect_sessions_stats_support_ticket_link_text: サポートチケットを提出する

--- a/apps/dashboard/config/locales/zh-CN.yml
+++ b/apps/dashboard/config/locales/zh-CN.yml
@@ -83,7 +83,6 @@ zh-CN:
     batch_connect_sessions_stats_created_at: 创建于：
     batch_connect_sessions_stats_host: 主机：
     batch_connect_sessions_stats_session_id: 会话ID：
-    batch_connect_sessions_stats_session_dir_link_text: 打开会话目录
     batch_connect_sessions_stats_session_dir_link_title: "打开 %{session_id} 的会话目录"
     batch_connect_sessions_stats_support_ticket: 此会话有问题吗？
     batch_connect_sessions_stats_support_ticket_link_text: 提交支持票

--- a/apps/dashboard/config/locales/zh-CN.yml
+++ b/apps/dashboard/config/locales/zh-CN.yml
@@ -83,6 +83,8 @@ zh-CN:
     batch_connect_sessions_stats_created_at: 创建于：
     batch_connect_sessions_stats_host: 主机：
     batch_connect_sessions_stats_session_id: 会话ID：
+    batch_connect_sessions_stats_session_dir_link_text: 打开会话目录
+    batch_connect_sessions_stats_session_dir_link_title: "打开 %{session_id} 的会话目录"
     batch_connect_sessions_stats_support_ticket: 此会话有问题吗？
     batch_connect_sessions_stats_support_ticket_link_text: 提交支持票
     batch_connect_sessions_stats_time_remaining: 剩余时间：


### PR DESCRIPTION
Fixes #5438

Make the session directory link clearer by not using the raw session UUID as the link text. Keep the session ID visible, but change the link to a more descriptive label so it’s easier to understand and better for accessibility.