### PR TITLE
Fix double encoding of spaces in Files app edit URLs (#5474)

### DIFF
--- a/apps/dashboard/app/helpers/files_helper.rb
+++ b/apps/dashboard/app/helpers/files_helper.rb
@@ -1,6 +1,6 @@
 # Helper for /files pages.
 
-require 'uri'
+require 'cgi'
 
 module FilesHelper
   include ApplicationHelper
@@ -40,7 +40,12 @@ module FilesHelper
   end
 
   def url_encode_path(path)
-    path.to_s.split('/').map { |seg| ERB::Util.url_encode(seg.to_s) }.join('/')
+    path.to_s.split('/').map do |seg|
+      next seg if seg.empty?
+
+      raw = seg.include?('%') ? CGI.unescape(seg.to_s) : seg.to_s
+      ERB::Util.url_encode(raw)
+    end.join('/')
   end
 
   def url_encode_url_path(url)

--- a/apps/dashboard/test/helpers/files_helper_test.rb
+++ b/apps/dashboard/test/helpers/files_helper_test.rb
@@ -34,4 +34,10 @@ end
     expected_link = "<a target=\"_top\" class=\"btn btn-primary btn-sm files-button\" href=\"/files/fs/blargh/cat_videos/projects/path/to/file\">Open in files app</a>"
     assert_equal(expected_link, files_button(path)) 
   end
+
+  test 'url_encode_url_path encodes hash without double encoding OodAppkit paths' do
+    editor_url = '/files/edit/fs/home/A%20B/bstepanovski#foo.txt#'
+    expected = '/files/edit/fs/home/A%20B/bstepanovski%23foo.txt%23'
+    assert_equal(expected, url_encode_url_path(editor_url))
+  end
 end

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -894,6 +894,28 @@ class FilesTest < ApplicationSystemTestCase
     end
   end
 
+  test 'filenames with spaces in path are url-escaped once for edit' do
+    OodAppkit.stubs(:files).returns(OodAppkit::Urls::Files.new(title: 'Files', base_url: '/files'))
+    OodAppkit.stubs(:editor).returns(OodAppkit::Urls::Editor.new(title: 'Editor', base_url: '/files'))
+
+    Dir.mktmpdir do |dir|
+      spaced_dir = File.join(dir, 'A B')
+      FileUtils.mkdir_p(spaced_dir)
+      name = 'test'
+      FileUtils.touch(File.join(spaced_dir, name))
+
+      visit files_url(spaced_dir)
+
+      row = find('tbody a', exact_text: name).ancestor('tr')
+
+      row.find('button.dropdown-toggle').click
+      href = row.find('a.edit-file')[:href]
+
+      assert_includes href, '%20'
+      refute_includes href, '%2520'
+    end
+  end
+  
   test 'will not render HTML files by default' do
     data = <<-HEREDOC
     <html>


### PR DESCRIPTION
Fixes #5474

Files with spaces in their path could not be edited because already encoded paths were being encoded a second time in edit URLs
- Updated url_encode_url_path to decode already encoded segments before re-encoding so spaces are handled correctly while still escaping # in hrefs
- Added helper and system test coverage for editing files in directories with spaces in the path