### PR TITLE
Fix undefined data-label on select options

### DIFF
--- a/apps/dashboard/app/javascript/dynamic_forms.js
+++ b/apps/dashboard/app/javascript/dynamic_forms.js
@@ -214,11 +214,24 @@ function newLabel(changeElement, key) {
   return selectedOptionLabel.dataset[key];
 };
 
+function captureDefaultLabel(changeId) {
+  const wrapper = $(`#${changeId}_wrapper`);
+  if (wrapper.data('defaultLabel') !== undefined) return;
+
+  const label = $(`label[for="${changeId}"]`);
+  wrapper.data('defaultLabel', label.length ? label[0].innerHTML : '');
+}
+
 function updateLabel(changeId, changeElement, key) {
-  var labelContent = newLabel(changeElement, key);
+  if (changeId === undefined) return;
+
+  captureDefaultLabel(changeId);
+  const labelContent = newLabel(changeElement, key);
+  const defaultLabel = $(`#${changeId}_wrapper`).data('defaultLabel');
+  const contentToSet = labelContent === undefined ? defaultLabel : labelContent;
   const originalInfo = getWidgetInfo(changeId);
-  $(`label[for="${changeId}"]`)[0].innerHTML = labelContent;
-  ariaStream(`Changed label on ${originalInfo} to new label ${labelContent}`);
+  $(`label[for="${changeId}"]`)[0].innerHTML = contentToSet;
+  ariaStream(`Changed label on ${originalInfo} to new label ${contentToSet}`);
 }
 
 function addLabelHandler(optionId, option, key, configValue) {

--- a/apps/dashboard/test/system/batch_connect_widgets_test.rb
+++ b/apps/dashboard/test/system/batch_connect_widgets_test.rb
@@ -342,6 +342,89 @@ class BatchConnectWidgetsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'data-label restores default label when option has no directive' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - node_type
+          - cores
+        attributes:
+          node_type:
+            widget: select
+            options:
+              - ['small', 'small', data-label-cores: 'Number of Cores (1-4)']
+              - ['medium', 'medium']
+              - ['large', 'large', data-label-cores: 'Number of Cores (1-16)']
+          cores:
+            widget: "number_field"
+            label: "Number of Cores"
+            required: true
+            value: 1
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores (1-4)', label.text
+
+      select('medium', from: bc_ele_id('node_type'))
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores', label.text
+
+      select('large', from: bc_ele_id('node_type'))
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores (1-16)', label.text
+
+      select('medium', from: bc_ele_id('node_type'))
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores', label.text
+    end
+  end
+
+  test 'data-label keeps default when initially selected option has no directive' do
+    Dir.mktmpdir do |dir|
+      form = <<~HEREDOC
+        ---
+        cluster:
+          - owens
+        form:
+          - node_type
+          - cores
+        attributes:
+          node_type:
+            widget: select
+            options:
+              - ['small', 'small']
+              - ['medium', 'medium', data-label-cores: 'Number of Cores (1-8)']
+              - ['large', 'large', data-label-cores: 'Number of Cores (1-16)']
+          cores:
+            widget: "number_field"
+            label: "Number of Cores"
+            required: true
+            value: 1
+      HEREDOC
+
+      make_bc_app(dir, form)
+      visit new_batch_connect_session_context_url('sys/app')
+
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores', label.text
+      refute_equal 'undefined', label.text
+
+      select('medium', from: bc_ele_id('node_type'))
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores (1-8)', label.text
+
+      select('small', from: bc_ele_id('node_type'))
+      label = find("label[for='#{bc_ele_id('cores')}']")
+      assert_equal 'Number of Cores', label.text
+    end
+  end
+  
   test 'global_bc_form_items work correctly' do
     Dir.mktmpdir do |dir|
       app_dir = "#{dir}/app".tap { |d| FileUtils.mkdir(d) }


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
Restores the field’s original label when a select option doesn’t define `data-label`. Before this, picking an option with a label and then one without could show the literal string `undefined`. Same approach as #5763 for `data-help`.

Fixes #4595

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation
Dynamic labels now fall back to the field’s default label when the selected option doesn’t set a `data-label` value.

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [x] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?
N/A