### PR TITLE
Ensure RAILS_ENV is set during test execution

### DIFF
--- a/apps/dashboard/bin/rails
+++ b/apps/dashboard/bin/rails
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
+
+# ensure local .env.* files are ignored during testing.
+if (ARGV.first.to_s == 't' || ARGV.first.to_s.start_with?('test')) && ENV['RAILS_ENV'].nil?
+  ENV['RAILS_ENV'] = "test"
+end
+
 require_relative '../config/boot'
 require 'rails/commands'

--- a/apps/dashboard/bin/rake
+++ b/apps/dashboard/bin/rake
@@ -1,10 +1,4 @@
 #!/usr/bin/env ruby
-
-# ensure local .env.* files are ignored during testing.
-if (ARGV.first.nil? || ARGV.first.to_s == "test") && ENV['RAILS_ENV'].nil?
-  ENV['RAILS_ENV'] = "test"
-end
-
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
A brief description of the change and why it's being made.

Fixes #5515 by setting the RAILS_ENV variable in bin/rails instead of in bin/rake. Setting it in rake worked for the CI, which always used rake as an entrypoint, but failed to set it when tests were run directly through bin/rails. By moving the declaration here, we ensure that it is always set no matter how tests are initiated.

I could be persuaded to leave bin/rake untouched as it doesn't hurt anything, the only case I can see where the behavior is different is that the variable will no longer be set when bin/rake is run without arguments. Though I can't say I understand why that behavior existed in the first place

To observe the variable being unset in the current iteration, simply log ENV['RAILS_ENV'] during the boot process, and see that it is 'test' when you run `bin/rake test` but nil when you run `bin/rails test`.