### PR TITLE
Revert "Add issue template config for Discourse (#5441)"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Ask a Question
-    url: https://discourse.openondemand.org
-    about: Have a question? Ask it on our Discourse forum instead.


### PR DESCRIPTION
This reverts commit 326acdc78ed9b966df57b8af9385f40a8c07136c. It made it so that no external contributors could open issues, since blank issues were prohibited and 'ask a question' linked to discourse, leaving vulnerability reporting as the only option