### PR TITLE
Touch up pinned app icon spacing

### DIFF
--- a/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
+++ b/apps/dashboard/app/assets/stylesheets/pinned_apps.scss
@@ -29,10 +29,13 @@
   }
 }
 
+.row:has(> .app-launcher-container) {
+  --bs-gutter-x: 1em;
+}
+
 .app-launcher {
   position: relative;
-  height: 95%;
-  margin-bottom: 1.2em;
+  margin-bottom: 1em;
 
   border-radius: 10%;
   box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
@@ -161,6 +164,12 @@
     margin: 0;
     font-size: 14px;
     font-weight: 300;
+  }
+
+  .app-caption {
+    margin-top: 0.125rem;
+    margin-bottom: 0;
+    padding-bottom: 0.5rem;
   }
 }
 

--- a/apps/dashboard/app/views/widgets/pinned_apps/_app_content.html.erb
+++ b/apps/dashboard/app/views/widgets/pinned_apps/_app_content.html.erb
@@ -4,9 +4,9 @@
   <%= content_tag(:p, tile_data.fetch(:title, link.title), class: "app-title") %>
 
   <% if tile_data.blank? %>
-    <%= content_tag(:p, content_tag(:span, link.caption), class: "text-muted mt-1") if link.caption %>
+    <%= content_tag(:p, content_tag(:span, link.caption), class: "app-caption text-muted") if link.caption %>
   <% else %>
-    <div class="mt-2 mb-1">
+    <div class="app-caption">
       <%- tile_data.fetch(:sub_caption, "").each_line do |line| -%>
         <%= content_tag(:p, line, class: "app-description text-muted") %>
       <%- end -%>

--- a/apps/dashboard/test/integration/pinned_apps_test.rb
+++ b/apps/dashboard/test/integration/pinned_apps_test.rb
@@ -94,11 +94,12 @@ class PinnedAppsTest < ActionDispatch::IntegrationTest
     assert_select pinned_app_link('/apps/show/pseudofun'), 1
     assert_select pinned_app_link('/batch_connect/sys/bc_desktop/owens/session_contexts/new'), 1
 
-    # pinned apps show captions
+    # pinned apps show captions with tightened spacing
+    assert_select "a[href='/batch_connect/sys/bc_jupyter/session_contexts/new'] p.app-caption.text-muted", 1
     assert_equal  'A really cool Jupyter app',
-                  css_select("a[href='/batch_connect/sys/bc_jupyter/session_contexts/new'] p.text-muted").text
+                  css_select("a[href='/batch_connect/sys/bc_jupyter/session_contexts/new'] p.app-caption").text
     assert_equal  'System Installed App',
-                  css_select("a[href='/batch_connect/sys/bc_paraview/session_contexts/new'] p.text-muted").text
+                  css_select("a[href='/batch_connect/sys/bc_paraview/session_contexts/new'] p.app-caption").text
   end
 
   test 'should add tile attributes to pinned app HTML' do


### PR DESCRIPTION
## What does this PR do, and what is the related issue, if applicable? 
Adjusted the spacing on pinned / quick-launch app tiles so the icons don't have unnecessary vertical padding and look more balanced. Played around with it for a while and ended up matching the horizontal gutter to the vertical gap (`1em`), removing the old `height: 95%`, and tightening the caption margins a bit seemed to look best. Happy to adjust if needed.

Fixes #2035

## Testing
- [x] Tests included
- [ ] If a maintainers' assistance is needed for tests, add label `test help`
- [ ] No test is needed because _____ (documentation fix, dependency update, etc.) 

## Documentation
N/A

## Code Authorship & Understanding

- [x] I can explain what this code does and answer questions about it
- [x] This PR was generated or assisted by AI tools (Copilot, Claude, agents). If so, I have reviewed and tested the code
and I take responsibility for its correctness.

## Checklist
- [x] Follows project code style and conventions
- [ ] This is a large pull request and was discussed first in an issue or with the maintainers.
      
## Anything else?
<img width="1734" height="1462" alt="image" src="https://github.com/user-attachments/assets/9b74a61a-7422-416c-8951-9d338a6dc2da" />