### PR TITLE
Detect ondemand dir instead of hardcoding

### DIFF
--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -81,10 +81,14 @@ namespace :dev do
     return target.nil? ? pwd : target
   end
 
+  def container_ondemand_directory
+    "/home/#{user.name}/ondemand"
+  end
+
   def dev_mounts
     [
       '-v', "#{config_directory}:/etc/ood/config",
-      '-v', "#{ondemand_directory}:#{user.dir}/ondemand"
+      '-v', "#{ondemand_directory}:#{ondemand_directory}"
     ].tap do |mnts|
       unless ENV['OOD_MNT_PORTAL'].nil?
         mnts.concat(['-v',
@@ -116,7 +120,18 @@ namespace :dev do
     ctr_args.concat container_rt_args
 
     ctr_args.concat ["#{dev_image_name}:latest"]
+
     sh ctr_args.join(' ')
+
+    if ondemand_directory != container_ondemand_directory
+      # Create symlink from detected ondemand directory to ~/ondemand inside the container
+      symlink_cmd = [
+        container_runtime, 'exec', dev_container_name,
+        '/bin/bash', '-c',
+        "\"rm -rf #{container_ondemand_directory} && ln -s #{ondemand_directory} #{container_ondemand_directory}\""
+      ]
+      sh symlink_cmd.join(' ')
+    end
   end
 
   desc 'Stop development container'

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -33,7 +33,6 @@ namespace :dev do
         'port'                   => 8080,
         'listen_addr_port'       => 8080,
         'oidc_remote_user_claim' => 'email',
-        'oidc_crypto_passphrase' => SecureRandom.uuid,
         'dex'                    => {
           'static_passwords' => [{
             'email'    => "#{user.name}@localhost",

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -72,10 +72,19 @@ namespace :dev do
     end
   end
 
+  def ondemand_dir
+    pwd = FileUtils.pwd
+    target = Pathname.new(pwd).ascend do |path|
+      break path if path.basename.to_s == 'ondemand'
+    end
+
+    return target.nil? ? pwd : target
+  end
+
   def dev_mounts
     [
       '-v', "#{config_directory}:/etc/ood/config",
-      '-v', "#{user.dir}/ondemand:#{user.dir}/ondemand"
+      '-v', "#{ondemand_dir}:#{user.dir}/ondemand"
     ].tap do |mnts|
       unless ENV['OOD_MNT_PORTAL'].nil?
         mnts.concat(['-v',

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -81,8 +81,12 @@ namespace :dev do
     return target.nil? ? pwd : target
   end
 
+  def linux_home
+    "/home/#{user.name}"
+  end
+
   def container_ondemand_directory
-    "/home/#{user.name}/ondemand"
+    "#{linux_home}/ondemand"
   end
 
   def dev_mounts
@@ -154,9 +158,9 @@ namespace :dev do
   task :exec do
     ctr_args = [container_runtime, 'exec', '-it']
     # home is set to /root? could be bug for me
-    ctr_args.concat ['-e', "HOME=#{user.dir}"]
+    ctr_args.concat ['-e', "HOME=#{linux_home}"]
     ctr_args.concat term_container_args
-    ctr_args.concat ['--workdir', user.dir.to_s]
+    ctr_args.concat ['--workdir', linux_home.to_s]
     ctr_args.concat [dev_container_name, '/bin/bash']
 
     sh ctr_args.join(' ')

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -78,7 +78,7 @@ namespace :dev do
       break path if path.basename.to_s == 'ondemand'
     end
 
-    return target.nil? ? pwd : target
+    return target.nil? ? container_ondemand_directory : target
   end
 
   def linux_home

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -33,6 +33,7 @@ namespace :dev do
         'port'                   => 8080,
         'listen_addr_port'       => 8080,
         'oidc_remote_user_claim' => 'email',
+        'oidc_crypto_passphrase' => SecureRandom.uuid,
         'dex'                    => {
           'static_passwords' => [{
             'email'    => "#{user.name}@localhost",
@@ -92,7 +93,7 @@ namespace :dev do
   def dev_mounts
     [
       '-v', "#{config_directory}:/etc/ood/config",
-      '-v', "#{ondemand_directory}:#{ondemand_directory}"
+      '-v', "#{ondemand_directory}:#{container_ondemand_directory}"
     ].tap do |mnts|
       unless ENV['OOD_MNT_PORTAL'].nil?
         mnts.concat(['-v',
@@ -124,18 +125,7 @@ namespace :dev do
     ctr_args.concat container_rt_args
 
     ctr_args.concat ["#{dev_image_name}:latest"]
-
     sh ctr_args.join(' ')
-
-    if ondemand_directory.to_s != container_ondemand_directory
-      # Create symlink from detected ondemand directory to ~/ondemand inside the container
-      symlink_cmd = [
-        container_runtime, 'exec', dev_container_name,
-        '/bin/bash', '-c',
-        "\"mkdir -p /tmp#{container_ondemand_directory} && mv #{container_ondemand_directory} /tmp#{container_ondemand_directory} && ln -s #{ondemand_directory} #{container_ondemand_directory}\""
-      ]
-      sh symlink_cmd.join(' ')
-    end
   end
 
   desc 'Stop development container'

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -127,12 +127,12 @@ namespace :dev do
 
     sh ctr_args.join(' ')
 
-    if ondemand_directory != container_ondemand_directory
+    if ondemand_directory.to_s != container_ondemand_directory
       # Create symlink from detected ondemand directory to ~/ondemand inside the container
       symlink_cmd = [
         container_runtime, 'exec', dev_container_name,
         '/bin/bash', '-c',
-        "\"rm -rf #{container_ondemand_directory} && ln -s #{ondemand_directory} #{container_ondemand_directory}\""
+        "\"mkdir -p /tmp#{container_ondemand_directory} && mv #{container_ondemand_directory} /tmp#{container_ondemand_directory} && ln -s #{ondemand_directory} #{container_ondemand_directory}\""
       ]
       sh symlink_cmd.join(' ')
     end

--- a/lib/tasks/development.rb
+++ b/lib/tasks/development.rb
@@ -72,7 +72,7 @@ namespace :dev do
     end
   end
 
-  def ondemand_dir
+  def ondemand_directory
     pwd = FileUtils.pwd
     target = Pathname.new(pwd).ascend do |path|
       break path if path.basename.to_s == 'ondemand'
@@ -84,7 +84,7 @@ namespace :dev do
   def dev_mounts
     [
       '-v', "#{config_directory}:/etc/ood/config",
-      '-v', "#{ondemand_dir}:#{user.dir}/ondemand"
+      '-v', "#{ondemand_directory}:#{user.dir}/ondemand"
     ].tap do |mnts|
       unless ENV['OOD_MNT_PORTAL'].nil?
         mnts.concat(['-v',


### PR DESCRIPTION
Fixes #5463. Searches for a directory named 'ondemand' in the ancestry of the working directory. Defaults to pwd if no directory named 'ondemand' is found