### PR TITLE
change to assert_equal to get rid of warnings

### DIFF
--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1729,19 +1729,19 @@ class BatchConnectTest < ApplicationSystemTestCase
       help = find("##{bc_ele_id('node_type')}_wrapper small")
 
       # defaults: owens + gpu
-      help.assert_text('GPU nodes on Owens')
+      assert_equal('GPU nodes on Owens', help.text)
 
       select('ascend', from: bc_ele_id('cluster'))
-      help.assert_text('GPU nodes on Ascend')
+      assert_equal('GPU nodes on Ascend', help.text)
 
       select('standard', from: bc_ele_id('node_type'))
-      help.assert_text('Standard nodes on Ascend')
+      assert_equal('Standard nodes on Ascend', help.text)
 
       select('owens', from: bc_ele_id('cluster'))
-      help.assert_text('Standard nodes on Owens')
+      assert_equal('Standard nodes on Owens', help.text)
 
       select('gpu', from: bc_ele_id('node_type'))
-      help.assert_text('GPU nodes on Owens')
+      assert_equal('GPU nodes on Owens', help.text)
     end
   end
 

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1729,19 +1729,19 @@ class BatchConnectTest < ApplicationSystemTestCase
       help = find("##{bc_ele_id('node_type')}_wrapper small")
 
       # defaults: owens + gpu
-      assert_equal('GPU nodes on Owens', help.text)
+      assert_text(help, 'GPU nodes on Owens')
 
       select('ascend', from: bc_ele_id('cluster'))
-      assert_equal('GPU nodes on Ascend', help.text)
+      assert_text(help, 'GPU nodes on Ascend')
 
       select('standard', from: bc_ele_id('node_type'))
-      assert_equal('Standard nodes on Ascend', help.text)
+      assert_text(help, 'Standard nodes on Ascend')
 
       select('owens', from: bc_ele_id('cluster'))
-      assert_equal('Standard nodes on Owens', help.text)
+      assert_text(help, 'Standard nodes on Owens')
 
       select('gpu', from: bc_ele_id('node_type'))
-      assert_equal('GPU nodes on Owens', help.text)
+      assert_text(help, 'GPU nodes on Owens')
     end
   end
 


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/master/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do, and what is the related issue, if applicable? 

Apparently `assert_text` will give warnings about missing assertions because it's not directly minitest. So this changes that to get rid of warnings about missing assertions like this:

`Test is missing assertions: `test_data-help_responds_to_for-cluster_value` /home/runner/work/ondemand/ondemand/apps/dashboard/test/system/batch_connect_test.rb:1698`

Fixes #_______

## Testing
- [ ] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [x] No test is needed because this fixes current tests.

## Documentation

NA

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [ ] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?
No
