### PR TITLE
Add value specific data-help attributes

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -20,7 +20,7 @@ const setHandlerCache = [];
 // hide handler cache is a map in the form '{ from: [hideThing1, hideThing2] }'
 const hideHandlerCache = {};
 const labelHandlerCache = {};
-const helpHandlerCache = {};
+const helpHandlerCache = [];
 // Lookup tables for setting min & max values
 // for different directives.
 const minMaxLookup = {};
@@ -240,15 +240,93 @@ function addLabelHandler(optionId, option, key, configValue) {
   updateLabel(changeId, changeElement, key);
 };
 
-function getNewHelp(changeElement, key) {
-  const selectedOptionHelpIndex = changeElement[0].selectedIndex;
-  const selectedOptionHelp = changeElement[0].options[selectedOptionHelpIndex];
-  return selectedOptionHelp.dataset[key];
-}
+/**
+ *
+ * @param {*} subjectId batch_connect_session_context_node_type
+ * @param {*} option gpu
+ * @param {*} key helpNodeTypeForClusterAscend
+ * @param {*} configValue 'GPU nodes on Ascend ...'
+ *
+ * node_type:
+ *   widget: select
+ *   options:
+ *    - [
+ *        'gpu',
+ *        data-help-node-type-for-cluster-ascend: 'GPU nodes on Ascend ...'
+ *      ]
+ */
+ function addHelpHandler(subjectId, option, key, configValue) {
+  subjectId = String(subjectId || '');
 
-function updateHelp(changeId, changeElement, key) {
-  const helpContent = getNewHelp(changeElement, key);
+  const configObj = parseHelpFor(key);
+  const objectId = configObj['subjectId'];
+  // this is the id of the target object we're setting the help for.
+  // if it's undefined - there's nothing to do, it was likely configured wrong.
+  if(objectId === undefined) return;
+
+  const secondDimId = configObj['predicateId'];
+  const secondDimValue = configObj['predicateValue'];
+
+  // several subjects can try to change the object, so the table lookup key has to have both
+  const lookupKey = `${subjectId}_${objectId}`;
+  if(helpLookup[lookupKey] === undefined) helpLookup[lookupKey] = new Table(subjectId, secondDimId);
+  const table = helpLookup[lookupKey];
+  table.put(option, secondDimValue, configValue);
+
+  let cacheKey = `${objectId}_${subjectId}_${secondDimId}`;
+  if(!helpHandlerCache.includes(cacheKey)) {
+    const changeElement = $(`#${subjectId}`);
+
+    changeElement.on('change', (event) => {
+      toggleHelp(event, objectId, secondDimId);
+    });
+
+    helpHandlerCache.push(cacheKey);
+  }
+
+  cacheKey = `${objectId}_${secondDimId}_${subjectId}`;
+  if(secondDimId !== undefined && !helpHandlerCache.includes(cacheKey)){
+    const secondEle = $(`#${secondDimId}`);
+
+    secondEle.on('change', (event) => {
+      toggleHelp(event, objectId, subjectId);
+    });
+
+    helpHandlerCache.push(cacheKey);
+  }
+
+  toggleHelp({ target: document.querySelector(`#${subjectId}`) }, objectId, secondDimId);
+};
+
+/**
+ * Update the help text of `changeId` based on the
+ * event, the `otherId` and the settings in helpLookup table.
+ */
+function toggleHelp(event, changeId, otherId) {
+  let x = undefined, y = undefined;
+
+  // many subjects can change the object, so we have to find the correct table
+  // in the form <subject>_<object>
+  let lookupKey = `${event.target['id']}_${changeId}`;
+  if(helpLookup[lookupKey] === undefined) {
+    lookupKey = `${otherId}_${changeId}`;
+  }
+
+  const table = helpLookup[lookupKey];
+
+  // in the example of cluster & node_type, either element can trigger a change
+  // so let's figure out the axis' based on the change element's id.
+  if(event.target['id'] == table.x) {
+    x = snakeCaseWords(event.target.value);
+    y = snakeCaseWords($(`#${otherId}`).val());
+  } else {
+    y = snakeCaseWords(event.target.value);
+    x = snakeCaseWords($(`#${otherId}`).val());
+  }
+
+  const helpContent = table.get(x, y);
   if (helpContent === undefined || changeId === undefined) return;
+
   const wrapper_id = `#${changeId}_wrapper`;
   var helpElement = $(`${wrapper_id} small p`);
   if (helpElement.length == 0) {
@@ -261,25 +339,6 @@ function updateHelp(changeId, changeElement, key) {
   ariaStream(`Changed help text on ${getWidgetInfo(changeId)} to ${helpContent}`);
 }
 
-function addHelpHandler(optionId, option, key, configValue) {
-  const changeId = idFromToken(key.replace(/^help/, ''));
-  const changeElement = $(`#${optionId}`);
-
-  if(helpLookup[optionId] === undefined) helpLookup[optionId] = new Table(changeId, undefined);
-  const table = helpLookup[optionId];
-  table.put(changeId, option, configValue);
-
-  if(helpHandlerCache[optionId] === undefined) helpHandlerCache[optionId] = [];
-  
-  if(!helpHandlerCache[optionId].includes(changeId)) {
-    helpHandlerCache[optionId].push(changeId);
-    changeElement.on('change', (event) => {
-      updateHelp(changeId, changeElement, key);
-    });
-  };
-
-  updateHelp(changeId, changeElement, key);
-};
 /**
  *
  * @param {*} subjectId batch_connect_session_context_node_type
@@ -739,6 +798,22 @@ function parseMinMaxFor(key) {
     'predicateId': predicateId,
     'predicateValue': snakeCaseWords(predicateValue),
   }
+}
+
+/**
+ *
+ * @param {*} key helpNodeTypeForClusterAscend
+ * @returns
+ *
+ *  {
+ *    'subjectId': 'batch_connect_session_context_node_type',
+ *    'predicateId': 'batch_connect_session_context_cluster',
+ *    'predicateValue': 'ascend'
+ *  }
+ */
+ function parseHelpFor(key) {
+  // reuse the same For-clause parser as min/max
+  return parseMinMaxFor(key.replace(/^help/, 'min'));
 }
 
 function minOrMax(key) {

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1695,6 +1695,105 @@ class BatchConnectTest < ApplicationSystemTestCase
     end
   end
 
+  test 'data-help responds to for-cluster value' do
+    form = <<~HEREDOC
+      ---
+      form:
+        - cluster
+        - node_type
+      attributes:
+        cluster:
+          widget: select
+          options:
+            - owens
+            - ascend
+        node_type:
+          widget: select
+          options:
+            - [
+                'gpu', 'gpu',
+                data-help-node-type-for-cluster-owens: 'GPU nodes on Owens',
+                data-help-node-type-for-cluster-ascend: 'GPU nodes on Ascend',
+              ]
+            - [
+                'standard', 'standard',
+                data-help-node-type-for-cluster-owens: 'Standard nodes on Owens',
+                data-help-node-type-for-cluster-ascend: 'Standard nodes on Ascend',
+              ]
+    HEREDOC
+
+    Dir.mktmpdir do |dir|
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      widget_selector = '#batch_connect_session_context_node_type'
+      assert_selector(widget_selector)
+      widget = find(widget_selector)
+      parent = widget.all(:xpath, 'ancestor::div[contains(@class,"mb-3")]').first
+      help = parent.find(':scope > small')
+
+      # defaults: owens + gpu
+      help.assert_text('GPU nodes on Owens')
+
+      select 'ascend', from: 'batch_connect_session_context_cluster'
+      help.assert_text('GPU nodes on Ascend')
+
+      select 'standard', from: 'batch_connect_session_context_node_type'
+      help.assert_text('Standard nodes on Ascend')
+
+      select 'owens', from: 'batch_connect_session_context_cluster'
+      help.assert_text('Standard nodes on Owens')
+
+      select 'gpu', from: 'batch_connect_session_context_node_type'
+      help.assert_text('GPU nodes on Owens')
+    end
+  end
+
+  test 'data-help for-cluster keeps previous help when unmatched' do
+    form = <<~HEREDOC
+      ---
+      form:
+        - cluster
+        - node_type
+      attributes:
+        cluster:
+          widget: select
+          options:
+            - owens
+            - ascend
+        node_type:
+          widget: select
+          help: 'Default node type help'
+          options:
+            - [
+                'gpu', 'gpu',
+                data-help-node-type-for-cluster-ascend: 'GPU nodes on Ascend',
+              ]
+            - 'standard'
+    HEREDOC
+
+    Dir.mktmpdir do |dir|
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      widget_selector = '#batch_connect_session_context_node_type'
+      assert_selector(widget_selector)
+      widget = find(widget_selector)
+      parent = widget.all(:xpath, 'ancestor::div[contains(@class,"mb-3")]').first
+      help = parent.find(':scope > small')
+
+      # owens + gpu has no matching for-clause, so keep attribute help
+      help.assert_text('Default node type help')
+
+      select 'ascend', from: 'batch_connect_session_context_cluster'
+      help.assert_text('GPU nodes on Ascend')
+
+      # switching back to owens has no matching value, so keep previous help
+      select 'owens', from: 'batch_connect_session_context_cluster'
+      help.assert_text('GPU nodes on Ascend')
+    end
+  end
+
   test 'options with hyphens set min & max' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
 

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1726,71 +1726,22 @@ class BatchConnectTest < ApplicationSystemTestCase
       make_bc_app(dir, form)
       visit new_batch_connect_session_context_url('sys/app')
 
-      widget_selector = '#batch_connect_session_context_node_type'
-      assert_selector(widget_selector)
-      widget = find(widget_selector)
-      parent = widget.all(:xpath, 'ancestor::div[contains(@class,"mb-3")]').first
-      help = parent.find(':scope > small')
+      help = find("##{bc_ele_id('node_type')}_wrapper small")
 
       # defaults: owens + gpu
       help.assert_text('GPU nodes on Owens')
 
-      select 'ascend', from: 'batch_connect_session_context_cluster'
+      select('ascend', from: bc_ele_id('cluster'))
       help.assert_text('GPU nodes on Ascend')
 
-      select 'standard', from: 'batch_connect_session_context_node_type'
+      select('standard', from: bc_ele_id('node_type'))
       help.assert_text('Standard nodes on Ascend')
 
-      select 'owens', from: 'batch_connect_session_context_cluster'
+      select('owens', from: bc_ele_id('cluster'))
       help.assert_text('Standard nodes on Owens')
 
-      select 'gpu', from: 'batch_connect_session_context_node_type'
+      select('gpu', from: bc_ele_id('node_type'))
       help.assert_text('GPU nodes on Owens')
-    end
-  end
-
-  test 'data-help for-cluster keeps previous help when unmatched' do
-    form = <<~HEREDOC
-      ---
-      form:
-        - cluster
-        - node_type
-      attributes:
-        cluster:
-          widget: select
-          options:
-            - owens
-            - ascend
-        node_type:
-          widget: select
-          help: 'Default node type help'
-          options:
-            - [
-                'gpu', 'gpu',
-                data-help-node-type-for-cluster-ascend: 'GPU nodes on Ascend',
-              ]
-            - 'standard'
-    HEREDOC
-
-    Dir.mktmpdir do |dir|
-      make_bc_app(dir, form)
-      visit new_batch_connect_session_context_url('sys/app')
-
-      widget_selector = '#batch_connect_session_context_node_type'
-      assert_selector(widget_selector)
-      widget = find(widget_selector)
-      parent = widget.all(:xpath, 'ancestor::div[contains(@class,"mb-3")]').first
-      help = parent.find(':scope > small')
-
-      # owens + gpu has no matching for-clause, so keep attribute help
-      help.assert_text('Default node type help')
-
-      select 'ascend', from: 'batch_connect_session_context_cluster'
-      help.assert_text('GPU nodes on Ascend')
-
-      # switching back to owens has no matching value, so keep previous help
-      select 'owens', from: 'batch_connect_session_context_cluster'
-      help.assert_text('GPU nodes on Ascend')
     end
   end
 


### PR DESCRIPTION
Fixes #5692

Allows `data-help` directives to respond to specific config values, matching `data-min` and `data-max`.

- Supports `data-help-*-for-*` clauses for value-specific help messages
- Adds system tests for matching and unmatched values