### PR TITLE
Fix NoMethodError in FilesController when Accept header is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Changes are grouped by type:
 
 ## [Unreleased]
 
-- Nothing at the moment
+### Fixed
+
+- `FilesController#fs` no longer crashes with `NoMethodError: undefined method 'split' for nil:NilClass` when a request omits the `Accept` header (as Chrome's `<a download>` links sometimes do), which previously caused the global `rescue_action` handler to silently redirect the user to `$HOME` instead of serving the file.
 
 ## [4.1.5] - 2026-04-29
 

--- a/apps/dashboard/app/controllers/files_controller.rb
+++ b/apps/dashboard/app/controllers/files_controller.rb
@@ -8,7 +8,7 @@ class FilesController < ApplicationController
   before_action :strip_sendfile_headers, only: [:fs, :directory_frame]
 
   def fs
-    request.format = 'json' if request.headers['HTTP_ACCEPT'].split(',').include?('application/json')
+    request.format = 'json' if request.headers['HTTP_ACCEPT']&.split(',')&.include?('application/json')
     parse_path(fs_params[:filepath], fs_params[:fs])
     validate_path!
 


### PR DESCRIPTION
## Bug

`FilesController#fs` starts with:

```ruby
request.format = 'json' if request.headers['HTTP_ACCEPT'].split(',').include?('application/json')
```

If the incoming request has no `Accept` header, `request.headers['HTTP_ACCEPT']` is `nil` and `nil.split` raises `NoMethodError: undefined method 'split' for nil:NilClass`. The global `rescue_action` catches the exception and redirects the user to `$HOME` instead of serving the file.

## How we hit it

Building an Interactive App (ParaView pvserver) whose `view.html.erb` links to a session-specific file:

```erb
<a href="/pun/sys/dashboard/files/api/v1/fs<%= abs_path %>" download="<%= filename %>">
```

On Chrome 147 on macOS, the `<a download>` click omitted the `Accept` header. Result: error.log filled with `undefined method 'split' for nil:NilClass` and the user was bounced to their home directory instead of getting the file. Reproducible deterministically; log excerpt in the commit.

## Fix

Safe-navigate both `split` and `include?`. When the header is missing we simply leave the request format alone and Rails's normal content negotiation picks `html`:

```ruby
request.format = 'json' if request.headers['HTTP_ACCEPT']&.split(',')&.include?('application/json')
```

One-line change; CHANGELOG entry added.

Per upstream CLA — I don't see one in the repo; happy to sign if needed.