### PR TITLE
(4.2 Backport) Normalize dynamic batch connect tokens with underscores (#5462)

### DIFF
--- a/apps/dashboard/app/lib/account_cache.rb
+++ b/apps/dashboard/app/lib/account_cache.rb
@@ -45,7 +45,7 @@ module AccountCache
         invalid_clusters = job_cluster_names - valid_clusters
 
         data = invalid_clusters.map do |invalid_cluster|
-          ["data-option-for-cluster-#{invalid_cluster}", false]
+          ["data-option-for-cluster-#{invalid_cluster.tr('_', '-')}", false]
         end.compact.to_h
 
         [account_name, account_name, data]
@@ -67,9 +67,10 @@ module AccountCache
         end
 
         cluster_data = other_clusters.map do |other_cluster|
+          cluster_token = other_cluster.tr('_', '-')
           [
-            ["data-option-for-cluster-#{other_cluster}", false],
-            ["data-option-for-auto-batch-clusters-#{other_cluster}", false]
+            ["data-option-for-cluster-#{cluster_token}", false],
+            ["data-option-for-auto-batch-clusters-#{cluster_token}", false]
           ]
         end.flatten(1).to_h
 
@@ -108,7 +109,7 @@ module AccountCache
         unavailable_clusters = clusters.reject { |c| available_clusters.include?(c) }
 
         unavailable_clusters.each do |cluster|
-          data["data-option-for-cluster-#{cluster}"] = false
+          data["data-option-for-cluster-#{cluster.tr('_', '-')}"] = false
         end
 
         available_accounts = account_tuples.map { |tuple| tuple[0] }.uniq

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_modules.rb
@@ -61,7 +61,7 @@ module SmartAttributes
       def hpc_versions
         HpcModule.all_versions(@hpc_module).map do |mod|
           data_opts = Configuration.job_clusters.map do |cluster|
-            { "data-option-for-cluster-#{cluster.id}": false } unless mod.on_cluster?(cluster.id)
+            { "data-option-for-cluster-#{cluster.id.to_s.tr('_', '-')}" => false } unless mod.on_cluster?(cluster.id)
           end.compact
 
           [mod.version, mod.to_s].concat(data_opts)

--- a/apps/dashboard/test/lib/smart_attributes/auto_accounts_test.rb
+++ b/apps/dashboard/test/lib/smart_attributes/auto_accounts_test.rb
@@ -31,5 +31,14 @@ module SmartAttributes
         assert_equal('pzs0714', attribute.value.to_s)
       end
     end
+
+    test 'dynamic_accounts hyphenates underscores in data-option-for-cluster keys' do
+      Rails.cache.clear
+      Configuration.stubs(:job_clusters).returns([stub(id: 'owens'), stub(id: 'x-nextgen_ascend')])
+      SmartAttributes::AttributeFactory.stubs(:accounts).returns([stub(name: 'pzs0714', cluster: 'owens', to_s: 'pzs0714')])
+
+      data = SmartAttributes::AttributeFactory.dynamic_accounts.find { |t| t[0] == 'pzs0714' }.last
+      assert data.key?('data-option-for-cluster-x-nextgen-ascend')
+    end
   end
 end

--- a/apps/dashboard/test/lib/smart_attributes/auto_modules_test.rb
+++ b/apps/dashboard/test/lib/smart_attributes/auto_modules_test.rb
@@ -41,6 +41,18 @@ class SmartAttributes::AutoModulesTest < ActiveSupport::TestCase
     end
   end
 
+  test 'data-option-for-cluster uses hyphens for cluster ids with underscores' do
+    with_modified_env({ OOD_MODULE_FILE_DIR: fixture_dir }) do
+      attribute = SmartAttributes::AttributeFactory.build('auto_modules_R', {})
+      Configuration.stubs(:job_clusters).returns([stub(id: 'x-nextgen_ascend')])
+      HpcModule.stubs(:all_versions).returns([stub(on_cluster?: false, version: '1.0', to_s: 'R/1.0')])
+
+      data = attribute.send(:hpc_versions).first[2]
+      assert data.key?('data-option-for-cluster-x-nextgen-ascend')
+      refute data.key?('data-option-for-cluster-x-nextgen_ascend')
+    end
+  end
+
   test 'can filter modules when given an array' do
     with_modified_env({ OOD_MODULE_FILE_DIR: fixture_dir }) do
       attribute = SmartAttributes::AttributeFactory.build('auto_modules_R', { filter: [/Eliminate/, /GetRidOfMeToo/] })

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -726,6 +726,47 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'data-option-for-cluster with underscore cluster id uses hyphenated attribute name' do
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        form:
+          - cluster
+          - node_type
+        attributes:
+          cluster:
+            widget: "select"
+            options:
+              - owens
+              - ['Ascend Nextgen', 'ascend_nextgen']
+          node_type:
+            widget: "select"
+            options:
+              - standard
+              - ['gpu', 'gpu', data-option-for-cluster-ascend-nextgen: false]
+      HEREDOC
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+
+      visit new_batch_connect_session_context_url('sys/app')
+
+      select('owens', from: 'batch_connect_session_context_cluster')
+      assert_equal '', find_option_style('node_type', 'gpu')
+
+      select('gpu', from: 'batch_connect_session_context_node_type')
+
+      select('Ascend Nextgen', from: 'batch_connect_session_context_cluster')
+      assert_equal 'display: none;', find_option_style('node_type', 'gpu')
+      assert_equal 'standard', find('#batch_connect_session_context_node_type').value
+    end
+  end
+  
   test 'form element headers support markdown and html' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 


### PR DESCRIPTION
* Normalize dynamic batch connect tokens with underscores

* Add unit test for hyphenated data-option-for cluster handling

* Add system test for dashed cluster names in dynamic form