### PR TITLE
add expected start time to queued session cards

### DIFF
--- a/apps/dashboard/app/views/batch_connect/sessions/card/_card_body.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_card_body.html.erb
@@ -3,6 +3,7 @@
     <div class="float-end"><%= cancel_or_delete(session) %></div>
     <%= render_card_partial('host', session) %>
     <%= render_card_partial('created', session) %>
+    <%= render_card_partial('expected_time', session) %> 
     <%= render_card_partial('session_time', session) %>
     <%= render_card_partial('id', session) %>
     <%= render_card_partial('support_ticket', session) if Configuration.support_ticket_enabled? %>

--- a/apps/dashboard/app/views/batch_connect/sessions/card/_expected_time.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_expected_time.html.erb
@@ -1,0 +1,6 @@
+<% unless session.running? || !session.info.dispatch_time %>
+<p>
+  <strong><%= t('dashboard.batch_connect_sessions_stats_expected_time') %></strong>
+  <%= Time.at(session.info.dispatch_time).localtime.strftime("%Y-%m-%d %H:%M:%S %Z") %>
+</p>
+<% end %>

--- a/apps/dashboard/app/views/batch_connect/sessions/card/_expected_time.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/card/_expected_time.html.erb
@@ -1,4 +1,4 @@
-<% unless session.running? || !session.info.dispatch_time %>
+<% if session.queued? && session.info.dispatch_time %>
 <p>
   <strong><%= t('dashboard.batch_connect_sessions_stats_expected_time') %></strong>
   <%= Time.at(session.info.dispatch_time).localtime.strftime("%Y-%m-%d %H:%M:%S %Z") %>

--- a/apps/dashboard/config/locales/en.yml
+++ b/apps/dashboard/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
     batch_connect_sessions_relaunch_title: Relaunch
     batch_connect_sessions_staged_root: staged root directory
     batch_connect_sessions_stats_created_at: 'Created at:'
+    batch_connect_sessions_stats_expected_time: 'Expected start:'
     batch_connect_sessions_stats_host: 'Host:'
     batch_connect_sessions_stats_session_id: 'Session ID:'
     batch_connect_sessions_stats_session_dir_link_title: 'Open session directory for %{session_id}'


### PR DESCRIPTION
Fixes #5641. Slurm uses the same value for expected start time as it does for actual start time, but this value is sometimes nil when you check. This change simply adds a card item for expected time, which only applies to queued jobs where the dispatch time is defined. As the issue mentions, I am not sure if other schedulers use similar behavior, but if there is a dispatch_time defined before the job is running it seems fair to assume that is a projected start time