### PR TITLE
Handle duplicate uploads in Files app

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -217,6 +217,10 @@ small.form-text {
   color: #6a6a6a;
 }
 
+.text-danger {
+  color: rgb(216 49 65) !important
+}
+
 .bg-danger {
   .uppy-Dashboard-Item-statusSize, .uppy-Dashboard-Item-name {
     color: white;

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -217,8 +217,10 @@ small.form-text {
   color: #6a6a6a;
 }
 
-.bg-danger .uppy-Dashboard-Item-statusSize {
-  color: white;
+.bg-danger {
+  .uppy-Dashboard-Item-statusSize, .uppy-Dashboard-Item-name {
+    color: white;
+  }
 }
  
 .uppy-StatusBar.is-waiting .uppy-StatusBar-actionBtn--upload {
@@ -226,10 +228,10 @@ small.form-text {
 }
 
 .uppy-StatusBar.is-waiting .uppy-StatusBar-actionBtn--upload-danger {
-  background-color: red;
+  background-color: rgba(var(--bs-danger-rgb), 1) !important;
   color: white;
 
   :hover {
-    background-color: red;
+    background-color: rgba(var(--bs-danger-rgb), 0.85) !important;
   }
 }

--- a/apps/dashboard/app/assets/stylesheets/application.scss
+++ b/apps/dashboard/app/assets/stylesheets/application.scss
@@ -216,7 +216,20 @@ small.form-text {
 .uppy-Dashboard-note, a.uppy-Dashboard-poweredBy, .uppy-Dashboard-Item-status {
   color: #6a6a6a;
 }
+
+.bg-danger .uppy-Dashboard-Item-statusSize {
+  color: white;
+}
  
 .uppy-StatusBar.is-waiting .uppy-StatusBar-actionBtn--upload {
   background-color: rgb(66, 130, 66);
+}
+
+.uppy-StatusBar.is-waiting .uppy-StatusBar-actionBtn--upload-danger {
+  background-color: red;
+  color: white;
+
+  :hover {
+    background-color: red;
+  }
 }

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -322,7 +322,7 @@ function waitForElement(selector, deleted = false, { root = document.body, timeo
 
     const observer = new MutationObserver(() => {
       const el = root.querySelector(selector);
-      finished = deleted ? !el : el;
+      const finished = deleted ? !el : el;
       if (finished) {
         observer.disconnect();
         clearTimeout(timer);

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -274,7 +274,7 @@ function markOverwrite(file) {
 }
 
 const safeBtnId = 'safe-upload-btn';
-const uploadBtnSelector = '.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload';
+const uploadBtnSelector = '.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload:not(#safe-upload-btn)';
 
 function addOverwriteButton() {
   if(document.getElementById(safeBtnId) !== null) {
@@ -299,10 +299,11 @@ function addOverwriteButton() {
 }
 
 function removeOverwriteButton() {
-  if(document.getElementById(safeBtnId) !== null) {
+  const uploadBtn = document.querySelector(uploadBtnSelector);
+  const safeBtn = document.getElementById(safeBtnId)
+  if(safeBtn !== null && uploadBtn !== null) {
     document.getElementById(safeBtnId).remove();
     document.querySelector('div.uppy-StatusBar-actions span').remove();
-    const uploadBtn = document.querySelector(uploadBtnSelector);
     uploadBtn.classList.remove('mx-3', 'uppy-StatusBar-actionBtn--upload-danger');
   }
 }

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -111,6 +111,7 @@ jQuery(function() {
     if(file.meta.relativePath == null && file.data.webkitRelativePath){
       uppy.setFileMeta(file.id, { relativePath: file.data.webkitRelativePath });
     }
+    checkUpload(file.meta)
   });
 
   uppy.on('complete', (result) => {
@@ -207,3 +208,54 @@ function handleUploadSuccess(result) {
   }
 }
 
+function checkUpload(meta) {
+  const relPath = meta.relativePath || meta.name
+  console.log(`Checking path ${relPath}`);
+  if (checkOverwrite(relPath)) {
+    if (meta.relativePath == null) {
+      // then file is uploaded directly, and conflict is confirmed
+      markOverwrite(relPath)
+    } else {
+      // file was uploaded as part of a folder, and we have to check if its a true conflict
+      disableUploads()
+      investigateOverwrite(relPath).then((result) => {
+        if(result) {
+          markOverwrite(relPath);
+        }
+        enableUploads()
+      })
+    }
+    console.log('Overwrite detected for path')
+  } else {
+    console.log('No overwrite detected')
+  }
+}
+
+function checkOverwrite(relativePath) {
+  const overwritePath = relativePath.split('/')[0];
+  console.log(`overwrite path: ${overwritePath}`);
+  if(history.state.currentFilenames.includes(overwritePath)) {
+    return true
+  } else {
+    return false
+  }
+}
+
+async function investigateOverwrite(path) {
+  const targetPath = `${history.state.currentDirectory}/${relPath}`
+  const targetDir = targetPath.slice(0, targetPath.lastIndexOf('/'));
+  // fetch dir children, and see if targetPath exists
+  return true
+}
+
+function disableUploads() {
+  uploadBtn().setAttribute('disabled');
+}
+
+function enableUploads() {
+  uploadBtn().removeAttribute('disabled');
+}
+
+function uploadBtn() {
+  return document.querySelector('button.uppy-StatusBar-actionBtn--upload');
+}

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -83,9 +83,6 @@ jQuery(function() {
     onBeforeUpload: updateEndpoint,
     locale: uppyLocale(),
   });
-
-  //DEBUG
-  window.uppy = uppy;
   
   uppy.use(EmptyDirCreator);
 
@@ -116,6 +113,14 @@ jQuery(function() {
     }
     checkUpload(file);
   });
+
+  uppy.on('file-removed', (file) => {
+    window.filtered = window.filtered.filter(id => id !== file.id);
+    if(window.filtered.length === 0) {
+      removeOverwriteButton();
+      updateUppyCount();
+    }
+  })
 
   uppy.on('complete', (result) => {
     if(result.successful.length > 0){
@@ -230,6 +235,7 @@ async function checkUpload(file) {
   // After new file appears, ensure earlier ones are marked
   waitForElement(`.uppy-Dashboard-Item-name[title="${file.meta.name}"]`).then(title => {
     window.filtered.forEach(id => { markOverwrite(uppy.getFile(id)) });
+    updateUppyCount();
   })
 }
 
@@ -265,13 +271,15 @@ function markOverwrite(file) {
   });
 }
 
+const safeBtnId = 'safe-upload-btn';
+const uploadBtnSelector = '.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload';
+
 function addOverwriteButton() {
-  const safeBtnId = 'safe-upload-btn';
   if(document.getElementById(safeBtnId) !== null) {
     return
   }
 
-  const uploadBtn = document.querySelector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload');
+  const uploadBtn = document.querySelector(uploadBtnSelector);
   const safeBtn = uploadBtn.cloneNode();
   safeBtn.id = safeBtnId;
   safeBtn.textContent = 'Upload New Files';
@@ -286,6 +294,22 @@ function addOverwriteButton() {
   const actionsWrapper = document.querySelector('div.uppy-StatusBar-actions');
   actionsWrapper.prepend(safeBtn);
   actionsWrapper.append(warning);
+}
+
+function removeOverwriteButton() {
+  if(document.getElementById(safeBtnId) !== null) {
+    document.getElementById(safeBtnId).remove();
+    document.querySelector('div.uppy-StatusBar-actions span').remove();
+    const uploadBtn = document.querySelector(uploadBtnSelector);
+    uploadBtn.classList.remove('mx-3', 'uppy-StatusBar-actionBtn--upload-danger');
+  }
+}
+
+function updateUppyCount() {
+  if(document.getElementById(safeBtnId) === null) {
+    const uploadBtn = document.querySelector(uploadBtnSelector);
+    uploadBtn.textContent = `Upload ${uppy.getFiles().length} files`; 
+  }
 }
 
 function waitForElement(selector, { root = document.body, timeout = 5000 } = {}) {

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -83,6 +83,9 @@ jQuery(function() {
     onBeforeUpload: updateEndpoint,
     locale: uppyLocale(),
   });
+
+  //DEBUG
+  window.uppy = uppy;
   
   uppy.use(EmptyDirCreator);
 
@@ -111,7 +114,7 @@ jQuery(function() {
     if(file.meta.relativePath == null && file.data.webkitRelativePath){
       uppy.setFileMeta(file.id, { relativePath: file.data.webkitRelativePath });
     }
-    checkUpload(file)
+    checkUpload(file);
   });
 
   uppy.on('complete', (result) => {
@@ -209,86 +212,66 @@ function handleUploadSuccess(result) {
   }
 }
 
-function checkUpload(file) {
-  const meta = file.meta
-  const relPath = meta.relativePath || meta.name
-  console.log(`Checking path ${relPath}`);
+async function checkUpload(file) {
+  const meta = file.meta;
+  const relPath = meta.relativePath || meta.name;
   if (checkOverwrite(relPath)) {
     if (meta.relativePath == null) {
-      // then file is uploaded directly, and conflict is confirmed
-      markOverwrite(file)
+      // then file was uploaded directly, and conflict is confirmed
+      markOverwrite(file);
     } else {
       // file was uploaded as part of a folder, and we have to check if its a true conflict
-      disableUploads()
-      investigateOverwrite(relPath).then((result) => {
-        if(result) {
-          markOverwrite(file);
-        }
-        enableUploads()
-      })
+      const isOverwrite = await investigateOverwrite(relPath);
+      if(isOverwrite){
+        markOverwrite(file);
+      }
     }
-    console.log('Overwrite detected for path')
-  } else {
-    console.log('No overwrite detected')
   }
   // After new file appears, ensure earlier ones are marked
   waitForElement(`.uppy-Dashboard-Item-name[title="${file.meta.name}"]`).then(title => {
-    window.filtered.forEach(id => {
-      markOverwrite(uppy.getFile(id))
-    })
+    window.filtered.forEach(id => { markOverwrite(uppy.getFile(id)) });
   })
 }
 
 function safeUpload() {
-  window.filtered.forEach(id => {
-    uppy.removeFile(id);
-  })
+  window.filtered.forEach(id => { uppy.removeFile(id); })
   window.filtered = [];
   uppy.upload();
 }
 
 function checkOverwrite(relativePath) {
   const overwritePath = relativePath.split('/')[0];
-  console.log(`overwrite path: ${overwritePath}`);
-  if(history.state.currentFilenames.includes(overwritePath)) {
-    return true
-  } else {
-    return false
-  }
+  return history.state.currentFilenames.includes(overwritePath);
 }
 
 async function investigateOverwrite(path) {
   const directory = path.slice(0, path.lastIndexOf('/'));
-  const targetFile = path.slice(path.lastIndexOf('/') + 1);
-
-
   const url = `${history.state.currentDirectoryUrl}/${directory}`;
-  const data = fetch(url, { headers: { 'Accept': 'application/json' }})
-                 .then(response => response.json)
-  
-  return Array.from(data.files).includes(targetFile)
+  const response = await fetch(url, { headers: { 'Accept': 'application/json' }});
+  const data = await response.json();
+
+  const targetFile = path.slice(path.lastIndexOf('/') + 1);
+  return Array.from(data.files).map(file => file.name).includes(targetFile);
 }
 
 
 function markOverwrite(file) {
-  console.log(file)
   window.filtered.push(file.id);
-  console.log('pushed to filtered list')
   const name = file.meta.name;
   waitForElement(`.uppy-Dashboard-Item-name[title="${name}"]`).then(title => {
     const wrapper = title.closest('.uppy-Dashboard-Item');
     wrapper.classList.add('bg-danger', 'rounded', 'p-2');
-    swapButtons();
+    addOverwriteButton();
   });
 }
 
-function swapButtons() {
+function addOverwriteButton() {
   const safeBtnId = 'safe-upload-btn';
   if(document.getElementById(safeBtnId) !== null) {
     return
   }
 
-  const uploadBtn = document.querySelector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload')
+  const uploadBtn = document.querySelector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload');
   const safeBtn = uploadBtn.cloneNode();
   safeBtn.id = safeBtnId;
   safeBtn.textContent = 'Upload New Files';
@@ -326,16 +309,4 @@ function waitForElement(selector, { root = document.body, timeout = 5000 } = {})
       reject(new Error(`Timed out waiting for "${selector}"`));
     }, timeout);
   });
-}
-
-function disableUploads() {
-  uploadBtn().setAttribute('disabled');
-}
-
-function enableUploads() {
-  uploadBtn().removeAttribute('disabled');
-}
-
-function uploadBtn() {
-  return document.querySelector('button.uppy-StatusBar-actionBtn--upload');
 }

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -111,7 +111,7 @@ jQuery(function() {
     if(file.meta.relativePath == null && file.data.webkitRelativePath){
       uppy.setFileMeta(file.id, { relativePath: file.data.webkitRelativePath });
     }
-    checkUpload(file.meta)
+    checkUpload(file)
   });
 
   uppy.on('complete', (result) => {
@@ -155,6 +155,7 @@ jQuery(function() {
     this.classList.remove('dragover');
   });
 
+  window.filtered = [];
 });
 
 function closeAndResetUppyModal(uppy){
@@ -208,19 +209,20 @@ function handleUploadSuccess(result) {
   }
 }
 
-function checkUpload(meta) {
+function checkUpload(file) {
+  const meta = file.meta
   const relPath = meta.relativePath || meta.name
   console.log(`Checking path ${relPath}`);
   if (checkOverwrite(relPath)) {
     if (meta.relativePath == null) {
       // then file is uploaded directly, and conflict is confirmed
-      markOverwrite(relPath)
+      markOverwrite(file)
     } else {
       // file was uploaded as part of a folder, and we have to check if its a true conflict
       disableUploads()
       investigateOverwrite(relPath).then((result) => {
         if(result) {
-          markOverwrite(relPath);
+          markOverwrite(file);
         }
         enableUploads()
       })
@@ -229,6 +231,20 @@ function checkUpload(meta) {
   } else {
     console.log('No overwrite detected')
   }
+  // After new file appears, ensure earlier ones are marked
+  waitForElement(`.uppy-Dashboard-Item-name[title="${file.meta.name}"]`).then(title => {
+    window.filtered.forEach(id => {
+      markOverwrite(uppy.getFile(id))
+    })
+  })
+}
+
+function safeUpload() {
+  window.filtered.forEach(id => {
+    uppy.removeFile(id);
+  })
+  window.filtered = [];
+  uppy.upload();
 }
 
 function checkOverwrite(relativePath) {
@@ -254,25 +270,32 @@ async function investigateOverwrite(path) {
 }
 
 
-function markOverwrite(path) {
-  const file = path.slice(path.lastIndexOf('/') + 1);
-
-  waitForElement(`.uppy-Dashboard-Item-name[title="${file}"]`).then(title => {
+function markOverwrite(file) {
+  console.log(file)
+  window.filtered.push(file.id);
+  console.log('pushed to filtered list')
+  const name = file.meta.name;
+  waitForElement(`.uppy-Dashboard-Item-name[title="${name}"]`).then(title => {
     const wrapper = title.closest('.uppy-Dashboard-Item');
-    wrapper.classList.add('bg-danger', 'rounded');
+    wrapper.classList.add('bg-danger', 'rounded', 'p-2');
+    swapButtons();
   });
 }
 
 function swapButtons() {
-  const overwriteBtnId = 'upload-and-overwrite-btn';
-  if(document.getElementById(overwriteBtnId) !== null) {
+  const safeBtnId = 'safe-upload-btn';
+  if(document.getElementById(safeBtnId) !== null) {
     return
   }
 
-  var newButton = document.createElement('btn');
-  newButton.id = overwriteBtnId;
-  newButton.classList.add('btn-bg-da')
-  document.querySelector('div.uppy-StatusBar-actions')
+  const uploadBtn = document.querySelector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload')
+  const safeBtn = uploadBtn.cloneNode();
+  safeBtn.id = safeBtnId;
+  safeBtn.textContent = 'Upload New Files';
+  safeBtn.addEventListener('click', safeUpload);
+  uploadBtn.classList.add('mx-3', 'uppy-StatusBar-actionBtn--upload-danger');
+  uploadBtn.textContent = 'Upload and Overwrite';
+  document.querySelector('div.uppy-StatusBar-actions').prepend(safeBtn);
 }
 
 function waitForElement(selector, { root = document.body, timeout = 5000 } = {}) {

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -242,10 +242,60 @@ function checkOverwrite(relativePath) {
 }
 
 async function investigateOverwrite(path) {
-  const targetPath = `${history.state.currentDirectory}/${relPath}`
-  const targetDir = targetPath.slice(0, targetPath.lastIndexOf('/'));
-  // fetch dir children, and see if targetPath exists
-  return true
+  const directory = path.slice(0, path.lastIndexOf('/'));
+  const targetFile = path.slice(path.lastIndexOf('/') + 1);
+
+
+  const url = `${history.state.currentDirectoryUrl}/${directory}`;
+  const data = fetch(url, { headers: { 'Accept': 'application/json' }})
+                 .then(response => response.json)
+  
+  return Array.from(data.files).includes(targetFile)
+}
+
+
+function markOverwrite(path) {
+  const file = path.slice(path.lastIndexOf('/') + 1);
+
+  waitForElement(`.uppy-Dashboard-Item-name[title="${file}"]`).then(title => {
+    const wrapper = title.closest('.uppy-Dashboard-Item');
+    wrapper.classList.add('bg-danger', 'rounded');
+  });
+}
+
+function swapButtons() {
+  const overwriteBtnId = 'upload-and-overwrite-btn';
+  if(document.getElementById(overwriteBtnId) !== null) {
+    return
+  }
+
+  var newButton = document.createElement('btn');
+  newButton.id = overwriteBtnId;
+  newButton.classList.add('btn-bg-da')
+  document.querySelector('div.uppy-StatusBar-actions')
+}
+
+function waitForElement(selector, { root = document.body, timeout = 5000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const existing = root.querySelector(selector);
+    if (existing) return resolve(existing);
+
+    const observer = new MutationObserver(() => {
+      const el = root.querySelector(selector);
+      if (el) {
+        observer.disconnect();
+        clearTimeout(timer);
+        resolve(el);
+      }
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+
+    const timer = setTimeout(() => {
+      observer.disconnect();
+      reject(new Error(`Timed out waiting for "${selector}"`));
+    }, timeout);
+  });
 }
 
 function disableUploads() {

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -295,7 +295,14 @@ function swapButtons() {
   safeBtn.addEventListener('click', safeUpload);
   uploadBtn.classList.add('mx-3', 'uppy-StatusBar-actionBtn--upload-danger');
   uploadBtn.textContent = 'Upload and Overwrite';
-  document.querySelector('div.uppy-StatusBar-actions').prepend(safeBtn);
+
+  const warning = document.createElement('span');
+  warning.classList.add('text-danger', 'lh-base')
+  warning.textContent = 'Duplicate files identified. Uploading these files will overwrite existing content.'
+  
+  const actionsWrapper = document.querySelector('div.uppy-StatusBar-actions');
+  actionsWrapper.prepend(safeBtn);
+  actionsWrapper.append(warning);
 }
 
 function waitForElement(selector, { root = document.body, timeout = 5000 } = {}) {

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -115,11 +115,13 @@ jQuery(function() {
   });
 
   uppy.on('file-removed', (file) => {
-    window.filtered = window.filtered.filter(id => id !== file.id);
-    if(window.filtered.length === 0) {
+    if(window.overwriteFiles.delete(file.id) && window.overwriteFiles.size === 0) {
       removeOverwriteButton();
-      updateUppyCount();
     }
+    waitForElement(`.uppy-Dashboard-Item-name[title="${file.meta.name}"]`, true).then(_title => {
+      window.overwriteFiles.forEach(id => { markOverwrite(uppy.getFile(id)) });
+      updateUppyCount();
+    })
   })
 
   uppy.on('complete', (result) => {
@@ -163,7 +165,7 @@ jQuery(function() {
     this.classList.remove('dragover');
   });
 
-  window.filtered = [];
+  window.overwriteFiles = new Set;
 });
 
 function closeAndResetUppyModal(uppy){
@@ -234,14 +236,14 @@ async function checkUpload(file) {
   }
   // After new file appears, ensure earlier ones are marked
   waitForElement(`.uppy-Dashboard-Item-name[title="${file.meta.name}"]`).then(title => {
-    window.filtered.forEach(id => { markOverwrite(uppy.getFile(id)) });
+    window.overwriteFiles.forEach(id => { markOverwrite(uppy.getFile(id)) });
     updateUppyCount();
   })
 }
 
 function safeUpload() {
-  window.filtered.forEach(id => { uppy.removeFile(id); })
-  window.filtered = [];
+  window.overwriteFiles.forEach(id => { uppy.removeFile(id); })
+  window.overwriteFiles.clear();
   uppy.upload();
 }
 
@@ -262,7 +264,7 @@ async function investigateOverwrite(path) {
 
 
 function markOverwrite(file) {
-  window.filtered.push(file.id);
+  window.overwriteFiles.add(file.id);
   const name = file.meta.name;
   waitForElement(`.uppy-Dashboard-Item-name[title="${name}"]`).then(title => {
     const wrapper = title.closest('.uppy-Dashboard-Item');
@@ -306,20 +308,22 @@ function removeOverwriteButton() {
 }
 
 function updateUppyCount() {
-  if(document.getElementById(safeBtnId) === null) {
-    const uploadBtn = document.querySelector(uploadBtnSelector);
-    uploadBtn.textContent = `Upload ${uppy.getFiles().length} files`; 
+  const uploadBtn = document.querySelector(uploadBtnSelector);
+  if(document.getElementById(safeBtnId) === null && uploadBtn !== null) {
+    const count = uppy.getFiles().length;
+    uploadBtn.textContent = `Upload ${count} file${(count == 1) ? '': 's'}`; 
   }
 }
 
-function waitForElement(selector, { root = document.body, timeout = 5000 } = {}) {
+function waitForElement(selector, deleted = false, { root = document.body, timeout = 5000 } = {}) {
   return new Promise((resolve, reject) => {
     const existing = root.querySelector(selector);
     if (existing) return resolve(existing);
 
     const observer = new MutationObserver(() => {
       const el = root.querySelector(selector);
-      if (el) {
+      finished = deleted ? !el : el;
+      if (finished) {
         observer.disconnect();
         clearTimeout(timer);
         resolve(el);

--- a/apps/dashboard/app/javascript/files/uppy_ops.js
+++ b/apps/dashboard/app/javascript/files/uppy_ops.js
@@ -201,6 +201,7 @@ function updateEndpoint() {
   uppy.getPlugin('XHRUpload').setOptions({
     endpoint: history.state.currentFilesUploadPath,
   });
+  removeOverwriteButton();
 }
 
 function reloadTable() {

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -382,6 +382,12 @@ class FilesTest < ApplicationSystemTestCase
     end
   end
 
+  def assert_overwrite_buttons
+    assert_selector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload', text: 'Upload New Files')
+    assert_selector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload-danger', text: 'Upload and Overwrite')
+    assert_selector('.uppy-StatusBar-actions span', text: 'Duplicate files identified. Uploading these files will overwrite existing content.')
+  end
+
   test 'uploading duplicate files' do
     Dir.mktmpdir do |dir|
       File.stubs(:umask).returns(18) # ensure default umask is 644
@@ -414,7 +420,11 @@ class FilesTest < ApplicationSystemTestCase
       find('#upload-btn').click
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       attach_file 'files[]', src_file, visible: false, match: :first
-      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      assert_selector(".uppy-Dashboard-Item-name[title='testfile.sh']")
+      assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2")
+      assert_overwrite_buttons
+
+      click_on('Upload and Overwrite')
       find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
 
       # and it's still there, now with new content and it keeps the 755 permissions
@@ -423,6 +433,52 @@ class FilesTest < ApplicationSystemTestCase
       assert_equal File.stat(upload_file).mode, 33_261 # still 755
     end
   end
+
+  # test 'uploading duplicate files without overwriting' do
+  #   Dir.mktmpdir do |dir|
+  #     File.stubs(:umask).returns(18) # ensure default umask is 644
+  #     upload_dir = File.join(dir, 'upload')
+  #     FileUtils.mkpath(upload_dir)
+
+  #     src_file = "#{dir}/testfile.sh"
+  #     upload_file = "#{upload_dir}/testfile.sh"
+  #     `echo 'here some initial content' > #{src_file}`
+
+  #     visit files_url(upload_dir)
+  #     find('#upload-btn').click
+  #     find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+
+  #     attach_file 'files[]', src_file, visible: false, match: :first
+  #     find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+  #     find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+  #     assert File.exist?(upload_file)
+  #     assert_equal File.read(src_file), File.read(upload_file)
+  #     assert_equal(33_188, File.stat(upload_file).mode) # default 644
+
+  #     # now change the permissions and verify
+  #     `chmod 755 #{upload_file}`
+  #     assert_equal(33_261, File.stat(upload_file).mode) # now 755
+
+  #     # add something more to the original file
+  #     `echo 'and some more content' >> #{src_file}`
+
+  #     # upload the file again
+  #     find('#upload-btn').click
+  #     find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+  #     attach_file 'files[]', src_file, visible: false, match: :first
+  #     assert_selector(".uppy-Dashboard-Item-name[title='testfile.sh']")
+  #     assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2")
+  #     assert_overwrite_buttons
+
+  #     click_on('Upload and Overwrite')
+  #     find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+
+  #     # and it's still there, now with new content and it keeps the 755 permissions
+  #     assert File.exist?(upload_file)
+  #     assert_equal File.read(src_file), File.read(upload_file)
+  #     assert_equal File.stat(upload_file).mode, 33_261 # still 755
+  #   end
+  # end
 
   test 'changing directory' do
     visit files_url(Rails.root.to_s)

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -474,6 +474,7 @@ class FilesTest < ApplicationSystemTestCase
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       attach_file 'files[]', src_file, visible: false, match: :first
       click_on('Add more')
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       attach_file 'files[]', new_file, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(new_file)}']")
@@ -585,9 +586,9 @@ class FilesTest < ApplicationSystemTestCase
 
       # in order to find the directory input, we have to swap so that it is first in the DOM
       SWAP_FILE_INPUT_SCRIPT = <<~HEREDOC
-        inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
-        fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
-        dirInput = inputsWrapper.querySelector('[webkitdirectory]');
+        const inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
+        const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
+        const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
         inputsWrapper.insertBefore(dirInput, fileInput);
       HEREDOC
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
@@ -662,6 +663,140 @@ class FilesTest < ApplicationSystemTestCase
         assert File.exist?(target_path)
         assert_equal File.read(file), File.read(target_path)
       end
+    end
+  end
+
+  test 'uppy count remains accurate after overwrite warning' do
+    Dir.mktmpdir do |dir|
+      upload_dir = File.join(dir, 'upload')
+      FileUtils.mkpath(upload_dir)
+
+      src_dir = "#{dir}/testdir"
+
+      target_dir = "#{upload_dir}/testdir"
+
+      Dir.mkdir(src_dir)
+      src_file_1 = "#{src_dir}/test1.sh"
+      src_file_2 = "#{src_dir}/test2.sh"
+      src_file_3 = "#{src_dir}/test3.sh"
+      src_file_4 = "#{src_dir}/test4.sh"
+      src_file_5 = "#{src_dir}/test5.sh"
+
+      src_files = [src_file_1, src_file_2, src_file_3, src_file_4, src_file_5]
+      src_files.each_with_index do |file, index|
+        `echo 'some content in file #{index + 1}' > #{file}`
+      end
+
+      visit files_url(upload_dir)
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+
+      # in order to find the directory input, we have to swap so that it is first in the DOM
+      SWAP_FILE_INPUT_SCRIPT = <<~HEREDOC
+        inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
+        const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
+        const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
+        inputsWrapper.insertBefore(dirInput, fileInput);
+      HEREDOC
+      page.execute_script(SWAP_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', src_dir, visible: false, match: :first
+      assert_selector('.uppy-StatusBar-actionBtn--upload', text: 'Upload 5 files')
+      click_on('Upload 5 files')
+
+      assert_selector('tbody a', exact_text: File.basename(src_dir))
+      click_on(File.basename(src_dir))
+      src_files.each do |file|
+        assert_selector('tbody a', exact_text: File.basename(file))
+        target_path = File.join(target_dir, File.basename(file))
+        assert File.exist?(target_path)
+        assert_equal File.read(file), File.read(target_path)
+      end
+      
+      # delete all but one file
+      saved_file = src_file_3
+      src_files.each do |file|
+        if file != saved_file
+          find('tbody a', exact_text: File.basename(file)).ancestor('tr').check
+        end
+      end
+      accept_alert do
+        find('#delete-btn').click
+      end
+
+      src_files.each do |file|
+        if file != saved_file
+          refute_selector('tbody a', exact_text: File.basename(file))
+        else
+          assert_selector('tbody a', exact_text: File.basename(file))
+        end
+      end
+
+      # reupload and check overwrite warning
+      click_on(File.basename(upload_dir))
+      assert_selector('tbody a', exact_text: File.basename(target_dir))
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      page.execute_script(SWAP_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', src_dir, visible: false, match: :first
+
+      assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 1)
+      assert_selector(".uppy-Dashboard-Item:not(.bg-danger)", count: 4)
+      assert_overwrite_buttons
+
+      # remove overwrite file and check buttons again
+      find('.uppy-Dashboard-Item.bg-danger .uppy-Dashboard-Item-action--remove').click
+      refute_selector(".uppy-Dashboard-Item-name[title='#{File.basename(saved_file)}']")
+      refute_selector('.uppy-Dashboard-Item.bg-danger')
+      refute_selector('#safe-upload-btn')
+      refute_selector('.uppy-StatusBar-actionBtn--upload-danger')
+      refute_selector('.uppy-StatusBar-actions span')
+      assert_selector('.uppy-StatusBar-actionBtn--upload', exact_text: 'Upload 4 files')
+
+      # count remains accurate when removing files
+      find('.uppy-Dashboard-Item .uppy-Dashboard-Item-action--remove', match: :first).click
+      assert_selector('.uppy-StatusBar-actionBtn--upload', exact_text: 'Upload 3 files')     
+      find('.uppy-Dashboard-Item .uppy-Dashboard-Item-action--remove', match: :first).click
+      assert_selector('.uppy-StatusBar-actionBtn--upload', exact_text: 'Upload 2 files')
+
+      # count remains accurate when adding files
+      new_file = "#{dir}/newfile.sh"
+      `echo 'some content in this file' > #{new_file}`
+      click_on('Add more')
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      # have to swap back to add a file
+      RESET_FILE_INPUT_SCRIPT = <<~HEREDOC
+        inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
+        const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
+        const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
+        inputsWrapper.insertBefore(fileInput, dirInput);
+      HEREDOC
+      page.execute_script(RESET_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', new_file, visible: false, match: :first
+      assert_selector('.uppy-StatusBar-actionBtn--upload', exact_text: 'Upload 3 files')
+
+      # count remains accurate when adding directories
+      new_dir = "#{dir}/testdir/subdir"
+      Dir.mkdir(new_dir)
+      new_file_1 = "#{new_dir}/file1"
+      new_file_2 = "#{new_dir}/file2"
+      new_file_3 = "#{new_dir}/file3"
+      `echo 'new content in subdir file 1' > #{new_file_1}`
+      `echo 'new content in subdir file 2' > #{new_file_2}`
+      `echo 'new content in subdir file 3' > #{new_file_3}`
+      click_on('Add more')
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      page.execute_script(SWAP_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', new_dir, visible: false, match: :first
+      assert_selector('.uppy-StatusBar-actionBtn--upload', text: 'Upload 6 files')
+
+      # verify upload since we're here
+      click_on('Upload 6 files')
+      assert_selector('tbody a', exact_text: File.basename(new_file))
+      click_on(File.basename(src_dir))
+      assert_selector('tbody a', count: 3)
+      click_on(File.basename(upload_dir))
+      click_on(File.basename(new_dir))
+      assert_selector('tbody a', count: 3)
     end
   end
 

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -558,6 +558,113 @@ class FilesTest < ApplicationSystemTestCase
     end
   end
 
+  test 'uploading duplicate files within directories' do
+    Dir.mktmpdir do |dir|
+      upload_dir = File.join(dir, 'upload')
+      FileUtils.mkpath(upload_dir)
+
+      src_dir = "#{dir}/testdir"
+
+      target_dir = "#{upload_dir}/testdir"
+
+      Dir.mkdir(src_dir)
+      src_file_1 = "#{src_dir}/test1.sh"
+      src_file_2 = "#{src_dir}/test2.sh"
+      src_file_3 = "#{src_dir}/test3.sh"
+      src_file_4 = "#{src_dir}/test4.sh"
+      src_file_5 = "#{src_dir}/test5.sh"
+
+      src_files = [src_file_1, src_file_2, src_file_3, src_file_4, src_file_5]
+      src_files.each_with_index do |file, index|
+        `echo 'some content in file #{index + 1}' > #{file}`
+      end
+
+      visit files_url(upload_dir)
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+
+      # in order to find the directory input, we have to swap so that it is first in the DOM
+      SWAP_FILE_INPUT_SCRIPT = <<~HEREDOC
+        inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
+        fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
+        dirInput = inputsWrapper.querySelector('[webkitdirectory]');
+        inputsWrapper.insertBefore(dirInput, fileInput);
+      HEREDOC
+      page.execute_script(SWAP_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', src_dir, visible: false, match: :first
+      assert_selector('.uppy-StatusBar-actionBtn--upload', text: 'Upload 5 files')
+      click_on('Upload 5 files')
+
+      assert_selector('tbody a', exact_text: File.basename(src_dir))
+      click_on(File.basename(src_dir))
+      src_files.each do |file|
+        assert_selector('tbody a', exact_text: File.basename(file))
+        target_path = File.join(target_dir, File.basename(file))
+        assert File.exist?(target_path)
+        assert_equal File.read(file), File.read(target_path)
+      end
+
+      # Delete one file so we can re-upload it later
+      deleted_file = src_file_3
+      find('tbody a', exact_text: File.basename(deleted_file)).ancestor('tr').check
+      accept_alert do
+        find('#delete-btn').click
+      end
+      refute_selector('tbody a', exact_text: File.basename(deleted_file))
+
+      click_on(File.basename(upload_dir))
+      assert_selector('tbody a', exact_text: File.basename(target_dir))
+
+      # add new content to each file
+      src_files.each do |file|
+        `echo ' and some new content too!' >> #{file}`
+      end
+
+      # upload the directory again
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      page.execute_script(SWAP_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', src_dir, visible: false, match: :first
+
+      assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 4)
+      assert_selector(".uppy-Dashboard-Item:not(.bg-danger)", count: 1)
+      assert_overwrite_buttons
+
+      click_on('Upload New Files')
+      assert_selector('tbody a', exact_text: File.basename(src_dir))
+      # only the file we deleted has updated content
+      src_files.each do |file|
+        target_path = File.join(target_dir, File.basename(file))
+        assert File.exist?(target_path)
+        if file == deleted_file
+          assert_equal File.read(file), File.read(target_path)
+        else
+          assert File.read(file) != File.read(target_path), message: "expected #{File.read(file)} to have more content than #{File.read(target_path)}"
+        end
+      end
+
+      # repeat the process but overwrite this time
+      src_files.each do |file|
+        `echo ' and some even newer content!' >> #{file}`
+      end
+
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      page.execute_script(SWAP_FILE_INPUT_SCRIPT)
+      attach_file 'files[]', src_dir, visible: false, match: :first
+      assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 5)
+      assert_overwrite_buttons
+
+      click_on('Upload and Overwrite')
+      assert_selector('tbody a', exact_text: File.basename(src_dir))
+      src_files.each do |file|
+        target_path = File.join(target_dir, File.basename(file))
+        assert File.exist?(target_path)
+        assert_equal File.read(file), File.read(target_path)
+      end
+    end
+  end
+
   test 'changing directory' do
     visit files_url(Rails.root.to_s)
     assert_selector('tbody a', exact_text: 'app')

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -485,8 +485,8 @@ class FilesTest < ApplicationSystemTestCase
       assert_overwrite_buttons
 
       click_on('Upload New Files')
-      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
-      find('tbody a', exact_text: File.basename(new_file), wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: File.basename(src_file))
+      assert_selector('tbody a', exact_text: File.basename(new_file))
 
       # and it's still there, with content and mode unchanged
       assert File.exist?(upload_file)
@@ -514,11 +514,11 @@ class FilesTest < ApplicationSystemTestCase
 
       visit files_url(upload_dir)
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
 
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
-      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: File.basename(src_file))
       assert File.exist?(upload_file)
       assert_equal File.read(src_file), File.read(upload_file)
 
@@ -530,7 +530,7 @@ class FilesTest < ApplicationSystemTestCase
 
       # upload the file again
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       attach_file 'files[]', src_file, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
       click_on('Add more')
@@ -551,8 +551,8 @@ class FilesTest < ApplicationSystemTestCase
 
       click_on('Upload 1 file')
 
-      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
-      find('tbody a', exact_text: File.basename(new_file), wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: File.basename(src_file))
+      assert_selector('tbody a', exact_text: File.basename(new_file))
 
       # and it's still there, with content and mode unchanged
       assert File.exist?(upload_file)
@@ -602,7 +602,7 @@ class FilesTest < ApplicationSystemTestCase
 
       visit files_url(upload_dir)
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
 
       # in order to find the directory input, we have to swap so that it is first in the DOM
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
@@ -637,7 +637,7 @@ class FilesTest < ApplicationSystemTestCase
 
       # upload the directory again
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', src_dir, visible: false, match: :first
 
@@ -664,7 +664,7 @@ class FilesTest < ApplicationSystemTestCase
       end
 
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', src_dir, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 5)
@@ -705,7 +705,7 @@ class FilesTest < ApplicationSystemTestCase
 
       visit files_url(upload_dir)
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
 
       # in order to find the directory input, we have to swap so that it is first in the DOM
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
@@ -745,7 +745,7 @@ class FilesTest < ApplicationSystemTestCase
       click_on(File.basename(upload_dir))
       assert_selector('tbody a', exact_text: File.basename(target_dir))
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', src_dir, visible: false, match: :first
 
@@ -774,7 +774,7 @@ class FilesTest < ApplicationSystemTestCase
       click_on('Add more')
       # Even though we attach to the hidden input, we need to shift focus from 'Add more' before the next contrast check
       click_on('browse files')
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       # have to swap back to add a file
       page.execute_script(RESET_FILE_INPUT_SCRIPT)
       attach_file 'files[]', new_file, visible: false, match: :first
@@ -792,7 +792,7 @@ class FilesTest < ApplicationSystemTestCase
       click_on('Add more')
       # Even though we attach to the hidden input, we need to shift focus from 'Add more' before the next contrast check
       click_on('browse files')
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', new_dir, visible: false, match: :first
       assert_selector('.uppy-StatusBar-actionBtn--upload', text: 'Upload 6 files')

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -383,7 +383,7 @@ class FilesTest < ApplicationSystemTestCase
   end
 
   def assert_overwrite_buttons
-    assert_selector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload', text: 'Upload New Files')
+    assert_selector('.uppy-StatusBar-actions #safe-upload-btn.uppy-StatusBar-actionBtn--upload', text: 'Upload New Files')
     assert_selector('.uppy-StatusBar-actions .uppy-StatusBar-actionBtn--upload-danger', text: 'Upload and Overwrite')
     assert_selector('.uppy-StatusBar-actions span', text: 'Duplicate files identified. Uploading these files will overwrite existing content.')
   end
@@ -488,6 +488,69 @@ class FilesTest < ApplicationSystemTestCase
       assert File.exist?(upload_file)
       assert_equal original_content, File.read(upload_file)
       assert_equal File.stat(upload_file).mode, 33_261 # still 755
+
+      # and the new file now exists
+      assert File.exist?(new_upload_file)
+      assert_equal File.read(new_file), File.read(new_upload_file)
+    end
+  end
+
+  test 'uploading duplicate files and removing overwrites manually' do
+    Dir.mktmpdir do |dir|
+      upload_dir = File.join(dir, 'upload')
+      FileUtils.mkpath(upload_dir)
+
+      src_file = "#{dir}/testfile.sh"
+      new_file = "#{dir}/newfile.sh"
+      upload_file = "#{upload_dir}/testfile.sh"
+      new_upload_file = "#{upload_dir}/newfile.sh"
+
+      `echo 'here some initial content' > #{src_file}`
+      `echo 'here some new content' > #{new_file}`
+
+      visit files_url(upload_dir)
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+
+      attach_file 'files[]', src_file, visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      assert File.exist?(upload_file)
+      assert_equal File.read(src_file), File.read(upload_file)
+
+      # add something more to the original file
+      `echo 'and some more content' >> #{src_file}`
+
+      # save original file content
+      original_content = File.read(upload_file)
+
+      # upload the file again
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      attach_file 'files[]', src_file, visible: false, match: :first
+      assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
+      click_on('Add more')
+      attach_file 'files[]', new_file, visible: false, match: :first
+      assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(new_file)}']")
+      assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 1)
+      assert_overwrite_buttons
+      find('.uppy-Dashboard-Item.bg-danger .uppy-Dashboard-Item-action--remove').click
+
+      # after the duplicate file is removed, things return to normal
+      refute_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
+      refute_selector('.uppy-Dashboard-Item.bg-danger')
+      refute_selector('#safe-upload-btn')
+      refute_selector('.uppy-StatusBar-actionBtn--upload-danger')
+      refute_selector('.uppy-StatusBar-actions span')
+
+      click_on('Upload 1 file')
+
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      find('tbody a', exact_text: File.basename(new_file), wait: MAX_WAIT)
+
+      # and it's still there, with content and mode unchanged
+      assert File.exist?(upload_file)
+      assert_equal original_content, File.read(upload_file)
 
       # and the new file now exists
       assert File.exist?(new_upload_file)

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -420,7 +420,7 @@ class FilesTest < ApplicationSystemTestCase
       find('#upload-btn').click
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       attach_file 'files[]', src_file, visible: false, match: :first
-      assert_selector(".uppy-Dashboard-Item-name[title='testfile.sh']")
+      assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
       assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2")
       assert_overwrite_buttons
 
@@ -434,51 +434,66 @@ class FilesTest < ApplicationSystemTestCase
     end
   end
 
-  # test 'uploading duplicate files without overwriting' do
-  #   Dir.mktmpdir do |dir|
-  #     File.stubs(:umask).returns(18) # ensure default umask is 644
-  #     upload_dir = File.join(dir, 'upload')
-  #     FileUtils.mkpath(upload_dir)
+  test 'uploading duplicate files without overwriting' do
+    Dir.mktmpdir do |dir|
+      File.stubs(:umask).returns(18) # ensure default umask is 644
+      upload_dir = File.join(dir, 'upload')
+      FileUtils.mkpath(upload_dir)
 
-  #     src_file = "#{dir}/testfile.sh"
-  #     upload_file = "#{upload_dir}/testfile.sh"
-  #     `echo 'here some initial content' > #{src_file}`
+      src_file = "#{dir}/testfile.sh"
+      new_file = "#{dir}/newfile.sh"
+      upload_file = "#{upload_dir}/testfile.sh"
+      new_upload_file = "#{upload_dir}/newfile.sh"
 
-  #     visit files_url(upload_dir)
-  #     find('#upload-btn').click
-  #     find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      `echo 'here some initial content' > #{src_file}`
+      `echo 'here some new content' > #{new_file}`
 
-  #     attach_file 'files[]', src_file, visible: false, match: :first
-  #     find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
-  #     find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
-  #     assert File.exist?(upload_file)
-  #     assert_equal File.read(src_file), File.read(upload_file)
-  #     assert_equal(33_188, File.stat(upload_file).mode) # default 644
+      visit files_url(upload_dir)
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
 
-  #     # now change the permissions and verify
-  #     `chmod 755 #{upload_file}`
-  #     assert_equal(33_261, File.stat(upload_file).mode) # now 755
+      attach_file 'files[]', src_file, visible: false, match: :first
+      find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      assert File.exist?(upload_file)
+      assert_equal File.read(src_file), File.read(upload_file)
+      assert_equal(33_188, File.stat(upload_file).mode) # default 644
 
-  #     # add something more to the original file
-  #     `echo 'and some more content' >> #{src_file}`
+      # now change the permissions and verify
+      `chmod 755 #{upload_file}`
+      assert_equal(33_261, File.stat(upload_file).mode) # now 755
 
-  #     # upload the file again
-  #     find('#upload-btn').click
-  #     find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
-  #     attach_file 'files[]', src_file, visible: false, match: :first
-  #     assert_selector(".uppy-Dashboard-Item-name[title='testfile.sh']")
-  #     assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2")
-  #     assert_overwrite_buttons
+      # add something more to the original file
+      `echo 'and some more content' >> #{src_file}`
 
-  #     click_on('Upload and Overwrite')
-  #     find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      # save original file content
+      original_content = File.read(upload_file)
 
-  #     # and it's still there, now with new content and it keeps the 755 permissions
-  #     assert File.exist?(upload_file)
-  #     assert_equal File.read(src_file), File.read(upload_file)
-  #     assert_equal File.stat(upload_file).mode, 33_261 # still 755
-  #   end
-  # end
+      # upload the file again
+      find('#upload-btn').click
+      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      attach_file 'files[]', src_file, visible: false, match: :first
+      click_on('Add more')
+      attach_file 'files[]', new_file, visible: false, match: :first
+      assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
+      assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(new_file)}']")
+      assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 1)
+      assert_overwrite_buttons
+
+      click_on('Upload New Files')
+      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      find('tbody a', exact_text: File.basename(new_file), wait: MAX_WAIT)
+
+      # and it's still there, with content and mode unchanged
+      assert File.exist?(upload_file)
+      assert_equal original_content, File.read(upload_file)
+      assert_equal File.stat(upload_file).mode, 33_261 # still 755
+
+      # and the new file now exists
+      assert File.exist?(new_upload_file)
+      assert_equal File.read(new_file), File.read(new_upload_file)
+    end
+  end
 
   test 'changing directory' do
     visit files_url(Rails.root.to_s)

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -400,11 +400,11 @@ class FilesTest < ApplicationSystemTestCase
 
       visit files_url(upload_dir)
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
 
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
-      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: File.basename(src_file))
       assert File.exist?(upload_file)
       assert_equal File.read(src_file), File.read(upload_file)
       assert_equal(33_188, File.stat(upload_file).mode) # default 644
@@ -418,14 +418,15 @@ class FilesTest < ApplicationSystemTestCase
 
       # upload the file again
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       attach_file 'files[]', src_file, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
       assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2")
       assert_overwrite_buttons
 
       click_on('Upload and Overwrite')
-      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      refute_selector('.uppy-Dashboard-AddFiles')
+      assert_selector('tbody a', exact_text: File.basename(src_file))
 
       # and it's still there, now with new content and it keeps the 755 permissions
       assert File.exist?(upload_file)
@@ -450,11 +451,11 @@ class FilesTest < ApplicationSystemTestCase
 
       visit files_url(upload_dir)
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
 
       attach_file 'files[]', src_file, visible: false, match: :first
       find('.uppy-StatusBar-actionBtn--upload', wait: MAX_WAIT).click
-      find('tbody a', exact_text: File.basename(src_file), wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: File.basename(src_file))
       assert File.exist?(upload_file)
       assert_equal File.read(src_file), File.read(upload_file)
       assert_equal(33_188, File.stat(upload_file).mode) # default 644
@@ -471,10 +472,12 @@ class FilesTest < ApplicationSystemTestCase
 
       # upload the file again
       find('#upload-btn').click
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      assert_selector('.uppy-Dashboard-AddFiles')
       attach_file 'files[]', src_file, visible: false, match: :first
       click_on('Add more')
-      find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
+      # Even though we attach to the hidden input, we need to shift focus from 'Add more' before the next contrast check
+      click_on('browse files')
+      assert_selector('.uppy-Dashboard-AddFiles')
       attach_file 'files[]', new_file, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(new_file)}']")
@@ -531,6 +534,8 @@ class FilesTest < ApplicationSystemTestCase
       attach_file 'files[]', src_file, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(src_file)}']")
       click_on('Add more')
+      # Even though we attach to the hidden input, we need to shift focus from 'Add more' before the next contrast check
+      click_on('browse files')
       attach_file 'files[]', new_file, visible: false, match: :first
       assert_selector(".uppy-Dashboard-Item-name[title='#{File.basename(new_file)}']")
       assert_selector(".uppy-Dashboard-Item.bg-danger.rounded.p-2", count: 1)
@@ -558,6 +563,21 @@ class FilesTest < ApplicationSystemTestCase
       assert_equal File.read(new_file), File.read(new_upload_file)
     end
   end
+  
+  # The following scripts are required when uploading directories
+  SWAP_FILE_INPUT_SCRIPT = <<~HEREDOC
+    const inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
+    const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
+    const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
+    inputsWrapper.insertBefore(dirInput, fileInput);
+  HEREDOC
+
+  RESET_FILE_INPUT_SCRIPT = <<~HEREDOC
+    const inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
+    const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
+    const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
+    inputsWrapper.insertBefore(fileInput, dirInput);
+  HEREDOC
 
   test 'uploading duplicate files within directories' do
     Dir.mktmpdir do |dir|
@@ -585,12 +605,6 @@ class FilesTest < ApplicationSystemTestCase
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
 
       # in order to find the directory input, we have to swap so that it is first in the DOM
-      SWAP_FILE_INPUT_SCRIPT = <<~HEREDOC
-        const inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
-        const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
-        const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
-        inputsWrapper.insertBefore(dirInput, fileInput);
-      HEREDOC
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', src_dir, visible: false, match: :first
       assert_selector('.uppy-StatusBar-actionBtn--upload', text: 'Upload 5 files')
@@ -658,7 +672,9 @@ class FilesTest < ApplicationSystemTestCase
 
       click_on('Upload and Overwrite')
       assert_selector('tbody a', exact_text: File.basename(src_dir))
+      click_on(File.basename(src_dir))
       src_files.each do |file|
+        assert_selector('tbody a', exact_text: File.basename(file))
         target_path = File.join(target_dir, File.basename(file))
         assert File.exist?(target_path)
         assert_equal File.read(file), File.read(target_path)
@@ -692,12 +708,6 @@ class FilesTest < ApplicationSystemTestCase
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
 
       # in order to find the directory input, we have to swap so that it is first in the DOM
-      SWAP_FILE_INPUT_SCRIPT = <<~HEREDOC
-        inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
-        const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
-        const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
-        inputsWrapper.insertBefore(dirInput, fileInput);
-      HEREDOC
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', src_dir, visible: false, match: :first
       assert_selector('.uppy-StatusBar-actionBtn--upload', text: 'Upload 5 files')
@@ -762,14 +772,10 @@ class FilesTest < ApplicationSystemTestCase
       new_file = "#{dir}/newfile.sh"
       `echo 'some content in this file' > #{new_file}`
       click_on('Add more')
+      # Even though we attach to the hidden input, we need to shift focus from 'Add more' before the next contrast check
+      click_on('browse files')
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       # have to swap back to add a file
-      RESET_FILE_INPUT_SCRIPT = <<~HEREDOC
-        inputsWrapper = document.querySelector('.uppy-Dashboard-AddFiles');
-        const fileInput = inputsWrapper.querySelector('input:not([webkitdirectory])');
-        const dirInput = inputsWrapper.querySelector('[webkitdirectory]');
-        inputsWrapper.insertBefore(fileInput, dirInput);
-      HEREDOC
       page.execute_script(RESET_FILE_INPUT_SCRIPT)
       attach_file 'files[]', new_file, visible: false, match: :first
       assert_selector('.uppy-StatusBar-actionBtn--upload', exact_text: 'Upload 3 files')
@@ -784,6 +790,8 @@ class FilesTest < ApplicationSystemTestCase
       `echo 'new content in subdir file 2' > #{new_file_2}`
       `echo 'new content in subdir file 3' > #{new_file_3}`
       click_on('Add more')
+      # Even though we attach to the hidden input, we need to shift focus from 'Add more' before the next contrast check
+      click_on('browse files')
       find('.uppy-Dashboard-AddFiles', wait: MAX_WAIT)
       page.execute_script(SWAP_FILE_INPUT_SCRIPT)
       attach_file 'files[]', new_dir, visible: false, match: :first


### PR DESCRIPTION
A complete reworking of #5477, fixes #2679. This minimalist approach modifies the existing uppy modal, enhancing its communication of potential overwrites and avoiding permanent accidents. The user-facing approach is laid out quite well already in https://github.com/OSC/ondemand/pull/5477#issuecomment-4739681495, though this was written before this specific implementation. The basic premise is that every single upload gets checked by an async `checkUpload` function. This compares the would-be file's path to the information we already have about the current directory, requesting JSON if necessary to check subdirectories of the current dir. If an overwrite is found, we do 4 things. 
1. Highlight the overwrite files in red
2. add a green button to the left of the 'Upload X files' button, effectively taking the place of the normal button. This button gets attached to the `safeUpload` function that filters out overwrites just before initiating the upload through uppy, making it a fully reversible operation
3. Change the color of the normal button to red and change the text to communicate the danger of content being overwritten. This button still functions exactly the same as the 'Upload X files' button, just has some style changes
4. Adds a short text blurb explaining that overwrites exist and content could be overwritten

The user is free to pick either safe or dangerous uploading, but due to the clear colors and change in position, shouldn't ever overwrite content by mistake. If a user deletes all overwriting files from the upload portal, the uppy window returns to normal.

The messiest pieces of this involve how we identify the various uppy components, which appear to use classes both for styles and for communication of role (eg. `.uppy-StatusBar-actionBtn--upload`). This makes it a bit difficult to make similar looking buttons while still clearly differentiating between the new button and the original uppy one. As you can see this is currently done by assigning our custom `safe-btn` an id, and then querying for the upload class without it to get the uppy button. Since diving into the uppy UI in this way is unfortunately fragile, I have made a strong effort to test all of the various ways this could go wrong, so that we have a good way of knowing when things need to be updated. 

While the change is significant in raw numbers, it should be noted that this includes only about 100 new lines of javascript code and 400 lines of tests.