### PR TITLE
Grouped form items

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -1,6 +1,6 @@
 # Helper for creating new batch connect sessions.
 module BatchConnect::SessionContextsHelper
-  def create_widget(form, attrib, format: nil, hide_excludable: true, hide_fixed: true)
+  def create_widget(form, attrib, format: nil, hide_excludable: true, hide_fixed: true, grouped: false)
     return '' if hide_fixed && attrib.fixed?
     return '' if attrib.hide_when_empty? && attrib.value.blank?
 
@@ -45,7 +45,7 @@ module BatchConnect::SessionContextsHelper
     wrapped = content_tag(
       :div, 
       id: [form.object_name, attrib.id, 'wrapper'].join('_'), 
-      class: attrib.hide_by_default? ? 'd-none' : '',
+      class: wrapper_class(attrib.hide_by_default?, grouped),
       data: {
         widget_type: widget,
         hide_by_default: attrib.hide_by_default?
@@ -56,6 +56,14 @@ module BatchConnect::SessionContextsHelper
 
     header = sanitize(OodAppkit.markdown.render(attrib.header))
     safe_join([header, wrapped])
+  end
+
+  def wrapper_class(hidden, grouped)
+    css = ''
+    css += 'd-none' if hidden
+    css += ' col' if grouped
+
+    css.empty? ? nil : css
   end
 
   def resolution_field(form, id, opts = {})

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -61,9 +61,19 @@ module BatchConnect::SessionContextsHelper
   def wrapper_class(hidden, grouped)
     css = ''
     css += 'd-none' if hidden
-    css += ' col' if grouped
+    css += "#{hidden ? ' ' : nil}col" if grouped
 
     css.empty? ? nil : css
+  end
+
+  def format_bc_id(id)
+    # global bc_ options strip global_ prefix from their id.
+    ga_bc_rex = /\Aglobal_bc_([\w-]+)\z/.freeze
+    if id.match?(ga_bc_rex)
+      "bc_#{id.match(ga_bc_rex)[1]}"
+    else
+      id
+    end
   end
 
   def resolution_field(form, id, opts = {})

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -73,7 +73,7 @@ module BatchConnect::SessionContextsHelper
       "bc_#{id.match(ga_bc_rex)[1]}"
     else
       # auto_modules cast - and / to _
-      id.to_s.gsub(/[-\/]/, '_')
+      id.to_s.downcase.gsub(/[-\/]/, '_')
     end
   end
 

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -72,7 +72,8 @@ module BatchConnect::SessionContextsHelper
     if id.match?(ga_bc_rex)
       "bc_#{id.match(ga_bc_rex)[1]}"
     else
-      id
+      # auto_modules cast - and / to _
+      id.to_s.gsub(/[-\/]/, '_')
     end
   end
 

--- a/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/session_contexts_helper.rb
@@ -59,11 +59,11 @@ module BatchConnect::SessionContextsHelper
   end
 
   def wrapper_class(hidden, grouped)
-    css = ''
-    css += 'd-none' if hidden
-    css += "#{hidden ? ' ' : nil}col" if grouped
+    classes = []
+    classes.push('d-none') if hidden
+    classes.push('col') if grouped
 
-    css.empty? ? nil : css
+    classes.empty? ? nil : classes.join(' ')
   end
 
   def format_bc_id(id)

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -244,12 +244,16 @@ module BatchConnect
       end
     end
 
+    def form_layout
+      @form_layout ||= form_config.fetch(:form, [])
+    end
+
     def attributes
       @attributes ||= begin
         return [] unless valid?
 
         local_attribs = form_config.fetch(:attributes, {})
-        attrib_list   = form_config.fetch(:form, [])
+        attrib_list   = form_layout.flatten
         add_cluster_widget(local_attribs, attrib_list)
 
         attrib_list.map do |attribute_id|

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -248,7 +248,7 @@ module BatchConnect
       @form_layout ||= begin
         # FIXME: duplicate logic in add_cluster_widget
         form = form_config.fetch(:form, [])
-        form.include?('cluster') ? form : form.prepend('cluster')
+        form.exclude?('cluster') && clusters.any? ? form.prepend('cluster') : form
       end
     end
 

--- a/apps/dashboard/app/models/batch_connect/app.rb
+++ b/apps/dashboard/app/models/batch_connect/app.rb
@@ -245,7 +245,11 @@ module BatchConnect
     end
 
     def form_layout
-      @form_layout ||= form_config.fetch(:form, [])
+      @form_layout ||= begin
+        # FIXME: duplicate logic in add_cluster_widget
+        form = form_config.fetch(:form, [])
+        form.include?('cluster') ? form : form.prepend('cluster')
+      end
     end
 
     def attributes

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -40,7 +40,7 @@ module BatchConnect
     # @param id [Object] id of attribute object
     # @return [SmartAttribute::Attribute, nil] attribute object if found
     def [](id)
-      @attributes.detect { |attribute| attribute == id }
+      @attributes.detect { |attribute| attribute == id.to_s.gsub(/[-\/]/, '_').downcase }
     end
 
     # For a block {|attribute| ...}

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -40,7 +40,7 @@ module BatchConnect
     # @param id [Object] id of attribute object
     # @return [SmartAttribute::Attribute, nil] attribute object if found
     def [](id)
-      @attributes.detect { |attribute| attribute == id.to_s.gsub(/[-\/]/, '_').downcase }
+      @attributes.detect { |attribute| attribute == id }
     end
 
     # For a block {|attribute| ...}

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -11,12 +11,12 @@
     <%- if form_item.is_a?(Array) -%>
     <div class="row">
       <%- form_item.each do |grouped_item| -%>
-        <%- attrib = @session_context[grouped_item] %>
+        <%- attrib = @session_context[format_bc_id(grouped_item)] %>
         <%= create_widget(f, attrib, format: @render_format, grouped: true) %>
       <%- end -%>
     </div>
     <%- else -%>
-      <%- attrib = @session_context[form_item] %>
+      <%- attrib = @session_context[format_bc_id(form_item)] %>
       <%= create_widget(f, attrib, format: @render_format) %>
     <%-  end -%>
   <%- end -%>

--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -7,9 +7,19 @@
   <span class='sr-only' tabindex='0'><%= t('dashboard.batch_connect_form_dynamic_disclaimer') %></span>
 <% end %>
 <%= bootstrap_form_for(@session_context, html: { autocomplete: "off", }) do |f| %>
-  <% f.object.each do |attrib| %>
-    <%= create_widget(f, attrib, format: @render_format) %>
-  <% end %>
+  <%- @app.form_layout.each do |form_item| -%>
+    <%- if form_item.is_a?(Array) -%>
+    <div class="row">
+      <%- form_item.each do |grouped_item| -%>
+        <%- attrib = @session_context[grouped_item] %>
+        <%= create_widget(f, attrib, format: @render_format, grouped: true) %>
+      <%- end -%>
+    </div>
+    <%- else -%>
+      <%- attrib = @session_context[form_item] %>
+      <%= create_widget(f, attrib, format: @render_format) %>
+    <%-  end -%>
+  <%- end -%>
 
   <%- if Configuration.bc_saved_settings? -%>
   <div class="mb-3 form-check">

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -1127,4 +1127,74 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       assert_equal('display: none;', find_option_style('gpu_type', 'better'))
     end
   end
+
+  test 'grouped form items work' do
+    Dir.mktmpdir do |dir|
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - [
+              first_group_item,
+              second_group_item
+            ]
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # wrappers are columns in a row.
+      ['first_group_item', 'second_group_item'].each do |item|
+        wrapper = find("##{bc_ele_id(item)}_wrapper")
+        parent = wrapper.find(:xpath, '..')
+
+        assert_equal('col', wrapper[:class])
+        assert_equal('row', parent[:class])
+      end
+    end
+  end
+
+  test 'grouped form items can be hidden' do
+    Dir.mktmpdir do |dir|
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - hide_items
+          - [
+              first_group_item,
+              second_group_item
+            ]
+        attributes:
+          hide_items:
+            widget: check_box
+            html_options:
+              data-hide-first-group-item-when-checked: true
+              data-hide-second-group-item-when-un-checked: true
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # defaults
+      assert_unchecked_field('Hide Items')
+      refute(find("##{bc_ele_id('second_group_item')}", visible: :hidden).visible?)
+      assert(find("##{bc_ele_id('first_group_item')}").visible?)
+
+      # check to hide and they flip
+      check('Hide Items')
+      assert(find("##{bc_ele_id('second_group_item')}").visible?)
+      refute(find("##{bc_ele_id('first_group_item')}", visible: :hidden).visible?)
+    end
+  end
 end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -1180,4 +1180,74 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       assert_equal('select', partition.tag_name)
     end
   end
+
+  test 'grouped form items work' do
+    Dir.mktmpdir do |dir|
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - [
+              first_group_item,
+              second_group_item
+            ]
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # wrappers are columns in a row.
+      ['first_group_item', 'second_group_item'].each do |item|
+        wrapper = find("##{bc_ele_id(item)}_wrapper")
+        parent = wrapper.find(:xpath, '..')
+
+        assert_equal('col', wrapper[:class])
+        assert_equal('row', parent[:class])
+      end
+    end
+  end
+
+  test 'grouped form items can be hidden' do
+    Dir.mktmpdir do |dir|
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - hide_items
+          - [
+              first_group_item,
+              second_group_item
+            ]
+        attributes:
+          hide_items:
+            widget: check_box
+            html_options:
+              data-hide-first-group-item-when-checked: true
+              data-hide-second-group-item-when-un-checked: true
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # defaults
+      assert_unchecked_field('Hide Items')
+      refute(find("##{bc_ele_id('second_group_item')}", visible: :hidden).visible?)
+      assert(find("##{bc_ele_id('first_group_item')}").visible?)
+
+      # check to hide and they flip
+      check('Hide Items')
+      assert(find("##{bc_ele_id('second_group_item')}").visible?)
+      refute(find("##{bc_ele_id('first_group_item')}", visible: :hidden).visible?)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1456 

Given a form like this:

```yaml
---
cluster:
  - ascend
form:
  - [
      first_group_item,
      second_group_item
    ]
```
You'll see form items grouped in a row like this:

<img width="803" height="168" alt="image" src="https://github.com/user-attachments/assets/e1bbd2d1-c7ce-4acd-8a10-fab0d9614930" />
