### PR TITLE
Add tests for auto_batch_clusters setting auto_cores

### DIFF
--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -2747,6 +2747,29 @@ class BatchConnectTest < ApplicationSystemTestCase
     end
   end
 
+  test 'auto_cores are cluster aware' do
+    Dir.mktmpdir do |dir|
+      "#{dir}/app".tap { |d| Dir.mkdir(d) }
+      SysRouter.stubs(:base_path).returns(Pathname.new(dir))
+      stub_scontrol
+      stub_sacctmgr
+      stub_git("#{dir}/app")
+
+      form = <<~HEREDOC
+        form:
+          - auto_batch_clusters
+          - auto_cores
+      HEREDOC
+
+      Pathname.new("#{dir}/app/").join('form.yml').write(form)
+      visit new_batch_connect_session_context_url('sys/app')
+      raise StandardError
+    end
+  end
+
+  test 'auto_cores are queue aware' do
+  end
+
   test 'path_selector works' do
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }

--- a/apps/dashboard/test/system/batch_connect_test.rb
+++ b/apps/dashboard/test/system/batch_connect_test.rb
@@ -2751,8 +2751,7 @@ class BatchConnectTest < ApplicationSystemTestCase
     Dir.mktmpdir do |dir|
       "#{dir}/app".tap { |d| Dir.mkdir(d) }
       SysRouter.stubs(:base_path).returns(Pathname.new(dir))
-      stub_scontrol
-      stub_sacctmgr
+      stub_sinfo
       stub_git("#{dir}/app")
 
       form = <<~HEREDOC
@@ -2763,11 +2762,13 @@ class BatchConnectTest < ApplicationSystemTestCase
 
       Pathname.new("#{dir}/app/").join('form.yml').write(form)
       visit new_batch_connect_session_context_url('sys/app')
-      raise StandardError
-    end
-  end
+      
+      assert_equal('oakley', find_value('auto_batch_clusters'))
+      assert_equal(80, find_max('auto_cores'))
 
-  test 'auto_cores are queue aware' do
+      select('owens', from: bc_ele_id('auto_batch_clusters'))
+      assert_equal(48, find_max('auto_cores'))
+    end
   end
 
   test 'path_selector works' do


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
A brief description of the change and why it's being made.

Fixes #5677 by showing that auto_batch_clusters currently sets the max for auto_cores, as stated in our docs. I was going to add auto_queues interaction here, but after discovering https://github.com/OSC/ood_core/issues/981, it seems like we have more work to do on `auto_cores` before we can reliably attach this to a 'max cpus per node' value coming out of QueueInfo.

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [ ] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?
Screenshots, context, or anything reviewers should know.
