### PR TITLE
pass nil so there's not an empty class attribute

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -45,7 +45,7 @@ module BatchConnect::SessionContextsHelper
     wrapped = content_tag(
       :div, 
       id: [form.object_name, attrib.id, 'wrapper'].join('_'), 
-      class: attrib.hide_by_default? ? 'd-none' : '',
+      class: attrib.hide_by_default? ? 'd-none' : nil,
       data: {
         widget_type: widget,
         hide_by_default: attrib.hide_by_default?


### PR DESCRIPTION
This a super minor thing, but looking at something else today I noticed that these `div` elements have an empty `class` attribute which seems off. 

<img width="790" height="135" alt="image" src="https://github.com/user-attachments/assets/d2964f58-8795-43df-bcb9-d64d455609b4" />

Semantically it may be OK, and surely doesn't make a difference to the machine, but to a human it seems off to see it there. So instead, this passes `nil` so there's no attribute at all.