### PR TITLE
Preserve batch connect session card tab state

### DIFF
--- a/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
+++ b/apps/dashboard/app/helpers/batch_connect/sessions_helper.rb
@@ -197,8 +197,10 @@ module BatchConnect::SessionsHelper
         concat(
           content_tag(:ul, class: "nav nav-tabs") do
             tabs.map { |t| t[:title] }.map.with_index do |title, idx|
+              tab_data = { 'bs-toggle': "tab" }
+              tab_data[:default_tab] = true if idx.zero?
               content_tag(:li, class: "nav-item #{"active" if idx.zero?}") do
-                link_to title, "#c_#{id}_#{idx}", data: { 'bs-toggle': "tab" }, aria: { selected: (true if idx.zero?) }, class: "nav-link #{"active" if idx.zero?}"
+                link_to title, "#c_#{id}_#{idx}", data: tab_data, aria: { selected: (true if idx.zero?) }, class: "nav-link #{"active" if idx.zero?}"
               end
             end.join("\n").html_safe
           end

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -13,37 +13,33 @@ const selectedConnectionTabs = new Map();
 
 function trackConnectionTabSelection(container) {
   container.addEventListener('shown.bs.tab', (event) => {
-    const tabLink = event.target;
+    const tabLink = event.target.closest('.nav-tabs .nav-link');
+    const card = tabLink?.closest('[data-bc-card]');
+    const href = tabLink?.getAttribute('href');
 
-    if (!tabLink.matches('.nav-tabs .nav-link')) {
+    if (!tabLink || !card || !href?.startsWith('#')) {
       return;
     }
 
-    const card = tabLink.closest('[data-bc-card]');
-
-    if (!card) {
+    if (tabLink.hasAttribute('data-default-tab')) {
+      selectedConnectionTabs.delete(card.dataset.id);
       return;
     }
 
-    const href = tabLink.getAttribute('href');
-
-    if (href && href.startsWith('#')) {
-      selectedConnectionTabs.set(card.dataset.id, href);
-    }
+    selectedConnectionTabs.set(card.dataset.id, href);
   });
 }
 
 function restoreConnectionTabs() {
   selectedConnectionTabs.forEach((tabTarget, sessionId) => {
-    const card = document.querySelector(`[data-bc-card][data-id="${CSS.escape(sessionId)}"]`);
+    const tabLink = document.querySelector(`#id_${CSS.escape(sessionId)} .nav-tabs .nav-link[href="${tabTarget}"]`);
 
-    if (!card) {
+    if (!tabLink) {
+      selectedConnectionTabs.delete(sessionId);
       return;
     }
 
-    const tabLink = card.querySelector(`.nav-tabs .nav-link[href="${tabTarget}"]`);
-
-    if (!tabLink || tabLink.classList.contains('active')) {
+    if (tabLink.classList.contains('active')) {
       return;
     }
 

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import { Tab } from 'bootstrap';
 import { bcIndexUrl, bcPollDelay } from './config';
 import { bindFullPageSpinnerEvent, ariaNotify, pushNotify } from './utils';
 import { pollAndReplace } from './turbo_shim';
@@ -7,6 +8,48 @@ import {
   notificationsEnabled, getNotifiedSessionIds, storeNotifiedSessionIds, 
   pruneNotifiedSessionIds, setupNotificationToggle,
 } from './batch_connect/bc_notifications';
+
+const selectedConnectionTabs = new Map();
+
+function trackConnectionTabSelection(container) {
+  container.addEventListener('shown.bs.tab', (event) => {
+    const tabLink = event.target;
+
+    if (!tabLink.matches('.nav-tabs .nav-link')) {
+      return;
+    }
+
+    const card = tabLink.closest('[data-bc-card]');
+
+    if (!card) {
+      return;
+    }
+
+    const href = tabLink.getAttribute('href');
+
+    if (href && href.startsWith('#')) {
+      selectedConnectionTabs.set(card.dataset.id, href);
+    }
+  });
+}
+
+function restoreConnectionTabs() {
+  selectedConnectionTabs.forEach((tabTarget, sessionId) => {
+    const card = document.querySelector(`[data-bc-card][data-id="${CSS.escape(sessionId)}"]`);
+
+    if (!card) {
+      return;
+    }
+
+    const tabLink = card.querySelector(`.nav-tabs .nav-link[href="${tabTarget}"]`);
+
+    if (!tabLink || tabLink.classList.contains('active')) {
+      return;
+    }
+
+    Tab.getOrCreateInstance(tabLink).show();
+  });
+}
 
 function continuePolling() {
   const bcSessionsContainer = document.getElementById('bc_sessions_content');
@@ -99,7 +142,9 @@ document.addEventListener('DOMContentLoaded', function () {
   
   const bcSessionsContainer = document.getElementById('batch_connect_sessions');
   if (bcSessionsContainer) {
+    trackConnectionTabSelection(bcSessionsContainer);
     pollAndReplace(bcIndexUrl(), bcPollDelay(), "batch_connect_sessions", () => {
+      restoreConnectionTabs();
       bindFullPageSpinnerEvent();
       checkStatusChanges(sessions, notifiedSessionIds);
     }, continuePolling);

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -31,6 +31,11 @@ function trackConnectionTabSelection(container) {
 }
 
 function restoreConnectionTabs() {
+  if (!document.querySelector('[data-bc-card]')) {
+    selectedConnectionTabs.clear();
+    return;
+  }
+  
   selectedConnectionTabs.forEach((tabTarget, sessionId) => {
     const tabLink = document.querySelector(`#id_${CSS.escape(sessionId)} .nav-tabs .nav-link[href="${tabTarget}"]`);
 

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -22,10 +22,9 @@ function trackConnectionTabSelection(container) {
 
     if (tabLink.hasAttribute('data-default-tab')) {
       selectedConnectionTabs.delete(card.dataset.id);
-      return;
+    } else {
+      selectedConnectionTabs.set(card.dataset.id, href);
     }
-
-    selectedConnectionTabs.set(card.dataset.id, href);
   });
 }
 
@@ -38,16 +37,13 @@ function restoreConnectionTabs() {
   selectedConnectionTabs.forEach((tabTarget, sessionId) => {
     const tabLink = document.querySelector(`#id_${CSS.escape(sessionId)} .nav-tabs .nav-link[href="${tabTarget}"]`);
 
-    if (!tabLink) {
+    if (tabLink) {
+      if (!tabLink.classList.contains('active')) {
+        tabLink.click();
+      }
+    } else {
       selectedConnectionTabs.delete(sessionId);
-      return;
     }
-
-    if (tabLink.classList.contains('active')) {
-      return;
-    }
-
-    tabLink.click();
   });
 }
 

--- a/apps/dashboard/app/javascript/batch_connect_sessions.js
+++ b/apps/dashboard/app/javascript/batch_connect_sessions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import { Tab } from 'bootstrap';
 import { bcIndexUrl, bcPollDelay } from './config';
 import { bindFullPageSpinnerEvent, ariaNotify, pushNotify } from './utils';
 import { pollAndReplace } from './turbo_shim';
@@ -48,7 +47,7 @@ function restoreConnectionTabs() {
       return;
     }
 
-    Tab.getOrCreateInstance(tabLink).show();
+    tabLink.click();
   });
 }
 

--- a/apps/dashboard/test/helpers/batch_connect/sessions_helper_test.rb
+++ b/apps/dashboard/test/helpers/batch_connect/sessions_helper_test.rb
@@ -86,4 +86,17 @@ class BatchConnect::SessionsHelperTest < ActionView::TestCase
   def delete_session_title
     I18n.t('dashboard.batch_connect_sessions_delete_full_title', title: 'AppName')
   end
+
+  test 'connection_tabs marks the first tab as the default tab' do
+    tabs = [
+      { title: 'Tab One', partial: 'starting', locals: {} },
+      { title: 'Tab Two', partial: 'queued', locals: {} }
+    ]
+
+    html = Nokogiri::HTML(connection_tabs('session-id', tabs))
+
+    assert_equal 1, html.css('.nav-tabs .nav-link[data-default-tab="true"]').size
+    assert_equal 'Tab One', html.at_css('.nav-tabs .nav-link[data-default-tab="true"]').text.strip
+    assert_nil html.at_css('.nav-tabs .nav-link[href="#c_session-id_1"][data-default-tab]')
+  end
 end

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -37,22 +37,24 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     File.write("#{dir}/#{get_test_bc_id}", get_test_data(token: token, title: title, script_type: script_type).to_json)
   end
 
-  def create_vnc_running_session(db_dir, dataroot_dir, token: 'sys/bc_desktop/owens', title: 'Desktop')
-    create_test_file(db_dir, token: token, title: title, script_type: 'vnc')
-    OodAppkit.stubs(:dataroot).returns(Pathname.new(dataroot_dir))
+  def create_vnc_running_session(dir, token: 'sys/bc_paraview', title: 'Paraview')
+    create_test_file(dir, token: token, title: title, script_type: 'vnc')
+    OodAppkit.stubs(:dataroot).returns(Pathname.new(dir))
 
-    connect = {
-      'host'      => 'node1.example.edu',
-      'port'      => 5901,
-      'password'  => 'testpassword',
-      'websocket' => '5901'
-    }
-
-    output_dir = Pathname.new(dataroot_dir).join(
-      'batch_connect', 'owens', token, 'output', get_test_bc_id
+    session = BatchConnect::Session.new.from_json(
+      get_test_data(token: token, title: title, script_type: 'vnc').to_json
     )
-    FileUtils.mkdir_p(output_dir)
-    File.write(output_dir.join('connection.yml'), connect.to_yaml)
+    FileUtils.mkdir_p(session.staged_root)
+    File.write(session.connect_file, vnc_connect_info.stringify_keys.to_yaml)
+  end
+
+  def vnc_connect_info
+    {
+      host:      'node1.example.edu',
+      port:      5901,
+      password:  'testpassword',
+      websocket: '5901'
+    }
   end
 
   def stub_scheduler(state, cores: 1, nodes: 1)
@@ -230,31 +232,39 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
   end
 
   test 'session card connection tabs remain selected when replaced' do
-    Dir.mktmpdir do |db_dir|
-      Dir.mktmpdir do |dataroot_dir|
-        with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SESSIONS_POLL_DELAY: '10' }) do
-          create_vnc_running_session(db_dir, dataroot_dir)
-          stub_scheduler(:running)
+    Dir.mktmpdir do |dir|
+      with_modified_env({ ENABLE_NATIVE_VNC: 'true' }) do
+        Configuration.stubs(:bc_sessions_poll_delay).returns(100)
+        create_vnc_running_session(dir)
+        stub_scheduler(:running)
 
-          visit(batch_connect_sessions_path)
+        visit(batch_connect_sessions_path)
 
-          card_selector = "#id_#{get_test_bc_id}"
-          assert_selector(card_selector)
+        card_selector = "#id_#{get_test_bc_id}"
+        assert_selector(card_selector)
 
-          within(card_selector) do
-            click_link('Native Instructions')
-            assert_selector('.nav-link.active', text: 'Native Instructions')
-          end
-
-          execute_script("$('#{card_selector}').attr('data-original-marker', 'true')")
-          assert_no_selector("#{card_selector}[data-original-marker='true']", wait: 5)
-
-          within(card_selector) do
-            assert_selector('.nav-link.active', text: 'Native Instructions')
-            assert_text('establish the SSH tunnel')
-          end
+        within(card_selector) do
+          assert_selector('.h5', text: /Running/)
+          assert_selector('.nav-link', text: 'Native Instructions')
+          click_link('Native Instructions')
+          assert_selector('.nav-link.active', text: 'Native Instructions')
         end
+
+        execute_script("$('#{card_selector}').attr('data-original-marker', 'true')")
+        assert_no_selector("#{card_selector}[data-original-marker='true']", wait: 5)
+
+        within(card_selector) do
+          assert_selector('.nav-link.active', text: 'Native Instructions')
+          assert_text('establish the SSH tunnel')
+        end
+
+        visit root_path
       end
     end
+  ensure
+    Configuration.unstub(:bc_sessions_poll_delay) if Configuration.respond_to?(:unstub)
+    BatchConnect::Session.unstub(:db_root) if BatchConnect::Session.respond_to?(:unstub)
+    OodAppkit.unstub(:dataroot) if OodAppkit.respond_to?(:unstub)
+    OodCore::Job::Adapters::Slurm.any_instance.unstub(:info)
   end
 end

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -11,7 +11,7 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     stub_sys_apps
   end
 
-  def get_test_data(token: 'sys/bc_paraview', title: 'Paraview')
+  def get_test_data(token: 'sys/bc_paraview', title: 'Paraview', script_type: 'basic')
     {
       'id':              get_test_bc_id,
       'cluster_id':      'owens',
@@ -19,7 +19,7 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
       "created_at":      1_701_184_869,
       "token":           token,
       "title":           title,
-      "script_type":     'basic',
+      "script_type":     script_type,
       "cache_completed": false
     }
   end
@@ -32,9 +32,27 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
     'abc-123'
   end
 
-  def create_test_file(dir, token: 'sys/bc_paraview', title: 'Paraview')
+  def create_test_file(dir, token: 'sys/bc_paraview', title: 'Paraview', script_type: 'basic')
     BatchConnect::Session.stubs(:db_root).returns(Pathname.new(dir))
-    File.write("#{dir}/#{get_test_bc_id}", get_test_data(token: token, title: title).to_json)
+    File.write("#{dir}/#{get_test_bc_id}", get_test_data(token: token, title: title, script_type: script_type).to_json)
+  end
+
+  def create_vnc_running_session(db_dir, dataroot_dir, token: 'sys/bc_desktop/owens', title: 'Desktop')
+    create_test_file(db_dir, token: token, title: title, script_type: 'vnc')
+    OodAppkit.stubs(:dataroot).returns(Pathname.new(dataroot_dir))
+
+    connect = {
+      'host'      => 'node1.example.edu',
+      'port'      => 5901,
+      'password'  => 'testpassword',
+      'websocket' => '5901'
+    }
+
+    output_dir = Pathname.new(dataroot_dir).join(
+      'batch_connect', 'owens', token, 'output', get_test_bc_id
+    )
+    FileUtils.mkdir_p(output_dir)
+    File.write(output_dir.join('connection.yml'), connect.to_yaml)
   end
 
   def stub_scheduler(state, cores: 1, nodes: 1)
@@ -205,6 +223,35 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
 
             assert_no_selector("#{card_selector}[data-original-marker='true']")
             assert_equal(selector.split('.')[1..], evaluate_script('document.activeElement.classList'))
+          end
+        end
+      end
+    end
+  end
+
+  test 'session card connection tabs remain selected when replaced' do
+    Dir.mktmpdir do |db_dir|
+      Dir.mktmpdir do |dataroot_dir|
+        with_modified_env({ ENABLE_NATIVE_VNC: 'true', OOD_BC_SESSIONS_POLL_DELAY: '10' }) do
+          create_vnc_running_session(db_dir, dataroot_dir)
+          stub_scheduler(:running)
+
+          visit(batch_connect_sessions_path)
+
+          card_selector = "#id_#{get_test_bc_id}"
+          assert_selector(card_selector)
+
+          within(card_selector) do
+            click_link('Native Instructions')
+            assert_selector('.nav-link.active', text: 'Native Instructions')
+          end
+
+          execute_script("$('#{card_selector}').attr('data-original-marker', 'true')")
+          assert_no_selector("#{card_selector}[data-original-marker='true']", wait: 5)
+
+          within(card_selector) do
+            assert_selector('.nav-link.active', text: 'Native Instructions')
+            assert_text('establish the SSH tunnel')
           end
         end
       end

--- a/apps/dashboard/test/system/batch_connect_sessions_test.rb
+++ b/apps/dashboard/test/system/batch_connect_sessions_test.rb
@@ -261,10 +261,5 @@ class BatchConnectSessionsTest < ApplicationSystemTestCase
         visit root_path
       end
     end
-  ensure
-    Configuration.unstub(:bc_sessions_poll_delay) if Configuration.respond_to?(:unstub)
-    BatchConnect::Session.unstub(:db_root) if BatchConnect::Session.respond_to?(:unstub)
-    OodAppkit.unstub(:dataroot) if OodAppkit.respond_to?(:unstub)
-    OodCore::Job::Adapters::Slurm.any_instance.unstub(:info)
   end
 end

--- a/apps/dashboard/test/system/toggle_behavior_test.rb
+++ b/apps/dashboard/test/system/toggle_behavior_test.rb
@@ -47,6 +47,15 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
     launcher_element[:id].gsub('launcher_', '')
   end
 
+  def wait_for_initial_bc_sessions_poll
+    execute_script(<<~JS)
+      const url = document.getElementById('ood_config')?.dataset?.bcIndexUrl;
+      if (!url) return Promise.resolve();
+      return fetch(url, { headers: { Accept: 'text/vnd.turbo-stream.html' } })
+        .then(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    JS
+  end
+  
   # FIXME: Duplicated from project_test_helper.rb
   def setup_workflow(dir)
     workflow_dir = Pathname.new(dir).join('workflows')
@@ -106,6 +115,7 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
 
   test 'collapsible batch connect app menu toggles' do
     visit(batch_connect_sessions_path)
+    wait_for_initial_bc_sessions_poll
 
     within('nav[aria-label="Interactive Apps Menu"]') do
       card = find('.collapsible-app-card', match: :first)
@@ -114,18 +124,19 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
       list_group = card.find("##{target_id}", visible: :all)
 
       assert_selector("##{target_id}.show")
-      assert_equal('true', button['aria-expanded'])
+      assert list_group.visible?, 'App list should be visible initially'
 
       button.click
 
       refute_selector("##{target_id}.show")
       refute_selector("##{target_id}.collapsing")
-      assert_equal('false', card.find('button.collapsible-app-card-toggle')['aria-expanded'])
+      assert_not list_group.visible?, 'App list should be hidden after toggle'
 
       card.find('button.collapsible-app-card-toggle').click
-      
+
+      refute_selector("##{target_id}.collapsing")
       assert_selector("##{target_id}.show")
-      assert_equal('true', card.find('button.collapsible-app-card-toggle')['aria-expanded'])
+      assert list_group.visible?, 'App list should be visible after second toggle'
     end
   end
   

--- a/apps/dashboard/test/system/toggle_behavior_test.rb
+++ b/apps/dashboard/test/system/toggle_behavior_test.rb
@@ -120,12 +120,12 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
 
       refute_selector("##{target_id}.show")
       refute_selector("##{target_id}.collapsing")
-      assert_equal('false', button['aria-expanded'])
+      assert_equal('false', card.find('button.collapsible-app-card-toggle')['aria-expanded'])
 
-      button.click
+      card.find('button.collapsible-app-card-toggle').click
       
       assert_selector("##{target_id}.show")
-      assert_equal('true', button['aria-expanded'])
+      assert_equal('true', card.find('button.collapsible-app-card-toggle')['aria-expanded'])
     end
   end
   

--- a/apps/dashboard/test/system/toggle_behavior_test.rb
+++ b/apps/dashboard/test/system/toggle_behavior_test.rb
@@ -46,15 +46,6 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
     launcher_element = all('#launcher_list div.list-group-item').first
     launcher_element[:id].gsub('launcher_', '')
   end
-
-  def wait_for_initial_bc_sessions_poll
-    execute_script(<<~JS)
-      const url = document.getElementById('ood_config')?.dataset?.bcIndexUrl;
-      if (!url) return Promise.resolve();
-      return fetch(url, { headers: { Accept: 'text/vnd.turbo-stream.html' } })
-        .then(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
-    JS
-  end
   
   # FIXME: Duplicated from project_test_helper.rb
   def setup_workflow(dir)
@@ -115,7 +106,6 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
 
   test 'collapsible batch connect app menu toggles' do
     visit(batch_connect_sessions_path)
-    wait_for_initial_bc_sessions_poll
 
     within('nav[aria-label="Interactive Apps Menu"]') do
       card = find('.collapsible-app-card', match: :first)
@@ -124,19 +114,18 @@ class ToggleBehaviorTest < ApplicationSystemTestCase
       list_group = card.find("##{target_id}", visible: :all)
 
       assert_selector("##{target_id}.show")
-      assert list_group.visible?, 'App list should be visible initially'
+      assert_equal('true', button['aria-expanded'])
 
       button.click
 
       refute_selector("##{target_id}.show")
       refute_selector("##{target_id}.collapsing")
-      assert_not list_group.visible?, 'App list should be hidden after toggle'
+      assert_equal('false', button['aria-expanded'])
 
-      card.find('button.collapsible-app-card-toggle').click
+      button.click
 
-      refute_selector("##{target_id}.collapsing")
       assert_selector("##{target_id}.show")
-      assert list_group.visible?, 'App list should be visible after second toggle'
+      assert_equal('true', button['aria-expanded'])
     end
   end
   

--- a/spec/e2e/browser_spec.rb
+++ b/spec/e2e/browser_spec.rb
@@ -75,6 +75,7 @@ describe 'OnDemand browser test' do
     browser.goto "#{ctr_base_url}/pun/sys/files/fs/var/www/ood"
     expect(browser.url).to eq("#{ctr_base_url}/pun/sys/dashboard/files/fs/var/www/ood")
     expect(browser.title).to match(/File browsing - Open OnDemand\b/)
+    sleep 5
     expect(browser.table(id: 'directory-contents').present?).to be true
   end
 end


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
Preserves the selected connection tab on batch connect session cards when polling refreshes the card.

- Tracks the active connection tab per session using Bootstrap’s `shown.bs.tab` event
- Restores the selected tab after each card replacement using the existing `pollAndReplace` callback

Fixes #5750

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation
If this PR is for a new feature or behavior change, please help us kick start the documentation with a blurb. 

Not applicable

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [x] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
