### PR TITLE
correct enumerable APIs in bc session contexts

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -91,6 +91,26 @@ module BatchConnect
       OpenStruct.new(context_attrs.merge(addons.symbolize_keys))
     end
 
+    # Redefine 'partition' from Enumerable so that sites can use it in a form.
+    def partition(&block)
+      if block_given?
+        @attributes.partition(&block)
+      else
+        # method_missing above returns value, so this does too.
+        self['partition'].value
+      end
+    end
+
+    # Redefine 'filter' from Enumerable so that sites can use it in a form.
+    def filter(&block)
+      if block_given?
+        @attributes.filter(&block)
+      else
+        # method_missing above returns value, so this does too.
+        self['filter'].value
+      end
+    end
+
     private
 
     # @return [Boolean]

--- a/apps/dashboard/test/models/batch_connect/session_context_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_context_test.rb
@@ -178,5 +178,29 @@ cacheable: true } }, form: ['bc_account', 'num_cores']
 
       assert_equal struct.to_h, { :bc_account => '', :queue => 'gpu', :new_thing => 'some_new_thing' }
     end
+
+    test 'enumerable filter still works' do
+      test_attrs = [
+        SmartAttributes::Attribute.new('cb', { widget: 'check_box' }),
+        SmartAttributes::Attribute.new('filter')
+      ]
+      cxt = BatchConnect::SessionContext.new(test_attrs)
+      filtered = cxt.filter { |a| a.id == 'cb' }
+      assert_equal(1, filtered.size)
+      assert_equal('cb', filtered.first.id)
+    end
+
+    test 'enumerable partition still works' do
+      test_attrs = [
+        SmartAttributes::Attribute.new('cb', { widget: 'check_box' }),
+        SmartAttributes::Attribute.new('parititon')
+      ]
+      cxt = BatchConnect::SessionContext.new(test_attrs)
+      partitioned = cxt.partition { |a| a.widget == 'check_box' }
+
+      # splits the input array into 2 arrays of size 1
+      assert_equal(1, partitioned[0].size)
+      assert_equal(1, partitioned[1].size)
+    end
   end
 end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -1127,4 +1127,57 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       assert_equal('display: none;', find_option_style('gpu_type', 'better'))
     end
   end
+
+  test 'enumerable overrides display corrrectly as text fields' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+      ---
+      cluster:
+      - oakley
+      form:
+        - partition
+        - filter
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # previosly these would be something like '#<Enumerator:0x00007f0ea4430788>'
+      assert_equal('', find_value('partition'))
+      assert_equal('', find_value('filter'))
+    end
+  end
+
+  test 'enumerable overrides can be checkboxes and select' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+      ---
+      cluster:
+      - oakley
+      form:
+        - partition
+        - filter
+      attributes:
+        partition:
+          widget: select
+          options:
+            - 'a'
+            - 'b'
+        filter:
+          widget: check_box
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      filter = find("##{bc_ele_id('filter')}")
+      partition = find("##{bc_ele_id('partition')}")
+
+      assert_equal('1', filter.value)
+      assert_equal('input', filter.tag_name)
+      assert_equal('checkbox', filter[:type])
+      assert_equal('a', partition.value)
+      assert_equal('select', partition.tag_name)
+    end
+  end
 end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -1128,7 +1128,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'enumerable overrides display corrrectly as text fields' do
+  test 'enumerable overrides display correctly as text fields' do
     Dir.mktmpdir do |dir|
       form = <<~HEREDOC
       ---
@@ -1142,7 +1142,7 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       make_bc_app(dir, form)
       visit new_batch_connect_session_context_url('sys/app')
 
-      # previosly these would be something like '#<Enumerator:0x00007f0ea4430788>'
+      # previously these would be something like '#<Enumerator:0x00007f0ea4430788>'
       assert_equal('', find_value('partition'))
       assert_equal('', find_value('filter'))
     end


### PR DESCRIPTION
Correct enumerable APIs in bc session contexts.

Fixes #5085

Also related tickets are #605 and #3604 when these things are text fields their default value is something like `#<Enumerator:0x00007f0ea4430788>` in the form.

This fix is for `filter` and `partition` with tests to ensure that the Enumerable APIs still work when a block is given.