### PR TITLE
Add tests for GET files API with UTF-8 files

### DIFF
--- a/apps/dashboard/test/fixtures/files/download/utf8_content.txt
+++ b/apps/dashboard/test/fixtures/files/download/utf8_content.txt
@@ -1,0 +1,5 @@
+Hello — UTF-8 content test
+日本語のテキストです。
+Àccented çharacters: café, résumé, naïve
+Emoji test: 🐶🐱🚀✨
+Math symbols: 0.123 × 1045−8140 ÷ 2 ≈ π

--- a/apps/dashboard/test/integration/files_test.rb
+++ b/apps/dashboard/test/integration/files_test.rb
@@ -51,7 +51,7 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
 
   # like download_and_test but skips the download param, so we get the inline response
   def get_file(dest_path, file)
-    put_file(files_path(filepath: dest_path), file)
+    FileUtils.cp(file, dest_path)
     get files_path(filepath: dest_path)
     @response
   end

--- a/apps/dashboard/test/integration/files_test.rb
+++ b/apps/dashboard/test/integration/files_test.rb
@@ -49,6 +49,13 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
     "/files/edit/#{fs}#{filepath}"
   end
 
+  # like download_and_test but skips the download param, so we get the inline response
+  def get_file(dest_path, file)
+    put_file(files_path(filepath: dest_path), file)
+    get files_path(filepath: dest_path)
+    @response
+  end
+
   test 'can download file as text/plain' do
     download_and_test('test_text.txt', 'text/plain')
   end
@@ -83,6 +90,63 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'can upload file binary files as text/plain as application/octet-stream' do
     upload_and_test('hello-world-c', content_type: 'application/octet-stream')
+  end
+
+  test 'can get a text file and its content-type comes back right' do
+    Dir.mktmpdir do |tmpdir|
+      src_file = 'test/fixtures/files/download/test_text.txt'
+      dest_path = "#{tmpdir}/test_text.txt"
+
+      response = get_file(dest_path, src_file)
+
+      assert_response :success
+      assert_match(%r{\Atext/plain}, response.headers['Content-Type'])
+      assert_equal File.read(src_file, encoding: 'BINARY'), response.body.dup.force_encoding('BINARY')
+    end
+  end
+
+  test 'files with utf8 content come back correctly, this is the bug from #1218' do
+    Dir.mktmpdir do |tmpdir|
+      src_file = 'test/fixtures/files/download/utf8_content.txt'
+      dest_path = "#{tmpdir}/utf8_content.txt"
+
+      response = nil
+      assert_nothing_raised { response = get_file(dest_path, src_file) }
+
+      assert_response :success
+      assert_match(/charset=utf-8/i, response.headers['Content-Type'])
+      assert_equal File.read(src_file, encoding: 'BINARY'), response.body.dup.force_encoding('BINARY')
+    end
+  end
+
+  test 'utf8 files can be downloaded too, not just viewed inline' do
+    download_and_test('utf8_content.txt', 'text/plain')
+  end
+
+  test 'filenames with utf8 characters work' do
+    Dir.mktmpdir do |tmpdir|
+      src_file = 'test/fixtures/files/download/utf8_content.txt'
+      utf8_filename = "日本語ファイル_résumé_★.txt"
+      dest_path = "#{tmpdir}/#{utf8_filename}"
+
+      response = get_file(dest_path, src_file)
+
+      assert_response :success
+      assert_equal File.read(src_file, encoding: 'BINARY'), response.body.dup.force_encoding('BINARY')
+    end
+  end
+
+  test 'directory listing shows utf8 filenames correctly' do
+    Dir.mktmpdir do |tmpdir|
+      utf8_filename = "café_日本語.txt"
+      FileUtils.touch("#{tmpdir}/#{utf8_filename}")
+
+      get files_path(filepath: tmpdir), headers: { 'Accept': 'application/json' }
+
+      assert_response :success
+      names = JSON.parse(@response.body)['files'].map { |f| f['name'] }
+      assert_includes names, utf8_filename
+    end
   end
 
   test 'edit redirects when file is not editable' do

--- a/apps/dashboard/test/integration/files_test.rb
+++ b/apps/dashboard/test/integration/files_test.rb
@@ -51,7 +51,7 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
 
   # like download_and_test but skips the download param, so we get the inline response
   def get_file(dest_path, file)
-    FileUtils.cp(file, dest_path)
+    put_file(files_path(filepath: dest_path), file)
     get files_path(filepath: dest_path)
     @response
   end
@@ -93,30 +93,23 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'can get a text file and its content-type comes back right' do
-    Dir.mktmpdir do |tmpdir|
-      src_file = 'test/fixtures/files/download/test_text.txt'
-      dest_path = "#{tmpdir}/test_text.txt"
+    src_file = Rails.root.join('test/fixtures/files/download/test_text.txt').to_s
 
-      response = get_file(dest_path, src_file)
+    get files_path(filepath: src_file)
 
-      assert_response :success
-      assert_match(%r{\Atext/plain}, response.headers['Content-Type'])
-      assert_equal File.read(src_file, encoding: 'BINARY'), response.body.dup.force_encoding('BINARY')
-    end
+    assert_response :success
+    assert_equal 'text/plain; charset=utf-8', response.headers['Content-Type']
+    assert_equal File.read(src_file), response.body
   end
 
   test 'files with utf8 content come back correctly, this is the bug from #1218' do
-    Dir.mktmpdir do |tmpdir|
-      src_file = 'test/fixtures/files/download/utf8_content.txt'
-      dest_path = "#{tmpdir}/utf8_content.txt"
+    src_file = Rails.root.join('test/fixtures/files/download/utf8_content.txt').to_s
 
-      response = nil
-      assert_nothing_raised { response = get_file(dest_path, src_file) }
+    assert_nothing_raised { get files_path(filepath: src_file) }
 
-      assert_response :success
-      assert_match(/charset=utf-8/i, response.headers['Content-Type'])
-      assert_equal File.read(src_file, encoding: 'BINARY'), response.body.dup.force_encoding('BINARY')
-    end
+    assert_response :success
+    assert_equal 'text/plain; charset=utf-8', response.headers['Content-Type']
+    assert_equal File.read(src_file), response.body.force_encoding('UTF-8')
   end
 
   test 'utf8 files can be downloaded too, not just viewed inline' do
@@ -144,6 +137,7 @@ class FilesIntegrationTest < ActionDispatch::IntegrationTest
       get files_path(filepath: tmpdir), headers: { 'Accept': 'application/json' }
 
       assert_response :success
+      assert_equal 'application/json; charset=utf-8', response.headers['Content-Type']
       names = JSON.parse(@response.body)['files'].map { |f| f['name'] }
       assert_includes names, utf8_filename
     end


### PR DESCRIPTION
What does this PR do, and what is the related issue, if applicable?

Closes #1268  (part of #2199)

There was a bug where files with UTF-8 content or filenames would error out (#1218), fixed in #1254, but no tests were added at the time so nothing would catch it if it regressed.

This adds a handful of integration tests in files_test.rb:

baseline check that normal text file downloads still work and return the right content-type
UTF-8 file content comes back correctly (no encoding exception, right bytes, charset=utf-8 header)
UTF-8 content also works through the download path, not just inline viewing
filenames with UTF-8 characters resolve correctly
directory listings show UTF-8 filenames properly in the JSON response

No changes to files_controller.rb itself, this is test-only.