### PR TITLE
Restore saved settings when editing regardless of caching

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -88,7 +88,7 @@ module BatchConnect
         return
       end
 
-      @session_context.update_with_cache(settings)
+      @session_context.update_with_cache(settings, ignore_cacheable: true)
 
       set_app_groups
       set_saved_settings

--- a/apps/dashboard/app/models/batch_connect/session_context.rb
+++ b/apps/dashboard/app/models/batch_connect/session_context.rb
@@ -69,9 +69,9 @@ module BatchConnect
       /^(?<id>[^=]+)=?$/ =~ method_name.to_s && self[id] || super
     end
 
-    def update_with_cache(cache)
+    def update_with_cache(cache, ignore_cacheable: false)
       self.attributes = cache.select do |k, _v|
-        self[k.to_sym] && self[k.to_sym].cacheable?(app_specific_cache_enabled?)
+        self[k.to_sym] && (ignore_cacheable || self[k.to_sym].cacheable?(app_specific_cache_enabled?))
       end
     end
 

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_paraview/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_paraview/form.yml
@@ -9,6 +9,7 @@ attributes:
     required: true
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."
+    cacheable: false
 form:
   - bc_num_hours
   - bc_account

--- a/apps/dashboard/test/integration/batch_connect_test.rb
+++ b/apps/dashboard/test/integration/batch_connect_test.rb
@@ -124,6 +124,12 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
       file = "#{Rails.root}/test/fixtures/file_output/user_settings/saved_settings_edit.yml"
       Configuration.stubs(:user_settings_file).returns(file)
 
+      # Keep bc_account non-cacheable to test that it works regardless of caching.
+      bc_account_attr = BatchConnect::App.from_token('sys/bc_paraview')
+                                         .attributes.find { |a| a.id == 'bc_account' }
+      refute bc_account_attr.cacheable?(true),
+             'bc_account must stay `cacheable: false` in the sys/bc_paraview fixture'
+
       get batch_connect_edit_settings_path(token: 'sys/bc_paraview', id: 'edit_name')
       assert_response :ok
 

--- a/apps/dashboard/test/models/batch_connect/session_context_test.rb
+++ b/apps/dashboard/test/models/batch_connect/session_context_test.rb
@@ -118,6 +118,17 @@ cacheable: true } }, form: ['bc_account', 'num_cores']
       assert_equal ['', '28'], [context['bc_account'].value, context['num_cores'].value]
     end
 
+    test 'should update field ignoring cacheable when ignore_cacheable is true' do
+      app = BatchConnect::App.new(router: nil)
+      app.stubs(:form_config).returns(cacheable: false,
+                                      attributes: { num_cores: { widget: 'number_field', value: '1', cacheable: false } }, form: ['bc_account', 'num_cores'])
+      context = app.build_session_context
+
+      context.update_with_cache({ 'bc_account' => 'project_1234', 'num_cores' => '28' }, ignore_cacheable: true)
+
+      assert_equal ['project_1234', '28'], [context['bc_account'].value, context['num_cores'].value]
+    end
+
     test 'should ignore bad cache keys when updating cache using update_with_cache' do
       app = BatchConnect::App.new(router: nil)
       app.stubs(:form_config).returns(attributes: { num_cores: { widget: 'number_field', value: '1' } },

--- a/apps/dashboard/test/system/saved_settings_test.rb
+++ b/apps/dashboard/test/system/saved_settings_test.rb
@@ -95,6 +95,22 @@ class SavedSettingsTest < ApplicationSystemTestCase
     find('.alert', text: I18n.t('dashboard.bc_saved_settings.missing_settings'))
   end
 
+  test 'editing saved settings restores non-cacheable field values' do
+    with_modified_env({ ENABLE_NATIVE_VNC: '1' }) do
+      bc_account_attr = BatchConnect::App.from_token('sys/bc_paraview')
+                                         .attributes.find { |a| a.id == 'bc_account' }
+      refute bc_account_attr.cacheable?(true),
+             'bc_account must stay `cacheable: false` in the sys/bc_paraview fixture'
+
+      stub_user_settings("#{Rails.root}/test/fixtures/file_output/user_settings/saved_settings_edit.yml")
+
+      visit(batch_connect_edit_settings_url('sys/bc_paraview', 'edit_name'))
+
+      assert_equal('edit_account', find_field(bc_ele_id('bc_account')).value)
+      assert_equal('10', find_field(bc_ele_id('bc_num_hours')).value)
+    end
+  end
+
   test 'password_fields settings are encrypted when saved' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }


### PR DESCRIPTION
Fixes #5744.

Makes the interactive app form fields always use the values from the saved settings whenever editing a saved setting to avoid the `cacheable` field having any effect.
I expanded the existing test for saved settings editing to check this behaviour.