### PR TITLE
Restore default text when dynamic option is unset

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -267,7 +267,7 @@ function updateHelp(changeId, changeElement, key) {
   var helpElement = $(`${wrapper_id} small p`);
   const helpSmall = $(`${wrapper_id} small`);
 
-  if (contentToSet === '' && helpElement.length === 0 && helpSmall.length === 0) return;
+  if (contentToSet === '' && helpSmall.length === 0) return;
 
   if (helpElement.length == 0) {
     const small = document.createElement('small');

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -246,19 +246,37 @@ function getNewHelp(changeElement, key) {
   return selectedOptionHelp.dataset[key];
 }
 
+function captureDefaultHelp(changeId) {
+  const wrapper = $(`#${changeId}_wrapper`);
+  if (wrapper.data('defaultHelp') !== undefined) return;
+
+  const helpSmall = wrapper.find('small').first();
+  wrapper.data('defaultHelp', helpSmall.length > 0 ? helpSmall.text() : '');
+}
+
 function updateHelp(changeId, changeElement, key) {
+  if (changeId === undefined) return;
+
+  captureDefaultHelp(changeId);
+
   const helpContent = getNewHelp(changeElement, key);
-  if (helpContent === undefined || changeId === undefined) return;
+  const defaultHelp = $(`#${changeId}_wrapper`).data('defaultHelp');
+  const contentToSet = helpContent === undefined ? defaultHelp : helpContent;
+
   const wrapper_id = `#${changeId}_wrapper`;
   var helpElement = $(`${wrapper_id} small p`);
+  const helpSmall = $(`${wrapper_id} small`);
+
+  if (contentToSet === '' && helpElement.length === 0 && helpSmall.length === 0) return;
+
   if (helpElement.length == 0) {
     const small = document.createElement('small');
     small.classList.add('form-text', 'text-muted');
     helpElement = document.createElement('p');
     $(helpElement).appendTo($(small).appendTo($(wrapper_id).children()[0]));
   }
-  $(helpElement).text(helpContent);
-  ariaStream(`Changed help text on ${getWidgetInfo(changeId)} to ${helpContent}`);
+  $(helpElement).text(contentToSet);
+  ariaStream(`Changed help text on ${getWidgetInfo(changeId)} to ${contentToSet}`);
 }
 
 function addHelpHandler(optionId, option, key, configValue) {

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -259,15 +259,13 @@ function updateHelp(changeId, changeElement, key) {
 
   captureDefaultHelp(changeId);
 
-  const helpContent = getNewHelp(changeElement, key);
-  const defaultHelp = $(`#${changeId}_wrapper`).data('defaultHelp');
-  const contentToSet = helpContent === undefined ? defaultHelp : helpContent;
-
   const wrapper_id = `#${changeId}_wrapper`;
+  const helpContent = getNewHelp(changeElement, key);
+  const defaultHelp = $(wrapper_id).data('defaultHelp');
+  const contentToSet = helpContent === undefined ? defaultHelp : helpContent;
   var helpElement = $(`${wrapper_id} small p`);
-  const helpSmall = $(`${wrapper_id} small`);
 
-  if (contentToSet === '' && helpSmall.length === 0) return;
+  if (contentToSet === '' && helpElement.length === 0) return;
 
   if (helpElement.length == 0) {
     const small = document.createElement('small');

--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -255,7 +255,7 @@ function addLabelHandler(optionId, option, key, configValue) {
  *        data-help-node-type-for-cluster-ascend: 'GPU nodes on Ascend ...'
  *      ]
  */
- function addHelpHandler(subjectId, option, key, configValue) {
+function addHelpHandler(subjectId, option, key, configValue) {
   subjectId = String(subjectId || '');
 
   const configObj = parseHelpFor(key);
@@ -298,11 +298,22 @@ function addLabelHandler(optionId, option, key, configValue) {
   toggleHelp({ target: document.querySelector(`#${subjectId}`) }, objectId, secondDimId);
 };
 
+function captureDefaultHelp(changeId) {
+  const wrapper = $(`#${changeId}_wrapper`);
+  if (wrapper.data('defaultHelp') !== undefined) return;
+
+  const helpSmall = wrapper.find('small').first();
+  wrapper.data('defaultHelp', helpSmall.length > 0 ? helpSmall.text() : '');
+}
+
 /**
  * Update the help text of `changeId` based on the
  * event, the `otherId` and the settings in helpLookup table.
  */
 function toggleHelp(event, changeId, otherId) {
+  if (changeId === undefined) return;
+
+  captureDefaultHelp(changeId);
   let x = undefined, y = undefined;
 
   // many subjects can change the object, so we have to find the correct table
@@ -325,12 +336,7 @@ function toggleHelp(event, changeId, otherId) {
   }
 
   const helpContent = table.get(x, y);
-  if (helpContent === undefined || changeId === undefined) return;
-
-  captureDefaultHelp(changeId);
-
   const wrapper_id = `#${changeId}_wrapper`;
-  const helpContent = getNewHelp(changeElement, key);
   const defaultHelp = $(wrapper_id).data('defaultHelp');
   const contentToSet = helpContent === undefined ? defaultHelp : helpContent;
   var helpElement = $(`${wrapper_id} small p`);

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1632,13 +1632,57 @@ class BatchConnectTest < ApplicationSystemTestCase
       help.assert_text('Choose yes')
 
       select 'First', from: 'batch_connect_session_context_group'
-      help.assert_text('Choose yes')
+      help.assert_text('Choose anything')
 
       select 'Second', from: 'batch_connect_session_context_group'
       help.assert_text('Choose no')
 
       select 'First', from: 'batch_connect_session_context_group'
-      help.assert_text('Choose no')
+      help.assert_text('Choose anything')
+    end
+  end
+
+  test 'data-help restores default help when option has no directive' do
+    form = <<~HEREDOC
+      ---
+      cluster:
+        - owens
+      form:
+        - group
+        - hard_choice
+      attributes:
+        group:
+          widget: 'select'
+          label: Membership group
+          help: 'you can find your group in your personal page'
+          options:
+            - ['First',  data-help-hard-choice: 'Choose yes']
+            - ['Second']
+            - ['Third',  data-help-hard-choice: 'Choose whatever']
+        hard_choice:
+          widget: 'number_field'
+          help: 'Default help text'
+    HEREDOC
+    Dir.mktmpdir do |dir|
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      widget_selector = '#batch_connect_session_context_hard_choice'
+      assert_selector(widget_selector)
+      widget = find(widget_selector)
+      parent = widget.all(:xpath, 'ancestor::div[contains(@class,"mb-3")]').first
+
+      help = parent.find(':scope > small')
+      help.assert_text('Choose yes')
+
+      select 'Second', from: 'batch_connect_session_context_group'
+      help.assert_text('Default help text')
+
+      select 'Third', from: 'batch_connect_session_context_group'
+      help.assert_text('Choose whatever')
+
+      select 'Second', from: 'batch_connect_session_context_group'
+      help.assert_text('Default help text')
     end
   end
 
@@ -1685,13 +1729,13 @@ class BatchConnectTest < ApplicationSystemTestCase
       help.assert_text('Choose yes')
 
       select 'Broken', from: 'batch_connect_session_context_group'
-      help.assert_text('Choose yes')
+      help.assert_text('Choose anything')
 
       select 'Second', from: 'batch_connect_session_context_group'
       help.assert_text('Choose no')
 
       select 'Broken', from: 'batch_connect_session_context_group'
-      help.assert_text('Choose no')
+      help.assert_text('Choose anything')
     end
   end
 


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
Restore the default help text when a select option does not have a `data-help` directive. Previously, the help text would keep the value from the previously selected option.

Fixes #5746

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation
Dynamic help text now falls back to the field's default help text when the selected option does not define a `data-help` value.

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [x] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?
Added a system test covering a select where some options define `data-help` and others do not.
