### PR TITLE
Fix Apps navbar dropdown spacing (#5611)

### DIFF
--- a/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
+++ b/apps/dashboard/app/views/layouts/nav/_featured_apps.html.erb
@@ -1,7 +1,9 @@
 <% if @featured_group.present? %>
   <% group = @featured_group %>
   <li class="nav-item dropdown" role="none">
-    <a role="menuitem" href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="menuitem" title="<%= group.title %>"><%= group.title %><span class="caret"></span></a>
+    <a role="menuitem" href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="<%= group.title %>">
+      <span> <%= group.title %></span><span class="caret"></span>
+    </a>
 
     <ul class="dropdown-menu" role="menu" title="<%= group.title %>">
       <% OodAppGroup.groups_for(apps: group.apps, group_by: :subcategory, nav_limit: group.nav_limit).each_with_index do |g, index| %>


### PR DESCRIPTION
Fixes #5611

Fixes inconsistent spacing in the Apps navbar dropdown.

- Wrap the Apps dropdown title in a `<span>` to match other navbar dropdown items
- Visually tested to ensure the Apps dropdown is consistent with the other dropdowns