### PR TITLE
fix the job composers ability to change the job script (release_4.2)

### DIFF
--- a/apps/myjobs/app/controllers/workflows_controller.rb
+++ b/apps/myjobs/app/controllers/workflows_controller.rb
@@ -218,7 +218,7 @@ class WorkflowsController < ApplicationController
   # Only allow a trusted parameter "white list" through.
   def workflow_params
     params.require(:workflow).permit(
-      :name, :batch_host, :script_name, :staging_template_dir,
+      :name, :batch_host, :script_path, :staging_template_dir,
       :account, :job_array_request, :copy_environment
     )
   end


### PR DESCRIPTION
Backport #5722 to 4.2 fixing the job composers ability to change the job script.