### PR TITLE
Fix saved values for non cacheable interactive app fields

### DIFF
--- a/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/apps/dashboard/app/controllers/batch_connect/session_contexts_controller.rb
@@ -88,7 +88,7 @@ module BatchConnect
         return
       end
 
-      @session_context.update_with_cache(settings)
+      @session_context.attributes = settings
 
       set_app_groups
       set_saved_settings

--- a/apps/dashboard/test/fixtures/file_output/user_settings/saved_settings_edit.yml
+++ b/apps/dashboard/test/fixtures/file_output/user_settings/saved_settings_edit.yml
@@ -6,3 +6,5 @@ batch_connect_templates:
       bc_num_hours: '10'
       bc_account: edit_account
       bc_vnc_resolution: 800x600
+      field_a: '2'
+      field_b: '2'

--- a/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_paraview/form.yml
+++ b/apps/dashboard/test/fixtures/sys_with_gateway_apps/bc_paraview/form.yml
@@ -9,7 +9,16 @@ attributes:
     required: true
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."
+  field_a:
+    value: 1
+    widget: number_field
+  field_b:
+    value: 1
+    widget: number_field
+    cacheable: false
 form:
   - bc_num_hours
   - bc_account
   - bc_vnc_resolution
+  - field_a
+  - field_b

--- a/apps/dashboard/test/integration/batch_connect_test.rb
+++ b/apps/dashboard/test/integration/batch_connect_test.rb
@@ -135,6 +135,19 @@ class BatchConnectTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'edit saved settings applies non-cacheable field values' do
+    with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SAVED_SETTINGS: 'true' }) do
+      file = "#{Rails.root}/test/fixtures/file_output/user_settings/saved_settings_edit.yml"
+      Configuration.stubs(:user_settings_file).returns(file)
+
+      get batch_connect_edit_settings_path(token: 'sys/bc_paraview', id: 'edit_name')
+      assert_response :ok
+
+      assert_equal '2', css_select('input[name="batch_connect_session_context[field_a]"]').first['value']
+      assert_equal '2', css_select('input[name="batch_connect_session_context[field_b]"]').first['value']
+    end
+  end
+  
   test 'form header is rendered correctly' do
     get new_batch_connect_session_context_url('sys/bc_jupyter')
     header_link = css_select('span.form_header_supports_some_html>a').first


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
Fixes an issue where saved interactive app settings were not restored for fields with `cacheable: false`.

When editing saved settings, all saved field values are now restored instead of only cached values.

Fixes #5744

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation
If this PR is for a new feature or behavior change, please help us kick start the documentation with a blurb. 

Not applicable.

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [x] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?
Added an integration test covering saved settings with a non-cacheable field.