### PR TITLE
remove these dependency limits as we no longer support ruby 2.7

### DIFF
--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -47,7 +47,7 @@ end
 gem 'nokogiri', force_ruby_platform: true
 
 # have to lock these gems for ruby 3.1 support in Debian 12.
-gem 'net-imap', '> 0.5', '< 0.6'
+gem 'net-imap', '~> 0.5'
 
 # These silence warnings, but can be
 # removed after upgrades include them

--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -46,6 +46,9 @@ end
 # TODO: figure out if we still need to force_ruby_platform here
 gem 'nokogiri', force_ruby_platform: true
 
+# have to lock these gems for ruby 3.1 support in Debian 12.
+gem 'net-imap', '0.6.4'
+
 # These silence warnings, but can be
 # removed after upgrades include them
 gem 'ostruct'

--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -43,13 +43,8 @@ group :development do
   gem 'ruby-openai'
 end
 
-# lock gems to versions that are compatible with ruby 2.7.0,
-# which Ubuntu 20.04 uses.
+# TODO: figure out if we still need to force_ruby_platform here
 gem 'nokogiri', force_ruby_platform: true
-gem 'net-imap', '~> 0.4'
-gem 'public_suffix', '~> 5.0', '< 6.0'
-gem 'turbo-rails', '2.0.7'
-gem 'zeitwerk', '2.6.18'
 
 # These silence warnings, but can be
 # removed after upgrades include them
@@ -69,6 +64,7 @@ gem 'zip_kit', '~> 6.2'
 gem 'rss', '~> 0.2'
 gem 'climate_control', '~> 0.2'
 gem 'rest-client', '~> 2.0'
+gem 'turbo-rails'
 
 gem 'jsbundling-rails', '~> 1.0'
 gem 'cssbundling-rails', '~> 1.1'

--- a/apps/dashboard/Gemfile
+++ b/apps/dashboard/Gemfile
@@ -47,7 +47,7 @@ end
 gem 'nokogiri', force_ruby_platform: true
 
 # have to lock these gems for ruby 3.1 support in Debian 12.
-gem 'net-imap', '0.6.4'
+gem 'net-imap', '> 0.5', '< 0.6'
 
 # These silence warnings, but can be
 # removed after upgrades include them

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     mustermann (3.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -420,7 +420,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
-  net-imap (= 0.6.4)
+  net-imap (> 0.5, < 0.6)
   nokogiri
   ood_appkit (~> 2)
   ood_core (~> 0.24)

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -420,6 +420,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
+  net-imap (= 0.6.4)
   nokogiri
   ood_appkit (~> 2)
   ood_core (~> 0.24)

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -375,10 +375,9 @@ GEM
     timecop (0.9.11)
     timeout (0.6.1)
     tsort (0.2.0)
-    turbo-rails (2.0.7)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -421,14 +420,12 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
-  net-imap (~> 0.4)
   nokogiri
   ood_appkit (~> 2)
   ood_core (~> 0.24)
   ood_support (~> 0.0.2)
   ostruct
   pry
-  public_suffix (~> 5.0, < 6.0)
   puma (~> 7.2)
   rails (= 7.2.3.1)
   redcarpet (~> 3.3)
@@ -441,9 +438,8 @@ DEPENDENCIES
   sinatra-contrib
   sprockets-rails (>= 2.0.0)
   timecop (~> 0.9)
-  turbo-rails (= 2.0.7)
+  turbo-rails
   webrick
-  zeitwerk (= 2.6.18)
   zip_kit (~> 6.2)
 
 BUNDLED WITH

--- a/apps/dashboard/Gemfile.lock
+++ b/apps/dashboard/Gemfile.lock
@@ -420,7 +420,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
-  net-imap (> 0.5, < 0.6)
+  net-imap (~> 0.5)
   nokogiri
   ood_appkit (~> 2)
   ood_core (~> 0.24)

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -74,4 +74,4 @@ gem 'rdoc', '6.3.4.1'
 gem 'nokogiri', force_ruby_platform: true
 
 # have to lock these gems for ruby 3.1 support in Debian 12.
-gem 'net-imap', '0.6.4'
+gem 'net-imap', '> 0.5', '< 0.6'

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -74,4 +74,4 @@ gem 'rdoc', '6.3.4.1'
 gem 'nokogiri', force_ruby_platform: true
 
 # have to lock these gems for ruby 3.1 support in Debian 12.
-gem 'net-imap', '> 0.5', '< 0.6'
+gem 'net-imap', '~> 0.5'

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -72,3 +72,6 @@ gem 'rdoc', '6.3.4.1'
 
 # TODO: figure out if we still need to force_ruby_platform here
 gem 'nokogiri', force_ruby_platform: true
+
+# have to lock these gems for ruby 3.1 support in Debian 12.
+gem 'net-imap', '0.6.4'

--- a/apps/myjobs/Gemfile
+++ b/apps/myjobs/Gemfile
@@ -70,9 +70,5 @@ gem 'minitest', '< 6.0'
 # Psych::BadAlias: Cannot load database configuration: Unknown alias: default
 gem 'rdoc', '6.3.4.1'
 
-# lock gems to versions that are compatible with ruby 2.7.0,
-# which Ubuntu 20.04 uses.
+# TODO: figure out if we still need to force_ruby_platform here
 gem 'nokogiri', force_ruby_platform: true
-gem 'net-imap', '~> 0.4'
-gem 'public_suffix', '~> 5.0', '< 6.0'
-gem 'zeitwerk', '2.6.18'

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       ruby2_keywords (>= 0.0.5)
     multi_json (1.21.1)
     mustache (1.1.2)
-    net-imap (0.6.4)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -336,7 +336,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
-  net-imap (= 0.6.4)
+  net-imap (> 0.5, < 0.6)
   nokogiri
   ood_appkit (~> 2.0)
   osc_machete_rails (~> 2.1.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -336,6 +336,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
+  net-imap (= 0.6.4)
   nokogiri
   ood_appkit (~> 2.0)
   osc_machete_rails (~> 2.1.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -336,7 +336,7 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
-  net-imap (> 0.5, < 0.6)
+  net-imap (~> 0.5)
   nokogiri
   ood_appkit (~> 2.0)
   osc_machete_rails (~> 2.1.2)

--- a/apps/myjobs/Gemfile.lock
+++ b/apps/myjobs/Gemfile.lock
@@ -336,12 +336,10 @@ DEPENDENCIES
   local_time (~> 1.0.3)
   minitest (< 6.0)
   mocha (~> 2.1)
-  net-imap (~> 0.4)
   nokogiri
   ood_appkit (~> 2.0)
   osc_machete_rails (~> 2.1.2)
   pbs (~> 2.2.1)
-  public_suffix (~> 5.0, < 6.0)
   rails (= 7.2.3.1)
   rails-controller-testing
   rdoc (= 6.3.4.1)
@@ -350,7 +348,6 @@ DEPENDENCIES
   sqlite3 (= 1.7.3)
   timecop (~> 0.9)
   uglifier (>= 1.3.0)
-  zeitwerk (= 2.6.18)
 
 BUNDLED WITH
    2.5.23


### PR DESCRIPTION
remove these dependency limits as we no longer support ruby 2.7.

Note we still depend on these gems, they're just dependencies of dependencies and we no longer lock the version as we had to for ruby 2.7 (Ubuntu 20.04).