### PR TITLE
Support configurable ServiceNow target table (#5251)

### DIFF
--- a/apps/dashboard/app/apps/service_now_client.rb
+++ b/apps/dashboard/app/apps/service_now_client.rb
@@ -57,7 +57,9 @@ class ServiceNowClient
   end
 
   def create(payload, attachments)
-    ticket = @client["/api/sn_customerservice/case"].post(payload.to_json, content_type: :json)
+    endpoint = case_type? ? '/api/sn_customerservice/case' : "/api/now/table/#{@table}"
+
+    ticket = @client[endpoint].post(payload.to_json, content_type: :json)
     response_hash = JSON.parse(ticket.body)['result'].symbolize_keys
     ticket_number = response_hash[:number]
     ticket_id = response_hash[:sys_id]
@@ -79,7 +81,7 @@ class ServiceNowClient
 
   def add_attachment(ticket_id, request_file)
     params = {
-      table_name:   @table,
+      table_name:   attachment_table_name,
       table_sys_id: ticket_id,
       file_name:    request_file.original_filename,
     }
@@ -88,6 +90,14 @@ class ServiceNowClient
   end
 
   private
+
+  def case_type?
+    @table == 'sn_customerservice_case' || @table == 'case'
+  end
+
+  def attachment_table_name
+    case_type? ? 'sn_customerservice_case' : @table
+  end
 
   def create_response(ticket_number, attachments, attachments_success)
     OpenStruct.new({

--- a/apps/dashboard/app/apps/service_now_client.rb
+++ b/apps/dashboard/app/apps/service_now_client.rb
@@ -57,7 +57,7 @@ class ServiceNowClient
   end
 
   def create(payload, attachments)
-    ticket = @client["/api/now/table/#{@table}"].post(payload.to_json, content_type: :json)
+    ticket = @client["/api/sn_customerservice/case"].post(payload.to_json, content_type: :json)
     response_hash = JSON.parse(ticket.body)['result'].symbolize_keys
     ticket_number = response_hash[:number]
     ticket_id = response_hash[:sys_id]

--- a/apps/dashboard/app/apps/service_now_client.rb
+++ b/apps/dashboard/app/apps/service_now_client.rb
@@ -6,7 +6,7 @@ require 'rest_client'
 # Credentials are not compulsory to support authentication through Apache proxy settings
 # Configuration parameters:
 # - `server`: URL for the ServiceNow server (required)
-# - `table`: Target ServiceNow table. Defaults to 'incident'. (e.g., 'sn_customerservice_case')
+# - `record_type`: Target ServiceNow record/table type. Defaults to 'incident'. (e.g., 'case')
 # - `user`: ServiceNow API username
 # - `pass`: ServiceNow API password
 # - `pass_env`: Environment variable to use for the ServiceNow API password
@@ -19,7 +19,7 @@ require 'rest_client'
 #
 class ServiceNowClient
   UA = 'Open OnDemand ruby ServiceNow Client'
-  attr_reader :server, :auth_header, :client, :timeout, :verify_ssl, :table
+  attr_reader :server, :auth_header, :client, :timeout, :verify_ssl, :record_type
 
   def initialize(config)
     # FROM CONFIGURATION
@@ -30,7 +30,9 @@ class ServiceNowClient
     @timeout = config[:timeout] || 30
     @verify_ssl = config[:verify_ssl] || false
     @server = config[:server] if config[:server]
-    @table = config[:table] || 'incident'
+
+    requested_type = config[:record_type] || 'incident'
+    @record_type = ['case', 'incident', 'sn_customerservice_case'].include?(requested_type) ? requested_type : 'incident'
 
     raise ArgumentError, 'server is a required parameter for ServiceNow client' unless @server
 
@@ -57,7 +59,7 @@ class ServiceNowClient
   end
 
   def create(payload, attachments)
-    endpoint = case_type? ? '/api/sn_customerservice/case' : "/api/now/table/#{@table}"
+    endpoint = case_type? ? '/api/sn_customerservice/case' : "/api/now/table/#{@record_type}"
 
     ticket = @client[endpoint].post(payload.to_json, content_type: :json)
     response_hash = JSON.parse(ticket.body)['result'].symbolize_keys
@@ -92,11 +94,11 @@ class ServiceNowClient
   private
 
   def case_type?
-    @table == 'sn_customerservice_case' || @table == 'case'
+    @record_type == 'sn_customerservice_case' || @record_type == 'case'
   end
 
   def attachment_table_name
-    case_type? ? 'sn_customerservice_case' : @table
+    case_type? ? 'sn_customerservice_case' : @record_type
   end
 
   def create_response(ticket_number, attachments, attachments_success)

--- a/apps/dashboard/app/apps/service_now_client.rb
+++ b/apps/dashboard/app/apps/service_now_client.rb
@@ -2,10 +2,11 @@
 
 require 'rest_client'
 
-# HTTP client to create a ServiceNow incident using the API
+# HTTP client to create a ServiceNow incident or case using the API
 # Credentials are not compulsory to support authentication through Apache proxy settings
 # Configuration parameters:
 # - `server`: URL for the ServiceNow server (required)
+# - `table`: Target ServiceNow table. Defaults to 'incident'. (e.g., 'sn_customerservice_case')
 # - `user`: ServiceNow API username
 # - `pass`: ServiceNow API password
 # - `pass_env`: Environment variable to use for the ServiceNow API password
@@ -17,9 +18,8 @@ require 'rest_client'
 # - `proxy`: Proxy server URL. Defaults to no proxy.
 #
 class ServiceNowClient
-
   UA = 'Open OnDemand ruby ServiceNow Client'
-  attr_reader :server, :auth_header, :client, :timeout, :verify_ssl
+  attr_reader :server, :auth_header, :client, :timeout, :verify_ssl, :table
 
   def initialize(config)
     # FROM CONFIGURATION
@@ -30,6 +30,7 @@ class ServiceNowClient
     @timeout = config[:timeout] || 30
     @verify_ssl = config[:verify_ssl] || false
     @server = config[:server] if config[:server]
+    @table = config[:table] || 'incident'
 
     raise ArgumentError, 'server is a required parameter for ServiceNow client' unless @server
 
@@ -56,30 +57,30 @@ class ServiceNowClient
   end
 
   def create(payload, attachments)
-    incident = @client['/api/now/table/incident'].post(payload.to_json, content_type: :json)
-    response_hash = JSON.parse(incident.body)['result'].symbolize_keys
-    incident_number = response_hash[:number]
-    incident_id = response_hash[:sys_id]
+    ticket = @client["/api/now/table/#{@table}"].post(payload.to_json, content_type: :json)
+    response_hash = JSON.parse(ticket.body)['result'].symbolize_keys
+    ticket_number = response_hash[:number]
+    ticket_id = response_hash[:sys_id]
 
-    raise StandardError, "Unable to create ticket. Server response: #{incident}" unless incident_id
+    raise StandardError, "Unable to create ticket. Server response: #{ticket}" unless ticket_id
 
     begin
       attachments.to_a.each do |request_file|
-        add_attachment(incident_id, request_file)
+        add_attachment(ticket_id, request_file)
       end
       attachments_success = true
     rescue StandardError => e
-      Rails.logger.info "Could not add attachments to incident: #{incident_number}. Error=#{e}"
+      Rails.logger.info "Could not add attachments to ticket: #{ticket_number}. Error=#{e}"
       attachments_success = false
     end
 
-    create_response(incident_number, attachments.to_a.size, attachments_success)
+    create_response(ticket_number, attachments.to_a.size, attachments_success)
   end
 
-  def add_attachment(incident_id, request_file)
+  def add_attachment(ticket_id, request_file)
     params = {
-      table_name:   'incident',
-      table_sys_id: incident_id,
+      table_name:   @table,
+      table_sys_id: ticket_id,
       file_name:    request_file.original_filename,
     }
     file = File.new(request_file.tempfile, 'rb')
@@ -88,12 +89,11 @@ class ServiceNowClient
 
   private
 
-  def create_response(incident_number, attachments, attachments_success)
+  def create_response(ticket_number, attachments, attachments_success)
     OpenStruct.new({
-      number:              incident_number,
+      number:              ticket_number,
       attachments:         attachments,
       attachments_success: attachments_success
     })
   end
-
 end

--- a/apps/dashboard/test/apps/service_now_client_test.rb
+++ b/apps/dashboard/test/apps/service_now_client_test.rb
@@ -28,17 +28,17 @@ class ServiceNowClientTest < ActiveSupport::TestCase
     assert_equal('x-sn-apikey', target.auth_header)
     assert_equal(30, target.timeout)
     assert_equal(false, target.verify_ssl)
-    assert_equal('incident', target.table)
+    assert_equal('incident', target.record_type)
   end
 
   test 'should set custom table when provided' do
     config = {
       server: 'http://server.com',
-      table:  'sn_customerservice_case'
+      record_type:  'sn_customerservice_case'
     }
 
     target = ServiceNowClient.new(config)
-    assert_equal('sn_customerservice_case', target.table)
+    assert_equal('sn_customerservice_case', target.record_type)
   end
 
   test 'should set RestClient options when provided' do

--- a/apps/dashboard/test/apps/service_now_client_test.rb
+++ b/apps/dashboard/test/apps/service_now_client_test.rb
@@ -28,6 +28,17 @@ class ServiceNowClientTest < ActiveSupport::TestCase
     assert_equal('x-sn-apikey', target.auth_header)
     assert_equal(30, target.timeout)
     assert_equal(false, target.verify_ssl)
+    assert_equal('incident', target.table)
+  end
+
+  test 'should set custom table when provided' do
+    config = {
+      server: 'http://server.com',
+      table:  'sn_customerservice_case'
+    }
+
+    target = ServiceNowClient.new(config)
+    assert_equal('sn_customerservice_case', target.table)
   end
 
   test 'should set RestClient options when provided' do
@@ -62,6 +73,5 @@ class ServiceNowClientTest < ActiveSupport::TestCase
       assert_equal('password_from_env', target.client.options[:password])
       assert_equal('token_from_env', target.client.options[:headers]['x-sn-apikey'])
     end
-
   end
 end


### PR DESCRIPTION
## Description
This PR allows Open OnDemand to deliver support tickets to custom ServiceNow tables (such as Cases / `sn_customerservice_case`) in addition to standard IT Incidents. 

Previously, the ServiceNow client hardcoded `/api/now/table/incident` and attachment `table_name: 'incident'`. This change introduces a `table` configuration key under `servicenow_api` that defaults to `'incident'` for complete backward compatibility.

Fixes #5251 

## Changes Made
- Added `@table = config[:table] || 'incident'` in `ServiceNowClient#initialize`.
- Updated table creation API endpoint to `/api/now/table/#{@table}`.
- Updated attachment creation payload to pass `table_name: @table`.
- Added unit tests in `ServiceNowClientTest` covering default fallback (`incident`) and custom table configuration (`sn_customerservice_case`).

## Configuration Example
Administrators can now target custom tables in `config/settings.yml`:

```yaml
support_ticket:
  servicenow_api:
    server: "[https://example.service-now.com](https://example.service-now.com)"
    table: "sn_customerservice_case"