### PR TITLE
Add auto_num_nodes smart attribute

### DIFF
--- a/apps/dashboard/app/controllers/launchers_controller.rb
+++ b/apps/dashboard/app/controllers/launchers_controller.rb
@@ -8,6 +8,7 @@ class LaunchersController < ApplicationController
   SAVE_LAUNCHER_KEYS = [
     :cluster, :auto_accounts, :auto_accounts_exclude, :auto_accounts_fixed,
     :auto_cores, :auto_cores_fixed, :auto_cores_min, :auto_cores_max,
+    :auto_num_nodes, :auto_num_nodes_fixed, :auto_num_nodes_min, :auto_num_nodes_max,
     :auto_scripts, :auto_scripts_exclude, :auto_scripts_fixed,
     :auto_queues, :auto_queues_exclude, :auto_queues_fixed,
     :auto_batch_clusters, :auto_batch_clusters_exclude, :auto_batch_clusters_fixed,

--- a/apps/dashboard/app/helpers/launchers_helper.rb
+++ b/apps/dashboard/app/helpers/launchers_helper.rb
@@ -70,6 +70,11 @@ module LaunchersHelper
     create_editable_widget(script_form_double, attrib)
   end
 
+  def auto_num_nodes_template
+    attrib = SmartAttributes::AttributeFactory.build_auto_num_nodes
+    create_editable_widget(script_form_double, attrib)
+  end
+  
   def auto_log_location_template
     attrib = SmartAttributes::AttributeFactory.build_auto_log_location
     create_editable_widget(script_form_double, attrib)

--- a/apps/dashboard/app/javascript/launcher_edit.js
+++ b/apps/dashboard/app/javascript/launcher_edit.js
@@ -27,6 +27,10 @@ const newFieldData = {
     label: "Nodes",
     help: "How many nodes the job will run on."
   },
+  auto_num_nodes: {
+    label: 'Auto Nodes',
+    help: 'How many nodes the job will run on.'
+  },
   auto_environment_variable: {
     label: 'Environment Variable',
     help: 'Add an environment variable.'

--- a/apps/dashboard/app/lib/smart_attributes.rb
+++ b/apps/dashboard/app/lib/smart_attributes.rb
@@ -25,5 +25,6 @@ module SmartAttributes
   require 'smart_attributes/attributes/bc_vnc_resolution'
   require 'smart_attributes/attributes/auto_environment_variable'
   require 'smart_attributes/attributes/auto_cores'
+  require 'smart_attributes/attributes/auto_num_nodes'
   require 'smart_attributes/attributes/global_attribute'
 end

--- a/apps/dashboard/app/lib/smart_attributes/attributes/auto_num_nodes.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attributes/auto_num_nodes.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module SmartAttributes
+  class AttributeFactory
+    # Build this attribute object. No options are used as this Attribute
+    # is meant to be dynamically generated
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::AutoNumNodes] the attribute object
+    def self.build_auto_num_nodes(opts = {})
+      Attributes::AutoNumNodes.new('auto_num_nodes', opts)
+    end
+  end
+
+  module Attributes
+    class AutoNumNodes < Attribute
+      def initialize(id, opts)
+        super(id, opts)
+        @opts = @opts.reverse_merge(min: 1, step: 1)
+      end
+
+      # Value of attribute
+      # @return [String] attribute value
+      def value
+        (opts[:value] || '1').to_s
+      end
+
+      # Type of form widget used for this attribute
+      # @return [String] widget type
+      def widget
+        'number_field'
+      end
+
+      # Form label for this attribute
+      # @param fmt [String, nil] formatting of form label
+      # @return [String] form label
+      def label(fmt: nil)
+        (opts[:label] || 'Number of nodes').to_s
+      end
+
+      # Submission hash describing how to submit this attribute
+      # @param fmt [String, nil] formatting of hash
+      # @return [Hash] submission hash
+      def submit(fmt: nil)
+        nodes = value.blank? ? 1 : value.to_i
+        native = case fmt
+                 when 'torque'
+                   { resources: { nodes: nodes } }
+                 when 'slurm'
+                   ['-N', nodes]
+                 when 'pbspro'
+                   ['-l', "select=#{nodes}"]
+                 when 'lsf'
+                   ['-n', nodes]
+                 when 'fujitsu_tcs'
+                   ['-L', "node=#{nodes}"]
+                 end
+        native ? { script: { native: native } } : {}
+      end
+    end
+  end
+end

--- a/apps/dashboard/app/views/launchers/edit.html.erb
+++ b/apps/dashboard/app/views/launchers/edit.html.erb
@@ -43,6 +43,10 @@
   <%= auto_cores_template %>
 </template>
 
+<template id="auto_num_nodes_template">
+  <%= auto_num_nodes_template %>
+</template>
+
 <template id="auto_log_location_template">
   <%= auto_log_location_template %>
 </template>

--- a/apps/dashboard/test/lib/smart_attributes/auto_num_nodes_test.rb
+++ b/apps/dashboard/test/lib/smart_attributes/auto_num_nodes_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class SmartAttributes::AutoNumNodesTest < ActiveSupport::TestCase
+  test 'build creates AutoNumNodes attribute' do
+    attribute = SmartAttributes::AttributeFactory.build('auto_num_nodes')
+
+    assert_instance_of SmartAttributes::Attributes::AutoNumNodes, attribute
+    assert_equal 'number_field', attribute.widget
+    assert_equal '1', attribute.value
+    assert_equal 'Number of nodes', attribute.label
+    assert_equal 1, attribute.opts[:min]
+    assert_equal 1, attribute.opts[:step]
+  end
+
+  test 'can set value and label' do
+    attribute = SmartAttributes::AttributeFactory.build('auto_num_nodes', { value: '4', label: 'Nodes' })
+
+    assert_equal '4', attribute.value
+    assert_equal 'Nodes', attribute.label
+  end
+
+  test 'submit returns native options for supported formats' do
+    attribute = SmartAttributes::AttributeFactory.build('auto_num_nodes', { value: '3' })
+
+    assert_equal({ script: { native: ['-N', 3] } }, attribute.submit(fmt: 'slurm'))
+    assert_equal({ script: { native: { resources: { nodes: 3 } } } }, attribute.submit(fmt: 'torque'))
+    assert_equal({ script: { native: ['-l', 'select=3'] } }, attribute.submit(fmt: 'pbspro'))
+    assert_equal({ script: { native: ['-n', 3] } }, attribute.submit(fmt: 'lsf'))
+    assert_equal({ script: { native: ['-L', 'node=3'] } }, attribute.submit(fmt: 'fujitsu_tcs'))
+    assert_equal({}, attribute.submit(fmt: 'unknown'))
+  end
+
+  test 'submit defaults blank value to 1' do
+    attribute = SmartAttributes::AttributeFactory.build('auto_num_nodes', { value: '' })
+
+    assert_equal({ script: { native: ['-N', 1] } }, attribute.submit(fmt: 'slurm'))
+  end
+end

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1135,7 +1135,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
 
       actual_new_options = page.all("##{new_field_id} option").map(&:value).to_set
       expected_new_options = [
-        'bc_num_hours', 'auto_queues', 'bc_num_nodes', 'auto_cores',
+        'bc_num_hours', 'auto_queues', 'bc_num_nodes', 'auto_cores', 'auto_num_nodes',
         'auto_accounts', 'auto_job_name', 'auto_environment_variable',
         'auto_log_location'
       ].to_set


### PR DESCRIPTION
Fixes #5680

Adds an `auto_num_nodes` smart attribute for dynamically driven node counts.

- Adds `auto_num_nodes` as a number field with the same scheduler submit behavior as `bc_num_nodes`
- Keeps `bc_num_nodes` for static limits so implementers can distinguish dynamic/fixed fields
- Wires Project Manager support
- Covers defaults and submit formats with a unit test, and includes it in the PM system test