### PR TITLE
Rename test_ helper methods to avoid spurious no-assertion warnings

### DIFF
--- a/apps/dashboard/test/integration/dashboard_layout_test.rb
+++ b/apps/dashboard/test/integration/dashboard_layout_test.rb
@@ -17,7 +17,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
     Router.instance_variable_set('@pinned_apps', nil)
   end
 
-  def test_env
+  def env_config
     {
       MOTD_FORMAT:    'osc',
       MOTD_PATH:      Rails.root.join('test/fixtures/files/motd_valid').to_s,
@@ -88,7 +88,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
                               }
                             })
 
-    with_modified_env(test_env) do
+    with_modified_env(env_config) do
       get '/'
     end
 
@@ -121,7 +121,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
                               }
                             })
 
-    with_modified_env(test_env) do
+    with_modified_env(env_config) do
       get '/'
     end
 
@@ -215,7 +215,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
                               }
                             })
 
-    with_modified_env(test_env) do
+    with_modified_env(env_config) do
       get '/'
     end
 
@@ -265,7 +265,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
                               }
                             })
 
-    with_modified_env(test_env) do
+    with_modified_env(env_config) do
       get '/'
     end
 
@@ -299,7 +299,7 @@ class DashboardLayoutTest < ActionDispatch::IntegrationTest
                               }
                             })
 
-    with_modified_env(test_env) do
+    with_modified_env(env_config) do
       get '/'
     end
 

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -11,7 +11,7 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     stub_sys_apps
   end
 
-  def session_data(token: 'sys/bc_paraview', title: 'Paraview')
+  def fixture_session_data(token: 'sys/bc_paraview', title: 'Paraview')
     {
       'id':              fixture_bc_id,
       'cluster_id':      'owens',
@@ -34,7 +34,7 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
 
   def create_test_file(dir, token: 'sys/bc_paraview', title: 'Paraview')
     BatchConnect::Session.stubs(:db_root).returns(Pathname.new(dir))
-    File.write("#{dir}/#{fixture_bc_id}", session_data(token: token, title: title).to_json)
+    File.write("#{dir}/#{fixture_bc_id}", fixture_session_data(token: token, title: title).to_json)
   end
 
   def stub_scheduler(state, cores: 1, nodes: 1)

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -11,11 +11,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     stub_sys_apps
   end
 
-  def test_data(token: 'sys/bc_paraview', title: 'Paraview')
+  def session_data(token: 'sys/bc_paraview', title: 'Paraview')
     {
-      'id':              test_bc_id,
+      'id':              bc_id,
       'cluster_id':      'owens',
-      "job_id":          test_job_id,
+      "job_id":          job_id,
       "created_at":      1_701_184_869,
       "token":           token,
       "title":           title,
@@ -24,22 +24,22 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     }
   end
 
-  def test_job_id
+  def job_id
     '1234'
   end
 
-  def test_bc_id
+  def bc_id
     'abc-123'
   end
 
   def create_test_file(dir, token: 'sys/bc_paraview', title: 'Paraview')
     BatchConnect::Session.stubs(:db_root).returns(Pathname.new(dir))
-    File.write("#{dir}/#{test_bc_id}", test_data(token: token, title: title).to_json)
+    File.write("#{dir}/#{bc_id}", session_data(token: token, title: title).to_json)
   end
 
   def stub_scheduler(state, cores: 1, nodes: 1)
     info = OodCore::Job::Info.new(
-      id: test_job_id, status: state.to_sym, procs: cores.to_i, 
+      id: job_id, status: state.to_sym, procs: cores.to_i, 
       allocated_nodes: Array.new(nodes.to_i, { name: 'foo', features: [] })
     )
     OodCore::Job::Adapters::Slurm.any_instance.stubs(:info).returns(info)
@@ -57,11 +57,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:queued)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Paraview (#{test_job_id})\nQueued", header_text)
+      assert_equal("Paraview (#{job_id})\nQueued", header_text)
     end
   end
 
@@ -71,11 +71,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:completed)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{test_job_id})\nCompleted | |", header_text)
+      assert_equal("Jupyter (#{job_id})\nCompleted | |", header_text)
     end
   end
 
@@ -85,11 +85,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:completed)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Paraview (#{test_job_id})\nCompleted | |", header_text)
+      assert_equal("Paraview (#{job_id})\nCompleted | |", header_text)
 
       completed_text = card.find('#completed_test_div').text
       assert_equal('This is a test message for a completed view.', completed_text)
@@ -102,11 +102,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{test_job_id})\n1 node | 1 core | Starting", header_text)
+      assert_equal("Jupyter (#{job_id})\n1 node | 1 core | Starting", header_text)
     end
   end
 
@@ -116,11 +116,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Paraview (#{test_job_id})\n1 node | 1 core | Starting", header_text)
+      assert_equal("Paraview (#{job_id})\n1 node | 1 core | Starting", header_text)
 
       info_text = card.find("#info_test_div").text
       assert_equal('This is a test message for an info view.', info_text)
@@ -133,11 +133,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 0, cores: 0)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{test_job_id})\nStarting", header_text)
+      assert_equal("Jupyter (#{job_id})\nStarting", header_text)
     end
   end
 
@@ -147,11 +147,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 0, cores: 1)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{test_job_id})\n1 core | Starting", header_text)
+      assert_equal("Jupyter (#{job_id})\n1 core | Starting", header_text)
     end
   end
 
@@ -161,11 +161,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 0, cores: 1)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{test_job_id})\n1 core | Starting", header_text)
+      assert_equal("Jupyter (#{job_id})\n1 core | Starting", header_text)
     end
   end
 
@@ -175,11 +175,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 2, cores: 2)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{test_bc_id}")
+      card = find("#id_#{bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{test_job_id})\n2 nodes | 2 cores | Starting", header_text)
+      assert_equal("Jupyter (#{job_id})\n2 nodes | 2 cores | Starting", header_text)
     end
   end
 end

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -13,9 +13,9 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
 
   def session_data(token: 'sys/bc_paraview', title: 'Paraview')
     {
-      'id':              bc_id,
+      'id':              fixture_bc_id,
       'cluster_id':      'owens',
-      "job_id":          job_id,
+      "fixture_job_id":          fixture_job_id,
       "created_at":      1_701_184_869,
       "token":           token,
       "title":           title,
@@ -24,22 +24,22 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     }
   end
 
-  def job_id
+  def fixture_job_id
     '1234'
   end
 
-  def bc_id
+  def fixture_bc_id
     'abc-123'
   end
 
   def create_test_file(dir, token: 'sys/bc_paraview', title: 'Paraview')
     BatchConnect::Session.stubs(:db_root).returns(Pathname.new(dir))
-    File.write("#{dir}/#{bc_id}", session_data(token: token, title: title).to_json)
+    File.write("#{dir}/#{fixture_bc_id}", session_data(token: token, title: title).to_json)
   end
 
   def stub_scheduler(state, cores: 1, nodes: 1)
     info = OodCore::Job::Info.new(
-      id: job_id, status: state.to_sym, procs: cores.to_i, 
+      id: fixture_job_id, status: state.to_sym, procs: cores.to_i, 
       allocated_nodes: Array.new(nodes.to_i, { name: 'foo', features: [] })
     )
     OodCore::Job::Adapters::Slurm.any_instance.stubs(:info).returns(info)
@@ -57,11 +57,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:queued)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Paraview (#{job_id})\nQueued", header_text)
+      assert_equal("Paraview (#{fixture_job_id})\nQueued", header_text)
     end
   end
 
@@ -71,11 +71,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:completed)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{job_id})\nCompleted | |", header_text)
+      assert_equal("Jupyter (#{fixture_job_id})\nCompleted | |", header_text)
     end
   end
 
@@ -85,11 +85,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:completed)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Paraview (#{job_id})\nCompleted | |", header_text)
+      assert_equal("Paraview (#{fixture_job_id})\nCompleted | |", header_text)
 
       completed_text = card.find('#completed_test_div').text
       assert_equal('This is a test message for a completed view.', completed_text)
@@ -102,11 +102,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{job_id})\n1 node | 1 core | Starting", header_text)
+      assert_equal("Jupyter (#{fixture_job_id})\n1 node | 1 core | Starting", header_text)
     end
   end
 
@@ -116,11 +116,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Paraview (#{job_id})\n1 node | 1 core | Starting", header_text)
+      assert_equal("Paraview (#{fixture_job_id})\n1 node | 1 core | Starting", header_text)
 
       info_text = card.find("#info_test_div").text
       assert_equal('This is a test message for an info view.', info_text)
@@ -133,11 +133,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 0, cores: 0)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{job_id})\nStarting", header_text)
+      assert_equal("Jupyter (#{fixture_job_id})\nStarting", header_text)
     end
   end
 
@@ -147,11 +147,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 0, cores: 1)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{job_id})\n1 core | Starting", header_text)
+      assert_equal("Jupyter (#{fixture_job_id})\n1 core | Starting", header_text)
     end
   end
 
@@ -161,11 +161,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 0, cores: 1)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{job_id})\n1 core | Starting", header_text)
+      assert_equal("Jupyter (#{fixture_job_id})\n1 core | Starting", header_text)
     end
   end
 
@@ -175,11 +175,11 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       stub_scheduler(:running, nodes: 2, cores: 2)
       visit(batch_connect_sessions_path)
 
-      card = find("#id_#{bc_id}")
+      card = find("#id_#{fixture_bc_id}")
       assert_not_nil(card)
 
       header_text = card.find('.h5').text
-      assert_equal("Jupyter (#{job_id})\n2 nodes | 2 cores | Starting", header_text)
+      assert_equal("Jupyter (#{fixture_job_id})\n2 nodes | 2 cores | Starting", header_text)
     end
   end
 end


### PR DESCRIPTION
Part of #5249.

Rails 7.2 warns when a test method runs with no assertions. Minitest treats any public method starting with `test` as a test case — so helper methods used to build fixture data were being picked up and run as empty tests.

**`batch_connect_sessions_test.rb`**
- `test_data` → `fixture_session_data`
- `test_job_id` → `fixture_job_id`
- `test_bc_id` → `fixture_bc_id`

**`dashboard_layout_test.rb`**
- `test_env` → `env_config`

All call sites updated. No logic changes.