### PR TITLE
add cron to debian packages dependencies

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -15,7 +15,7 @@ Package: ondemand
 Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends},
-  ruby, apache2, sudo | sudo-rs, lsof, lua-posix, tzdata, file,
+  ruby, apache2, sudo | sudo-rs, lsof, lua-posix, tzdata, file, cron,
   nodejs (>= 22.0), nodejs (<< 23.0),
   ondemand-nginx (>= 1.28.0.p6.1.2.ood4.2.0),  ondemand-nginx (<< 1.29),
   ondemand-passenger (>= 6.1.2.ood4.2.0), ondemand-passenger (<< 6.1.3),


### PR DESCRIPTION
Fixes #5592 

Though I do wonder if it should be added under `Suggests` instead...