### PR TITLE
Refactor custom pages and dashboard to share index partial (#2364)

### DIFF
--- a/apps/dashboard/app/views/custom_pages/index.html.erb
+++ b/apps/dashboard/app/views/custom_pages/index.html.erb
@@ -1,15 +1,6 @@
 <%- content_for :head do -%>
-  <%= javascript_include_tag 'dashboard', nonce: true %>
+  <%= javascript_include_tag 'dashboard', nonce: true, type: 'module' %>
   <%= javascript_include_tag 'pinned_apps', nonce: true %>
 <%- end -%>
-<%- @page_layout.fetch(:rows, []).each do |row| -%>
-<div class="row">
-  <%- row.fetch(:columns, []).each do |col| -%>
-  <div class='<%= "col-md-#{col.fetch(:width, "12")}" %>'>
-    <%- Array(col.fetch(:widgets, [])).each do |widget| -%>
-      <%= render_widget(widget.to_s) %>
-    <%- end -%>
-  </div>
-  <%- end -%>
-</div>
-<%- end -%>
+
+<%= render partial: 'shared/page_layout', locals: { layout: @page_layout } %>

--- a/apps/dashboard/app/views/dashboard/index.html.erb
+++ b/apps/dashboard/app/views/dashboard/index.html.erb
@@ -4,14 +4,4 @@
 <%- end -%>
 <%= render partial: 'shared/welcome' unless @user_configuration.disable_dashboard_welcome_message%>
 
-<%- dashboard_layout.fetch(:rows, []).each do |row| -%>
-<div class="row">
-  <%- row.fetch(:columns, []).each do |col| -%>
-  <div class='<%= "col-md-#{col[:width]}" %>'> <%# FIXME: what if width is not specified!? %>
-    <%- Array(col.fetch(:widgets, [])).each do |widget| -%>
-      <%= render_widget(widget.to_s) %>
-    <%- end -%>
-  </div>
-  <%- end -%>
-</div>
-<%- end -%>
+<%= render partial: 'shared/page_layout', locals: { layout: dashboard_layout } %>

--- a/apps/dashboard/app/views/shared/_page_layout.html.erb
+++ b/apps/dashboard/app/views/shared/_page_layout.html.erb
@@ -1,0 +1,12 @@
+<%- layout.fetch(:rows, []).each do |row| -%>
+  <div class="row">
+    <%- row.fetch(:columns, []).each do |col| -%>
+    <div class='<%= "col-md-#{col.fetch(:width, "12")}" %>'>
+      <%- Array(col.fetch(:widgets, [])).each do |widget| -%>
+        <%= render_widget(widget.to_s) %>
+      <%- end -%>
+    </div>
+    <%- end -%>
+  </div>
+  <%- end -%>
+  


### PR DESCRIPTION
Fixes #2364

- Refactored the custom pages and dashboard index views to use the same shared partial instead of maintaining duplicate templates
- Added a default column width fallback while moving the shared layout code and cleaned up the old FIXME
- No tests added since this is just cleaning up duplicated view code and doesn’t change behavior