### PR TITLE
(4.2 Backport) Bump faraday from 2.14.1 to 2.14.2 in apps/dashboard

### DIFF
--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     excon (1.4.2)
       logger
     execjs (2.10.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
Based off of #5472, which was resolved by weekly updates on master. This PR was generated by running `bundle update faraday --conservative` on the `release_4.2` branch, yielding the same result as the original PR to master.