### PR TITLE
feat(dashboard): allow configuring ood_bc_ssh_to_compute_node via YAML

### DIFF
--- a/apps/dashboard/app/models/batch_connect/session.rb
+++ b/apps/dashboard/app/models/batch_connect/session.rb
@@ -633,7 +633,7 @@ module BatchConnect
 
     # @return [Boolean]
     def global_ssh_to_compute_node?
-      Configuration.ood_bc_ssh_to_compute_node
+      Configuration.bc_ssh_to_compute_node
     end
 
     # A unique identifier that details the current state of a session

--- a/apps/dashboard/app/views/active_jobs/_extended_data_table.html.erb
+++ b/apps/dashboard/app/views/active_jobs/_extended_data_table.html.erb
@@ -38,7 +38,7 @@
         <% if Configuration.can_access_files? %>
           <%= link_to("#{fa_icon("folder-open", classes: nil)} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-outline-dark m-1") if data.file_explorer_url %>
         <% end %>
-        <% if Configuration.ood_bc_ssh_to_compute_node && Configuration.can_access_shell? %>
+        <% if Configuration.bc_ssh_to_compute_node && Configuration.can_access_shell? %>
           <%= link_to("#{fa_icon("terminal", classes: nil)} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-outline-dark m-1") if data.shell_url %>
         <% end %>
           <%= link_to("#{fa_icon("trash", classes: nil)} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-outline-danger pull-right m-1", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" }) %>

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -61,7 +61,7 @@ class ConfigurationSingleton
       :project_size_enabled         => true,
       :widget_partials_enabled      => false,
       :unsafe_render_html           => false,
-      :ood_bc_ssh_to_compute_node => true,
+      :bc_ssh_to_compute_node => true,
     }.freeze
   end
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -110,7 +110,10 @@ class ConfigurationSingleton
   end
 
   def ood_bc_ssh_to_compute_node
-    read_bool(ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] || true)
+    env_val = ENV['OOD_BC_SSH_TO_COMPUTE_NODE']
+    return read_bool(env_val) unless env_val.nil?
+
+    read_bool(config.fetch(:ood_bc_ssh_to_compute_node, true))
   end
 
   # @return [String, nil] version string from git describe, or nil if not git repo

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -61,6 +61,7 @@ class ConfigurationSingleton
       :project_size_enabled         => true,
       :widget_partials_enabled      => false,
       :unsafe_render_html           => false,
+      :ood_bc_ssh_to_compute_node => true,
     }.freeze
   end
 
@@ -109,12 +110,6 @@ class ConfigurationSingleton
     @ood_version ||= (ood_version_from_env || version_from_file('/opt/ood') || version_from_git('/opt/ood') || "Unknown").strip
   end
 
-  def ood_bc_ssh_to_compute_node
-    env_val = ENV['OOD_BC_SSH_TO_COMPUTE_NODE']
-    return read_bool(env_val) unless env_val.nil?
-
-    read_bool(config.fetch(:ood_bc_ssh_to_compute_node, true))
-  end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
   def version_from_git(dir)

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -563,28 +563,4 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       refute ConfigurationSingleton.new.rails_env_production?
     end
   end
-
-  test "ood_bc_ssh_to_compute_node defaults to true" do
-    config = ConfigurationSingleton.new
-    assert_equal true, config.ood_bc_ssh_to_compute_node
-  end
-
-  test "ood_bc_ssh_to_compute_node respects yaml configuration" do
-    config = ConfigurationSingleton.new
-    config.stubs(:config).returns({ ood_bc_ssh_to_compute_node: false })
-
-    assert_equal false, config.ood_bc_ssh_to_compute_node
-  end
-
-  test "ood_bc_ssh_to_compute_node env overrides yaml configuration" do
-    begin
-      ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] = 'false'
-      config = ConfigurationSingleton.new
-      config.stubs(:config).returns({ ood_bc_ssh_to_compute_node: true })
-
-      assert_equal false, config.ood_bc_ssh_to_compute_node
-    ensure
-      ENV.delete('OOD_BC_SSH_TO_COMPUTE_NODE')
-    end
-  end
 end

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -563,4 +563,28 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
       refute ConfigurationSingleton.new.rails_env_production?
     end
   end
+
+  test "ood_bc_ssh_to_compute_node defaults to true" do
+    config = ConfigurationSingleton.new
+    assert_equal true, config.ood_bc_ssh_to_compute_node
+  end
+
+  test "ood_bc_ssh_to_compute_node respects yaml configuration" do
+    config = ConfigurationSingleton.new
+    config.stubs(:config).returns({ ood_bc_ssh_to_compute_node: false })
+
+    assert_equal false, config.ood_bc_ssh_to_compute_node
+  end
+
+  test "ood_bc_ssh_to_compute_node env overrides yaml configuration" do
+    begin
+      ENV['OOD_BC_SSH_TO_COMPUTE_NODE'] = 'false'
+      config = ConfigurationSingleton.new
+      config.stubs(:config).returns({ ood_bc_ssh_to_compute_node: true })
+
+      assert_equal false, config.ood_bc_ssh_to_compute_node
+    ensure
+      ENV.delete('OOD_BC_SSH_TO_COMPUTE_NODE')
+    end
+  end
 end

--- a/apps/dashboard/test/models/batch_connect/session_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_test.rb
@@ -431,7 +431,7 @@ module BatchConnect
       session = BatchConnect::Session.new
       session.stubs(:cluster).returns(OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' },
   batch_connect: { ssh_allow: false } }))
-      Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(true)
+      Configuration.stubs(:bc_ssh_to_compute_node).returns(true)
       refute session.ssh_to_compute_node?
     end
 
@@ -439,7 +439,7 @@ module BatchConnect
       session = BatchConnect::Session.new
       session.stubs(:token).returns('rstudio')
       session.stubs(:cluster).returns(OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' } }))
-      Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
+      Configuration.stubs(:bc_ssh_to_compute_node).returns(false)
       refute session.ssh_to_compute_node?
     end
 
@@ -449,7 +449,7 @@ module BatchConnect
       session.stubs(:cluster).returns(OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' },
   batch_connect: { ssh_allow: true } }))
       session.stubs(:app_ssh_to_compute_node).returns(true)
-      Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
+      Configuration.stubs(:bc_ssh_to_compute_node).returns(false)
       assert session.ssh_to_compute_node?
     end
 
@@ -459,7 +459,7 @@ module BatchConnect
       session.stubs(:cluster).returns(OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' },
   batch_connect: { ssh_allow: true } }))
       session.stubs(:app_ssh_to_compute_node).returns(false)
-      Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
+      Configuration.stubs(:bc_ssh_to_compute_node).returns(false)
       refute session.ssh_to_compute_node?
     end
 
@@ -469,7 +469,7 @@ module BatchConnect
       session.stubs(:cluster).returns(OodCore::Cluster.new({ id: 'owens', job: { foo: 'bar' },
   batch_connect: { ssh_allow: false } }))
       session.stubs(:app_ssh_to_compute_node).returns(true)
-      Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
+      Configuration.stubs(:bc_ssh_to_compute_node).returns(false)
       refute session.ssh_to_compute_node?
     end
 
@@ -477,7 +477,7 @@ module BatchConnect
       session = BatchConnect::Session.new
       session.stubs(:token).returns('rstudio')
       session.stubs(:cluster).raises(BatchConnect::Session::ClusterNotFound, 'Session specifies nonexistent')
-      Configuration.stubs(:ood_bc_ssh_to_compute_node).returns(false)
+      Configuration.stubs(:bc_ssh_to_compute_node).returns(false)
       refute session.ssh_to_compute_node?
     end
 


### PR DESCRIPTION
### Summary
Part of #1454. Per review feedback, this PR pivots to porting the ENV-only configuration setting `ood_bc_ssh_to_compute_node` to support `ondemand.d` YAML configurations.
closes #1454 

### Changes
* **`apps/dashboard/config/configuration_singleton.rb`**: Updated `ood_bc_ssh_to_compute_node` to check the `ondemand.d` YAML `config` hash with `config.fetch(:ood_bc_ssh_to_compute_node, true)` while maintaining backward compatibility for `OOD_BC_SSH_TO_COMPUTE_NODE` environment variable overrides.
* **`apps/dashboard/test/config/configuration_singleton_test.rb`**: Added unit tests covering:
  * Default behavior (`true`)
  * YAML configuration override (`false`)
  * ENV variable precedence over YAML settings

### Testing
Ran unit tests locally:
```bash
bin/rails test test/config/configuration_singleton_test.rb
# 64 runs, 124 assertions, 0 failures, 0 errors, 0 skips