### PR TITLE
Detect SSH keys from any algorithm

### DIFF
--- a/apps/dashboard/app/helpers/products_helper.rb
+++ b/apps/dashboard/app/helpers/products_helper.rb
@@ -60,8 +60,8 @@ module ProductsHelper
   end
 
   def ssh_key
-    target = Pathname.new("~/.ssh/id_rsa.pub").expand_path
-    File.read(target) if target.file?
+    keys = Pathname.glob("#{CurrentUser.home}/.ssh/id_*.pub")
+    File.read(keys.first) unless keys.empty?
   end
 
   # A custom button helper for command line tools


### PR DESCRIPTION
Fixes #5516 by searching the for any `id_*.pub` file in the ssh directory, instead of specifying `id_rsa.pub`