### PR TITLE
Add path assertions to ProductsUsrTest to fix no-assertion warnings

### DIFF
--- a/apps/dashboard/test/system/products_usr_test.rb
+++ b/apps/dashboard/test/system/products_usr_test.rb
@@ -18,9 +18,11 @@ class ProductsUsrTest < ApplicationSystemTestCase
   test 'Index of my_shared_app can be accessed' do
     UsrRouter.stubs(:base_path).returns(Pathname.new('test/fixtures/usr/me'))
     visit products_path(:usr)
+    assert_equal products_path(:usr), current_path
   end
 
   test 'Show of my_shared_app url can be accessed' do
     visit product_path(:usr, 'my_shared_app')
+    assert_equal product_path(:usr, 'my_shared_app'), current_path
   end
 end


### PR DESCRIPTION
Part of #5249.

Both tests in `ProductsUsrTest` verified page accessibility using `visit` alone. In Rails 7.2, `visit` does not register as an assertion, so these tests produced "this test has no assertions" warnings.

Adding `assert_equal current_path` after each `visit` confirms the page loaded without redirect — which is what "can be accessed" means.

```ruby
# Before
visit products_path(:usr)

# After
visit products_path(:usr)
assert_equal products_path(:usr), current_path
```

This pattern matches the existing usage in `products_dev_test.rb`.
