### PR TITLE
Pass the session information through to the "bad" session state partial,

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -24,7 +24,7 @@ module BatchConnect::SessionsHelper
     elsif session.completed?
       views = { partial: "completed", locals: { session: session } }
     else
-      views = { partial: "bad" }
+      views = { partial: "bad", locals: { session: session } } }
     end
 
     connection_tabs(session.id, views)

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -24,7 +24,7 @@ module BatchConnect::SessionsHelper
     elsif session.completed?
       views = { partial: "completed", locals: { session: session } }
     else
-      views = { partial: "bad", locals: { session: session } } }
+      views = { partial: "bad", locals: { session: session } }
     end
 
     connection_tabs(session.id, views)


### PR DESCRIPTION
so that sites can override the partial with something that can provide more information (eg the reason a job is held).

This does not change existing behaviour.