### PR TITLE
Fix hidden clusters appearing in Active Jobs dropdown (#4156)

### DIFF
--- a/apps/dashboard/config/initializers/activejobs.rb
+++ b/apps/dashboard/config/initializers/activejobs.rb
@@ -1,2 +1,2 @@
 
-OODClusters = OodCore::Clusters.new(OodAppkit.clusters.select(&:allow?).reject { |c| c.metadata.hidden })
+OODClusters = Configuration.job_clusters

--- a/apps/dashboard/config/initializers/activejobs.rb
+++ b/apps/dashboard/config/initializers/activejobs.rb
@@ -1,2 +1,2 @@
 
-OODClusters = OodCore::Clusters.new(OodAppkit.clusters.select(&:allow?))
+OODClusters = OodCore::Clusters.new(OodAppkit.clusters.select(&:allow?).reject { |c| c.metadata.hidden })

--- a/apps/dashboard/test/config/activejobs_initializer_test.rb
+++ b/apps/dashboard/test/config/activejobs_initializer_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class ActivejobsInitializerTest < ActiveSupport::TestCase
+  test 'activejobs initializer rejects metadata.hidden clusters like ApplicationHelper#clusters' do
+    code = Rails.root.join('config/initializers/activejobs.rb').read
+    assert_match(/allow\?\).*\.reject\s*\{\s*\|c\|\s*c\.metadata\.hidden\s*\}/m, code)
+  end
+end

--- a/apps/dashboard/test/config/activejobs_initializer_test.rb
+++ b/apps/dashboard/test/config/activejobs_initializer_test.rb
@@ -1,8 +1,15 @@
 require 'test_helper'
 
 class ActivejobsInitializerTest < ActiveSupport::TestCase
-  test 'activejobs initializer rejects metadata.hidden clusters like ApplicationHelper#clusters' do
-    code = Rails.root.join('config/initializers/activejobs.rb').read
-    assert_match(/allow\?\).*\.reject\s*\{\s*\|c\|\s*c\.metadata\.hidden\s*\}/m, code)
+  setup do
+    stub_clusters
+    Object.send(:remove_const, :OODClusters)
+    load Rails.root.join('config/initializers/activejobs.rb')
+  end
+
+  test "should exclude hidden clusters from OODClusters" do
+    OodCore::Clusters.load_file('test/fixtures/config/clusters.d')
+      .select { |c| c.metadata.hidden }
+      .each { |cluster| assert_nil OODClusters[cluster.id.to_s] }
   end
 end


### PR DESCRIPTION
Fixes #4156

Hidden clusters were still showing in the Active Jobs cluster dropdown even though they’re filtered elsewhere in the dashboard
- Updated the Active Jobs initializer to reject clusters with `metadata.hidden`
- Added a test case to ensure clusters a being hidden