### PR TITLE
Fix manifest error handling

### DIFF
--- a/apps/dashboard/app/apps/manifest.rb
+++ b/apps/dashboard/app/apps/manifest.rb
@@ -4,6 +4,8 @@ require 'yaml'
 
 # Manifests provide metadata for applications (OodApps).
 class Manifest
+  include ActiveModel::Model
+
   attr_reader :exception
 
   # InvalidContentError is an error helper class to give users a nice
@@ -40,19 +42,17 @@ category: OSC
         Manifest.new(YAML.safe_load(content))
       end
     else
-      MissingManifest.new({})
+      MissingManifest.new(yaml_path)
     end
-  rescue Exception => e
-    # FIXME: if we rescue from exceptions, we should store the exception
-    # information in the manifest
-    # and be explicit about what we are handling
-    # probably a YAML formatting error?
+  rescue StandardError => e
+    Rails.logger.warn "Cannot load manifest: #{yaml_path} with error #{e.class}: #{e.message}"
     InvalidManifest.new(e)
   end
 
   def self.load_from_string(yaml)
     Manifest.new(YAML.safe_load(yaml))
-  rescue Exception => e
+  rescue StandardError => e
+    Rails.logger.warn "Cannot load manifest from string with error #{e.class}: #{e.message}"
     InvalidManifest.new(e)
   end
 
@@ -174,8 +174,10 @@ category: OSC
     Pathname.new(path).write(to_yaml)
 
     true
-  rescue StandardError
-    # TODO: Add a custom exception here to track why it erred. IO? Permissions? etc.
+  rescue StandardError => e
+    @exception = e
+    errors.add(:save, e.message)
+    Rails.logger.warn "Cannot save manifest: #{path} with error #{e.class}:#{e.message}"
     false
   end
 
@@ -209,6 +211,7 @@ category: OSC
       super({})
 
       @exception = exception
+      errors.add(:load, exception.message)
     end
 
     def valid?
@@ -221,6 +224,12 @@ category: OSC
   end
 
   class MissingManifest < Manifest
+    def initialize(yaml_path = nil)
+      super({})
+
+      errors.add(:load, "Manifest not found at #{yaml_path}") if yaml_path
+    end
+
     def valid?
       false
     end

--- a/apps/dashboard/app/models/product.rb
+++ b/apps/dashboard/app/models/product.rb
@@ -35,8 +35,20 @@ class Product
   end
 
   def manifest_is_valid
-    errors.add(:base, "Manifest is missing, add a title and description to fix this") unless app.manifest.exist?
-    errors.add(:base, "Manifest is corrupt, please edit the <code>manifest.yml</code> to fix this") if app.manifest.exist? && !app.manifest.valid?
+    manifest = app.manifest
+
+    unless manifest.exist?
+      errors.add(:base, "Manifest is missing, add a title and description to fix this")
+      return
+    end
+
+    return if manifest.valid?
+
+    if manifest.errors.any?
+      manifest.errors.full_messages.each { |msg| errors.add(:base, msg) }
+    else
+      errors.add(:base, "Manifest is corrupt, please edit the <code>manifest.yml</code> to fix this")
+    end
   end
 
   def gems_are_valid

--- a/apps/dashboard/test/models/manifest_test.rb
+++ b/apps/dashboard/test/models/manifest_test.rb
@@ -18,6 +18,8 @@ class ManifestTest < ActiveSupport::TestCase
     manifest = Manifest.load('test/fixtures/files/manifest_invalid')
     assert !manifest.valid?, 'manifest should not be valid'
     assert manifest.exist?, 'manifest should exist'
+    assert manifest.errors[:load].present?
+    assert_instance_of Psych::SyntaxError, manifest.exception
   end
 
   test 'load an empty manifest' do
@@ -30,6 +32,23 @@ class ManifestTest < ActiveSupport::TestCase
     manifest = Manifest.load('test/fixtures/files/manifest_missing')
     assert !manifest.valid?, 'manifest should not be valid'
     assert !manifest.exist?, 'manifest should not exist'
+    assert manifest.errors[:load].present?
+  end
+
+  test 'save failure records errors' do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'manifest.yml')
+      File.write(path, "name: test\n")
+      File.chmod(0o444, path)
+
+      manifest = Manifest.new(name: 'updated')
+      save_result = manifest.save(path)
+
+      assert_equal false, save_result
+      assert manifest.errors[:save].present?
+    ensure
+      File.chmod(0o644, path) if defined?(path) && File.exist?(path)
+    end
   end
 
   test 'save a valid manifest' do

--- a/apps/dashboard/test/models/product_test.rb
+++ b/apps/dashboard/test/models/product_test.rb
@@ -15,10 +15,27 @@ class ProductTest < ActiveSupport::TestCase
       product = DevProduct.new(name: 'myapp', found: true, title: 'New', description: 'desc', icon: 'fas://cog')
 
       refute product.update(title: 'Newer', description: 'desc')
-      assert product.errors[:base].present?
+      assert_includes product.errors[:base].first, 'Permission denied'
       assert_equal 'Old', Manifest.load(manifest).name
     ensure
       File.chmod(0o644, manifest) if defined?(manifest) && manifest.exist?
+    end
+  end
+
+  test 'manifest_is_valid surfaces load errors from corrupt manifest' do
+    Dir.mktmpdir do |dir|
+      base = Pathname.new(dir)
+      app_dir = base.join('myapp')
+      app_dir.mkpath
+      app_dir.join('manifest.yml').write("---\nname: x\n[\n")
+
+      DevRouter.stubs(:base_path).returns(base)
+      product = DevProduct.new(name: 'myapp', found: true)
+
+      product.valid?(:show_app)
+
+      assert product.errors[:base].present?
+      assert_not_includes product.errors[:base], 'Manifest is corrupt, please edit'
     end
   end
 end


### PR DESCRIPTION
Fixes #2040

- Improved manifest error handling so failures no longer fail silently and are easier to debug
- Added error logging and attached StandardError details
- Updated tests to assert error presence and captured exceptions for invalid YAML and save failures