### PR TITLE
replace click_on with find(id).click

### DIFF
--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -1933,18 +1933,17 @@ class BatchConnectTest < ApplicationSystemTestCase
     BatchConnect::Session.any_instance.stubs(:adapter).returns(BrokenAdapter.new)
 
     # defaults
-    click_on('Launch')
+    find('#batch_connect_session_context_launch').click
     verify_bc_alert('sys/bc_jupyter', I18n.t('dashboard.batch_connect_sessions_errors_submission'), err_msg)
   end
 
   test 'save errors are shown' do
     visit new_batch_connect_session_context_url('sys/bc_jupyter')
     err_msg = 'this is a just a test for staging error messages'
-    # Open3.stubs(:capture2e).returns(['', exit_failure])
     BatchConnect::Session.any_instance.stubs(:stage).raises(StandardError.new(err_msg))
 
     # defaults
-    click_on('Launch')
+    find('#batch_connect_session_context_launch').click
     verify_bc_alert('sys/bc_jupyter', 'save', err_msg)
   end
 
@@ -2302,7 +2301,7 @@ class BatchConnectTest < ApplicationSystemTestCase
 
       # the script.sh.erb raises the message 'context.auto_modules_netcdf_serial' (note the _ in the name)
       # which should be 'netcdf-serial/4.3.3.1'
-      click_on('Launch')
+      find('#batch_connect_session_context_launch').click
       verify_bc_alert('sys/bc_jupyter', I18n.t('dashboard.batch_connect_sessions_errors_staging'), module_value)
     end
   end
@@ -3245,8 +3244,8 @@ class BatchConnectTest < ApplicationSystemTestCase
         sleep 5 # modal needs to sleep?
         click_on('Save')
 
-        click_on('Launch', wait: 30)
-        sleep 3
+        sleep 1
+        find('#batch_connect_session_context_launch').click
         expected = output_fixture('user_settings/simple_bc_test.yml')
         actual = File.read("#{dir}/settings.yml")
 
@@ -3346,7 +3345,7 @@ class BatchConnectTest < ApplicationSystemTestCase
       value = find("##{id}").value
       assert_equal('A', value)
 
-      click_on('Launch')
+      find('#batch_connect_session_context_launch').click
       visit(new_batch_connect_session_context_url('sys/app'))
       cache_data = YAML.safe_load(File.read(cache_file.to_s)).to_h
       assert_equal('A', value)
@@ -3380,7 +3379,7 @@ class BatchConnectTest < ApplicationSystemTestCase
       raw_password = 'abc123'
       fill_in(bc_ele_id('some_field'), with: 42)
       fill_in(bc_ele_id('some_password_field'), with: raw_password)
-      click_on('Launch')
+      find('#batch_connect_session_context_launch').click
 
       sleep 3
       visit new_batch_connect_session_context_url('sys/app')

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -3246,6 +3246,7 @@ class BatchConnectTest < ApplicationSystemTestCase
 
         sleep 1
         find('#batch_connect_session_context_launch').click
+        sleep 1
         expected = output_fixture('user_settings/simple_bc_test.yml')
         actual = File.read("#{dir}/settings.yml")
 


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/master/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do, and what is the related issue, if applicable? 

`click_on` is inconsistent in testing. I'm finding that find(id).click is more consistent. 

Fixes #_______

## Testing
- [ ] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [x] No test is needed because this updates tests

## Documentation

NA

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [ ] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?

We have lots of test failures inconsistently from click_on where the driver fails to find the specific text we're looking for.
