### PR TITLE
Hide app version by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ Changes are grouped by type:
 - Packages no longer depend on rclone in [5436](https://github.com/OSC/ondemand/pull/5436).
 - oidc_cypto_passphrase must be set when using OIDC in [5559](https://github.com/OSC/ondemand/pull/5559).
 - Reverted new tab functionality so that VNC applications open in new tabs in [5562](https://github.com/OS10C/ondemand/pull/5562).
-- The app version is now hidden by default in [5715](https://github.com/OSC/ondemand/pull/5715).
 
 ## [4.2.3] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Changes are grouped by type:
 - Packages no longer depend on rclone in [5436](https://github.com/OSC/ondemand/pull/5436).
 - oidc_cypto_passphrase must be set when using OIDC in [5559](https://github.com/OSC/ondemand/pull/5559).
 - Reverted new tab functionality so that VNC applications open in new tabs in [5562](https://github.com/OS10C/ondemand/pull/5562).
+- The app version is now hidden by default in [5715](https://github.com/OSC/ondemand/pull/5715).
 
 ## [4.2.3] - 2026-06-24
 

--- a/apps/dashboard/config/configuration_singleton.rb
+++ b/apps/dashboard/config/configuration_singleton.rb
@@ -54,7 +54,7 @@ class ConfigurationSingleton
       :host_based_profiles          => false,
       :disable_bc_shell             => false,
       :cancel_session_enabled       => false,
-      :hide_app_version             => false,
+      :hide_app_version             => true,
       :motd_render_html             => false,
       :upload_enabled               => true,
       :download_enabled             => true,

--- a/apps/dashboard/test/config/configuration_singleton_test.rb
+++ b/apps/dashboard/test/config/configuration_singleton_test.rb
@@ -301,6 +301,12 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     end
   end
 
+  test "hides app version by default" do
+    with_modified_env(OOD_CONFIG_FILE: "/dev/null", OOD_CONFIG_D_DIRECTORY: "/dev/null", OOD_HIDE_APP_VERSION: nil) do
+      assert_equal ConfigurationSingleton.new.hide_app_version?, true
+    end
+  end
+
   test "does not read .bak files" do
     with_modified_env(config_fixtures) do
       cfg = ConfigurationSingleton.new.send(:config)


### PR DESCRIPTION
Fixes #5704

Flips the `hide_app_version` default to `true` so that the dashboard no longer displays each app's own version by default. As described in the issue, users generally care about the underlying application's version (e.g., Matlab's), not the version of its OnDemand wrapper, so displaying it is misleading.

Also adds a test pinning the new default (isolated from config fixtures and env overrides) and will add a changelog entry once this PR has a number to reference.

Note: I could not run the dashboard test suite locally (Ruby 2.6 system install), so CI validation is appreciated.