### PR TITLE
Fix batch connect form serialization for reserved attribute names (#5…

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -24,6 +24,12 @@ module BatchConnect
       end
     end
 
+    # Return smart attribute value for serialization instead of raw attribute object
+    def read_attribute_for_serialization(name)
+      attribute = self[name]
+      attribute ? attribute.value : super
+    end
+
     # @param attributes [Array<Attribute>] list of attribute objects
     def initialize(attributes = [], app_specific_cache_setting = nil)
       @attributes = attributes

--- a/apps/dashboard/test/models/batch_connect/session_context_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_context_test.rb
@@ -130,6 +130,19 @@ cacheable: true } }, form: ['bc_account', 'num_cores']
       assert_equal ['PZS0714', '28'], [context['bc_account'].value, context['num_cores'].value]
     end
 
+    test 'as_json includes attributes whose ids match Kernel method names' do
+      app = BatchConnect::App.new(router: nil)
+      app.stubs(:form_config).returns(
+        attributes: { format: { widget: 'text_field', value: 'pdf' } },
+        form:       ['bc_account', 'format']
+      )
+      context = app.build_session_context
+
+      expected = { 'bc_account' => '', 'format' => 'pdf' }
+      assert_equal expected, context.serializable_hash
+      assert_equal expected, context.as_json
+    end
+
     test 'to_openstruct throws error when using OpenStruct methods' do
       app = BatchConnect::App.new(router: nil)
       app.stubs(:form_config).returns(attributes: { table: { value: 'the_table' } }, form: ['bc_account', 'table'])


### PR DESCRIPTION
Fixes #5075

Batch Connect was failing when form fields used reserved Ruby method names like format, causing serialization to break during submit.

I first followed the ticket suggestion and overrode as_json, which did fix the issue. After digging a bit more, I switched to overriding read_attribute_for_serialization instead so attribute lookup goes through the smart attribute layer rather than relying on send. This feels like a more appropriate fix since it stays aligned with ActiveModel’s intended serialization hooks instead of replacing as_json entirely.

Added a test covering reserved names to ensure the issue doesn’t regress.