### PR TITLE
Fix product manifest save failing silently (#5468)

### DIFF
--- a/apps/dashboard/app/controllers/products_controller.rb
+++ b/apps/dashboard/app/controllers/products_controller.rb
@@ -69,6 +69,7 @@ class ProductsController < ApplicationController
         format.html { redirect_to product_url(@product.name, type: @type), notice: 'Product was successfully updated.' }
         format.json { render :show, status: :ok, location: @product }
       else
+        flash.now[:alert] = @product.errors.full_messages.to_sentence
         format.html { render :edit }
         format.json { render json: @product.errors, status: :unprocessable_entity }
       end

--- a/apps/dashboard/app/models/product.rb
+++ b/apps/dashboard/app/models/product.rb
@@ -227,7 +227,7 @@ class Product
       if (!title.blank? || !description.blank?) || !app.manifest_path.exist?
         unless manifest.save(app.manifest_path)
           message = manifest.errors[:save].first if manifest.respond_to?(:errors) && manifest.errors[:save].present?
-          errors.add(:base, message || I18n.t('dashboard.products_manifest_save_error', path: app.manifest_path))
+          errors.add(:base, message || I18n.t('dashboard.products_manifest_save_error', path: app.manifest_path.realpath))
           return false
         end
       end

--- a/apps/dashboard/app/models/product.rb
+++ b/apps/dashboard/app/models/product.rb
@@ -171,7 +171,7 @@ class Product
     add_icon_uri
 
     if self.valid?
-      write_manifest
+      return false unless write_manifest
       set_git_remote
       true
     else
@@ -219,14 +219,19 @@ class Product
 
     # Writes out a manifest to the router path unless the repository has been newly cloned.
     #
-    # @return [true] always returns true
+    # @return [true, false] true if the manifest is written successfully
     def write_manifest
-      manifest = Manifest.load( app.manifest_path )
+      manifest = Manifest.load(app.manifest_path)
+      manifest = manifest.merge({ name: title, description: description, icon: icon })
 
-      manifest = manifest.merge({ name: title, description: description, icon: icon})
-
-      manifest.save( app.manifest_path ) if (!title.blank? || !description.blank?) || !app.manifest_path.exist?
-
+      if (!title.blank? || !description.blank?) || !app.manifest_path.exist?
+        unless manifest.save(app.manifest_path)
+          message = manifest.errors[:save].first if manifest.respond_to?(:errors) && manifest.errors[:save].present?
+          errors.add(:base, message || I18n.t('dashboard.products_manifest_save_error', path: app.manifest_path))
+          return false
+        end
+      end
+      
       true
     end
 

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -282,6 +282,7 @@ en:
     pinned_apps_caption_html: A featured subset of <a href="%{all_apps_url}">all available apps</a>
     pinned_apps_category: Apps
     pinned_apps_title: Pinned Apps
+    products_manifest_save_error: Cannot save app manifest to %{path}
     project: Project
     project_balances: Project Balances
     project_zip_error_message: 'Error creating ZIP file: %{error}'

--- a/apps/dashboard/test/models/product_test.rb
+++ b/apps/dashboard/test/models/product_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ProductTest < ActiveSupport::TestCase
+  test 'update fails when manifest cannot be saved' do
+    Dir.mktmpdir do |dir|
+      base = Pathname.new(dir)
+      app_dir = base.join('myapp')
+      app_dir.mkpath
+      manifest = app_dir.join('manifest.yml')
+      manifest.write("---\nname: Old\n")
+
+      DevRouter.stubs(:base_path).returns(base)
+      File.chmod(0o444, manifest)
+
+      product = DevProduct.new(name: 'myapp', found: true, title: 'New', description: 'desc', icon: 'fas://cog')
+
+      refute product.update(title: 'Newer', description: 'desc')
+      assert product.errors[:base].present?
+      assert_equal 'Old', Manifest.load(manifest).name
+    ensure
+      File.chmod(0o644, manifest) if defined?(manifest) && manifest.exist?
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5468

Product manifest save failures were still being treated as successful updates and never surfaced back to the UI

- Updated Product#write_manifest to check manifest.save return values and add errors when saves fail
- Added alert messaging in the products controller so manifest save errors show up on the edit page
- Added a test case covering manifest save failures to ensure updates fail and errors are attached