### PR TITLE
Add overwrite warning for duplicate file uploads (#2679)

### DIFF
--- a/apps/dashboard/app/javascript/files/sweet_alert.js
+++ b/apps/dashboard/app/javascript/files/sweet_alert.js
@@ -82,7 +82,7 @@ function attachOKHandler(options) {
     }
 
     input.value = '';
-    $('#files_input_modal').modal('hide');
+    $(MODAL_ID).modal('hide');
   };
 }
 
@@ -114,8 +114,14 @@ function resetUploadOverwriteModal() {
 
   const span = document.getElementById('files_input_modal_text_span');
   if (span) {
-    span.textContent = '';
+    span.replaceChildren();
   }
+}
+
+function hideUploadOverwriteModal() {
+  resetUploadOverwriteModal();
+  $(MODAL_ID).modal('hide');
+  cleanupBootstrapModalStack();
 }
 
 function setUploadOverwriteContent(modalElement, titleElement, spanElement, conflictingFilenames) {
@@ -189,19 +195,16 @@ function showUploadOverwriteModal(conflictingFilenames) {
       }
 
       cleanup();
-      resetUploadOverwriteModal();
-      $(MODAL_ID).modal('hide');
-      cleanupBootstrapModalStack();
+      hideUploadOverwriteModal();
       resolve(true);
     };
 
     uploadOverwriteHiddenHandler = () => {
       cleanup();
-      resetUploadOverwriteModal();
-      cleanupBootstrapModalStack();
+      hideUploadOverwriteModal();
 
       if (!continued) {
-        reject(new Error('Upload cancelled'));
+        reject();
       }
     };
 
@@ -220,7 +223,7 @@ export function confirmUploadOverwrite(conflictingFilenames) {
     return Promise.resolve(true);
   }
 
-  return showUploadOverwriteModal(conflictingFilenames);
+  return showUploadOverwriteModal(conflictingFilenames).then(() => true, () => false);
 }
 
 jQuery(function() {

--- a/apps/dashboard/app/javascript/files/sweet_alert.js
+++ b/apps/dashboard/app/javascript/files/sweet_alert.js
@@ -1,6 +1,5 @@
 import {CONTENTID, EVENTNAME as DATATABLE_EVENTNAME} from './data_table.js';
-import { pageSpin, stopPageSpin } from '../utils';
-
+import { pageSpin, stopPageSpin, getBoolean, storeBoolean } from '../utils';
 export {EVENTNAME};
 
 const EVENTNAME = {
@@ -9,9 +8,24 @@ const EVENTNAME = {
   closeSwal: 'closeSwal',
 }
 
-let sweetAlert = null;
+const UPLOAD_OVERWRITE_STORAGE_KEY = 'files-upload-overwrite-warning-disabled';
+const MODAL_ID = '#files_input_modal';
+
+let uploadOverwriteOkHandler = null;
+let uploadOverwriteHiddenHandler = null;
+
+function cleanupBootstrapModalStack() {
+  document.querySelectorAll('.modal-backdrop').forEach((backdrop) => {
+    backdrop.remove();
+  });
+  document.body.classList.remove('modal-open');
+  document.body.style.removeProperty('overflow');
+  document.body.style.removeProperty('padding-right');
+}
 
 function modifyInput(options) {
+  resetUploadOverwriteModal();
+
   const title = options.inputOptions.title;
   const titleElement = document.getElementById('files_input_modal_title');
   titleElement.textContent = title;
@@ -70,6 +84,143 @@ function attachOKHandler(options) {
     input.value = '';
     $('#files_input_modal').modal('hide');
   };
+}
+
+function resetUploadOverwriteModal() {
+  const modalElement = document.getElementById('files_input_modal');
+  const okButton = document.getElementById('files_input_modal_ok_button');
+  const neverShowWrapper = document.getElementById('files_input_modal_never_show_wrapper');
+  const neverShowCheckbox = document.getElementById('files_input_modal_never_show');
+
+  if (neverShowWrapper) {
+    neverShowWrapper.classList.add('d-none');
+  }
+  
+  if (neverShowCheckbox) {
+    neverShowCheckbox.checked = false;
+  }
+  okButton.onclick = null;
+  okButton.textContent = modalElement.dataset.defaultOkLabel || okButton.textContent;
+
+  if (uploadOverwriteOkHandler) {
+    okButton.removeEventListener('click', uploadOverwriteOkHandler);
+    uploadOverwriteOkHandler = null;
+  }
+
+  if (uploadOverwriteHiddenHandler) {
+    modalElement.removeEventListener('hidden.bs.modal', uploadOverwriteHiddenHandler);
+    uploadOverwriteHiddenHandler = null;
+  }
+
+  const span = document.getElementById('files_input_modal_text_span');
+  if (span) {
+    span.textContent = '';
+  }
+}
+
+function setUploadOverwriteContent(modalElement, titleElement, spanElement, conflictingFilenames) {
+  const dataset = modalElement.dataset;
+
+  if (conflictingFilenames.length === 1) {
+    titleElement.textContent = dataset.uploadOverwriteTitle;
+    spanElement.textContent = dataset.uploadOverwriteMessageSingle.replace('%{filename}', conflictingFilenames[0]);
+    return;
+  }
+
+  titleElement.textContent = dataset.uploadOverwriteTitleMultiple;
+  spanElement.textContent = '';
+
+  spanElement.appendChild(document.createTextNode(`${dataset.uploadOverwriteMessageMultiple}:`));
+
+  const list = document.createElement('ul');
+  list.className = 'mb-0 mt-2';
+
+  conflictingFilenames.forEach((filename) => {
+    const item = document.createElement('li');
+    item.textContent = filename;
+    list.appendChild(item);
+  });
+
+  spanElement.appendChild(list);
+}
+
+function showUploadOverwriteModal(conflictingFilenames) {
+  resetUploadOverwriteModal();
+
+  const modalElement = document.getElementById('files_input_modal');
+  const titleElement = document.getElementById('files_input_modal_title');
+  const wrapper = document.getElementById('files_input_modal_input_wrapper');
+  const span = document.getElementById('files_input_modal_text_span');
+  const neverShowWrapper = document.getElementById('files_input_modal_never_show_wrapper');
+  const neverShowCheckbox = document.getElementById('files_input_modal_never_show');
+  const okButton = document.getElementById('files_input_modal_ok_button');
+
+  if (!modalElement.dataset.defaultOkLabel) {
+    modalElement.dataset.defaultOkLabel = okButton.textContent;
+  }
+
+  setUploadOverwriteContent(modalElement, titleElement, span, conflictingFilenames);
+  wrapper.classList.add('d-none');
+  if (neverShowWrapper) {
+    neverShowWrapper.classList.remove('d-none');
+  }
+  okButton.textContent = modalElement.dataset.uploadOverwriteContinue;
+
+  return new Promise((resolve, reject) => {
+    let continued = false;
+
+    const cleanup = () => {
+      if (uploadOverwriteOkHandler) {
+        okButton.removeEventListener('click', uploadOverwriteOkHandler);
+        uploadOverwriteOkHandler = null;
+      }
+
+      if (uploadOverwriteHiddenHandler) {
+        modalElement.removeEventListener('hidden.bs.modal', uploadOverwriteHiddenHandler);
+        uploadOverwriteHiddenHandler = null;
+      }
+    };
+
+    uploadOverwriteOkHandler = () => {
+      continued = true;
+
+      if (neverShowCheckbox.checked) {
+        storeBoolean(UPLOAD_OVERWRITE_STORAGE_KEY, true);
+      }
+
+      cleanup();
+      resetUploadOverwriteModal();
+      $(MODAL_ID).modal('hide');
+      cleanupBootstrapModalStack();
+      resolve(true);
+    };
+
+    uploadOverwriteHiddenHandler = () => {
+      cleanup();
+      resetUploadOverwriteModal();
+      cleanupBootstrapModalStack();
+
+      if (!continued) {
+        reject(new Error('Upload cancelled'));
+      }
+    };
+
+    okButton.addEventListener('click', uploadOverwriteOkHandler);
+    modalElement.addEventListener('shown.bs.modal', () => {
+      modalElement.addEventListener('hidden.bs.modal', uploadOverwriteHiddenHandler, { once: true });
+    }, { once: true });
+
+    $(MODAL_ID).modal('show');
+    okButton.focus();
+  });
+}
+
+export function confirmUploadOverwrite(conflictingFilenames) {
+  if (getBoolean(UPLOAD_OVERWRITE_STORAGE_KEY) || conflictingFilenames.length === 0) {
+    return Promise.resolve(true);
+  }
+
+  return showUploadOverwriteModal(conflictingFilenames);
 }
 
 jQuery(function() {

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import {CONTENTID, EVENTNAME as DATATABLE_EVENTNAME} from './data_table.js';
 import { maxFileSize, csrfToken, uppyLocale } from '../config.js';
 import { fileOps } from './file_ops.js';
+import { confirmUploadOverwrite } from './sweet_alert.js';
 
 let uppy = null;
 
@@ -80,7 +81,6 @@ jQuery(function() {
     restrictions: {
       maxFileSize: maxFileSize(),
     },
-    onBeforeUpload: updateEndpoint,
     locale: uppyLocale(),
   });
   
@@ -105,6 +105,8 @@ jQuery(function() {
     headers: { 'X-CSRF-Token': csrfToken() },
     timeout: 128 * 1000,
   });
+
+  document.addEventListener('click', interceptUppyUploadClick, true);
 
   uppy.on('file-added', (file) => {
     uppy.setFileMeta(file.id, { parent: history.state.currentDirectory });
@@ -183,6 +185,58 @@ function getEmptyDirs(entry){
       })
     }
   });
+}
+
+async function interceptUppyUploadClick(event) {
+  if (!uppy) {
+    return;
+  }
+
+  const uploadBtn = event.target.closest('.uppy-StatusBar-actionBtn--upload');
+  if (!uploadBtn || !uploadBtn.closest('.uppy-Dashboard')) {
+    return;
+  }
+
+  if (uppy.getFiles().length === 0) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+
+  updateEndpoint();
+
+  try {
+    await confirmUploadOverwrite(conflictingUploadNames(uppy.getFiles()));
+    uppy.upload();
+  } catch (_error) {
+    // User cancelled the overwrite warning; upload was never started.
+  }
+}
+
+function conflictingUploadNames(files) {
+  const listing = history.state.currentFilenames;
+  if (!Array.isArray(listing)) {
+    return [];
+  }
+
+  return files
+    .map(uploadNameInCurrentDirectory)
+    .filter((name) => name && listing.includes(name));
+}
+
+function uploadNameInCurrentDirectory(file) {
+  const relativePath = file.meta.relativePath;
+  if (relativePath && relativePath !== 'null') {
+    if (relativePath.includes('/')) {
+      return null;
+    }
+
+    return relativePath;
+  }
+
+  return file.name;
 }
 
 function updateEndpoint() {

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -106,6 +106,7 @@ jQuery(function() {
     timeout: 128 * 1000,
   });
 
+  // Intercept before Uppy handles Upload so we can confirm overwrites without starting an upload batch
   document.addEventListener('click', interceptUppyUploadClick, true);
 
   uppy.on('file-added', (file) => {
@@ -207,11 +208,8 @@ async function interceptUppyUploadClick(event) {
 
   updateEndpoint();
 
-  try {
-    await confirmUploadOverwrite(conflictingUploadNames(uppy.getFiles()));
+  if (await confirmUploadOverwrite(conflictingUploadNames(uppy.getFiles()))) {
     uppy.upload();
-  } catch (_error) {
-    // User cancelled the overwrite warning; upload was never started.
   }
 }
 

--- a/apps/dashboard/app/views/files/_input_modal.html.erb
+++ b/apps/dashboard/app/views/files/_input_modal.html.erb
@@ -1,6 +1,9 @@
-
-
-<div class="modal" id="files_input_modal" tabindex="-1" aria-labelledby="files_input_modal_title" aria-hidden="true">
+<div class="modal" id="files_input_modal" tabindex="-1" aria-labelledby="files_input_modal_title" aria-hidden="true"
+  data-upload-overwrite-title="<%= t('dashboard.files_upload_overwrite_title') %>"
+  data-upload-overwrite-title-multiple="<%= t('dashboard.files_upload_overwrite_title_multiple') %>"
+  data-upload-overwrite-message-single="<%= t('dashboard.files_upload_overwrite_message_single') %>"
+  data-upload-overwrite-message-multiple="<%= t('dashboard.files_upload_overwrite_message_multiple') %>"
+  data-upload-overwrite-continue="<%= t('dashboard.files_upload_overwrite_continue') %>">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <form method="dialog">
@@ -14,6 +17,12 @@
           <input id="files_input_modal_input" class="form-control">
         </div>
         <span id="files_input_modal_text_span"></span>
+        <div id="files_input_modal_never_show_wrapper" class="form-check d-none">
+          <input class="form-check-input" type="checkbox" id="files_input_modal_never_show">
+          <label class="form-check-label" for="files_input_modal_never_show">
+            <%= t('dashboard.files_upload_overwrite_never_show') %>
+          </label>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><%= t('dashboard.close') %></button>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -165,6 +165,12 @@ en:
     files_shell: Open in Terminal
     files_shell_dropdown: Select Cluster to Open in Terminal
     files_title: File browsing
+    files_upload_overwrite_title: File already exists
+    files_upload_overwrite_title_multiple: Files already exist
+    files_upload_overwrite_message_single: "%{filename} already exists. The previous file will be overwritten."
+    files_upload_overwrite_message_multiple: The following files already exist and will be overwritten
+    files_upload_overwrite_never_show: Never show this warning again
+    files_upload_overwrite_continue: Upload
     files_doesnt_exist: "%{path} does not exist."
     files_not_readable: "You do not have sufficient permissions to read '%{path}'."
     home_directory: Home Directory

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -358,13 +358,15 @@ class FilesTest < ApplicationSystemTestCase
       FileUtils.mkpath File.join(dir, 'foo')
 
       visit files_url(dir)
-      find('#upload-btn').click
+      find('tbody a', exact_text: 'foo', wait: MAX_WAIT)
 
+      find('#upload-btn').click
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
 
       src_file = 'test/fixtures/files/upload/osc-logo.png'
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
       find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
       assert File.exist?(File.join(dir, File.basename(src_file)))
 
@@ -378,11 +380,13 @@ class FilesTest < ApplicationSystemTestCase
       src_file = 'test/fixtures/files/upload/hello-world.c'
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
       find('tbody a', exact_text: 'hello-world.c', wait: MAX_WAIT)
     end
   end
 
   test 'uploading duplicate files' do
+    page.execute_script("localStorage.removeItem('files-upload-overwrite-warning-disabled')")
     Dir.mktmpdir do |dir|
       File.stubs(:umask).returns(18) # ensure default umask is 644
       upload_dir = File.join(dir, 'upload')
@@ -393,11 +397,15 @@ class FilesTest < ApplicationSystemTestCase
       `echo 'here some initial content' > #{src_file}`
 
       visit files_url(upload_dir)
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
+      assert_no_selector 'tbody a', exact_text: File.basename(src_file)
+
       find('#upload-btn').click
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
 
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
       find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
       assert File.exist?(upload_file)
       assert_equal File.read(src_file), File.read(upload_file)
@@ -415,12 +423,49 @@ class FilesTest < ApplicationSystemTestCase
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_selector '#files_input_modal', visible: true, wait: MAX_WAIT
+      assert_text 'testfile.sh already exists. The previous file will be overwritten.'
+      find('#files_input_modal_ok_button').click
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
       find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
 
       # and it's still there, now with new content and it keeps the 755 permissions
       assert File.exist?(upload_file)
       assert_equal File.read(src_file), File.read(upload_file)
       assert_equal File.stat(upload_file).mode, 33_261 # still 755
+    end
+  end
+
+  test 'upload overwrite warning can be disabled' do
+    page.execute_script("localStorage.removeItem('files-upload-overwrite-warning-disabled')")
+
+    Dir.mktmpdir do |dir|
+      upload_dir = File.join(dir, 'upload')
+      FileUtils.mkpath(upload_dir)
+
+      src_file = 'test/fixtures/files/upload/osc-logo.png'
+      FileUtils.cp(src_file, File.join(upload_dir, File.basename(src_file)))
+
+      visit files_url(upload_dir)
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
+
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      attach_file 'files[]', src_file, visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_selector '#files_input_modal', visible: true, wait: MAX_WAIT
+      check 'Never show this warning again'
+      find('#files_input_modal_ok_button').click
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      attach_file 'files[]', src_file, visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_no_selector '#files_input_modal', visible: true, wait: 5
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
     end
   end
 

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -436,6 +436,41 @@ class FilesTest < ApplicationSystemTestCase
     end
   end
 
+  test 'uploading multiple duplicate files shows overwrite list' do
+    page.execute_script("localStorage.removeItem('files-upload-overwrite-warning-disabled')")
+
+    Dir.mktmpdir do |dir|
+      upload_dir = File.join(dir, 'upload')
+      FileUtils.mkpath(upload_dir)
+
+      file1 = 'test/fixtures/files/upload/hello-world.c'
+      file2 = 'test/fixtures/files/upload/funny_characters.sh'
+      FileUtils.cp(file1, File.join(upload_dir, File.basename(file1)))
+      FileUtils.cp(file2, File.join(upload_dir, File.basename(file2)))
+
+      visit files_url(upload_dir)
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
+
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      attach_file 'files[]', [file1, file2], visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+
+      assert_selector '#files_input_modal', visible: true, wait: MAX_WAIT
+      assert_text 'Files already exist'
+      assert_text 'The following files already exist and will be overwritten:'
+      within '#files_input_modal' do
+        assert_selector 'li', exact_text: 'hello-world.c'
+        assert_selector 'li', exact_text: 'funny_characters.sh'
+      end
+
+      find('#files_input_modal_ok_button').click
+      assert_selector '#directory-contents', visible: true, wait: MAX_WAIT
+      find('tbody a', exact_text: 'hello-world.c', wait: MAX_WAIT)
+      find('tbody a', exact_text: 'funny_characters.sh', wait: MAX_WAIT)
+    end
+  end
+
   test 'upload overwrite warning can be disabled' do
     page.execute_script("localStorage.removeItem('files-upload-overwrite-warning-disabled')")
 


### PR DESCRIPTION
Fixes #2679

Uploading a file with the same name as an existing file had no warning, so files could be overwritten without users realizing it

- Added an overwrite confirmation before uploads start with single and multi-file messaging plus a "never show again" option stored in localStorage
- Intercepted the upload button click instead of using a pre-upload hook so canceling the warning does not leave uploads in a failed state
- Added system tests covering single file overwrite warnings, multi file overwrite warnings, and disabling the warning