### PR TITLE
fix this flaky test and replace aria-label with title

### DIFF
--- a/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/apps/dashboard/app/views/batch_connect/session_contexts/_form.html.erb
@@ -34,7 +34,7 @@
   <%- end -%>
 
   <div class="d-grid gap-2">
-    <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary" %>
+    <%= f.submit t('dashboard.batch_connect_form_launch'), class: "btn btn-primary", id: 'batch_connect_session_context_launch' %>
   </div>
 <% end %>
 

--- a/apps/dashboard/app/views/projects/_import.html.erb
+++ b/apps/dashboard/app/views/projects/_import.html.erb
@@ -37,7 +37,7 @@
         </div>
       </div>
     <p>
-      <%= form.submit I18n.t('dashboard.import'), class: 'btn btn-primary', title: 'Save project', data: {turbo_frame: '_top'} %>
+      <%= form.submit I18n.t('dashboard.import'), class: 'btn btn-primary', data: {turbo_frame: '_top'}, id: 'import_project' %>
       <%= form.button I18n.t('dashboard.reset'), type: :reset, class: 'btn btn-default', title: 'Clear form fields' %>
     </p>
   <% end %>

--- a/apps/dashboard/app/views/projects/index.html.erb
+++ b/apps/dashboard/app/views/projects/index.html.erb
@@ -9,7 +9,7 @@
     <div class="row">
       <% @projects.each do |project| %>
         <div id="<%= project.id %>" class="project-card">
-          <%= link_to(project_path(project.id), class: "text-dark project-icon #{project.mine? ? '' : 'shared'}", aria: {label: t('dashboard.jobs_project_open_label', name: project.title) }) do %>
+          <%= link_to(project_path(project.id), class: "text-dark project-icon #{project.mine? ? '' : 'shared'}", title: t('dashboard.jobs_project_open_label', name: project.title)) do %>
             <div class="text-center d-flex justify-content-center">
               <strong>
                 <%= icon_tag(URI.parse(project.icon)) %>

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1828,7 +1828,7 @@ class BatchConnectTest < ApplicationSystemTestCase
     Open3.stubs(:capture2e).raises(StandardError.new(err_msg))
 
     # defaults
-    click_on('Launch')
+    find('#batch_connect_session_context_launch').click
     verify_bc_alert('sys/bc_jupyter', I18n.t('dashboard.batch_connect_sessions_errors_staging'), err_msg)
   end
 

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1657,8 +1657,9 @@ class ProjectManagerTest < ApplicationSystemTestCase
       fill_in('project_directory', with: "#{Rails.root}/test/fixtures/projects/chemistry-5533")
       click_on(I18n.t('dashboard.import'))
 
-      sleep 2 # sleep ensure the project has been imported
-      # redirected back to the index and it has imported the project with a success notice
+      sleep 1 # sleep ensure the project has been imported
+      # visit again becuase the turbo frame is inconsistent in tests.
+      visit(projects_root_path)
       assert_current_path(projects_root_path)
       assert_selector('a[href="/projects/abc123"]', text: 'Chemistry 5533')
       assert_selector('.alert-success', text: I18n.t('dashboard.jobs_project_imported'))

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -228,10 +228,13 @@ class ProjectManagerTest < ApplicationSystemTestCase
       project_id = setup_project(dir)
 
       click_on 'Edit'
+      assert_current_path(project_edit_path(project_id))
       find('#project_name').set('my-test-project', clear: :backspace)
       click_on 'Save'
+      assert_current_path(projects_path)
       assert_selector "[href='/projects/#{project_id}']", text: 'My Test Project'
       click_on 'Edit'
+      assert_current_path(project_edit_path(project_id))
       assert_selector 'h1', text: 'Editing: My Test Project'
       assert_equal 'my-test-project', find('#project_name').value
       assert_equal "#{dir}/projects/#{project_id}", find('#project_directory').value

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1611,9 +1611,12 @@ class ProjectManagerTest < ApplicationSystemTestCase
       select('Chemistry 5533', from: 'project_template')
       click_on(I18n.t('dashboard.save'))
 
-      find('i.fa-atom').click
-      input_data = File.read('test/fixtures/projects/chemistry-5533/assignment_1.sh')
+      assert_current_path(projects_root_path)
+      ref = find("a[title='#{I18n.t('dashboard.jobs_project_open_label', name: 'Chemistry 5533')}']")
+      chem_project_path = ref[:href]
+      ref.click
 
+      input_data = File.read('test/fixtures/projects/chemistry-5533/assignment_1.sh')
       project_dir = Dir.children(dir).select { |p| Pathname.new("#{dir}/#{p}").directory? }.first
       project_dir = "#{dir}/#{project_dir}"
 
@@ -1628,6 +1631,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       OodCore::Job::Adapters::Slurm.any_instance
                                    .stubs(:info).returns(OodCore::Job::Info.new(id: 'job-id-123', status: :running))
 
+      assert_current_path(chem_project_path)
       find('#launch_8woi7ghd').click
 
       assert_selector('.alert-success', text: 'job-id-123')

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -905,6 +905,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
         .returns(['', 'some error message', exit_failure])
 
       click_on 'Launch'
+      assert_current_path(project_path(project_id))
       assert_selector('.alert-danger', text: "some error message")
       assert_nil YAML.safe_load(File.read("#{ondemand_dir}/job_log.yml"))
     end

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1655,9 +1655,9 @@ class ProjectManagerTest < ApplicationSystemTestCase
       find("a[title='#{I18n.t('dashboard.jobs_import_shared_project')}']").click
 
       fill_in('project_directory', with: "#{Rails.root}/test/fixtures/projects/chemistry-5533")
-      click_on(I18n.t('dashboard.import'))
+      find('#import_project').click
 
-      sleep 3 # sleep ensure the project has been imported
+      sleep 1 # sleep ensure the project has been imported
       assert_current_path(projects_root_path)
       assert_selector('a[href="/projects/abc123"]', text: 'Chemistry 5533')
       assert_selector('.alert-success', text: I18n.t('dashboard.jobs_project_imported'))

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -228,13 +228,13 @@ class ProjectManagerTest < ApplicationSystemTestCase
       project_id = setup_project(dir)
 
       click_on 'Edit'
-      assert_current_path(project_edit_path(project_id))
+      assert_current_path(edit_project_path(project_id))
       find('#project_name').set('my-test-project', clear: :backspace)
       click_on 'Save'
       assert_current_path(projects_path)
       assert_selector "[href='/projects/#{project_id}']", text: 'My Test Project'
       click_on 'Edit'
-      assert_current_path(project_edit_path(project_id))
+      assert_current_path(edit_project_path(project_id))
       assert_selector 'h1', text: 'Editing: My Test Project'
       assert_equal 'my-test-project', find('#project_name').value
       assert_equal "#{dir}/projects/#{project_id}", find('#project_directory').value

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1657,9 +1657,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       fill_in('project_directory', with: "#{Rails.root}/test/fixtures/projects/chemistry-5533")
       click_on(I18n.t('dashboard.import'))
 
-      sleep 1 # sleep ensure the project has been imported
-      # visit again becuase the turbo frame is inconsistent in tests.
-      visit(projects_root_path)
+      sleep 3 # sleep ensure the project has been imported
       assert_current_path(projects_root_path)
       assert_selector('a[href="/projects/abc123"]', text: 'Chemistry 5533')
       assert_selector('.alert-success', text: I18n.t('dashboard.jobs_project_imported'))

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1657,6 +1657,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       fill_in('project_directory', with: "#{Rails.root}/test/fixtures/projects/chemistry-5533")
       click_on(I18n.t('dashboard.import'))
 
+      sleep 1 # sleep ensure the project has been imported
       # redirected back to the index and it has imported the project with a success notice
       assert_current_path(projects_root_path)
       assert_selector('a[href="/projects/abc123"]', text: 'Chemistry 5533')

--- a/apps/dashboard/test/system/project_manager_test.rb
+++ b/apps/dashboard/test/system/project_manager_test.rb
@@ -1657,7 +1657,7 @@ class ProjectManagerTest < ApplicationSystemTestCase
       fill_in('project_directory', with: "#{Rails.root}/test/fixtures/projects/chemistry-5533")
       click_on(I18n.t('dashboard.import'))
 
-      sleep 1 # sleep ensure the project has been imported
+      sleep 2 # sleep ensure the project has been imported
       # redirected back to the index and it has imported the project with a success notice
       assert_current_path(projects_root_path)
       assert_selector('a[href="/projects/abc123"]', text: 'Chemistry 5533')

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -54,6 +54,7 @@ describe 'OnDemand browser test' do
     browser.goto "#{ctr_base_url}/pun/sys/file-editor"
     expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/files/fs/home/ood")
     expect(browser.title).to match(/File browsing - Open OnDemand\b/)
+    sleep 1 # give the table a second to load
     expect(browser.table(id: 'directory-contents').present?).to be true
   end
 

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -54,7 +54,7 @@ describe 'OnDemand browser test' do
     browser.goto "#{ctr_base_url}/pun/sys/file-editor"
     expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/files/fs/home/ood")
     expect(browser.title).to match(/File browsing - Open OnDemand\b/)
-    sleep 1 # give the table a second to load
+    sleep 1 # give the table time to create
     expect(browser.table(id: 'directory-contents').present?).to be true
   end
 

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -75,6 +75,7 @@ describe 'OnDemand browser test' do
     browser.goto "#{ctr_base_url}/pun/sys/files/fs/var/www/ood"
     expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/files/fs/var/www/ood")
     expect(browser.title).to match(/File browsing - Open OnDemand\b/)
+    sleep 1 # give the table time to create
     expect(browser.table(id: 'directory-contents').present?).to be true
   end
 end

--- a/spec/e2e/pun_pre_hook_spec.rb
+++ b/spec/e2e/pun_pre_hook_spec.rb
@@ -29,6 +29,7 @@ describe 'Pun Pre Hook' do
     it 'does not crash login when pre hook crashes' do
       browser_login(browser)
       browser.goto ctr_base_url
+      sleep 1 # give it time to login
       expect(browser.title).to eq('Dashboard - Open OnDemand')
     end
 


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/master/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do, and what is the related issue, if applicable? 

This fixes a flaky test `ProjectManagerTest#test_submitting_launchers_from_a_template_project_works:` that often fails with this error below.

```

Selenium::WebDriver::Error::UnknownError: unknown error: unhandled inspector error: {"code":-32000,"message":"Node with given id does not belong to the document"}
  (Session info: chrome=151.0.7922.173)
    /opt/hostedtoolcache/Ruby/3.4.10/x64/lib/ruby/gems/3.4.0/gems/selenium-webdriver-4.26.0/lib/selenium/webdriver/remote/response.rb:63:in 'Selenium::WebDriver::Remote::Response#add_cause'
    /opt/hostedtoolcache/Ruby/3.4.10/x64/lib/ruby/gems/3.4.0/gems/selenium-webdriver-4.26.0/lib/selenium/webdriver/remote/response.rb:41:in 'Selenium::WebDriver::Remote::Response#error'
```

This test fails because the code executing the test runs faster than the page, so the method to `find` is being executed on what is expected to be the previous page, but is actually the current page.

The fix is to simply add an assertion on the current page path before the `find` because that has the ability to wait.

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation
NA


## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [ ] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?

This also changes the `aria-label` into a `title` because we should be using native HTML attributes where we can, but also will give visual users the popup.
