### PR TITLE
A minor bug where Job Hash is not saved in Workflows

### DIFF
--- a/apps/dashboard/app/controllers/workflows_controller.rb
+++ b/apps/dashboard/app/controllers/workflows_controller.rb
@@ -107,9 +107,10 @@ class WorkflowsController < ApplicationController
   def submit
     return unless load_project_and_workflow_objects(render_json: true)
     metadata = metadata_params(permit_json_data)
-    @workflow.update(metadata)
     submit_param = Workflow.build_submit_params(metadata, project_directory)
     result = @workflow.submit(submit_param)
+    metadata[:metadata][:job_hash] = result if result.present?
+    @workflow.update(metadata)
     if !result.nil?
       render json: { message: I18n.t('dashboard.jobs_workflow_submitted'), job_hash: result }
     else


### PR DESCRIPTION
Related to Epic https://github.com/OSC/ondemand/issues/4338
Detailed Discussion under https://github.com/OSC/ondemand/pull/4960

- Job Hash was not saved in the backend upon retuning from the `submit` function this PR fixes that.
- Current version will have two distinct behaviours:
   - If session is valid, you will see the latest job info on the `workflow show`
   - If session is old/expired, you will see plain white workflow the job hash is not saved in backend