### PR TITLE
Add configurable user not found error message (#4616)

### DIFF
--- a/nginx_stage/lib/nginx_stage/configuration.rb
+++ b/nginx_stage/lib/nginx_stage/configuration.rb
@@ -395,6 +395,12 @@ module NginxStage
     # @return [String] Error message
     attr_accessor :disabled_shell_message
 
+    # Define an error message that is displayed to users when their account
+    #     cannot be found on the local system (e.g. not yet provisioned).
+    #     Use %s as a placeholder for the username.
+    # @return [String] Error message
+    attr_accessor :missing_user_message
+
     # Hide the stderr "Run 'nginx_stage --help' to see a full list of available 
     #     command line options." message when calling nginx_stage
     # @return [Boolean]
@@ -523,6 +529,7 @@ module NginxStage
       self.min_uid        = 1000
       self.disabled_shell = '/access/denied'
       self.disabled_shell_message = 'user has a disabled shell: %s'
+      self.missing_user_message = "can't find user for %s"
       self.show_nginx_stage_help_message = true
 
       self.disable_bundle_user_config = true

--- a/nginx_stage/lib/nginx_stage/generator_helpers.rb
+++ b/nginx_stage/lib/nginx_stage/generator_helpers.rb
@@ -14,7 +14,11 @@ module NginxStage
           required: true,
           before_init: -> (user) do
             raise InvalidUser, "invalid user name syntax: #{user}" unless user =~ NginxStage.user_regex
-            user ? User.new(user) : nil
+            begin
+              user ? User.new(user) : nil
+            rescue ArgumentError
+              raise InvalidUser, NginxStage.missing_user_message % user
+            end
           end
         }
       end

--- a/nginx_stage/share/nginx_stage_example.yml
+++ b/nginx_stage/share/nginx_stage_example.yml
@@ -248,6 +248,11 @@
 #     disabled_shell.
 #disabled_shell_message: 'user has a disabled shell: %s'
 
+# Define an error message that is displayed to users when their account cannot
+#     be found on the local system (e.g. the user authenticated but has not been
+#     provisioned yet). Use %s as a placeholder for the username.
+#missing_user_message: "can't find user for %s"
+
 # Hide the stderr "Run 'nginx_stage --help' to see a full list of available 
 #     command line options." message when calling nginx_stage
 #show_nginx_stage_help_message: true

--- a/nginx_stage/spec/generators/pun_config_generator_spec.rb
+++ b/nginx_stage/spec/generators/pun_config_generator_spec.rb
@@ -25,6 +25,31 @@ describe NginxStage::PunConfigGenerator do
     expect { described_class.new }.to raise_error(NginxStage::MissingOption, 'missing option: user')
   end
 
+  describe 'missing user' do
+    let(:missing_user) { 'nobody_here' }
+
+    before do
+      allow(Etc).to receive(:getpwnam).with(missing_user)
+        .and_raise(ArgumentError, "can't find user for #{missing_user}")
+    end
+
+    it 'raises InvalidUser with the default missing_user_message' do
+      expect { described_class.new({ :user => missing_user }) }
+        .to raise_error(NginxStage::InvalidUser, "can't find user for nobody_here")
+    end
+
+    it 'raises InvalidUser with a custom missing_user_message' do
+      allow(NginxStage).to receive(:missing_user_message)
+        .and_return('User %s was not found. Ask your advisor to add you to an HPC allocation.')
+
+      expect { described_class.new({ :user => missing_user }) }
+        .to raise_error(
+          NginxStage::InvalidUser,
+          'User nobody_here was not found. Ask your advisor to add you to an HPC allocation.'
+        )
+    end
+  end
+
   describe 'pre_hook_root_cmd' do
     let(:generator)  do
       described_class.new({


### PR DESCRIPTION
Fixes #4616

Allows sites to customize the error shown when nginx_stage cannot find a user.

- Adds a `missing_user_message` configuration option with `%s` for the username, defaulting to the existing error message
- Raises `InvalidUser` with the configured message when user lookup fails
- Manually tested the default and custom `missing_user_message` configuration

Note: Not tested on a real OOD host