### PR TITLE
Revert new tab functionality  (#5562) (release_4.2)

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -170,7 +170,11 @@ module BatchConnect::SessionsHelper
     version  = "1.3.0"
     password = view_only ? connect.spassword : connect.password
     resize   = view_only ? "downscale" : "remote"
-    asset_path("noVNC-#{version}/vnc.html?autoconnect=true&password=#{password}&path=rnode/#{connect.host}/#{connect.websocket}/websockify&resize=#{resize}", skip_pipeline: true)
+    base = asset_path(
+      "noVNC-#{version}/vnc.html?autoconnect=true&path=rnode/#{connect.host}/#{connect.websocket}/websockify&resize=#{resize}",
+      skip_pipeline: true
+    )
+    "#{base}#password=#{ERB::Util.url_encode(password)}"
   end
 
   def connection_tabs(id, tabs)

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -1,8 +1,9 @@
-<%= bootstrap_form_tag(url: asset_path("noVNC-1.3.0/vnc.html", skip_pipeline: true), method: "get") do |f| %>
+<% form_id = "novnc-form-#{SecureRandom.hex(4)}" %>
+<%= bootstrap_form_tag(url: asset_path("noVNC-1.3.0/vnc.html", skip_pipeline: true),
+                       method: "get", id: form_id) do |f| %>
  <%= hidden_field_tag(:autoconnect, 'true') %>
  <%= hidden_field_tag(:path, "rnode/#{connect.host}/#{connect.websocket}/websockify") %>
  <%= hidden_field_tag(:resize, "remote") %>
- <%= hidden_field_tag(:password, connect.password) %>
 
  <div class="row">
   <div class="col-sm-6">
@@ -15,12 +16,23 @@
 
   <%= javascript_tag nonce: true do -%>
     // Functions defined in batch_connect_sessions.js
-    for(var name of ['compression', 'quality']) {
+    for (var name of ['compression', 'quality']) {
       tryUpdateSetting(name);
       installSettingHandlers(name);
     }
+    // Move the VNC password from the query string into the URL fragment so
+    // it never reaches the server (and never lands in NGINX access logs).
+    document.getElementById('<%= form_id %>').addEventListener('submit', function (e) {
+      e.preventDefault();
+      var qs = new URLSearchParams(new FormData(this)).toString();
+      window.open(this.action + '?' + qs + '#password=' + encodeURIComponent('<%= j connect.password %>'), '_blank');
+    });
   <% end -%>
 
  <%= f.submit( t('dashboard.batch_connect_sessions_novnc_launch', app_title: app_title), class: 'btn btn-primary') %>
- <%= link_to t('dashboard.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true), class: 'btn btn-light float-end border border-dark' %>
+ <% if connect.spassword.present? %>
+  <%= link_to(t('dashboard.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true),
+              class: 'btn btn-light float-end border border-dark', target: '_blank',
+              title: t('dashboard.opens_in_new_tab'), data: { 'bs-toggle': 'tooltip' }) %>
+ <% end %>
 <% end %>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -275,6 +275,7 @@ en:
     not_grouped: Other Apps
     nsf_access_events: NSF ACCESS Events
     ok: OK
+    opens_in_new_tab: 'opens in new tab'
     owner: Owner
     path_selector_default_popup_title: Select Your Working Directory
     path_selector_home: home


### PR DESCRIPTION
Backport #5562 to 4.2.

Revert new tab functionality with VNC connections while supplying a tooltip and change how credentials are being passed.