### PR TITLE
rename this variable

### DIFF
--- a/apps/dashboard/app/helpers/app_helper.rb
+++ b/apps/dashboard/app/helpers/app_helper.rb
@@ -21,8 +21,8 @@ module AppHelper
   end
 
   def recent_settings(app)
-    content = app.attributes.select(&:display?).map do |attr|
-      "<div class='row'> <dt>#{html_escape(attr.label)}:</dt> <dd>#{html_escape(attr.value)}</dd> </div>"
+    content = app.attributes.select(&:display?).map do |attrib|
+      "<div class='row'> <dt>#{html_escape(attrib.label)}:</dt> <dd>#{html_escape(attrib.value)}</dd> </div>"
     end
     content.empty? ? nil : ['<dl class="app-settings-popup">', content.join('<hr>'), '</dl>'].join
   end


### PR DESCRIPTION
While reviewing the recent changes here, I noticed we used `attr` which apparently ruby lets us do? Even so, I don't think it's a good idea to keep it as `attr` is actually a reserved word, so this changes that variable name to avoid that.