### PR TITLE
Send focus to file modal input

### DIFF
--- a/apps/dashboard/app/javascript/files/sweet_alert.js
+++ b/apps/dashboard/app/javascript/files/sweet_alert.js
@@ -77,6 +77,7 @@ jQuery(function() {
   $(CONTENTID).on(EVENTNAME.showInput, function(e, options) {
     modifyInput(options);
     $('#files_input_modal').modal('show');
+    $('#files_input_modal_input').focus();
   });
 
   $(CONTENTID).on(EVENTNAME.showLoading, function(e,options) {

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -43,7 +43,7 @@ class FilesTest < ApplicationSystemTestCase
       assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
       find('#files_input_modal_input').set('bar.txt')
       find('#files_input_modal_ok_button').click
-      find('tbody a', exact_text: 'bar.txt', wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: 'bar.txt')
       assert File.file? File.join(dir, 'bar.txt')
     end
   end
@@ -55,7 +55,7 @@ class FilesTest < ApplicationSystemTestCase
       assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
       find('#files_input_modal_input').set('bar')
       find('#files_input_modal_ok_button').click
-      find('tbody a[data-type="d"]', exact_text: 'bar', wait: MAX_WAIT)
+      assert_selector('tbody a[data-type="d"]', exact_text: 'bar')
       assert File.directory? File.join(dir, 'bar')
     end
   end
@@ -294,7 +294,7 @@ class FilesTest < ApplicationSystemTestCase
       find('#files_input_modal_input').set('bar.txt')
       find('#files_input_modal_ok_button').click
 
-      find('tbody a', exact_text: 'bar.txt', wait: MAX_WAIT)
+      assert_selector('tbody a', exact_text: 'bar.txt')
       assert File.file? File.join(dir, 'bar.txt')
     end
   end

--- a/apps/dashboard/test/system/files_test.rb
+++ b/apps/dashboard/test/system/files_test.rb
@@ -40,6 +40,7 @@ class FilesTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       visit files_url(dir)
       find('#new-file-btn').click
+      assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
       find('#files_input_modal_input').set('bar.txt')
       find('#files_input_modal_ok_button').click
       find('tbody a', exact_text: 'bar.txt', wait: MAX_WAIT)
@@ -51,6 +52,7 @@ class FilesTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       visit files_url(dir)
       find('#new-dir-btn').click
+      assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
       find('#files_input_modal_input').set('bar')
       find('#files_input_modal_ok_button').click
       find('tbody a[data-type="d"]', exact_text: 'bar', wait: MAX_WAIT)
@@ -286,6 +288,7 @@ class FilesTest < ApplicationSystemTestCase
       tr = find('a', exact_text: 'foo.txt').ancestor('tr')
       tr.find('button.dropdown-toggle').click
       tr.find('.rename-file').click
+      assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
 
       # rename dialog input
       find('#files_input_modal_input').set('bar.txt')
@@ -430,6 +433,7 @@ class FilesTest < ApplicationSystemTestCase
     assert_selector('tbody a', exact_text: 'config')
 
     find('#goto-btn').click
+    assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
     find('#files_input_modal_input').set(Rails.root.join('app'))
     find('#files_input_modal_ok_button').click
     assert_selector('tbody a', exact_text: 'helpers')
@@ -1069,7 +1073,7 @@ class FilesTest < ApplicationSystemTestCase
       tr = find('a', exact_text: 'foo').ancestor('tr')
       tr.find('button.dropdown-toggle').click
       tr.find('.rename-file').click
-
+      assert page.evaluate_script('document.activeElement === document.getElementById("files_input_modal_input")')
       find('#files_input_modal_input').set('foo')
       find('#files_input_modal_ok_button').click
 


### PR DESCRIPTION
Fixes #5604. Saves a click during simple text input operations around the files app, such as new file/directory creation, renaming, and changing directories via text field. Updates the tests around the above functionalities to ensure that this behavior persists.