### PR TITLE
Fix Files dropdown button in "All Apps"

### DIFF
--- a/apps/dashboard/app/views/apps/_app_group_rows.html.erb
+++ b/apps/dashboard/app/views/apps/_app_group_rows.html.erb
@@ -7,7 +7,7 @@
           <span title="FontAwesome icon specified: folder" aria-hidden="true" class="fas fa-folder fa-fw"></span> Files
         <% end %>
 
-        <button type="button" class="btn dropdown-toggle dropdown-toggle-split btn-primary" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="btn dropdown-toggle dropdown-toggle-split btn-primary" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
 
         <ul class="dropdown-menu" data-popper-placement="right-start">
           <%- app.links.each do |link| -%>


### PR DESCRIPTION
While testing out Open OnDemand 4.2.2 I found that the "Files" button has a dropdown, but when I tried to select one of the directories it wouldn't do anything. All of the links looked correct, so I looked into the code and it appears that there was a missing end tag for the button element. 

In this PR I add the missing `</button>` to `_app_group_rows.html.erb`. I have tested this out in our dev environment and it fixes the issue for me. 

I searched the current issues and pull requests and I could not find an item that addresses this. Apologies if I missed it! 

Please let me know if you would like me to modify the syntax or make any changes. 