### PR TITLE
correct this parameter in the job composer

### DIFF
--- a/apps/myjobs/app/controllers/workflows_controller.rb
+++ b/apps/myjobs/app/controllers/workflows_controller.rb
@@ -218,7 +218,7 @@ class WorkflowsController < ApplicationController
   # Only allow a trusted parameter "white list" through.
   def workflow_params
     params.require(:workflow).permit(
-      :name, :batch_host, :script_name, :staging_template_dir,
+      :name, :batch_host, :script_path, :staging_template_dir,
       :account, :job_array_request, :copy_environment
     )
   end


### PR DESCRIPTION
Looks like when I updated this controller to only accept these parameters I misnamed this field as you can see from the form it's `script_path` not `script_name`.


https://github.com/OSC/ondemand/blob/e5bbaf1d7c4b518685c5d11c5e3a932b32fe1f93/apps/myjobs/app/views/workflows/_form.html.erb#L18