### PR TITLE
add motd class to motd content

### DIFF
--- a/apps/dashboard/app/views/dashboard/_motd_markdown.html.erb
+++ b/apps/dashboard/app/views/dashboard/_motd_markdown.html.erb
@@ -1,3 +1,3 @@
 <h2><%= @motd.title %></h2>
-0;256;0c<hr />
+<hr />
 <div class="motd" data-motd-md="true"><%= @motd.content %></div>

--- a/apps/dashboard/app/views/dashboard/_motd_markdown.html.erb
+++ b/apps/dashboard/app/views/dashboard/_motd_markdown.html.erb
@@ -1,3 +1,3 @@
 <h2><%= @motd.title %></h2>
-<hr />
-<div data-motd-md="true"><%= @motd.content %></div>
+0;256;0c<hr />
+<div class="motd" data-motd-md="true"><%= @motd.content %></div>

--- a/apps/dashboard/app/views/dashboard/_motd_plaintext.html.erb
+++ b/apps/dashboard/app/views/dashboard/_motd_plaintext.html.erb
@@ -1,3 +1,3 @@
 <h2><%= @motd.title %></h2>
 <hr />
-<pre class="motd-monospaced"><%= @motd.content %></pre>
+<pre class="motd motd-monospaced"><%= @motd.content %></pre>

--- a/apps/dashboard/app/views/dashboard/_motd_rss.html.erb
+++ b/apps/dashboard/app/views/dashboard/_motd_rss.html.erb
@@ -2,7 +2,7 @@
 <hr />
 <% if @motd.content %>
   <% @motd.content.items.each do |item| %>
-    <div>
+    <div class="motd">
       <%= content_tag(:strong, item.pubDate.strftime("%m-%d-%Y")) if item.pubDate %>
       <h3><a href="<%= item.link %>"><%= item.title %></a></h3>
       <%= render_motd_rss_item(item) %>


### PR DESCRIPTION
Fixes #4036. This issue caught my eye because I had seen the motd class with lots of overflow protection in it, but it looks like this was only ever applied to motd_osc. So this change adds that class to the rest of the motd partials.