### PR TITLE
sanitize help content in bc forms

### DIFF
--- a/apps/dashboard/app/lib/smart_attributes/attribute.rb
+++ b/apps/dashboard/app/lib/smart_attributes/attribute.rb
@@ -5,6 +5,8 @@ module SmartAttributes
   # should subclass.
   class Attribute
     include BoolReader
+    include ActionView::Helpers::SanitizeHelper
+
     # Unique identifier of attribute
     # @return [String] attribute id
     attr_reader :id
@@ -90,7 +92,8 @@ module SmartAttributes
     end
 
     def help_html(fmt: nil)
-      OodAppkit.markdown.render(help(fmt: fmt)).html_safe
+      content = OodAppkit.markdown.render(help(fmt: fmt))
+      sanitize(content)
     end
 
     def hide_by_default?

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -1250,4 +1250,44 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
       refute(find("##{bc_ele_id('first_group_item')}", visible: :hidden).visible?)
     end
   end
+
+  # 
+  test 'help does not include dangerous tags while preserving safe tags' do
+    Dir.mktmpdir do |dir|
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - test_item
+        attributes:
+          test_item:
+            help: |
+              # A header
+              <script>window.alert('hello');</script>
+              <a href="https://github.com/OSC/ondemand">an html anchor</a>
+              [a markdown anchor](https://github.com/OSC/ondemand)
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      # note there's no <script> tag here.
+      expected_html = <<~HEREDOC
+        <h1>A header</h1>
+
+        window.alert('hello');
+
+        <p><a href="https://github.com/OSC/ondemand">an html anchor</a>
+        <a href="https://github.com/OSC/ondemand">a markdown anchor</a></p>
+      HEREDOC
+
+      help_html = find("##{bc_ele_id('test_item')}_wrapper small")['innerHTML']
+      assert_equal(expected_html, help_html)
+    end
+  end
 end

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -1251,7 +1251,6 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
-  # 
   test 'help does not include dangerous tags while preserving safe tags' do
     Dir.mktmpdir do |dir|
       SysRouter.stubs(:base_path).returns(Pathname.new(dir))


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/master/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do, and what is the related issue, if applicable? 

This sanitizes `help` content in batch connect forms.

Fixes #_______

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation

https://github.com/OSC/ood-documentation/pull/1417

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [ ] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?

Note that this is not a vulnerability because app publishers can provide a `form.js` for javascript content on the same page.
