### PR TITLE
Test project file structure and permissions

### DIFF
--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -611,7 +611,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
   
   test 'creating and showing launchers' do
     Dir.mktmpdir do |dir|
-      CurrentUser.stubs(:home).returns('/tmp/')
+      CurrentUser.stubs(:home).returns(Pathname.new(dir).parent.to_s)
       project_id = setup_project(dir)
       launcher_id = setup_launcher(project_id)
 

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -95,9 +95,26 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
   test 'creates .ondemand directory with project' do
     Dir.mktmpdir do |dir|
+      CurrentUser.stubs(:home).returns('/tmp')
       project_id = setup_project(dir)
+      ondemand_dir = File.join("#{dir}/projects", project_id, '.ondemand')
+      assert File.directory? ondemand_dir
+      stats = File.stat ondemand_dir
+      assert_equal 0o040700, stats.mode
+      exp_children = %w(launchers workflows job_log.yml manifest.yml)
+      assert_equal exp_children, Dir.children(ondemand_dir)
+    end
+  end
 
-      assert File.directory? File.join("#{dir}/projects", project_id, '.ondemand')
+  test 'shared project creates .ondemand directory with proper permissions' do
+    Dir.mktmpdir do |dir|
+      project_id = setup_project(dir)
+      ondemand_dir = File.join("#{dir}/projects", project_id, '.ondemand')
+      assert File.directory? ondemand_dir
+      stats = File.stat ondemand_dir
+      assert_equal 0o040770, stats.mode
+      exp_children = %w(launchers workflows job_log.yml manifest.yml)
+      assert_equal exp_children, Dir.children(ondemand_dir)
     end
   end
 

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -102,7 +102,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       stats = File.stat ondemand_dir
       assert_equal 0o040700, stats.mode
       exp_children = %w(launchers workflows job_log.yml manifest.yml)
-      assert_equal exp_children, Dir.children(ondemand_dir)
+      assert_equal exp_children.sort, Dir.children(ondemand_dir).sort
       exp_children.each do |child|
         msg = "Path #{child} is not writable"
         assert File.writable?(File.join(ondemand_dir, child))
@@ -118,7 +118,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       stats = File.stat ondemand_dir
       assert_equal 0o040770, stats.mode
       exp_children = %w(launchers workflows job_log.yml manifest.yml)
-      assert_equal exp_children, Dir.children(ondemand_dir)
+      assert_equal exp_children.sort, Dir.children(ondemand_dir).sort
       assert File.writable?(File.join(ondemand_dir, 'manifest.yml'))
       exp_children.each do |child|
         unless child == 'manifest.yml'

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -103,6 +103,15 @@ class ProjectManagerTest < ApplicationSystemTestCase
       assert_equal 0o040700, stats.mode
       exp_children = %w(launchers workflows job_log.yml manifest.yml)
       assert_equal exp_children, Dir.children(ondemand_dir)
+      exp_children.each do |child|
+        stats = File.stat(File.join(ondemand_dir, child))
+        msg = "Path #{child} exists with incorrect permissions"
+        if %w(launchers workflows).include?(child)
+          assert_equal 0o040700, stats.mode, msg
+        elsif child == 'job_log.yml'
+          assert_equal 0o0100600, stats.mode, msg
+        end
+      end
     end
   end
 
@@ -115,6 +124,17 @@ class ProjectManagerTest < ApplicationSystemTestCase
       assert_equal 0o040770, stats.mode
       exp_children = %w(launchers workflows job_log.yml manifest.yml)
       assert_equal exp_children, Dir.children(ondemand_dir)
+      exp_children.each do |child|
+        unless child == 'manifest.yml'
+          stats = File.stat(File.join(ondemand_dir, child))
+          msg = "Path #{child} exists with incorrect permissions"
+          if %w(launchers workflows).include?(child)
+            assert_equal 0o040770, stats.mode, msg
+          elsif child == 'job_log.yml'
+            assert_equal 0o0100660, stats.mode, msg
+          end
+        end
+      end
     end
   end
 

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -95,7 +95,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
   test 'creates .ondemand directory with project' do
     Dir.mktmpdir do |dir|
-      CurrentUser.stubs(:home).returns('/tmp')
+      CurrentUser.stubs(:home).returns(Pathname.new(dir).parent.to_s)
       project_id = setup_project(dir)
       ondemand_dir = File.join("#{dir}/projects", project_id, '.ondemand')
       assert File.directory? ondemand_dir

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -104,13 +104,8 @@ class ProjectManagerTest < ApplicationSystemTestCase
       exp_children = %w(launchers workflows job_log.yml manifest.yml)
       assert_equal exp_children, Dir.children(ondemand_dir)
       exp_children.each do |child|
-        stats = File.stat(File.join(ondemand_dir, child))
-        msg = "Path #{child} exists with incorrect permissions"
-        if %w(launchers workflows).include?(child)
-          assert_equal 0o040700, stats.mode, msg
-        elsif child == 'job_log.yml'
-          assert_equal 0o0100600, stats.mode, msg
-        end
+        msg = "Path #{child} is not writable"
+        assert File.writable?(File.join(ondemand_dir, child))
       end
     end
   end
@@ -124,6 +119,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       assert_equal 0o040770, stats.mode
       exp_children = %w(launchers workflows job_log.yml manifest.yml)
       assert_equal exp_children, Dir.children(ondemand_dir)
+      assert File.writable?(File.join(ondemand_dir, 'manifest.yml'))
       exp_children.each do |child|
         unless child == 'manifest.yml'
           stats = File.stat(File.join(ondemand_dir, child))
@@ -615,6 +611,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
   
   test 'creating and showing launchers' do
     Dir.mktmpdir do |dir|
+      CurrentUser.stubs(:home).returns('/tmp/')
       project_id = setup_project(dir)
       launcher_id = setup_launcher(project_id)
 
@@ -651,14 +648,31 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       success_message = I18n.t('dashboard.jobs_launchers_created')
       assert_selector('.alert-success', text: "#{success_message}")
-      assert_equal(expected_yml, File.read("#{dir}/projects/#{project_id}/.ondemand/launchers/#{launcher_id}/form.yml"))
+      launcher_dir = File.join(dir, 'projects', project_id, '.ondemand', 'launchers', launcher_id)
+      assert_equal(expected_yml, File.read("#{launcher_dir}/form.yml"))
 
+      Pathname.new(launcher_dir).children do |child|
+        msg = "#{child} is not writable"
+        assert child.writable?, msg
+      end
+      
       launcher_path = project_launcher_path(project_id, launcher_id)
       find("[href='#{launcher_path}'].btn-info").click
       assert_selector('h1', text: 'the launcher title', count: 1)
     end
   end
 
+  test 'launcher files in shared projects have proper permissions' do
+    Dir.mktmpdir do |dir|
+      project_id = setup_project(dir)
+      launcher_id = setup_launcher(project_id)
+      launcher_dir = File.join(dir, 'projects', project_id, '.ondemand', 'launchers', launcher_id)
+      assert_equal 0o040770, File.stat(launcher_dir).mode
+      assert_equal ['form.yml'], Dir.children(launcher_dir)
+      assert_equal 0o0100644, File.stat(File.join(launcher_dir, 'form.yml')).mode
+    end
+  end
+    
   test 'creates new launcher with default items' do
     Dir.mktmpdir do |dir|
       Configuration.stubs(:launcher_default_items).returns(['bc_num_hours'])


### PR DESCRIPTION
Fixes #4937. Adds assertions to make sure that project and launcher files are being created with the proper permissions. For personal projects this means checking the main .ondemand dir of the project (which should be 700) and ensuring all child paths are writable. For shared projects, this means asserting the mode of each file that is created using the ProjectPermissions module. We do not test the mode of files created with the user's default umask (aside from checking writability), as those modes could change depending on the test environment.