### PR TITLE
Fix file editor control panel overflow at small screen widths (#5120)

### DIFF
--- a/apps/dashboard/app/views/files/edit.html.erb
+++ b/apps/dashboard/app/views/files/edit.html.erb
@@ -2,7 +2,7 @@
 <div id="editor-filename" class="text-center mb-2"><%= @path %></div>
 
 <div class="d-flex flex-row flex-grow-1">
-  <div class="editor-controls flex-column col-sm-1 card mx-2 text-center">
+  <div class="editor-controls flex-column col-1 card mx-2 text-center">
 
     <div class="card-header">
       <div class="d-grid gap-2">


### PR DESCRIPTION
Fixes #5120

- File editor controls were getting too wide on small screens (~576px) and stealing space from the editor
- Switched col-sm-1 to col-1 on the controls container so the width stays consistent and doesn’t jump
- Visual changes, no test case necessary - tested on dashboard only