### PR TITLE
fix #5518 by preserving undefined in snakeCaseWords

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -100,7 +100,7 @@ function mountainCaseWords(str) {
 function snakeCaseWords(str) {
   if(str === undefined) {
     return undefined;
-  }else if(str === "") {
+  } else if(str === "") {
     return "";
   }
 

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -98,7 +98,11 @@ function mountainCaseWords(str) {
  * @example  given 'OSC_JUPYTER' this returns 'osc_jupyter'
  */
 function snakeCaseWords(str) {
-  if(str === undefined || str === "") return "";
+  if(str === undefined) {
+    return undefined;
+  }else if(str === "") {
+    return "";
+  }
 
   // find all the capital case words and if none are found, we'll just basically
   // return the same string.


### PR DESCRIPTION
fix #5518 by preserving undefined in snakeCaseWords

I found that there was an issue here where `y` is undefined when it's passed here (meaning we want a 1d vector instead of a 2d table) but then is returned as `""` resulting in a 2d table.

https://github.com/OSC/ondemand/blob/e5f301d1a4e3de8e52446b9b6f3bfb332bed80ca/apps/dashboard/app/javascript/dynamic_forms.js#L436

This mismatch propagated to other bits of the code thinking it was interacting with a 1d vector when it was actually a 2d table, resulting in an array instead of a single value.