### PR TITLE
Fix: Workflow#save passes I18n key as string literal instead of calling I18n.t

### DIFF
--- a/apps/dashboard/app/models/workflow.rb
+++ b/apps/dashboard/app/models/workflow.rb
@@ -84,7 +84,7 @@ class Workflow
     return false unless valid?(:create)
 
     if @project_dir.empty?
-      errors.add(:save, "I18n.t('dashboard.jobs_project_directory_error')")
+      errors.add(:save, I18n.t('dashboard.jobs_project_directory_error'))
       return false
     end
 

--- a/apps/dashboard/test/models/workflow_test.rb
+++ b/apps/dashboard/test/models/workflow_test.rb
@@ -15,6 +15,12 @@ class WorkflowsTest < ActiveSupport::TestCase
     assert_equal '0', workflow.sync_key_enabled
   end
 
+  test 'save without project_dir returns translated error message' do
+    workflow = Workflow.new(name: 'test', launcher_ids: ['sample'])
+    assert_not workflow.save
+    assert_equal I18n.t('dashboard.jobs_project_directory_error'), workflow.errors[:save].first
+  end
+
   test 'create workflow validation' do
     Dir.mktmpdir do |tmp|
       # add error in workflow save if project_dir is not valid
@@ -66,7 +72,7 @@ class WorkflowsTest < ActiveSupport::TestCase
         launcher_ids: ['sample']
       )
 
-      assert workflow.errors.inspect
+      assert_empty workflow.errors
       assert Dir.entries("#{project_dir}/.ondemand/workflows").include?("#{workflow_id}.yml")
       assert_equal workflow_id,          workflow.id
       assert_equal 'MyLocalName',        workflow.name
@@ -86,7 +92,7 @@ class WorkflowsTest < ActiveSupport::TestCase
         sync_key_enabled: '1'
       )
 
-      assert workflow.errors.inspect
+      assert_empty workflow.errors
       manifest_file = Pathname.new("#{project_dir}/.ondemand/workflows/#{workflow.id}.yml")
       assert_equal manifest_file, workflow.manifest_file
       assert File.file?(manifest_file)


### PR DESCRIPTION
The `Workflow#save` guards against a nil `project_dir` by adding an error and returning early.
The error message was passed as a string literal containing the I18n method call rather
than invoking it:

```ruby
# Before
errors.add(:save, "I18n.t('dashboard.jobs_project_directory_error')")

# After
errors.add(:save, I18n.t('dashboard.jobs_project_directory_error'))
```

The `WorkflowsController` always provides `project_dir` via `permit_params`, so this guard
only fires outside the normal controller flow, for direct model instantiation, rails console,
or API usage without a project context. In those cases the error bubbles up through
`handle_workflow_error` → `collect_errors`, producing the flash message:

> "There was an error processing your request: I18n.t('dashboard.jobs_project_directory_error')"

instead of the translated string "Project directory path is not set for this workflow".

**Changes**

- `app/models/workflow.rb` — call `I18n.t` instead of quoting it as a string
- `test/models/workflow_test.rb`
  - Add test asserting that `save` without `project_dir` returns the translated error message
  - Fix two pre-existing assertions that were silently passing regardless of error state: `assert workflow.errors.inspect` → `assert_empty workflow.errors`