### PR TITLE
(4.1 Backport) remove this default and enforce it be set (#5559)

### DIFF
--- a/ood-portal-generator/lib/ood_portal_generator/dex.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/dex.rb
@@ -45,8 +45,9 @@ module OodPortalGenerator
         @dex_config[:enablePasswordDB] = false
       end
       @dex_config[:frontend] = frontend
-      # Pass values back to main ood-portal.conf view
-      view.update_oidc_attributes(oidc_attributes) if enabled? && self.class.installed?
+      # Pass values back to main ood-portal.conf view, ensuring oidc_crypto_passphrase is sent back
+      passphrase_cfg = { :oidc_crypto_passphrase => opts[:oidc_crypto_passphrase] }
+      view.update_oidc_attributes(oidc_attributes.merge(passphrase_cfg)) if enabled? && self.class.installed?
     end
 
     # Render the config as a YAML string

--- a/ood-portal-generator/lib/ood_portal_generator/view.rb
+++ b/ood-portal-generator/lib/ood_portal_generator/view.rb
@@ -116,12 +116,26 @@ module OodPortalGenerator
       @oidc_redirect_uri                = opts.fetch(:oidc_redirect_uri, @oidc_uri || '/oidc')
       @oidc_remote_user_claim           = opts.fetch(:oidc_remote_user_claim, 'preferred_username')
       @oidc_scope                       = opts.fetch(:oidc_scope, "openid profile email")
-      @oidc_crypto_passphrase           = opts.fetch(:oidc_crypto_passphrase, Digest::SHA1.hexdigest(servername))
       @oidc_session_inactivity_timeout  = opts.fetch(:oidc_session_inactivity_timeout, 28800)
       @oidc_session_max_duration        = opts.fetch(:oidc_session_max_duration, 28800)
       @oidc_state_max_number_of_cookies = opts.fetch(:oidc_state_max_number_of_cookies, '10 true')
       @oidc_cookie_same_site            = opts.fetch(:oidc_cookie_same_site, @ssl ? 'Off' : 'On')
       @oidc_settings                    = opts.fetch(:oidc_settings, {})
+
+      @oidc_crypto_passphrase           = fetch_oidc_crypto_passphrase(opts)
+    end
+
+    def fetch_oidc_crypto_passphrase(opts)
+      # if you're trying to use OIDC
+      if @oidc_uri && @oidc_provider_metadata_url && @oidc_client_id
+        config_passphrase = opts.fetch(:oidc_crypto_passphrase, nil)
+        raise(StandardError, 'oidc_crypto_passphrase must be set when using OIDC.') if config_passphrase.nil?
+
+        return config_passphrase
+      end
+
+      # not trying to use OIDC, so it's OK to be nil
+      nil
     end
 
     def servername
@@ -205,6 +219,7 @@ module OodPortalGenerator
       end
 
       @auth = Dex.default_auth unless auth?
+      @oidc_crypto_passphrase = fetch_oidc_crypto_passphrase(attrs)
     end
   end
 end

--- a/ood-portal-generator/spec/application_spec.rb
+++ b/ood-portal-generator/spec/application_spec.rb
@@ -157,6 +157,16 @@ describe OodPortalGenerator::Application do
       test_generate('input/http_redirect_host.yml', 'output/http_redirect_host.conf')
     end
 
+    it 'rasies an error with incomplete oidc configs' do
+      config = {
+        oidc_uri:                   '/oidc',
+        oidc_provider_metadata_url: 'https://idp.example.com/auth/realms/osc/.well-known/openid-configuration',
+        oidc_client_id:             'ondemand.example.com'
+      }
+      allow(described_class).to receive(:context).and_return(config)
+      expect { described_class.generate }.to raise_error(StandardError, 'oidc_crypto_passphrase must be set when using OIDC.')
+    end
+
     it 'generates full OIDC config' do
       config = {
         servername: 'ondemand.example.com',
@@ -169,6 +179,7 @@ describe OodPortalGenerator::Application do
         oidc_session_inactivity_timeout: 28800,
         oidc_session_max_duration: 28800,
         oidc_state_max_number_of_cookies: '10 true',
+        oidc_crypto_passphrase: 'e2c5ee12c92a019f19b5e532641ac0da2f9acdac',
         oidc_settings: {
           OIDCPassIDTokenAs: 'serialized',
           OIDCPassRefreshToken: 'On',
@@ -199,6 +210,7 @@ describe OodPortalGenerator::Application do
         oidc_session_inactivity_timeout: 28800,
         oidc_session_max_duration: 28800,
         oidc_state_max_number_of_cookies: '10 true',
+        oidc_crypto_passphrase: 'e2c5ee12c92a019f19b5e532641ac0da2f9acdac',
         oidc_settings: {
           OIDCPassIDTokenAs: 'serialized',
           OIDCPassRefreshToken: 'On',
@@ -239,8 +251,14 @@ describe OodPortalGenerator::Application do
         allow(described_class).to receive(:dex_output).and_return(dex_config)
       end
 
+      it 'rasies an error with incomplete oidc configs in dex' do
+        config = { dex: true }
+        allow(described_class).to receive(:context).and_return(config)
+        expect { described_class.generate }.to raise_error(StandardError, 'oidc_crypto_passphrase must be set when using OIDC.')
+      end
+
       it 'generates default dex configs' do
-        allow(described_class).to receive(:context).and_return({ dex: true })
+        allow(described_class).to receive(:context).and_return({ dex: true, oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f' })
         expected_rendered = read_fixture('ood-portal.conf.dex')
         expect(described_class.output).to receive(:write).with(expected_rendered)
         expected_dex_yaml = read_fixture('dex.yaml.default').gsub('/etc/ood/dex', config_dir)
@@ -250,7 +268,7 @@ describe OodPortalGenerator::Application do
 
       it 'generates default dex configs from nil' do
         # this simulates a config of 'dex: '. I.e., uncommented dex
-        allow(described_class).to receive(:context).and_return({ dex: nil })
+        allow(described_class).to receive(:context).and_return({ dex: nil, oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f' })
         expected_rendered = read_fixture('ood-portal.conf.dex')
         expect(described_class.output).to receive(:write).with(expected_rendered)
         expected_dex_yaml = read_fixture('dex.yaml.default').gsub('/etc/ood/dex', config_dir)
@@ -259,7 +277,7 @@ describe OodPortalGenerator::Application do
       end
 
       it 'generates insecure default dex configs' do
-        allow(described_class).to receive(:context).and_return({ dex: true })
+        allow(described_class).to receive(:context).and_return({ dex: true, oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f' })
         allow(described_class).to receive(:insecure).and_return(true)
         expected_rendered = read_fixture('ood-portal.conf.dex')
         expect(described_class.output).to receive(:write).with(expected_rendered)
@@ -272,6 +290,7 @@ describe OodPortalGenerator::Application do
         allow(described_class).to receive(:insecure).and_return(true)
         allow_any_instance_of(OodPortalGenerator::Dex).to receive(:hash_password).with('secret').and_return('$2a$12$iKLecAIN9MrxOZ0UltRb.OQOms/bgQbs5F.qCehq15oc3CvGFYzLy')
         allow(described_class).to receive(:context).and_return({
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           dex: {
             static_passwords: [{
               'email'    => 'username@localhost',
@@ -292,6 +311,7 @@ describe OodPortalGenerator::Application do
         # same as test above, only it does not use --insecure and expects the default yaml, not static_passwords
         allow_any_instance_of(OodPortalGenerator::Dex).to receive(:hash_password).with('secret').and_return('$2a$12$iKLecAIN9MrxOZ0UltRb.OQOms/bgQbs5F.qCehq15oc3CvGFYzLy')
         allow(described_class).to receive(:context).and_return({
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           dex: {
             static_passwords: [{
               'email'    => 'username@localhost',
@@ -314,6 +334,7 @@ describe OodPortalGenerator::Application do
           servername: 'example.com',
           proxy_server: 'example-proxy.com',
           port: '443',
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           ssl: [
             'SSLCertificateFile /etc/pki/tls/certs/example.com.crt',
             'SSLCertificateKeyFile /etc/pki/tls/private/example.com.key',
@@ -333,6 +354,7 @@ describe OodPortalGenerator::Application do
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           port: '443',
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           ssl: [
             'SSLCertificateFile /etc/pki/tls/certs/example.com.crt',
             'SSLCertificateKeyFile /etc/pki/tls/private/example.com.key',
@@ -352,6 +374,7 @@ describe OodPortalGenerator::Application do
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           port: '443',
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           ssl: [
             'SSLCertificateFile /etc/pki/tls/certs/example.com.crt',
             'SSLCertificateKeyFile /etc/pki/tls/private/example.com.key',
@@ -372,6 +395,7 @@ describe OodPortalGenerator::Application do
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           port: '443',
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           ssl: [
             'SSLCertificateFile /etc/pki/tls/certs/example.com.crt',
             'SSLCertificateKeyFile /etc/pki/tls/private/example.com.key',
@@ -406,6 +430,7 @@ describe OodPortalGenerator::Application do
         File.open(key, 'w') { |f| f.write("KEY") }
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           port: '443',
           ssl: [
             "SSLCertificateFile #{cert}",
@@ -447,6 +472,7 @@ describe OodPortalGenerator::Application do
         allow(described_class).to receive(:context).and_return({
           servername: 'example.com',
           port: '443',
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           ssl: [
             'SSLCertificateFile /etc/pki/tls/certs/example.com.crt',
             'SSLCertificateKeyFile /etc/pki/tls/private/example.com.key',
@@ -492,6 +518,7 @@ describe OodPortalGenerator::Application do
         secret = Tempfile.new('secret')
         File.write(secret.path, "supersecret\n")
         allow(described_class).to receive(:context).and_return({
+          oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f',
           dex: {
             client_secret: secret.path,
           }

--- a/ood-portal-generator/spec/fixtures/ood_portal.dex.yaml
+++ b/ood-portal-generator/spec/fixtures/ood_portal.dex.yaml
@@ -1,4 +1,5 @@
 ---
+oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f'
 dex:
   tls_cert: dne.crt
   tls_key: dne.key

--- a/ood-portal-generator/spec/update_ood_portal_spec.rb
+++ b/ood-portal-generator/spec/update_ood_portal_spec.rb
@@ -124,7 +124,7 @@ describe 'update_ood_portal' do
   context 'dex' do
     before(:each) do
       allow(OodPortalGenerator::Dex).to receive(:installed?).and_return(true)
-      allow(OodPortalGenerator::Application).to receive(:context).and_return({ dex: true })
+      allow(OodPortalGenerator::Application).to receive(:context).and_return({ dex: true, oidc_crypto_passphrase: '0caaf24ab1a0c33440c06afe99df986365b0781f' })
       allow(OodPortalGenerator).to receive(:dex_user).and_return(user)
       allow(OodPortalGenerator).to receive(:dex_group).and_return(group)
       allow_any_instance_of(OodPortalGenerator::Dex).to receive(:default_secret_path).and_return(dex_secret_path.path)

--- a/spec/fixtures/config/ood_portal/portal.yml
+++ b/spec/fixtures/config/ood_portal/portal.yml
@@ -7,3 +7,4 @@ listen_addr_port: 8080
 servername: localhost
 port: 8080
 dex: true
+oidc_crypto_passphrase: '449df16c-6f17-11f1-84a7-5c6f69576620'

--- a/spec/fixtures/config/ood_portal/portal_dex_no_proxy.yml
+++ b/spec/fixtures/config/ood_portal/portal_dex_no_proxy.yml
@@ -8,3 +8,4 @@ servername: localhost
 port: 8080
 dex_uri: false
 dex: true
+oidc_crypto_passphrase: '449df16c-6f17-11f1-84a7-5c6f69576620'

--- a/spec/fixtures/config/ood_portal/portal_with_prehook.yml
+++ b/spec/fixtures/config/ood_portal/portal_with_prehook.yml
@@ -7,6 +7,7 @@ listen_addr_port: 8080
 servername: localhost
 port: 8080
 dex: true
+oidc_crypto_passphrase: '449df16c-6f17-11f1-84a7-5c6f69576620'
 
 pun_pre_hook_root_cmd: '/opt/hooks/pun_pre_hook'
 pun_pre_hook_exports: 'OIDC_ACCESS_TOKEN,OIDC_CLAIM_EMAIL'

--- a/spec/fixtures/config/ood_portal/portal_with_proxies.yml
+++ b/spec/fixtures/config/ood_portal/portal_with_proxies.yml
@@ -7,6 +7,7 @@ listen_addr_port: 8080
 servername: localhost
 port: 8080
 dex: true
+oidc_crypto_passphrase: '449df16c-6f17-11f1-84a7-5c6f69576620'
 
 rnode_uri: '/rnode'
 node_uri: '/node'


### PR DESCRIPTION
Backport #5559 to 4.1.

Remove the default oidc_crypto_passphrase and enforce it being set when using oidc.