### PR TITLE
Escape attr.label and attr.value in AppHelper#recent_settings (#5490) (release_4.2)

### DIFF
--- a/apps/dashboard/app/helpers/app_helper.rb
+++ b/apps/dashboard/app/helpers/app_helper.rb
@@ -2,6 +2,9 @@
 
 # Helper for /apps pages.
 module AppHelper
+
+  include ERB::Util
+  
   # FIXME: show_errors is not used
   def manifest_markdown(text, show_errors: false)
     RenderManifestMarkdown.renderer.render(text).html_safe
@@ -19,7 +22,7 @@ module AppHelper
 
   def recent_settings(app)
     content = app.attributes.select(&:display?).map do |attr|
-      "<div class='row'> <dt>#{attr.label}:</dt> <dd>#{attr.value}</dd> </div>"
+      "<div class='row'> <dt>#{html_escape(attr.label)}:</dt> <dd>#{html_escape(attr.value)}</dd> </div>"
     end
     content.empty? ? nil : ['<dl class="app-settings-popup">', content.join('<hr>'), '</dl>'].join
   end

--- a/apps/dashboard/test/helpers/app_helper_test.rb
+++ b/apps/dashboard/test/helpers/app_helper_test.rb
@@ -1,4 +1,42 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AppHelperTest < ActionView::TestCase
+  test 'recent_settings escapes label and value to prevent XSS' do
+    attrib = stub(
+      display?: true,
+      label:    '<script>alert("xss")</script>',
+      value:    '"><img src=x onerror=alert(1)>'
+    )
+    app = stub(attributes: [attrib])
+
+    result = recent_settings(app)
+
+    assert_not_nil(result)
+    assert_no_match(/<script>/, result)
+    assert_no_match(/<img/, result)
+    assert_includes(result, '&lt;script&gt;')
+    assert_includes(result, '&quot;')
+  end
+
+  test 'recent_settings returns nil when no displayable attributes' do
+    app = stub(attributes: [stub(display?: false)])
+    assert_nil(recent_settings(app))
+  end
+
+  test 'recent_settings returns nil when attributes list is empty' do
+    app = stub(attributes: [])
+    assert_nil(recent_settings(app))
+  end
+
+  test 'recent_settings renders safe label and value unchanged' do
+    attr = stub(display?: true, label: 'Number of cores', value: '4')
+    app = stub(attributes: [attr])
+
+    result = recent_settings(app)
+
+    assert_includes(result, 'Number of cores')
+    assert_includes(result, '4')
+  end
 end

--- a/apps/dashboard/test/helpers/app_helper_test.rb
+++ b/apps/dashboard/test/helpers/app_helper_test.rb
@@ -14,7 +14,7 @@ class AppHelperTest < ActionView::TestCase
     result = recent_settings(app)
 
     assert_not_nil(result)
-    assert_no_match(/<script>/, result)
+    assert_no_match(/<script>/i, result)
     assert_no_match(/<img/, result)
     assert_includes(result, '&lt;script&gt;')
     assert_includes(result, '&quot;')


### PR DESCRIPTION
Backport #5490 to 42.

* Escape attr.label and attr.value in recent_settings to prevent XSS

AppHelper#recent_settings builds an HTML string used as Bootstrap popover content rendered with bs_html: 'true'. The label and value fields were interpolated without escaping, allowing unescaped HTML to appear in the popover. Use html_escape() to escape both fields before insertion.