### PR TITLE
enforce relative init urls in nginx_stage

### DIFF
--- a/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
+++ b/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'syslog/logger'
+require 'uri'
 
 module NginxStage
   # This generator stages and generates the per-user NGINX environment.
@@ -38,14 +39,19 @@ module NginxStage
     # @!method app_init_url
     #   The app initialization URL the user is redirected to if can't find the
     #   app in the per-user NGINX config
-    #   @return [String] app init redirect url
+    #   @return [String] app init redirect path. Historically has been a URL, but is now just the path.
     add_option :app_init_url do
       {
         opt_args: ["-a", "--app-init-url=APP_INIT_URL", "# The user is redirected to the APP_INIT_URL if app doesn't exist"],
         default: nil,
         before_init: -> (uri) do
-          raise InvalidAppInitUri, "invalid app-init-url syntax: #{uri}" if uri =~ /[^-\w\/?$=&.:]/
-          uri
+          # can throw an error here for malformed URIs
+          parsed = URI(uri)
+          path = parsed.path
+          path = "#{path}?#{parsed.query}" unless parsed.query.nil?
+          path = "#{path}##{parsed.fragment}" unless parsed.fragment.nil?
+
+          path
         end
       }
     end

--- a/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
+++ b/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
@@ -51,7 +51,7 @@ module NginxStage
           path = "#{path}?#{parsed.query}" unless parsed.query.nil?
           path = "#{path}##{parsed.fragment}" unless parsed.fragment.nil?
 
-          path.empty? nil : path
+          path.empty? ? nil : path
         end
       }
     end

--- a/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
+++ b/nginx_stage/lib/nginx_stage/generators/pun_config_generator.rb
@@ -46,12 +46,12 @@ module NginxStage
         default: nil,
         before_init: -> (uri) do
           # can throw an error here for malformed URIs
-          parsed = URI(uri)
+          parsed = URI(uri.to_s)
           path = parsed.path
           path = "#{path}?#{parsed.query}" unless parsed.query.nil?
           path = "#{path}##{parsed.fragment}" unless parsed.fragment.nil?
 
-          path
+          path.empty? nil : path
         end
       }
     end


### PR DESCRIPTION
Fixes #5274 by enforcing a relative URL instead of a full url with scheme in it. Thereby just using whatever scheme is already in use.