### PR TITLE
Add option to disable navbar sorting of app links

### DIFF
--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -16,7 +16,7 @@ class NavBar
           if matched_apps.length == 1
             extend_link(matched_apps.first)
           elsif nav_item[:title]
-            extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon]), sort: nav_item.fetch(:sort, true))
+            extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon]), sort: sort_nav_group?(nav_item))
           end
         elsif nav_item[:profile]
           extend_link(nav_profile(nav_item))
@@ -134,10 +134,30 @@ class NavBar
       group = OodAppGroup.groups_for(apps: SysRouter.apps).select { |g| g.title.downcase == token.downcase }.first
       return nil if group.nil?
       group.apps = extract_links(group.apps)
-      extend_group(group, sort: true)
+      extend_group(group, sort: sort_category_group?(group))
     end
   end
 
+  def self.sort_nav_group?(nav_item)
+    return nav_item[:sort] if nav_item.key?(:sort)
+
+    files_apps_menu?(nav_item) ? false : true
+  end
+
+  def self.sort_category_group?(group)
+    group.title.to_s.casecmp('files').zero? ? false : true
+  end
+
+  def self.files_apps_menu?(nav_item)
+    return false unless nav_item[:apps]
+
+    Array.wrap(nav_item[:apps]).any? { |token| files_app_token?(token) }
+  end
+
+  def self.files_app_token?(token)
+    token.to_s.downcase == 'sys/files'
+  end
+  
   def self.extract_links(apps, category: nil, subcategory: nil)
     apps.map do |app|
       app.links.map do |link|

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -16,8 +16,10 @@ class NavBar
           if matched_apps.length == 1
             extend_link(matched_apps.first)
           elsif nav_item[:title]
-            extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon]), sort: true)
+            extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon]), sort: nav_item.fetch(:sort, true))
           end
+        elsif nav_item[:category]
+          item_from_token(nav_item[:category], sort: nav_item.fetch(:sort, true))
         elsif nav_item[:profile]
           extend_link(nav_profile(nav_item))
         elsif !nav_item[:page].blank?
@@ -63,7 +65,7 @@ class NavBar
       end
     end.flatten.compact
 
-    OodAppGroup.new(apps: apps, title: menu_title, icon_uri: menu_icon, sort: false)
+    OodAppGroup.new(apps: apps, title: menu_title, icon_uri: menu_icon, sort: hash_item.fetch(:sort, false))
   end
 
   def self.nav_link(item, category='', subcategory='')
@@ -115,7 +117,7 @@ class NavBar
     end
   end
 
-  def self.item_from_token(token)
+  def self.item_from_token(token, sort: true)
     static_template = STATIC_TEMPLATES.fetch(token.downcase.to_sym, nil)
     if static_template
       return NavItemDecorator.new(OodAppGroup.new, static_template)
@@ -134,7 +136,7 @@ class NavBar
       group = OodAppGroup.groups_for(apps: SysRouter.apps).select { |g| g.title.downcase == token.downcase }.first
       return nil if group.nil?
       group.apps = extract_links(group.apps)
-      extend_group(group, sort: true)
+      extend_group(group, sort: sort)
     end
   end
 
@@ -146,8 +148,8 @@ class NavBar
     end.flatten
   end
 
-  def self.extend_group(group, sort: false)
-    group.sort = sort
+  def self.extend_group(group, sort: nil)
+    group.sort = sort unless sort.nil?
     NavItemDecorator.new(group, 'layouts/nav/group')
   end
 

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -8,7 +8,7 @@ class NavBar
         item_from_token(nav_item)
       elsif nav_item.is_a?(Hash)
         if nav_item[:links]
-          extend_group(nav_menu(nav_item))
+          extend_group(nav_menu(nav_item), sort: nav_item.fetch(:sort, false))
         elsif nav_item[:url]
           extend_link(nav_link(nav_item))
         elsif nav_item[:apps]
@@ -18,8 +18,6 @@ class NavBar
           elsif nav_item[:title]
             extend_group(OodAppGroup.new(apps: matched_apps, title: nav_item[:title], icon_uri: nav_item[:icon]), sort: nav_item.fetch(:sort, true))
           end
-        elsif nav_item[:category]
-          item_from_token(nav_item[:category], sort: nav_item.fetch(:sort, true))
         elsif nav_item[:profile]
           extend_link(nav_profile(nav_item))
         elsif !nav_item[:page].blank?
@@ -65,7 +63,7 @@ class NavBar
       end
     end.flatten.compact
 
-    OodAppGroup.new(apps: apps, title: menu_title, icon_uri: menu_icon, sort: hash_item.fetch(:sort, false))
+    OodAppGroup.new(apps: apps, title: menu_title, icon_uri: menu_icon, sort: false)
   end
 
   def self.nav_link(item, category='', subcategory='')
@@ -117,7 +115,7 @@ class NavBar
     end
   end
 
-  def self.item_from_token(token, sort: true)
+  def self.item_from_token(token)
     static_template = STATIC_TEMPLATES.fetch(token.downcase.to_sym, nil)
     if static_template
       return NavItemDecorator.new(OodAppGroup.new, static_template)
@@ -136,7 +134,7 @@ class NavBar
       group = OodAppGroup.groups_for(apps: SysRouter.apps).select { |g| g.title.downcase == token.downcase }.first
       return nil if group.nil?
       group.apps = extract_links(group.apps)
-      extend_group(group, sort: sort)
+      extend_group(group, sort: true)
     end
   end
 
@@ -148,8 +146,8 @@ class NavBar
     end.flatten
   end
 
-  def self.extend_group(group, sort: nil)
-    group.sort = sort unless sort.nil?
+  def self.extend_group(group, sort: false)
+    group.sort = sort
     NavItemDecorator.new(group, 'layouts/nav/group')
   end
 

--- a/apps/dashboard/app/apps/nav_bar.rb
+++ b/apps/dashboard/app/apps/nav_bar.rb
@@ -149,9 +149,8 @@ class NavBar
   end
 
   def self.files_apps_menu?(nav_item)
-    return false unless nav_item[:apps]
-
-    Array.wrap(nav_item[:apps]).any? { |token| files_app_token?(token) }
+    tokens = Array.wrap(nav_item[:apps])
+    tokens.length == 1 && files_app_token?(tokens.first)
   end
 
   def self.files_app_token?(token)

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -216,6 +216,14 @@ class NavBarTest < ActiveSupport::TestCase
     ], link_titles
   end
 
+  test "apps menus that include files with other apps still sort by default" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+
+    result = NavBar.items([{ title: 'Mixed Apps', apps: ['sys/files', 'sys/shell'] }])
+    assert_equal 1, result.size
+    assert_equal true, result[0].sort
+  end
+
   test "NavBar.items should honor sort false for links navigation group" do
     nav_item = {
       title: "menu title",

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -163,20 +163,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal false, result[0].sort
   end
 
-  test "NavBar.items should return navigation group with sort=false when nav_item has category and sort false" do
-    nav_item = {
-      category: "Interactive Apps",
-      sort: false
-    }
-
-    result = NavBar.items([nav_item])
-    assert_equal 1, result.size
-    assert_equal "layouts/nav/group", result[0].partial_path
-    assert_equal false, result[0].sort
-    assert_equal "Interactive Apps", result[0].title
-  end
-
-  test "NavBar.items should preserve files link order when category has sort false" do
+  test "NavBar.items should preserve files link order when apps menu has sort false" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
     OodFilesApp.stubs(:candidate_favorite_paths).returns([
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/scratch'), title: 'Zebra'),
@@ -184,7 +171,7 @@ class NavBarTest < ActiveSupport::TestCase
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project2'), title: 'Middle')
     ])
 
-    result = NavBar.items([{ category: 'Files', sort: false }])
+    result = NavBar.items([{ title: 'Files', apps: 'sys/files', sort: false }])
     assert_equal 1, result.size
     assert_equal false, result[0].sort
 

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -192,9 +192,19 @@ class NavBarTest < ActiveSupport::TestCase
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project2'), title: 'Middle')
     ])
 
-    result = NavBar.items(['Files'])
+    result = NavBar.items([{ title: 'Files', apps: 'sys/files' }])
     assert_equal 1, result.size
     assert_equal true, result[0].sort
+
+    link_titles = OodAppGroup.groups_for(apps: result[0].apps, group_by: :subcategory, sort: result[0].sort).flat_map do |g|
+      g.apps.flat_map { |app| app.links.map(&:title) }
+    end
+    assert_equal [
+      'Alpha',
+      I18n.t('dashboard.home_directory'),
+      'Middle',
+      'Zebra'
+    ], link_titles
   end
 
   test "NavBar.items should honor sort false for links navigation group" do

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -151,6 +151,81 @@ class NavBarTest < ActiveSupport::TestCase
     end
   end
 
+  test "NavBar.items should return navigation group with sort=false when nav_item has apps, title, and sort false" do
+    nav_item = {
+      title: "Custom Apps",
+      apps: "sys/*",
+      sort: false
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal 1, result.size
+    assert_equal false, result[0].sort
+  end
+
+  test "NavBar.items should return navigation group with sort=false when nav_item has category and sort false" do
+    nav_item = {
+      category: "Interactive Apps",
+      sort: false
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal 1, result.size
+    assert_equal "layouts/nav/group", result[0].partial_path
+    assert_equal false, result[0].sort
+    assert_equal "Interactive Apps", result[0].title
+  end
+
+  test "NavBar.items should preserve files link order when category has sort false" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+    OodFilesApp.stubs(:candidate_favorite_paths).returns([
+      FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/scratch'), title: 'Zebra'),
+      FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project'), title: 'Alpha'),
+      FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project2'), title: 'Middle')
+    ])
+
+    result = NavBar.items([{ category: 'Files', sort: false }])
+    assert_equal 1, result.size
+    assert_equal false, result[0].sort
+
+    link_titles = result[0].links.map(&:title)
+    assert_equal [
+      I18n.t('dashboard.home_directory'),
+      'Zebra',
+      'Alpha',
+      'Middle'
+    ], link_titles
+  end
+
+  test "NavBar.items should enable sorting when category uses default sort" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+    OodFilesApp.stubs(:candidate_favorite_paths).returns([
+      FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/scratch'), title: 'Zebra'),
+      FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project'), title: 'Alpha'),
+      FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project2'), title: 'Middle')
+    ])
+
+    result = NavBar.items(['Files'])
+    assert_equal 1, result.size
+    assert_equal true, result[0].sort
+  end
+
+  test "NavBar.items should honor sort false for links navigation group" do
+    nav_item = {
+      title: "menu title",
+      sort: false,
+      links: [
+        { group: "subcategory" },
+        { title: "Zebra", url: "/z" },
+        { title: "Alpha", url: "/a" }
+      ]
+    }
+
+    result = NavBar.items([nav_item])
+    assert_equal false, result[0].sort
+    assert_equal ["Zebra", "Alpha"], result[0].apps.map(&:title)
+  end
+
   test "NavBar.items should return navigation link when nav_item has apps property and apps token matches 1 app" do
     nav_item = {
       apps: "sys/bc_jupyter",

--- a/apps/dashboard/test/apps/nav_bar_test.rb
+++ b/apps/dashboard/test/apps/nav_bar_test.rb
@@ -163,7 +163,7 @@ class NavBarTest < ActiveSupport::TestCase
     assert_equal false, result[0].sort
   end
 
-  test "NavBar.items should preserve files link order when apps menu has sort false" do
+  test "files app menus are unsorted by default for category and apps nav items" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
     OodFilesApp.stubs(:candidate_favorite_paths).returns([
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/scratch'), title: 'Zebra'),
@@ -171,20 +171,29 @@ class NavBarTest < ActiveSupport::TestCase
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project2'), title: 'Middle')
     ])
 
-    result = NavBar.items([{ title: 'Files', apps: 'sys/files', sort: false }])
-    assert_equal 1, result.size
-    assert_equal false, result[0].sort
-
-    link_titles = result[0].links.map(&:title)
-    assert_equal [
+    expected_link_titles = [
       I18n.t('dashboard.home_directory'),
       'Zebra',
       'Alpha',
       'Middle'
-    ], link_titles
+    ]
+
+    result = NavBar.items([
+      'files',
+      { title: 'Files App', apps: 'sys/files' }
+    ])
+
+    assert_equal 2, result.size
+    assert_equal 'Files', result[0].title
+    assert_equal 'Files App', result[1].title
+
+    result.each do |nav_item|
+      assert_equal false, nav_item.sort
+      assert_equal expected_link_titles, nav_item.links.map(&:title)
+    end
   end
 
-  test "NavBar.items should enable sorting when category uses default sort" do
+  test "files app menus can opt into sorting with sort true" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
     OodFilesApp.stubs(:candidate_favorite_paths).returns([
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/scratch'), title: 'Zebra'),
@@ -192,7 +201,7 @@ class NavBarTest < ActiveSupport::TestCase
       FavoritePath.new(File.expand_path('test/fixtures/dummy_fs/project2'), title: 'Middle')
     ])
 
-    result = NavBar.items([{ title: 'Files', apps: 'sys/files' }])
+    result = NavBar.items([{ title: 'Files', apps: 'sys/files', sort: true }])
     assert_equal 1, result.size
     assert_equal true, result[0].sort
 

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -59,7 +59,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     ], dditemurls, 'Files dropdown URLs are incorrect'
   end
 
-  test 'should preserve Files dropdown order when nav_bar category has sort false' do
+  test 'should preserve Files dropdown order when nav_bar apps menu has sort false' do
     scratch_path = File.expand_path 'test/fixtures/dummy_fs/scratch'
     project_path = File.expand_path 'test/fixtures/dummy_fs/project'
     project_path2 = Pathname.new('test/fixtures/dummy_fs/project2').expand_path
@@ -74,7 +74,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
 
     stub_user_configuration(
       nav_bar: [
-        { category: 'Files', sort: false }
+        { title: 'Files', apps: 'sys/files', sort: false }
       ]
     )
 

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -59,6 +59,36 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     ], dditemurls, 'Files dropdown URLs are incorrect'
   end
 
+  test 'should preserve Files dropdown order when nav_bar category has sort false' do
+    scratch_path = File.expand_path 'test/fixtures/dummy_fs/scratch'
+    project_path = File.expand_path 'test/fixtures/dummy_fs/project'
+    project_path2 = Pathname.new('test/fixtures/dummy_fs/project2').expand_path
+
+    OodFilesApp.stubs(:candidate_favorite_paths).returns(
+      [
+        FavoritePath.new(scratch_path, title: 'Scratch'),
+        project_path,
+        project_path2
+      ]
+    )
+
+    stub_user_configuration(
+      nav_bar: [
+        { category: 'Files', sort: false }
+      ]
+    )
+
+    get root_path
+
+    dditems = dropdown_list_items(dropdown_list('Files'))
+    assert_equal [
+      I18n.t('dashboard.home_directory'),
+      "Scratch #{scratch_path}",
+      project_path,
+      project_path2.to_s
+    ], dditems.map { |e| e.gsub(/\s+/, ' ') }
+  end
+
   test 'should create Clusters dropdown with valid clusters that are alphabetically ordered by title' do
     OodAppkit.stubs(:clusters).returns(
       OodCore::Clusters.new([

--- a/apps/dashboard/test/integration/dashboard_controller_test.rb
+++ b/apps/dashboard/test/integration/dashboard_controller_test.rb
@@ -59,7 +59,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     ], dditemurls, 'Files dropdown URLs are incorrect'
   end
 
-  test 'should preserve Files dropdown order when nav_bar apps menu has sort false' do
+  test 'should preserve Files dropdown order for files app nav_bar entries by default' do
     scratch_path = File.expand_path 'test/fixtures/dummy_fs/scratch'
     project_path = File.expand_path 'test/fixtures/dummy_fs/project'
     project_path2 = Pathname.new('test/fixtures/dummy_fs/project2').expand_path
@@ -74,19 +74,24 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
 
     stub_user_configuration(
       nav_bar: [
-        { title: 'Files', apps: 'sys/files', sort: false }
+        'files',
+        { title: 'Files App', apps: 'sys/files' }
       ]
     )
 
     get root_path
 
-    dditems = dropdown_list_items(dropdown_list('Files'))
-    assert_equal [
+    expected_items = [
       I18n.t('dashboard.home_directory'),
       "Scratch #{scratch_path}",
       project_path,
       project_path2.to_s
-    ], dditems.map { |e| e.gsub(/\s+/, ' ') }
+    ]
+
+    ['Files', 'Files App'].each do |menu_title|
+      dditems = dropdown_list_items(dropdown_list(menu_title))
+      assert_equal expected_items, dditems.map { |e| e.gsub(/\s+/, ' ') }
+    end
   end
 
   test 'should create Clusters dropdown with valid clusters that are alphabetically ordered by title' do


### PR DESCRIPTION
Fixes #3814

Add an option to disable automatic navbar sorting.

- Adds a `sort` option to `nav_bar` entries
- Supports `sort: false` for Files and other category based menus
- Keeps the existing sorting defaults for category/apps and links menus
- Adds tests for the new sorting behavior