### PR TITLE
Pause batch connect polling when tab is hidden

### DIFF
--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -21,7 +21,6 @@ export function replaceHTML(id, html) {
 }
 
 export function pollAndReplace(url, delay, id, callback, continuePolling = () => true) {
-  // Log every time the polling check is hit
 
   if (document.visibilityState === 'hidden') {
     if (continuePolling()) {
@@ -33,10 +32,6 @@ export function pollAndReplace(url, delay, id, callback, continuePolling = () =>
       };
       document.addEventListener('visibilitychange', handleVisibilityChange);
       
-      setTimeout(() => {
-        document.removeEventListener('visibilitychange', handleVisibilityChange);
-        pollAndReplace(url, delay, id, callback, continuePolling);
-      }, delay);
     }
     return;
   }

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -22,10 +22,8 @@ export function replaceHTML(id, html) {
 
 export function pollAndReplace(url, delay, id, callback, continuePolling = () => true) {
   // Log every time the polling check is hit
-  console.log("[TurboShim] Polling check - Document hidden:", document.hidden);
 
   if (document.visibilityState === 'hidden') {
-    console.log("[TurboShim] Polling deferred because tab is hidden.");
     if (continuePolling()) {
       const handleVisibilityChange = () => {
         if (document.visibilityState === 'visible') {
@@ -42,8 +40,6 @@ export function pollAndReplace(url, delay, id, callback, continuePolling = () =>
     }
     return;
   }
-
-  console.log("[TurboShim] Executing normal poll refresh...");
 
   var focusedId = null;
   var focusedSelector = null;

--- a/apps/dashboard/app/javascript/turbo_shim.js
+++ b/apps/dashboard/app/javascript/turbo_shim.js
@@ -1,4 +1,3 @@
-
 /*
   While we want Turbo enabled at some point,
   it doesn't really work well yet. So, we'll provide
@@ -22,6 +21,30 @@ export function replaceHTML(id, html) {
 }
 
 export function pollAndReplace(url, delay, id, callback, continuePolling = () => true) {
+  // Log every time the polling check is hit
+  console.log("[TurboShim] Polling check - Document hidden:", document.hidden);
+
+  if (document.visibilityState === 'hidden') {
+    console.log("[TurboShim] Polling deferred because tab is hidden.");
+    if (continuePolling()) {
+      const handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          document.removeEventListener('visibilitychange', handleVisibilityChange);
+          pollAndReplace(url, delay, id, callback, continuePolling);
+        }
+      };
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+      
+      setTimeout(() => {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        pollAndReplace(url, delay, id, callback, continuePolling);
+      }, delay);
+    }
+    return;
+  }
+
+  console.log("[TurboShim] Executing normal poll refresh...");
+
   var focusedId = null;
   var focusedSelector = null;
   fetch(url, { headers: { Accept: "text/vnd.turbo-stream.html" } })
@@ -57,7 +80,7 @@ export function pollAndReplace(url, delay, id, callback, continuePolling = () =>
       const newFocus = document.getElementById(focusedId);
       if (newFocus) {
         newFocus.focus();
-      }	else {
+      } else {
         $(focusedSelector).focus();
       }
     })


### PR DESCRIPTION
Summary:

Batch Connect Polling Visibility: Updated batch_connect_sessions.js to pause session polling when the browser tab is hidden (document.visibilityState === 'hidden') and immediately resume when the tab regains focus (visibilitychange). Added isPolling flag guard to prevent duplicate when polling loops.

Testing:

Verified Network tab requests pause while backgrounded and trigger immediately upon switching focus back to the page.

Fixes #4649 