### PR TITLE
uses noVNC in yarn and a dedicated partial instead of /public

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/sessions_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/sessions_controller.rb
@@ -50,6 +50,11 @@ class BatchConnect::SessionsController < ApplicationController
     end
   end
 
+  def show
+    set_session
+    render(partial: 'no_vnc', layout: false)
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_session

--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -11,7 +11,7 @@ module BatchConnect::SessionsHelper
       else
         if session.vnc?
           views = []
-          views << { title: "noVNC Connection",    partial: "novnc",      locals: { connect: session.connect, app_title: session.title } }
+          views << { title: "noVNC Connection",    partial: "novnc",      locals: { id: session.id, connect: session.connect, app_title: session.title } }
           views << { title: "Native Instructions", partial: "native_vnc", locals: { connect: session.connect } } if ENV["ENABLE_NATIVE_VNC"]
         else
           views = { partial: "missing_connection" }

--- a/apps/dashboard/app/javascript/no_vnc.js
+++ b/apps/dashboard/app/javascript/no_vnc.js
@@ -1,0 +1,51 @@
+'use strict;'
+
+import RFB from '@novnc/novnc';
+
+function connect() {
+  console.log('connected');
+}
+
+function disconnect() {
+  console.log('disconnected');
+}
+
+function credentialsAreRequired() {
+  console.log('credentials are required');
+}
+
+function updateDesktopName() {
+
+}
+
+function connectData() {
+  const ele = document.getElementById('novnc_info');
+  return ele.dataset;
+}
+
+function connectURL(origin, port) {
+
+  const scheme = window.location.protocol === "https:" ? 'wss' : 'ws';
+  const host = window.location.port == "" ? window.location.hostname : `${window.location.hostname}:${window.location.port}`;
+
+  return `${scheme}://${host}/rnode/${origin}/${port}/websockify`;
+}
+
+function makeNewRFB(){
+  // Creating a new RFB object will start a new connection
+  const data = connectData();
+
+  const rfb = new RFB(
+          document.getElementById('novnc_screen'), 
+          connectURL(data['host'], data['websocket']),
+          { credentials: { password: data['password'] } }
+        );
+
+  // Add listeners to important events from the RFB module
+  rfb.addEventListener("connect",  connect);
+  rfb.addEventListener("disconnect", disconnect);
+  rfb.addEventListener("credentialsrequired", credentialsAreRequired);
+  rfb.addEventListener("desktopname", updateDesktopName);
+}
+
+makeNewRFB();

--- a/apps/dashboard/app/views/batch_connect/sessions/_no_vnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/_no_vnc.html.erb
@@ -1,0 +1,12 @@
+
+<%= javascript_include_tag('no_vnc', type: 'module', nonce: true) %>
+
+<div id='novnc_info' style='display: none;'
+  data-password="<%= @session.connect.password %>"
+  data-host="<%= @session.connect.host %>"
+  data-port="<%= @session.connect.port %>"
+  data-websocket="<%= @session.connect.websocket %>"
+  >
+</div>
+
+<div id='novnc_screen'></div>

--- a/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/apps/dashboard/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -29,7 +29,11 @@
     });
   <% end -%>
 
- <%= f.submit( t('dashboard.batch_connect_sessions_novnc_launch', app_title: app_title), class: 'btn btn-primary') %>
+  <%= link_to(
+    t('dashboard.batch_connect_sessions_novnc_launch', app_title: app_title),
+    batch_connect_session_path(id), class: 'btn btn-primary', target: '_blank', title: t('dashboard.opens_in_new_tab'))
+  %>
+
  <% if connect.spassword.present? %>
   <%= link_to(t('dashboard.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true),
               class: 'btn btn-light float-end border border-dark', target: '_blank',

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
   end
 
   namespace :batch_connect do
-    resources :sessions, only: [:index, :destroy]
+    resources :sessions, only: [:index, :destroy, :show]
     post 'sessions/:id/cancel', to: 'sessions#cancel', as: 'cancel_session'
     scope '*token', constraints: { token: %r{((usr/[^/]+)|dev|sys)/[^/]+(/[^/]+)?} } do
       resources :settings, only: [:show, :destroy]

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hotwired/turbo-rails": ">=7.3.0 <8",
+    "@novnc/novnc": "github:novnc/novnc#7c36fa",
     "@popperjs/core": "^2.11.8",
     "@rails/ujs": "^7.0.1",
     "@uppy/core": "^4.0",

--- a/apps/dashboard/yarn.lock
+++ b/apps/dashboard/yarn.lock
@@ -150,6 +150,10 @@
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
   integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
 
+"@novnc/novnc@github:novnc/novnc#7c36fa":
+  version "1.7.0"
+  resolved "https://codeload.github.com/novnc/novnc/tar.gz/7c36fabe599e053c5a81e98e091ac636f6c1e174"
+
 "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"


### PR DESCRIPTION
Add noVNC to our asset pipeline instead of having files in /public.

In draft while we discuss if we want to take this on as this will likely require an Epic ticket and a few other PRs to resolve.

Future PRs/fixes needed
* provide a way to copy/paste for non Chromium browsers
* provide a mechanism for view only links/pages
* provide a mechanism for compression & quality settings
* the page/content is not exactly full screen

and possibly others.