### PR TITLE
Fix range in transfer_local_job_test

### DIFF
--- a/apps/dashboard/test/jobs/transfer_local_job_test.rb
+++ b/apps/dashboard/test/jobs/transfer_local_job_test.rb
@@ -102,6 +102,38 @@ class TransferLocalJobTest < ActiveJob::TestCase
     Transfer.transfers.clear
   end
 
+
+  def worst_case_update_calls(src_paths)
+    # This method computes the maximum number of update calls from the copy
+    # in the next test. There is guaranteed to be a call for each file and
+    # empty directory, but depending on filesystem order the number of mkdir_p
+    # calls can vary. This method assumes that every directory with a file child
+    # gets mkdir_p called on the file child before it gets called on a subdirectory,
+    # giving us an upper bound on how many calls we should expect.
+
+    files = 0
+    empty_dirs = 0
+    dirs_with_direct_children = Set.new
+
+    walk = ->(path) {
+      path = Pathname.new(path)
+      if path.file? || path.symlink?
+        files += 1
+      elsif path.directory?
+        if path.children.empty?
+          empty_dirs += 1
+        else
+          dirs_with_direct_children.push(path) if path.children.any? { |c| c.file? || c.symlink? }
+          path.children.each { |c| walk.call(c) }
+        end
+      end
+    }
+
+    src_paths.each { |sp| walk.call(sp) }
+    files + empty_dirs + dirs_with_direct_children.size
+  end
+
+
   # FIXME: need to change this interface to something simpler
   # and then use validations to limit the scope
   test "copy updates progress once per item copied" do
@@ -117,12 +149,12 @@ class TransferLocalJobTest < ActiveJob::TestCase
       num_paths = src_paths.map do |path|
         Dir["#{path}/**/*"].length
       end.sum
+
       transfer = PosixTransfer.build(action: 'cp', files: input)
       assert_equal(num_paths, transfer.steps)
-      # FIXME: This is a littly buggy - it's updating percent for all the parent
-      # directories + 1 more time. The difference depends on the file traversal
-      # order, since some mkdir_p calls create more paths than others.
-      transfer.expects(:percent=).times(num_paths..num_paths + src_paths.length + 2)
+      # The difference here depends on the file traversal order, since some mkdir_p 
+      # calls create more paths than others. See worst_case_update_calls for more info
+      transfer.expects(:percent=).times(num_paths..worst_case_update_calls(src_paths))
 
       transfer.perform
 

--- a/apps/dashboard/test/jobs/transfer_local_job_test.rb
+++ b/apps/dashboard/test/jobs/transfer_local_job_test.rb
@@ -120,8 +120,9 @@ class TransferLocalJobTest < ActiveJob::TestCase
       transfer = PosixTransfer.build(action: 'cp', files: input)
       assert_equal(num_paths, transfer.steps)
       # FIXME: This is a littly buggy - it's updating percent for all the parent
-      # directories + 1 more time.
-      transfer.expects(:percent=).times(num_paths..num_paths + src_paths.length + 1)
+      # directories + 1 more time. The difference depends on the file traversal
+      # order, since some mkdir_p calls create more paths than others.
+      transfer.expects(:percent=).times(num_paths..num_paths + src_paths.length + 2)
 
       transfer.perform
 

--- a/apps/dashboard/test/jobs/transfer_local_job_test.rb
+++ b/apps/dashboard/test/jobs/transfer_local_job_test.rb
@@ -123,7 +123,7 @@ class TransferLocalJobTest < ActiveJob::TestCase
         if path.children.empty?
           empty_dirs += 1
         else
-          dirs_with_direct_children.push(path) if path.children.any? { |c| c.file? || c.symlink? }
+          dirs_with_direct_children.add(path) if path.children.any? { |c| c.file? || c.symlink? }
           path.children.each { |c| walk.call(c) }
         end
       end


### PR DESCRIPTION
Updated expectations for percent method in transfer_local_job_test. There was a discrepancy between how many `mkdir_p` calls occurred depending on the file traversal order, leading to a bug that only appeared in the CI. This fixes it by recursively computing the maximum number of calls that we should expect before triggering a failure. 

Put simply, imagine the following two paths `app/models/foo.rb` and `app/models/concerns/bar.rb`. When the `cp_single` method gets called, the following block could be hit either once or twice
https://github.com/OSC/ondemand/blob/0153563c032c9e9ff752e89a4854082942d91563/apps/dashboard/app/models/posix_transfer.rb#L157-L160
depending on which one gets called first. If `bar.rb` gets copied first, then `app/models` will already exist when `foo.rb` gets copied, and there will be a total of 3 calls to `inc_cp_percent`. However, if `foo.rb` gets copied first then `app/models/concerns` will not exist by the time `bar.rb` gets copied, leading to 4 calls after both files are copied. This discrepancy is the root cause responsible for the failure. By assuming a worst case scenario, this change should stop this issue from recurring.