### PR TITLE
Solve batch connect alert test flakes

### DIFF
--- a/apps/dashboard/test/application_system_test_case.rb
+++ b/apps/dashboard/test/application_system_test_case.rb
@@ -70,6 +70,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def verify_bc_alert(token, header, message)
+    assert_selector('div[role="alert"]')
     assert_equal batch_connect_session_contexts_path(token), current_path
     assert_equal header, find('div[role="alert"]').find('h4').text
     assert_equal message, find('div[role="alert"]').find('pre').text


### PR DESCRIPTION
A common test flake we experience is that the url has not changed by the time we check that a failed batch connect submission has resulted in an alert. An example of one such flake is https://github.com/OSC/ondemand/actions/runs/30654343683/job/91249009228?pr=5638, and the associated screenshot 
<img width="1400" height="1257" alt="failures_test_save_errors_are_shown" src="https://github.com/user-attachments/assets/2ed36ecb-dc41-49f4-bf9c-b044013cd8a5" />
shows that the launch button has just been clicked, but the page has not refreshed. This assert selector should hopefully put this issue away for good, and wait for the page to update (or fail to update) before concluding the test.